### PR TITLE
Add basic QML support to Qt resource system

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -105,6 +105,7 @@ QT_QRC_LOCALE_CPP = qt/qrc_bitcoin_locale.cpp
 QT_QRC_LOCALE = qt/bitcoin_locale.qrc
 
 BITCOIN_QT_H = \
+  qml/bitcoin.h \
   qt/addressbookpage.h \
   qt/addresstablemodel.h \
   qt/askpassphrasedialog.h \
@@ -276,6 +277,9 @@ BITCOIN_QT_WALLET_CPP = \
   qt/walletmodeltransaction.cpp \
   qt/walletview.cpp
 
+BITCOIN_QML_BASE_CPP = \
+  qml/bitcoin.cpp
+
 BITCOIN_QT_CPP = $(BITCOIN_QT_BASE_CPP)
 if TARGET_WINDOWS
 BITCOIN_QT_CPP += $(BITCOIN_QT_WINDOWS_CPP)
@@ -302,6 +306,10 @@ if TARGET_DARWIN
 endif
 
 nodist_qt_libbitcoinqt_a_SOURCES = $(QT_MOC_CPP) $(QT_MOC) $(QT_QRC_CPP) $(QT_QRC_LOCALE_CPP)
+
+if BUILD_WITH_QML
+  qt_libbitcoinqt_a_SOURCES += $(BITCOIN_QML_BASE_CPP)
+endif # BUILD_WITH_QML
 
 # forms/foo.h -> forms/ui_foo.h
 QT_FORMS_H=$(join $(dir $(QT_FORMS_UI)),$(addprefix ui_, $(notdir $(QT_FORMS_UI:.ui=.h))))

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -280,6 +280,10 @@ BITCOIN_QT_WALLET_CPP = \
 BITCOIN_QML_BASE_CPP = \
   qml/bitcoin.cpp
 
