### PR TITLE
refactor: Make BitcoinCore class reusable

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -40,9 +40,10 @@ QT_MOC_CPP = \
   qt/moc_askpassphrasedialog.cpp \
   qt/moc_createwalletdialog.cpp \
   qt/moc_bantablemodel.cpp \
+  qt/moc_bitcoin.cpp \
   qt/moc_bitcoinaddressvalidator.cpp \
   qt/moc_bitcoinamountfield.cpp \
-  qt/moc_bitcoin.cpp \
+  qt/moc_bitcoincore.cpp \
   qt/moc_bitcoingui.cpp \
   qt/moc_bitcoinunits.cpp \
   qt/moc_clientmodel.cpp \
@@ -110,9 +111,10 @@ BITCOIN_QT_H = \
   qt/addresstablemodel.h \
   qt/askpassphrasedialog.h \
   qt/bantablemodel.h \
+  qt/bitcoin.h \
   qt/bitcoinaddressvalidator.h \
   qt/bitcoinamountfield.h \
-  qt/bitcoin.h \
+  qt/bitcoincore.h \
   qt/bitcoingui.h \
   qt/bitcoinunits.h \
   qt/clientmodel.h \
@@ -223,6 +225,7 @@ BITCOIN_QT_BASE_CPP = \
   qt/bitcoin.cpp \
   qt/bitcoinaddressvalidator.cpp \
   qt/bitcoinamountfield.cpp \
+  qt/bitcoincore.cpp \
   qt/bitcoingui.cpp \
   qt/bitcoinunits.cpp \
   qt/clientmodel.cpp \

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -7,9 +7,16 @@
 #endif
 
 #include <qt/bitcoin.h>
-#include <qt/bitcoingui.h>
 
 #include <chainparams.h>
+#include <init.h>
+#include <interfaces/handler.h>
+#include <interfaces/node.h>
+#include <node/context.h>
+#include <node/ui_interface.h>
+#include <noui.h>
+#include <qt/bitcoincore.h>
+#include <qt/bitcoingui.h>
 #include <qt/clientmodel.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
@@ -20,24 +27,17 @@
 #include <qt/splashscreen.h>
 #include <qt/utilitydialog.h>
 #include <qt/winshutdownmonitor.h>
+#include <uint256.h>
+#include <util/system.h>
+#include <util/threadnames.h>
+#include <util/translation.h>
+#include <validation.h>
 
 #ifdef ENABLE_WALLET
 #include <qt/paymentserver.h>
 #include <qt/walletcontroller.h>
 #include <qt/walletmodel.h>
 #endif // ENABLE_WALLET
-
-#include <init.h>
-#include <interfaces/handler.h>
-#include <interfaces/node.h>
-#include <node/context.h>
-#include <node/ui_interface.h>
-#include <noui.h>
-#include <uint256.h>
-#include <util/system.h>
-#include <util/threadnames.h>
-#include <util/translation.h>
-#include <validation.h>
 
 #include <boost/signals2/connection.hpp>
 #include <memory>
@@ -152,58 +152,6 @@ void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, cons
         LogPrint(BCLog::QT, "GUI: %s\n", msg.toStdString());
     } else {
         LogPrintf("GUI: %s\n", msg.toStdString());
-    }
-}
-
-BitcoinCore::BitcoinCore(interfaces::Node& node) :
-    QObject(), m_node(node)
-{
-    this->moveToThread(&m_thread);
-    m_thread.start();
-}
-
-BitcoinCore::~BitcoinCore()
-{
-    qDebug() << __func__ << ": Stopping thread";
-    m_thread.quit();
-    m_thread.wait();
-    qDebug() << __func__ << ": Stopped thread";
-}
-
-void BitcoinCore::handleRunawayException(const std::exception *e)
-{
-    PrintExceptionContinue(e, "Runaway exception");
-    Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings().translated));
-}
-
-void BitcoinCore::initialize()
-{
-    try
-    {
-        util::ThreadRename("qt-init");
-        qDebug() << __func__ << ": Running initialization in thread";
-        interfaces::BlockAndHeaderTipInfo tip_info;
-        bool rv = m_node.appInitMain(&tip_info);
-        Q_EMIT initializeResult(rv, tip_info);
-    } catch (const std::exception& e) {
-        handleRunawayException(&e);
-    } catch (...) {
-        handleRunawayException(nullptr);
-    }
-}
-
-void BitcoinCore::shutdown()
-{
-    try
-    {
-        qDebug() << __func__ << ": Running Shutdown in thread";
-        m_node.appShutdown();
-        qDebug() << __func__ << ": Shutdown finished";
-        Q_EMIT shutdownResult();
-    } catch (const std::exception& e) {
-        handleRunawayException(&e);
-    } catch (...) {
-        handleRunawayException(nullptr);
     }
 }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -212,7 +212,6 @@ static const char* qt_argv = "bitcoin-qt";
 
 BitcoinApplication::BitcoinApplication():
     QApplication(qt_argc, const_cast<char **>(&qt_argv)),
