### PR TITLE
Check whether initerrormessage.qml is loaded correctly

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -41,6 +41,9 @@ bool InitErrorMessageBox(
     QQmlApplicationEngine engine;
     engine.rootContext()->setContextProperty("message", QString::fromStdString(message.translated));
     engine.load(QUrl(QStringLiteral("qrc:///qml/pages/initerrormessage.qml")));
+    if (engine.rootObjects().isEmpty()) {
+        return EXIT_FAILURE;
+    }
     qGuiApp->exec();
     return false;
 }


### PR DESCRIPTION
If `QQmlApplicationEngine::load()` fails calling `qGuiApp->exec()` must be avoided.