+QML_QRC_CPP = qml/qrc_bitcoin.cpp
+QML_QRC = qml/bitcoin_qml.qrc
+RES_QML = $(wildcard $(srcdir)/qml/pages/*.qml)
+
 BITCOIN_QT_CPP = $(BITCOIN_QT_BASE_CPP)
 if TARGET_WINDOWS
 BITCOIN_QT_CPP += $(BITCOIN_QT_WINDOWS_CPP)
@@ -308,7 +312,8 @@ endif
 nodist_qt_libbitcoinqt_a_SOURCES = $(QT_MOC_CPP) $(QT_MOC) $(QT_QRC_CPP) $(QT_QRC_LOCALE_CPP)
 
 if BUILD_WITH_QML
-  qt_libbitcoinqt_a_SOURCES += $(BITCOIN_QML_BASE_CPP)
+  qt_libbitcoinqt_a_SOURCES += $(BITCOIN_QML_BASE_CPP) $(QML_QRC) $(RES_QML)
+  nodist_qt_libbitcoinqt_a_SOURCES += $(QML_QRC_CPP)
 endif # BUILD_WITH_QML
 
 # forms/foo.h -> forms/ui_foo.h
@@ -379,6 +384,12 @@ $(QT_QRC_LOCALE_CPP): $(QT_QRC_LOCALE) $(QT_QM)
 $(QT_QRC_CPP): $(QT_QRC) $(QT_FORMS_H) $(RES_FONTS) $(RES_ICONS) $(RES_ANIMATION)
 	@test -f $(RCC)
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(RCC) -name bitcoin --format-version 1 $< > $@
+
+if BUILD_WITH_QML
+$(QML_QRC_CPP): $(QML_QRC) $(RES_QML)
+	@test -f $(RCC)
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(RCC) --name bitcoin_qml --format-version 1 $< > $@
+endif # BUILD_WITH_QML
 
 CLEAN_QT = $(nodist_qt_libbitcoinqt_a_SOURCES) $(QT_QM) $(QT_FORMS_H) qt/*.gcda qt/*.gcno qt/temp_bitcoin_locale.qrc
 

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/bitcoin.h>
+
+#include <init.h>
+#include <interfaces/node.h>
+#include <node/context.h>
+#include <node/ui_interface.h>
+#include <noui.h>
+#include <qt/guiconstants.h>
+#include <util/system.h>
+#include <util/translation.h>
+
+#include <boost/signals2/connection.hpp>
+#include <memory>
+
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+
+namespace {
+void SetupUIArgs(ArgsManager& argsman)
+{
+    argsman.AddArg("-lang=<lang>", "Set language, for example \"de_DE\" (default: system locale)", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
+    argsman.AddArg("-min", "Start minimized", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
+    argsman.AddArg("-resetguisettings", "Reset all settings changed in the GUI", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
+    argsman.AddArg("-splash", strprintf("Show splash screen on startup (default: %u)", DEFAULT_SPLASHSCREEN), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
+}
+} // namespace
+
+
+int QmlGuiMain(int argc, char* argv[])
+{
+    NodeContext node_context;
+    std::unique_ptr<interfaces::Node> node = interfaces::MakeNode(&node_context);
+
+    // Subscribe to global signals from core
+    boost::signals2::scoped_connection handler_message_box = ::uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
+    boost::signals2::scoped_connection handler_question = ::uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
+    boost::signals2::scoped_connection handler_init_message = ::uiInterface.InitMessage_connect(noui_InitMessage);
+
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication app(argc, argv);
+    QQmlApplicationEngine engine;
+
+    // Parse command-line options. We do this after qt in order to show an error if there are problems parsing these.
+    SetupServerArgs(gArgs);
+    SetupUIArgs(gArgs);
+    std::string error;
+    if (!gArgs.ParseParameters(argc, argv, error)) {
+        InitError(strprintf(Untranslated("Error parsing command line arguments: %s\n"), error));
+        return EXIT_FAILURE;
+    }
+
+    return app.exec();
+}

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -18,6 +18,8 @@
 
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <QStringLiteral>
+#include <QUrl>
 
 namespace {
 void SetupUIArgs(ArgsManager& argsman)
@@ -40,9 +42,15 @@ int QmlGuiMain(int argc, char* argv[])
     boost::signals2::scoped_connection handler_question = ::uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
     boost::signals2::scoped_connection handler_init_message = ::uiInterface.InitMessage_connect(noui_InitMessage);
 
+    Q_INIT_RESOURCE(bitcoin_qml);
+
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
     QQmlApplicationEngine engine;
+    engine.load(QUrl(QStringLiteral("qrc:///qml/pages/stub.qml")));
+    if (engine.rootObjects().isEmpty()) {
+        return EXIT_FAILURE;
+    }
 
     // Parse command-line options. We do this after qt in order to show an error if there are problems parsing these.
     SetupServerArgs(gArgs);

--- a/src/qml/bitcoin.h
+++ b/src/qml/bitcoin.h
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_BITCOIN_H
+#define BITCOIN_QML_BITCOIN_H
+
+int QmlGuiMain(int argc, char* argv[]);
+
+#endif // BITCOIN_QML_BITCOIN_H

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+    <qresource prefix="/qml">
+        <file>pages/stub.qml</file>
+    </qresource>
+</RCC>

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -1,0 +1,9 @@
+import QtQuick.Controls 2.12
+
+ApplicationWindow {
+    id: appWindow
+    title: "Bitcoin Core TnG"
+    minimumWidth: 750
+    minimumHeight: 450
+    visible: true
+}

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -454,13 +454,6 @@ static void SetupUIArgs(ArgsManager& argsman)
 
 int GuiMain(int argc, char* argv[])
 {
-#ifdef WIN32
-    util::WinCmdLineArgs winArgs;
-    std::tie(argc, argv) = winArgs.get();
-#endif
-    SetupEnvironment();
-    util::ThreadSetInternalName("main");
-
     NodeContext node_context;
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode(&node_context);
 

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -4,6 +4,8 @@
 
 #include <qt/bitcoin.h>
 
+#include <util/system.h>
+#include <util/threadnames.h>
 #include <util/translation.h>
 #include <util/url.h>
 
@@ -11,6 +13,7 @@
 
 #include <functional>
 #include <string>
+#include <tuple>
 
 /** Translate string to current locale using Qt. */
 extern const std::function<std::string(const char*)> G_TRANSLATION_FUN = [](const char* psz) {
@@ -18,4 +21,15 @@ extern const std::function<std::string(const char*)> G_TRANSLATION_FUN = [](cons
 };
 UrlDecodeFn* const URL_DECODE = urlDecode;
 
-int main(int argc, char* argv[]) { return GuiMain(argc, argv); }
+int main(int argc, char* argv[])
+{
+#ifdef WIN32
+    util::WinCmdLineArgs win_args;
+    std::tie(argc, argv) = win_args.get();
+#endif // WIN32
+
+    SetupEnvironment();
+    util::ThreadSetInternalName("main");
+
+    return GuiMain(argc, argv);
+}

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -2,7 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#ifdef HAVE_CONFIG_H
+#include <config/bitcoin-config.h>
+#endif
+
+#if USE_QML
+#include <qml/bitcoin.h>
+#else
 #include <qt/bitcoin.h>
+#endif // USE_QML
 
 #include <util/system.h>
 #include <util/threadnames.h>
@@ -31,5 +39,9 @@ int main(int argc, char* argv[])
     SetupEnvironment();
     util::ThreadSetInternalName("main");
 
+#if USE_QML
+    return QmlGuiMain(argc, argv);
+#else
     return GuiMain(argc, argv);
+#endif // USE_QML
 }


### PR DESCRIPTION
Added basic support for QML to Qt resource system.

Suggested the following file directory layout:
- `src/qml/`
- `src/qml/*.{h|cpp}`
- `src/qml/pages/*.qml`
- `src/qml/<other resource directories>`