-    coreThread(nullptr),
     optionsModel(nullptr),
     clientModel(nullptr),
     window(nullptr),
@@ -240,14 +239,6 @@ void BitcoinApplication::setupPlatformStyle()
 
 BitcoinApplication::~BitcoinApplication()
 {
-    if(coreThread)
-    {
-        qDebug() << __func__ << ": Stopping thread";
-        coreThread->quit();
-        coreThread->wait();
-        qDebug() << __func__ << ": Stopped thread";
-    }
-
     delete window;
     window = nullptr;
     delete platformStyle;

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -9,11 +9,13 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <QApplication>
+#include <interfaces/node.h>
+
 #include <assert.h>
 #include <memory>
 
-#include <interfaces/node.h>
+#include <QApplication>
+#include <QThread>
 
 class BitcoinGUI;
 class ClientModel;
@@ -34,6 +36,7 @@ class BitcoinCore: public QObject
     Q_OBJECT
 public:
     explicit BitcoinCore(interfaces::Node& node);
+    ~BitcoinCore();
 
 public Q_SLOTS:
     void initialize();
@@ -49,6 +52,7 @@ private:
     void handleRunawayException(const std::exception *e);
 
     interfaces::Node& m_node;
+    QThread m_thread;
 };
 
 /** Main Bitcoin application object */
@@ -112,6 +116,7 @@ Q_SIGNALS:
     void windowShown(BitcoinGUI* window);
 
 private:
+    std::unique_ptr<BitcoinCore> m_core;
     QThread *coreThread;
     OptionsModel *optionsModel;
     ClientModel *clientModel;

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -117,7 +117,6 @@ Q_SIGNALS:
 
 private:
     std::unique_ptr<BitcoinCore> m_core;
-    QThread *coreThread;
     OptionsModel *optionsModel;
     ClientModel *clientModel;
     BitcoinGUI *window;

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -10,12 +10,12 @@
 #endif
 
 #include <interfaces/node.h>
+#include <qt/bitcoincore.h>
 
 #include <assert.h>
 #include <memory>
 
 #include <QApplication>
-#include <QThread>
 
 class BitcoinGUI;
 class ClientModel;
@@ -27,33 +27,6 @@ class SplashScreen;
 class WalletController;
 class WalletModel;
 
-
-/** Class encapsulating Bitcoin Core startup and shutdown.
- * Allows running startup and shutdown in a different thread from the UI thread.
- */
-class BitcoinCore: public QObject
-{
-    Q_OBJECT
-public:
-    explicit BitcoinCore(interfaces::Node& node);
-    ~BitcoinCore();
-
-public Q_SLOTS:
-    void initialize();
-    void shutdown();
-
-Q_SIGNALS:
-    void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
-    void shutdownResult();
-    void runawayException(const QString &message);
-
-private:
-    /// Pass fatal exception message to UI thread
-    void handleRunawayException(const std::exception *e);
-
-    interfaces::Node& m_node;
-    QThread m_thread;
-};
 
 /** Main Bitcoin application object */
 class BitcoinApplication: public QApplication

--- a/src/qt/bitcoincore.cpp
+++ b/src/qt/bitcoincore.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2014-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/bitcoincore.h>
+
+#include <interfaces/node.h>
+#include <util/system.h>
+#include <util/threadnames.h>
+
+#include <exception>
+
+#include <QDebug>
+#include <QObject>
+#include <QString>
+#include <QThread>
+
+BitcoinCore::BitcoinCore(interfaces::Node& node) :
+    QObject(), m_node(node)
+{
+    this->moveToThread(&m_thread);
+    m_thread.start();
+}
+
+BitcoinCore::~BitcoinCore()
+{
+    qDebug() << __func__ << ": Stopping thread";
+    m_thread.quit();
+    m_thread.wait();
+    qDebug() << __func__ << ": Stopped thread";
+}
+
+void BitcoinCore::handleRunawayException(const std::exception *e)
+{
+    PrintExceptionContinue(e, "Runaway exception");
+    Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings().translated));
+}
+
+void BitcoinCore::initialize()
+{
+    try
+    {
+        util::ThreadRename("qt-init");
+        qDebug() << __func__ << ": Running initialization in thread";
+        interfaces::BlockAndHeaderTipInfo tip_info;
+        bool rv = m_node.appInitMain(&tip_info);
+        Q_EMIT initializeResult(rv, tip_info);
+    } catch (const std::exception& e) {
+        handleRunawayException(&e);
+    } catch (...) {
+        handleRunawayException(nullptr);
+    }
+}
+
+void BitcoinCore::shutdown()
+{
+    try
+    {
+        qDebug() << __func__ << ": Running Shutdown in thread";
+        m_node.appShutdown();
+        qDebug() << __func__ << ": Shutdown finished";
+        Q_EMIT shutdownResult();
+    } catch (const std::exception& e) {
+        handleRunawayException(&e);
+    } catch (...) {
+        handleRunawayException(nullptr);
+    }
+}

