### PR TITLE
doc: document runtime dependencies

### DIFF
--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -41,10 +41,16 @@ The master branch is only guaranteed to work and build on Debian-based systems a
 Support for more systems will be confirmed and documented as the project matures.
 
 ### Dependencies
-Aside from the dependencies listed in [build-unix.md](../../doc/build-unix.md), Debian based systems require the following additional dependencies:
+Aside from the dependencies listed in [build-unix.md](../../doc/build-unix.md), Debian based systems require the following additional dependencies to compile:
 
 ```
 sudo apt install qtdeclarative5-dev qtquickcontrols2-5-dev
+```
+
+The following runtime dependencies are also needed:
+
+```
+sudo apt install qml-module-qtquick-controls qml-module-qtquick-dialogs
 ```
 
 No additional dependencies, besides those in [build-osx.md](../../doc/build-osx.md), are needed for macOS.


### PR DESCRIPTION
This is a follow-up to #17, which introduced new runtime dependencies. 
This PR documents the runtime dependencies required for proper execution. 📝