### PR TITLE
Handle initialization errors

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -32,6 +32,18 @@ void SetupUIArgs(ArgsManager& argsman)
     argsman.AddArg("-resetguisettings", "Reset all settings changed in the GUI", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-splash", strprintf("Show splash screen on startup (default: %u)", DEFAULT_SPLASHSCREEN), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
 }
+
+bool InitErrorMessageBox(
+    const bilingual_str& message,
+    [[maybe_unused]] const std::string& caption,
+    [[maybe_unused]] unsigned int style)
+{
+    QQmlApplicationEngine engine;
+    engine.rootContext()->setContextProperty("message", QString::fromStdString(message.translated));
+    engine.load(QUrl(QStringLiteral("qrc:///qml/pages/initerrormessage.qml")));
+    qGuiApp->exec();
+    return false;
+}
 } // namespace
 
 
@@ -41,6 +53,8 @@ int QmlGuiMain(int argc, char* argv[])
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
+
+    auto handler_message_box = ::uiInterface.ThreadSafeMessageBox_connect(InitErrorMessageBox);
 
     // Parse command-line options. We do this after qt in order to show an error if there are problems parsing these.
     SetupServerArgs(gArgs);
@@ -67,6 +81,8 @@ int QmlGuiMain(int argc, char* argv[])
     node_context.args = &gArgs;
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode(&node_context);
     node->baseInitialize();
+
+    handler_message_box.disconnect();
 
     NodeModel node_model;
     InitExecutor init_executor{*node};

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -56,20 +56,43 @@ int QmlGuiMain(int argc, char* argv[])
 
     auto handler_message_box = ::uiInterface.ThreadSafeMessageBox_connect(InitErrorMessageBox);
 
-    // Parse command-line options. We do this after qt in order to show an error if there are problems parsing these.
+    NodeContext node_context;
+
+    /// Parse command-line options. We do this after qt in order to show an error if there are problems parsing these.
+    node_context.args = &gArgs;
     SetupServerArgs(gArgs);
     SetupUIArgs(gArgs);
     std::string error;
     if (!gArgs.ParseParameters(argc, argv, error)) {
-        InitError(strprintf(Untranslated("Error parsing command line arguments: %s\n"), error));
+        InitError(strprintf(Untranslated("Cannot parse command line arguments: %s\n"), error));
         return EXIT_FAILURE;
     }
 
-    CheckDataDirOption();
+    /// Determine availability of data directory.
+    if (!CheckDataDirOption()) {
+        InitError(strprintf(Untranslated("Specified data directory \"%s\" does not exist.\n"), gArgs.GetArg("-datadir", "")));
+        return EXIT_FAILURE;
+    }
 
-    gArgs.ReadConfigFiles(error, true);
+    /// Read and parse bitcoin.conf file.
+    if (!gArgs.ReadConfigFiles(error, true)) {
+        InitError(strprintf(Untranslated("Cannot parse configuration file: %s\n"), error));
+        return EXIT_FAILURE;
+    }
 
-    SelectParams(gArgs.GetChainName());
+    /// Check for chain settings (Params() calls are only valid after this clause).
+    try {
+        SelectParams(gArgs.GetChainName());
+    } catch(std::exception &e) {
+        InitError(Untranslated(strprintf("%s\n", e.what())));
+        return EXIT_FAILURE;
+    }
+
+    /// Read and parse settings.json file.
+    if (!gArgs.InitSettings(error)) {
+        InitError(Untranslated(error));
+        return EXIT_FAILURE;
+    }
 
     // Default printtoconsole to false for the GUI. GUI programs should not
     // print to the console unnecessarily.
@@ -77,10 +100,11 @@ int QmlGuiMain(int argc, char* argv[])
     InitLogging(gArgs);
     InitParameterInteraction(gArgs);
 
-    NodeContext node_context;
-    node_context.args = &gArgs;
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode(&node_context);
-    node->baseInitialize();
+    if (!node->baseInitialize()) {
+        // A dialog with detailed error will have been shown by InitError().
+        return EXIT_FAILURE;
+    }
 
     handler_message_box.disconnect();
 

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -1,5 +1,6 @@
 <!DOCTYPE RCC><RCC version="1.0">
     <qresource prefix="/qml">
+        <file>pages/initerrormessage.qml</file>
         <file>pages/stub.qml</file>
     </qresource>
 </RCC>

--- a/src/qml/pages/initerrormessage.qml
+++ b/src/qml/pages/initerrormessage.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.12
+import QtQuick.Dialogs 1.3
+
+MessageDialog {
+    id: messageDialog
+    title: "Bitcoin Core TnG"
+    icon: StandardIcon.Critical
+    text: message
+    onAccepted: Qt.quit()
+    Component.onCompleted: visible = true
+}

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -452,11 +452,6 @@ int GuiMain(int argc, char* argv[])
     NodeContext node_context;
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode(&node_context);
 
-    // Subscribe to global signals from core
-    boost::signals2::scoped_connection handler_message_box = ::uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
-    boost::signals2::scoped_connection handler_question = ::uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
-    boost::signals2::scoped_connection handler_init_message = ::uiInterface.InitMessage_connect(noui_InitMessage);
-
     // Do not refer to data directory yet, this can be overridden by Intro::pickDataDirectory
 
     /// 1. Basic Qt initialization (not dependent on parameters or configuration)

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -12,6 +12,7 @@
 #include <qt/bitcoin.h>
 #endif // USE_QML
 
+#include <noui.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
@@ -38,6 +39,9 @@ int main(int argc, char* argv[])
 
     SetupEnvironment();
     util::ThreadSetInternalName("main");
+
+    // Subscribe to global signals from core.
+    noui_connect();
 
 #if USE_QML
     return QmlGuiMain(argc, argv);


### PR DESCRIPTION
This PR add functionality to handle initialization errors, and show error messages to users, e.g.:

![Screenshot from 2021-08-09 22-31-21](https://user-images.githubusercontent.com/32963518/128763388-dafd25a6-b7ef-41e1-8d2f-8bf8648a3878.png)

---

Note for designers. The easiest way to trigger an error is to provide an invalid command line option:

```
$ ./src/qt/bitcoin-qt -qq
```