--- a/src/qt/bitcoincore.cpp
+++ b/src/qt/bitcoincore.cpp
@@ -15,8 +15,8 @@
 #include <QString>
 #include <QThread>
 
-BitcoinCore::BitcoinCore(interfaces::Node& node) :
-    QObject(), m_node(node)
+BitcoinCore::BitcoinCore(interfaces::Node& node)
+    : QObject(), m_node(node)
 {
     this->moveToThread(&m_thread);
     m_thread.start();
@@ -30,7 +30,7 @@ BitcoinCore::~BitcoinCore()
     qDebug() << __func__ << ": Stopped thread";
 }
 
-void BitcoinCore::handleRunawayException(const std::exception *e)
+void BitcoinCore::handleRunawayException(const std::exception* e)
 {
     PrintExceptionContinue(e, "Runaway exception");
     Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings().translated));
@@ -38,8 +38,7 @@ void BitcoinCore::handleRunawayException(const std::exception *e)
 
 void BitcoinCore::initialize()
 {
-    try
-    {
+    try {
         util::ThreadRename("qt-init");
         qDebug() << __func__ << ": Running initialization in thread";
         interfaces::BlockAndHeaderTipInfo tip_info;
@@ -54,8 +53,7 @@ void BitcoinCore::initialize()
 
 void BitcoinCore::shutdown()
 {
-    try
-    {
+    try {
         qDebug() << __func__ << ": Running Shutdown in thread";
         m_node.appShutdown();
         qDebug() << __func__ << ": Shutdown finished";

--- a/src/qt/bitcoincore.h
+++ b/src/qt/bitcoincore.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2014-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_BITCOINCORE_H
+#define BITCOIN_QT_BITCOINCORE_H
+
+#include <interfaces/node.h>
+
+#include <exception>
+
+#include <QObject>
+#include <QThread>
+
+QT_BEGIN_NAMESPACE
+class QString;
+QT_END_NAMESPACE
+
+/** Class encapsulating Bitcoin Core startup and shutdown.
+ * Allows running startup and shutdown in a different thread from the UI thread.
+ */
+class BitcoinCore: public QObject
+{
+    Q_OBJECT
+public:
+    explicit BitcoinCore(interfaces::Node& node);
+    ~BitcoinCore();
+
+public Q_SLOTS:
+    void initialize();
+    void shutdown();
+
+Q_SIGNALS:
+    void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
+    void shutdownResult();
+    void runawayException(const QString &message);
+
+private:
+    /// Pass fatal exception message to UI thread
+    void handleRunawayException(const std::exception *e);
+
+    interfaces::Node& m_node;
+    QThread m_thread;
+};
+
+#endif // BITCOIN_QT_BITCOINCORE_H

--- a/src/qt/bitcoincore.h
+++ b/src/qt/bitcoincore.h
@@ -19,7 +19,7 @@ QT_END_NAMESPACE
 /** Class encapsulating Bitcoin Core startup and shutdown.
  * Allows running startup and shutdown in a different thread from the UI thread.
  */
-class BitcoinCore: public QObject
+class BitcoinCore : public QObject
 {
     Q_OBJECT
 public:
@@ -33,11 +33,11 @@ public Q_SLOTS:
 Q_SIGNALS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
     void shutdownResult();
-    void runawayException(const QString &message);
+    void runawayException(const QString& message);
 
 private:
     /// Pass fatal exception message to UI thread
-    void handleRunawayException(const std::exception *e);
+    void handleRunawayException(const std::exception* e);
 
     interfaces::Node& m_node;
     QThread m_thread;

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -8,6 +8,7 @@
 
 #include <interfaces/node.h>
 #include <qt/bitcoin.h>
+#include <qt/bitcoincore.h>
 #include <qt/test/apptests.h>
 #include <qt/test/rpcnestedtests.h>
 #include <qt/test/uritests.h>


### PR DESCRIPTION
This PR makes the `BitcoinCore` class reusable, i.e., it can be used by the widget-based GUI or by the QML-based one.

Required for #11.