### PR TITLE
Add copyright headers to QML files

### DIFF
--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -38,7 +38,7 @@ EXCLUDE_DIRS = [
     "src/crc32c/",
 ]
 
-INCLUDE = ['*.h', '*.cpp', '*.cc', '*.c', '*.mm', '*.py', '*.sh', '*.bash-completion']
+INCLUDE = ['*.h', '*.cpp', '*.cc', '*.c', '*.mm', '*.qml', '*.py', '*.sh', '*.bash-completion']
 INCLUDE_COMPILED = re.compile('|'.join([fnmatch.translate(m) for m in INCLUDE]))
 
 def applies_to_file(filename):
@@ -560,7 +560,7 @@ def insert_cmd(argv):
     if not os.path.isfile(filename):
         sys.exit("*** bad filename: %s" % filename)
     _, extension = os.path.splitext(filename)
-    if extension not in ['.h', '.cpp', '.cc', '.c', '.py', '.sh']:
+    if extension not in ['.h', '.cpp', '.cc', '.c', '.qml', '.py', '.sh']:
         sys.exit("*** cannot insert for file extension %s" % extension)
 
     if extension == '.py':

--- a/src/qml/pages/initerrormessage.qml
+++ b/src/qml/pages/initerrormessage.qml
@@ -1,3 +1,7 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 import QtQuick 2.12
 import QtQuick.Dialogs 1.3
 

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -1,3 +1,7 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 import QtQml 2.12
 import QtQuick.Controls 2.12
 


### PR DESCRIPTION
This PR:
- updates the `copyright_header.py` script to make it handle QML files
- adds copyright headers to QML files