### PR TITLE
build: Fix qt build for riscv64

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -13,7 +13,7 @@ $(package)_patches += support_new_android_ndks.patch fix_android_jni_static.patc
 $(package)_patches+= no_sdk_version_check.patch
 $(package)_patches+= fix_lib_paths.patch fix_android_pch.patch
 $(package)_patches+= qtbase-moc-ignore-gcc-macro.patch fix_limits_header.patch
-$(package)_patches += fix_qml_python.patch
+$(package)_patches += fix_qml_python.patch riscv_detection.patch
 
 $(package)_qtdeclarative_file_name = qtdeclarative-$($(package)_suffix)
 $(package)_qtdeclarative_sha256_hash = 1267e029abc8424424c419bc1681db069ec76e51270cc220994e0f442c9f78d3
@@ -267,6 +267,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/qtbase-moc-ignore-gcc-macro.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_limits_header.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_qml_python.patch && \
+  patch -p1 -i $($(package)_patch_dir)/riscv_detection.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -13,7 +13,7 @@ $(package)_patches += support_new_android_ndks.patch fix_android_jni_static.patc
 $(package)_patches+= no_sdk_version_check.patch
 $(package)_patches+= fix_lib_paths.patch fix_android_pch.patch
 $(package)_patches+= qtbase-moc-ignore-gcc-macro.patch fix_limits_header.patch
-$(package)_patches += fix_qml_python.patch riscv_detection.patch
+$(package)_patches += fix_qml_python.patch riscv_detection.patch fix_riscv_atomic.patch
 
 $(package)_qtdeclarative_file_name = qtdeclarative-$($(package)_suffix)
 $(package)_qtdeclarative_sha256_hash = 1267e029abc8424424c419bc1681db069ec76e51270cc220994e0f442c9f78d3
@@ -268,6 +268,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix_limits_header.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_qml_python.patch && \
   patch -p1 -i $($(package)_patch_dir)/riscv_detection.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fix_riscv_atomic.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/fix_riscv_atomic.patch
+++ b/depends/patches/qt/fix_riscv_atomic.patch
@@ -1,0 +1,17 @@
+A workaround for error when building for riscv64.
+
+Upstream report: https://bugreports.qt.io/browse/QTBUG-84580
+
+Patch concept: https://bugs.gentoo.org/790689
+
+
+--- old/qtdeclarative/src/qml/qml.pro
++++ new/qtdeclarative/src/qml/qml.pro
+@@ -19,6 +19,7 @@ solaris-cc*:QMAKE_CXXFLAGS_RELEASE -= -O2
+ 
+ # Ensure this gcc optimization is switched off for mips platforms to avoid trouble with JIT.
+ gcc:isEqual(QT_ARCH, "mips"): QMAKE_CXXFLAGS += -fno-reorder-blocks
++gcc:isEqual(QT_ARCH, "riscv64"): LIBS += -latomic
+ 
+ DEFINES += QT_NO_FOREACH
+ 

--- a/depends/patches/qt/riscv_detection.patch
+++ b/depends/patches/qt/riscv_detection.patch
@@ -1,0 +1,41 @@
+Add RISC-V detection
+
+Upstream commit:
+ - Qt 5.14: 9a6a84731131b205f74b10f866ae212e0895bd4a
+
+--- old/qtbase/src/corelib/global/archdetect.cpp
++++ new/qtbase/src/corelib/global/archdetect.cpp
+@@ -67,6 +67,10 @@
+ #  define ARCH_PROCESSOR "power"
+ #elif defined(Q_PROCESSOR_POWER_64)
+ #  define ARCH_PROCESSOR "power64"
++#elif defined(Q_PROCESSOR_RISCV_32)
++#  define ARCH_PROCESSOR "riscv32"
++#elif defined(Q_PROCESSOR_RISCV_64)
++#  define ARCH_PROCESSOR "riscv64"
+ #elif defined(Q_PROCESSOR_S390_X)
+ #  define ARCH_PROCESSOR "s390x"
+ #elif defined(Q_PROCESSOR_S390)
+
+--- old/qtbase/src/corelib/global/qprocessordetection.h
++++ old/qtbase/src/corelib/global/qprocessordetection.h
+@@ -282,6 +282,19 @@
+ // Q_BYTE_ORDER not defined, use endianness auto-detection
+ 
++ /*
++    RISC-V family, known variants: 32- and 64-bit
++    RISC-V is little-endian.
++*/
++#elif defined(__riscv)
++#  define Q_PROCESSOR_RISCV
++#  if __riscv_xlen == 64
++#    define Q_PROCESSOR_RISCV_64
++#  else
++#    define Q_PROCESSOR_RISCV_32
++#  endif
++#  define Q_BYTE_ORDER Q_LITTLE_ENDIAN
++
+ /*
+     S390 family, known variant: S390X (64-bit)
+ 
+     S390 is big-endian.


### PR DESCRIPTION
Fixes #29.

#### Guix build:
```
$ env HOSTS='riscv64-linux-gnu' ./contrib/guix/guix-build
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
9399101a4268eb78b4c13d0895964862211d87e9a12bd154c11ea4ca257f02d6  guix-build-3a0f948c0bc9/output/dist-archive/bitcoin-3a0f948c0bc9.tar.gz
c4c57780ee1d99721dc370c35cc68dfccdd5455a29c0c526a1171f3b8dfa4dc8  guix-build-3a0f948c0bc9/output/riscv64-linux-gnu/SHA256SUMS.part
4840f8a57c43e3956073681aeb3779f326fa89102a643c5bf5acd26790107284  guix-build-3a0f948c0bc9/output/riscv64-linux-gnu/bitcoin-3a0f948c0bc9-riscv64-linux-gnu-debug.tar.gz
95910c5070e14532c2b96a10662c1ae77c45199649234248ee71017e15cc7a71  guix-build-3a0f948c0bc9/output/riscv64-linux-gnu/bitcoin-3a0f948c0bc9-riscv64-linux-gnu.tar.gz
```