### PR TITLE
build: Disable QWidget-based GUI test binary for QML builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1690,6 +1690,9 @@ fi
 
 dnl these are only used when qt is enabled
 BUILD_TEST_QT=""
+if test "x$use_qml" != xno; then
+  use_gui_tests=no
+fi
 if test x$bitcoin_enable_qt != xno; then
   dnl enable dbus support
   AC_MSG_CHECKING([whether to build GUI with support for D-Bus])


### PR DESCRIPTION
QWidget based `test/test_bitcoin-qt` is useless for QML stuff.