### PR TITLE
build: Explicitly disable experimental Direct3D 12 adaptation for Windows

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -165,6 +165,7 @@ $(package)_config_opts_riscv64_linux = -platform linux-g++ -xplatform bitcoin-li
 $(package)_config_opts_s390x_linux = -platform linux-g++ -xplatform bitcoin-linux-g++
 
 $(package)_config_opts_mingw32 = -no-opengl
+$(package)_config_opts_mingw32 += -no-d3d12
 $(package)_config_opts_mingw32 += -no-dbus
 $(package)_config_opts_mingw32 += -xplatform win32-g++
 $(package)_config_opts_mingw32 += "QMAKE_CFLAGS = '$($(package)_cflags) $($(package)_cppflags)'"


### PR DESCRIPTION
The Direct3D 12 adaptation is an alternative renderer for Qt Quick 2 when running on Windows, both for Win32 and UWP applications.

Currently, being enabled it causes an error in Guix build for the `x86_64-w64-mingw32` host (https://github.com/bitcoin-core/gui-qml/issues/26#issuecomment-907603402).

This PR explicitly disables the [Direct3D 12 adaptation for Windows](https://doc.qt.io/qt-5.12//qtquick-visualcanvas-adaptations-d3d12.html).

Please note that D3D12 backend of Qt Quick has been removed in Qt 6 (https://bugreports.qt.io/browse/QTBUG-79925).

#### Guix build:
```
$ env HOSTS='x86_64-w64-mingw32' ./contrib/guix/guix-build
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
00bd2214012476a91e32cddc720ef3ba12dcd992c0fea4f656f8e1ca672b1768  guix-build-bd86bb536645/output/dist-archive/bitcoin-bd86bb536645.tar.gz
1f2f80002f6bda09073f3da6b292d232e1c657ecf1e6f0c59ac01b1f5d3dd474  guix-build-bd86bb536645/output/x86_64-w64-mingw32/SHA256SUMS.part
b988b0ce195f536799b30194f573a0ae0d26a32b00c1a5b54039d62e60f92db9  guix-build-bd86bb536645/output/x86_64-w64-mingw32/bitcoin-bd86bb536645-win-unsigned.tar.gz
e89793b517eb171ecf0668f5f004af2df43077614f2cb22e0eb9af736b51dc80  guix-build-bd86bb536645/output/x86_64-w64-mingw32/bitcoin-bd86bb536645-win64-debug.zip
ccc6fc78cf0de61772bab59a83b2370aa825bd5c6d0af126b19c02f985b04fda  guix-build-bd86bb536645/output/x86_64-w64-mingw32/bitcoin-bd86bb536645-win64-setup-unsigned.exe
d753a67e614ad33d6c07e8e32183feec81dee0edd51f319e9bea698c985cf0b6  guix-build-bd86bb536645/output/x86_64-w64-mingw32/bitcoin-bd86bb536645-win64.zip
```

Closes #26.