### PR TITLE
Log graphics API that is in use by the Qt Quick

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -109,6 +109,7 @@ QT_QRC_LOCALE = qt/bitcoin_locale.qrc
 BITCOIN_QT_H = \
   qml/bitcoin.h \
   qml/nodemodel.h \
+  qml/util.h \
   qt/addressbookpage.h \
   qt/addresstablemodel.h \
   qt/askpassphrasedialog.h \
@@ -284,7 +285,8 @@ BITCOIN_QT_WALLET_CPP = \
 
 BITCOIN_QML_BASE_CPP = \
   qml/bitcoin.cpp \
-  qml/nodemodel.cpp
+  qml/nodemodel.cpp \
+  qml/util.cpp
 
 QML_QRC_CPP = qml/qrc_bitcoin.cpp
 QML_QRC = qml/bitcoin_qml.qrc

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -10,6 +10,7 @@
 #include <node/ui_interface.h>
 #include <noui.h>
 #include <qml/nodemodel.h>
+#include <qml/util.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/initexecutor.h>
@@ -19,9 +20,11 @@
 #include <boost/signals2/connection.hpp>
 #include <memory>
 
+#include <QDebug>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QQuickWindow>
 #include <QStringLiteral>
 #include <QUrl>
 
@@ -145,6 +148,13 @@ int QmlGuiMain(int argc, char* argv[])
     if (engine.rootObjects().isEmpty()) {
         return EXIT_FAILURE;
     }
+
+    auto window = qobject_cast<QQuickWindow*>(engine.rootObjects().first());
+    if (!window) {
+        return EXIT_FAILURE;
+    }
+
+    qInfo() << "Graphics API in use:" << QmlUtil::GraphicsApi(window);
 
     return qGuiApp->exec();
 }

--- a/src/qml/util.cpp
+++ b/src/qml/util.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/util.h>
+
+#include <string>
+
+#include <QQuickWindow>
+#include <QSGRendererInterface>
+#include <QString>
+
+namespace QmlUtil {
+
+QString GraphicsApi(QQuickWindow* window)
+{
+    switch (window->rendererInterface()->graphicsApi()) {
+    case QSGRendererInterface::Unknown: return "Unknown";
+    case QSGRendererInterface::Software: return "The Qt Quick 2D Renderer";
+    case QSGRendererInterface::OpenGL: return "OpenGL ES 2.0 or higher";
+    case QSGRendererInterface::Direct3D12: return "Direct3D 12";
+    case QSGRendererInterface::OpenVG: return "OpenVG via EGL";
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    case QSGRendererInterface::OpenGLRhi: return "OpenGL ES 2.0 or higher via a graphics abstraction layer";
+    case QSGRendererInterface::Direct3D11Rhi: return "Direct3D 11 via a graphics abstraction layer";
+    case QSGRendererInterface::VulkanRhi: return "Vulkan 1.0 via a graphics abstraction layer";
+    case QSGRendererInterface::MetalRhi: return "Metal via a graphics abstraction layer";
+    case QSGRendererInterface::NullRhi: return "Null (no output) via a graphics abstraction layer";
+#endif
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}
+
+} // namespace QmlUtil

--- a/src/qml/util.h
+++ b/src/qml/util.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_UTIL_H
+#define BITCOIN_QML_UTIL_H
+
+#include <QString>
+#include <QtGlobal>
+
+QT_BEGIN_NAMESPACE
+class QQuickWindow;
+QT_END_NAMESPACE
+
+/**
+ * Utility functions used by the QML-based Bitcoin Core GUI.
+ */
+namespace QmlUtil {
+/**
+* Returns a human-readable description of the graphics API
+* that is in use by the Qt Quick scene graph renderer.
+*/
+QString GraphicsApi(QQuickWindow* window);
+
+} // namespace QmlUtil
+
+#endif // BITCOIN_QML_UTIL_H

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -903,7 +903,8 @@ void LogQtInfo()
     }
 
 #if USE_QML
-    LogPrintf("QQuickStyle: %s\n", QQuickStyle::name().toStdString());
+    const auto style = QQuickStyle::name().toStdString();
+    LogPrintf("QQuickStyle: %s\n", style.empty() ? "Default" : style);
 #else
     LogPrintf("Style: %s / %s\n", QApplication::style()->objectName().toStdString(), QApplication::style()->metaObject()->className());
 #endif // USE_QML


### PR DESCRIPTION
Some log excerpts with this PR:

- Linux Mint, system Qt 5.12.8
```
$ ./src/qt/bitcoin-qt -printtoconsole
Bitcoin Core version v22.99.0-76426d3948b2 (release build)
Qt 5.12.8 (dynamic), plugin=xcb (dynamic)
No static plugins.
QQuickStyle: Default
System: Linux Mint 20.2, x86_64-little_endian-lp64
Screen: HDMI-1 2560x1440, pixel ratio=1.0
Screen: DP-1 1920x1080, pixel ratio=1.0
...
GUI: Graphics API in use: "OpenGL ES 2.0 or higher"
...
```

- Ubuntu Hirsute, system Qt 5.15.2
```
$ QSG_RHI=1 ./src/qt/bitcoin-qt -printtoconsole
GUI: Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
Bitcoin Core version v22.99.0-76426d3948b2 (release build)
Qt 5.15.2 (dynamic), plugin=xcb (dynamic)
No static plugins.
QQuickStyle: Default
System: Ubuntu 21.04, x86_64-little_endian-lp64
Screen: XWAYLAND0 2560x1440, pixel ratio=1.0
...
GUI: Graphics API in use: "OpenGL ES 2.0 or higher via a graphics abstraction layer"
...
```