### PR TITLE
Expose init executor instance

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -163,16 +163,11 @@ int QmlGuiMain(int argc, char* argv[])
 
     NodeModel node_model{*node};
     InitExecutor init_executor{*node};
-    QObject::connect(&node_model, &NodeModel::requestedInitialize, &init_executor, &InitExecutor::initialize);
-    QObject::connect(&node_model, &NodeModel::requestedShutdown, &init_executor, &InitExecutor::shutdown);
-    QObject::connect(&init_executor, &InitExecutor::initializeResult, &node_model, &NodeModel::initializeResult);
-    QObject::connect(&init_executor, &InitExecutor::shutdownResult, qGuiApp, &QGuiApplication::quit, Qt::QueuedConnection);
-    // QObject::connect(&init_executor, &InitExecutor::runawayException, &node_model, &NodeModel::handleRunawayException);
 
     qGuiApp->setQuitOnLastWindowClosed(false);
     QObject::connect(qGuiApp, &QGuiApplication::lastWindowClosed, [&] {
         node->startShutdown();
-        node_model.startNodeShutdown();
+        init_executor.shutdown();
     });
 
     GUIUtil::LoadFont(":/fonts/inter/regular");
@@ -184,6 +179,7 @@ int QmlGuiMain(int argc, char* argv[])
     assert(!network_style.isNull());
     engine.addImageProvider(QStringLiteral("images"), new ImageProvider{network_style.data()});
 
+    engine.rootContext()->setContextProperty("initExecutor", &init_executor);
     engine.rootContext()->setContextProperty("nodeModel", &node_model);
 
     engine.load(QUrl(QStringLiteral("qrc:///qml/pages/stub.qml")));

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -23,16 +23,6 @@ void NodeModel::setBlockTipHeight(int new_height)
     }
 }
 
-void NodeModel::startNodeInitializionThread()
-{
-    Q_EMIT requestedInitialize();
-}
-
-void NodeModel::startNodeShutdown()
-{
-    Q_EMIT requestedShutdown();
-}
-
 void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::BlockAndHeaderTipInfo tip_info)
 {
     // TODO: Handle the `success` parameter,

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -28,16 +28,11 @@ public:
     int blockTipHeight() const { return m_block_tip_height; }
     void setBlockTipHeight(int new_height);
 
-    Q_INVOKABLE void startNodeInitializionThread();
-    void startNodeShutdown();
-
 public Q_SLOTS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
 
 Q_SIGNALS:
     void blockTipHeightChanged();
-    void requestedInitialize();
-    void requestedShutdown();
 
 private:
     // Properties that are exposed to QML.

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -18,7 +18,13 @@ ApplicationWindow {
     }
     visible: true
 
-    Component.onCompleted: nodeModel.startNodeInitializionThread();
+    Component.onCompleted: initExecutor.initialize()
+
+    Connections {
+        target: initExecutor
+        onInitializeResult: nodeModel.initializeResult(success, tip_info)
+    }
+
 
     Image {
         id: appLogo


### PR DESCRIPTION
This PR exposes `InitExecutor` instance to QML so that we can:
 - show the window as early as possible
 - display loading feedback on that window
 - connect/bind in QML to the relevant object's properties/signals to update the UI

The `InitExecutor` is then kept in the main GUI thread (otherwise QML engine complains) and the instance is exposed in the root engine context.

This change also removes the "proxy role" of `NodeModel`. Further simplifications/improvements will follow, but I'd like to present this approach first before going forward.