### PR TITLE
Add GUIUtil::LogQtInfo() call

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -11,6 +11,7 @@
 #include <noui.h>
 #include <qml/nodemodel.h>
 #include <qt/guiconstants.h>
+#include <qt/guiutil.h>
 #include <qt/initexecutor.h>
 #include <util/system.h>
 #include <util/translation.h>
@@ -112,6 +113,8 @@ int QmlGuiMain(int argc, char* argv[])
     gArgs.SoftSetBoolArg("-printtoconsole", false);
     InitLogging(gArgs);
     InitParameterInteraction(gArgs);
+
+    GUIUtil::LogQtInfo();
 
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode(&node_context);
     if (!node->baseInitialize()) {

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -2,6 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#ifdef HAVE_CONFIG_H
+#include <config/bitcoin-config.h>
+#endif
+
 #include <qt/guiutil.h>
 
 #include <qt/bitcoinaddressvalidator.h>
@@ -61,6 +65,9 @@
 #include <QThread>
 #include <QUrlQuery>
 #include <QtGlobal>
+#if USE_QML
+#include <QQuickStyle>
+#endif // USE_QML
 
 #include <cassert>
 #include <chrono>
@@ -881,7 +888,7 @@ void LogQtInfo()
 #else
     const std::string plugin_link{"dynamic"};
 #endif
-    LogPrintf("Qt %s (%s), plugin=%s (%s)\n", qVersion(), qt_link, QGuiApplication::platformName().toStdString(), plugin_link);
+    LogPrintf("Qt %s (%s), plugin=%s (%s)\n", qVersion(), qt_link, qGuiApp->platformName().toStdString(), plugin_link);
     const auto static_plugins = QPluginLoader::staticPlugins();
     if (static_plugins.empty()) {
         LogPrintf("No static plugins.\n");
@@ -895,7 +902,12 @@ void LogQtInfo()
         }
     }
 
+#if USE_QML
+    LogPrintf("QQuickStyle: %s\n", QQuickStyle::name().toStdString());
+#else
     LogPrintf("Style: %s / %s\n", QApplication::style()->objectName().toStdString(), QApplication::style()->metaObject()->className());
+#endif // USE_QML
+
     LogPrintf("System: %s, %s\n", QSysInfo::prettyProductName().toStdString(), QSysInfo::buildAbi().toStdString());
     for (const QScreen* s : QGuiApplication::screens()) {
         LogPrintf("Screen: %s %dx%d, pixel ratio=%.1f\n", s->name().toStdString(), s->size().width(), s->size().height(), s->devicePixelRatio());


### PR DESCRIPTION
Excerpt from the log:
```
$ src/qt/bitcoin-qt -signet -printtoconsole
initialize : Running initialization in thread
2021-08-27T22:44:47Z [main] Bitcoin Core version v22.99.0-6be715b83709 (release build)
2021-08-27T22:44:47Z [main] Qt 5.12.11 (static), plugin=xcb (static)
2021-08-27T22:44:47Z [main] Static plugins:
2021-08-27T22:44:47Z [main]  QXcbIntegrationPlugin, version 330752
2021-08-27T22:44:47Z [main]  QtQuick2DialogsPlugin, version 330752
2021-08-27T22:44:47Z [main]  QtQuick2Plugin, version 330752
2021-08-27T22:44:47Z [main]  QtQuick2WindowPlugin, version 330752
2021-08-27T22:44:47Z [main]  QtQuickControls1Plugin, version 330752
2021-08-27T22:44:47Z [main]  QtQuickControls2Plugin, version 330752
2021-08-27T22:44:47Z [main]  QtQuickTemplates2Plugin, version 330752
2021-08-27T22:44:47Z [main] QQuickStyle: 
2021-08-27T22:44:47Z [main] System: Linux Mint 20.2, x86_64-little_endian-lp64
2021-08-27T22:44:47Z [main] Screen: HDMI-1 2560x1440, pixel ratio=1.0
2021-08-27T22:44:47Z [main] Screen: DP-1 1920x1080, pixel ratio=1.0
...