### PR TITLE
Add ChainModel

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -298,6 +298,7 @@ QML_QRC_CPP = qml/qrc_bitcoin.cpp
 QML_QRC = qml/bitcoin_qml.qrc
 QML_RES_QML = \
   qml/components/BlockCounter.qml \
+  qml/controls/OptionButton.qml \
   qml/pages/initerrormessage.qml \
   qml/pages/stub.qml
 

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -298,6 +298,7 @@ QML_QRC_CPP = qml/qrc_bitcoin.cpp
 QML_QRC = qml/bitcoin_qml.qrc
 QML_RES_QML = \
   qml/components/BlockCounter.qml \
+  qml/components/ConnectionOptions.qml \
   qml/controls/OptionButton.qml \
   qml/pages/initerrormessage.qml \
   qml/pages/stub.qml

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -304,6 +304,7 @@ QML_QRC_CPP = qml/qrc_bitcoin.cpp
 QML_QRC = qml/bitcoin_qml.qrc
 QML_RES_QML = \
   qml/components/BlockCounter.qml \
+  qml/components/BlocksListView.qml \
   qml/components/ConnectionOptions.qml \
   qml/controls/OptionButton.qml \
   qml/pages/initerrormessage.qml \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -35,6 +35,7 @@ QT_FORMS_UI = \
   qt/forms/transactiondescdialog.ui
 
 QT_MOC_CPP = \
+  qml/moc_engine.cpp \
   qml/moc_nodemodel.cpp \
   qt/moc_addressbookpage.cpp \
   qt/moc_addresstablemodel.cpp \
@@ -108,6 +109,7 @@ QT_QRC_LOCALE = qt/bitcoin_locale.qrc
 
 BITCOIN_QT_H = \
   qml/bitcoin.h \
+  qml/engine.h \
   qml/imageprovider.h \
   qml/nodemodel.h \
   qml/util.h \
@@ -286,6 +288,7 @@ BITCOIN_QT_WALLET_CPP = \
 
 BITCOIN_QML_BASE_CPP = \
   qml/bitcoin.cpp \
+  qml/engine.cpp \
   qml/imageprovider.cpp \
   qml/nodemodel.cpp \
   qml/util.cpp
@@ -443,7 +446,7 @@ ui_%.h: %.ui
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_INCLUDES_UNSUPPRESSED) $(MOC_DEFS) $< > $@
 
 moc_%.cpp: %.h
-	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_INCLUDES_UNSUPPRESSED) $(MOC_DEFS) $< > $@
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_INCLUDES_UNSUPPRESSED) $(QT_QUICK_CFLAGS) $(MOC_DEFS) $< > $@
 
 %.qm: %.ts
 	@test -f $(LRELEASE)

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -35,6 +35,7 @@ QT_FORMS_UI = \
   qt/forms/transactiondescdialog.ui
 
 QT_MOC_CPP = \
+  qml/moc_chainmodel.cpp \
   qml/moc_engine.cpp \
   qml/moc_nodemodel.cpp \
   qt/moc_addressbookpage.cpp \
@@ -109,6 +110,7 @@ QT_QRC_LOCALE = qt/bitcoin_locale.qrc
 
 BITCOIN_QT_H = \
   qml/bitcoin.h \
+  qml/chainmodel.h \
   qml/engine.h \
   qml/imageprovider.h \
   qml/nodemodel.h \
@@ -288,6 +290,7 @@ BITCOIN_QT_WALLET_CPP = \
 
 BITCOIN_QML_BASE_CPP = \
   qml/bitcoin.cpp \
+  qml/chainmodel.cpp \
   qml/engine.cpp \
   qml/imageprovider.cpp \
   qml/nodemodel.cpp \

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -12,6 +12,7 @@
 #include <node/context.h>
 #include <node/ui_interface.h>
 #include <noui.h>
+#include <qml/engine.h>
 #include <qml/imageprovider.h>
 #include <qml/nodemodel.h>
 #include <qml/util.h>
@@ -30,7 +31,6 @@
 
 #include <QDebug>
 #include <QGuiApplication>
-#include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QQuickWindow>
 #include <QString>
@@ -176,7 +176,7 @@ int QmlGuiMain(int argc, char* argv[])
     GUIUtil::LoadFont(":/fonts/inter/regular");
     GUIUtil::LoadFont(":/fonts/inter/semibold");
 
-    QQmlApplicationEngine engine;
+    Engine engine(*node);
 
     QScopedPointer<const NetworkStyle> network_style{NetworkStyle::instantiate(Params().NetworkIDString())};
     assert(!network_style.isNull());

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -164,7 +164,6 @@ int QmlGuiMain(int argc, char* argv[])
 
     handler_message_box.disconnect();
 
-    NodeModel node_model{*node};
     InitExecutor init_executor{*node};
 
     qGuiApp->setQuitOnLastWindowClosed(false);
@@ -176,6 +175,8 @@ int QmlGuiMain(int argc, char* argv[])
     GUIUtil::LoadFont(":/fonts/inter/regular");
     GUIUtil::LoadFont(":/fonts/inter/semibold");
 
+    qmlRegisterType<NodeModel>("BitcoinCore", 1, 0, "NodeModel");
+
     Engine engine(*node);
 
     QScopedPointer<const NetworkStyle> network_style{NetworkStyle::instantiate(Params().NetworkIDString())};
@@ -183,7 +184,6 @@ int QmlGuiMain(int argc, char* argv[])
     engine.addImageProvider(QStringLiteral("images"), new ImageProvider{network_style.data()});
 
     engine.rootContext()->setContextProperty("initExecutor", &init_executor);
-    engine.rootContext()->setContextProperty("nodeModel", &node_model);
 
     engine.load(QUrl(QStringLiteral("qrc:///qml/pages/stub.qml")));
     if (engine.rootObjects().isEmpty()) {

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -166,16 +166,11 @@ int QmlGuiMain(int argc, char* argv[])
 
     NodeModel node_model{*node};
     InitExecutor init_executor{*node};
-    QObject::connect(&node_model, &NodeModel::requestedInitialize, &init_executor, &InitExecutor::initialize);
-    QObject::connect(&node_model, &NodeModel::requestedShutdown, &init_executor, &InitExecutor::shutdown);
-    QObject::connect(&init_executor, &InitExecutor::initializeResult, &node_model, &NodeModel::initializeResult);
-    QObject::connect(&init_executor, &InitExecutor::shutdownResult, qGuiApp, &QGuiApplication::quit, Qt::QueuedConnection);
-    // QObject::connect(&init_executor, &InitExecutor::runawayException, &node_model, &NodeModel::handleRunawayException);
 
     qGuiApp->setQuitOnLastWindowClosed(false);
     QObject::connect(qGuiApp, &QGuiApplication::lastWindowClosed, [&] {
         node->startShutdown();
-        node_model.startNodeShutdown();
+        init_executor.shutdown();
     });
 
     GUIUtil::LoadFont(":/fonts/inter/regular");
@@ -187,6 +182,7 @@ int QmlGuiMain(int argc, char* argv[])
     assert(!network_style.isNull());
     engine.addImageProvider(QStringLiteral("images"), new ImageProvider{network_style.data()});
 
+    engine.rootContext()->setContextProperty("initExecutor", &init_executor);
     engine.rootContext()->setContextProperty("nodeModel", &node_model);
 
     engine.load(QUrl(QStringLiteral("qrc:///qml/pages/stub.qml")));

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -12,6 +12,7 @@
 #include <node/context.h>
 #include <node/ui_interface.h>
 #include <noui.h>
+#include <qml/chainmodel.h>
 #include <qml/engine.h>
 #include <qml/imageprovider.h>
 #include <qml/nodemodel.h>
@@ -175,6 +176,7 @@ int QmlGuiMain(int argc, char* argv[])
     GUIUtil::LoadFont(":/fonts/inter/regular");
     GUIUtil::LoadFont(":/fonts/inter/semibold");
 
+    qmlRegisterType<ChainModel>("BitcoinCore", 1, 0, "ChainModel");
     qmlRegisterType<NodeModel>("BitcoinCore", 1, 0, "NodeModel");
 
     Engine engine(*node);

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -34,6 +34,7 @@
 #include <QQmlContext>
 #include <QQuickWindow>
 #include <QString>
+#include <QStyleHints>
 #include <QUrl>
 
 QT_BEGIN_NAMESPACE
@@ -99,6 +100,8 @@ int QmlGuiMain(int argc, char* argv[])
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
+
+    app.styleHints()->setTabFocusBehavior(Qt::TabFocusAllControls);
 
     auto handler_message_box = ::uiInterface.ThreadSafeMessageBox_connect(InitErrorMessageBox);
 

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -1,6 +1,7 @@
 <!DOCTYPE RCC><RCC version="1.0">
     <qresource prefix="/qml">
         <file>controls/OptionButton.qml</file>
+        <file>components/BlocksListView.qml</file>
         <file>components/BlockCounter.qml</file>
         <file>components/ConnectionOptions.qml</file>
         <file>pages/initerrormessage.qml</file>

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -1,5 +1,6 @@
 <!DOCTYPE RCC><RCC version="1.0">
     <qresource prefix="/qml">
+        <file>controls/OptionButton.qml</file>
         <file>components/BlockCounter.qml</file>
         <file>pages/initerrormessage.qml</file>
         <file>pages/stub.qml</file>

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/qml">
         <file>controls/OptionButton.qml</file>
         <file>components/BlockCounter.qml</file>
+        <file>components/ConnectionOptions.qml</file>
         <file>pages/initerrormessage.qml</file>
         <file>pages/stub.qml</file>
     </qresource>

--- a/src/qml/chainmodel.cpp
+++ b/src/qml/chainmodel.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/chainmodel.h>
+
+#include <interfaces/chain.h>
+#include <interfaces/handler.h>
+#include <interfaces/node.h>
+#include <qml/engine.h>
+#include <qt/guiutil.h>
+
+#include <vector>
+
+struct Block
+{
+    const int height;
+    const std::string hash;
+};
+
+struct ChainModelPrivate
+{
+    std::unique_ptr<interfaces::Handler> handler_notify_block_tip;
+    std::vector<Block> blocks;
+};
+
+ChainModel::ChainModel(QObject* parent)
+    : QAbstractListModel(parent)
+    , d(new ChainModelPrivate)
+{
+}
+
+ChainModel::~ChainModel()
+{
+}
+
+void ChainModel::classBegin()
+{
+}
+
+void ChainModel::componentComplete()
+{
+    assert(!d->handler_notify_block_tip);
+    d->handler_notify_block_tip = Engine::node(this).handleNotifyBlockTip(
+      [this](SynchronizationState state, interfaces::BlockTip tip, double verification_progress) {
+          // TODO: update existing model incrementally instead of reset
+          GUIUtil::ObjectInvoke(this, [this] {
+              beginResetModel();
+              d->blocks.clear();
+              endResetModel();
+          });
+      });
+}
+
+QHash<int, QByteArray> ChainModel::roleNames() const
+{
+    return {
+        { BlockHeightRole, "blockHeight" },
+        { BlockHashRole, "blockHash" }
+    };
+}
+
+bool ChainModel::canFetchMore(const QModelIndex&) const
+{
+    return d->blocks.size() == 0 || d->blocks[0].height > 0;
+}
+
+void ChainModel::fetchMore(const QModelIndex& parent)
+{
+    auto& chain = Engine::chain(this);
+    int height = d->blocks.size() > 0 ? d->blocks[d->blocks.size() - 1].height - 1 : *chain.getHeight();
+    // TODO: make page size configurable
+    // TODO: refactor to call beginInsertRows before the loop
+    for (int count = 10; count > 0 && height >= 0; --count, --height) {
+        const auto hash = chain.getBlockHash(height).ToString();
+        beginInsertRows(QModelIndex(), d->blocks.size(), d->blocks.size());
+        d->blocks.push_back({height, hash});
+        endInsertRows();
+    }
+}
+
+int ChainModel::rowCount(const QModelIndex& parent) const
+{
+    return d->blocks.size();
+}
+
+QVariant ChainModel::data(const QModelIndex& index, int role) const
+{
+    switch (role) {
+      case BlockHeightRole: return d->blocks[index.row()].height;
+      case BlockHashRole: return QString::fromStdString(d->blocks[index.row()].hash);
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}

--- a/src/qml/chainmodel.h
+++ b/src/qml/chainmodel.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_CHAINMODEL_H
+#define BITCOIN_QML_CHAINMODEL_H
+
+#include <memory>
+
+#include <QAbstractListModel>
+#include <QQmlParserStatus>
+
+class ChainModelPrivate;
+class ChainModel : public QAbstractListModel, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+    std::unique_ptr<ChainModelPrivate> d;
+
+public:
+    enum Role {
+        BlockHeightRole = Qt::UserRole + 1,
+        BlockHashRole,
+    };
+
+    explicit ChainModel(QObject* parent = nullptr);
+    ~ChainModel();
+
+    // QQmlParserStatus
+    void classBegin() override;
+    void componentComplete() override;
+
+    // QAbstractListModel
+    QHash<int, QByteArray> roleNames() const override;
+    bool canFetchMore(const QModelIndex& parent) const override;
+    void fetchMore(const QModelIndex& parent) override;
+    int rowCount(const QModelIndex& parent) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+};
+
+#endif // BITCOIN_QML_CHAINMODEL_H

--- a/src/qml/components/BlockCounter.qml
+++ b/src/qml/components/BlockCounter.qml
@@ -18,6 +18,6 @@ Label {
     verticalAlignment: Text.AlignVCenter
     font.family: "Inter"
     font.styleName: "Semi Bold"
-    font.pixelSize: height / 3
+    font.pixelSize: 20
     text: blockHeight
 }

--- a/src/qml/components/BlocksListView.qml
+++ b/src/qml/components/BlocksListView.qml
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import BitcoinCore 1.0
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.11
+import "../controls"
+
+ListView {
+    spacing: 15
+    model: ChainModel {
+    }
+    delegate: ItemDelegate {
+        id: delegate
+        padding: 15
+        background: Rectangle {
+            border.width: 1
+            border.color: delegate.hovered ? "white" : "#999999"
+            radius: 10
+            color: "transparent"
+        }
+        contentItem: ColumnLayout {
+            spacing: 3
+            Label {
+                color: "white"
+                font.family: "Inter"
+                font.styleName: "Regular"
+                font.pixelSize: 28
+                text: qsTrId('Block #%1').arg(blockHeight)
+            }
+            Label {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 0
+                color: "white"
+                elide: Text.ElideRight
+                font.family: "Inter"
+                font.styleName: "Regular"
+                font.pixelSize: 13
+                text: blockHash
+            }
+        }
+    }
+}

--- a/src/qml/components/ConnectionOptions.qml
+++ b/src/qml/components/ConnectionOptions.qml
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.11
+import "../controls"
+
+ColumnLayout {
+    spacing: 15
+
+    ButtonGroup {
+        id: group
+    }
+
+    OptionButton {
+        ButtonGroup.group: group
+        Layout.fillWidth: true
+        text: qsTr("Fast always on")
+        description: qsTr("Loads quickly at all times and uses as much cellular data as needed.")
+        recommended: true
+    }
+
+    OptionButton {
+        ButtonGroup.group: group
+        Layout.fillWidth: true
+        checked: true
+        text: qsTr("Slow always on")
+        description: qsTr("Loads quickly at all times and uses as much cellular data as needed.")
+    }
+
+    OptionButton {
+        ButtonGroup.group: group
+        Layout.fillWidth: true
+        text: qsTr("Only when on Wi-Fi")
+        description: qsTr("Loads quickly when on wi-fi and pauses when on cellular data.")
+    }
+}

--- a/src/qml/controls/OptionButton.qml
+++ b/src/qml/controls/OptionButton.qml
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.11
+
+Button {
+    property string description
+    property bool recommended: false
+    id: button
+    padding: 15
+    checkable: true
+    background: Rectangle {
+        border.width: 1
+        border.color: button.checked ? "#F7931A" : button.hovered ? "white" : "#999999"
+        radius: 10
+        color: "transparent"
+        Rectangle {
+            visible: button.activeFocus
+            anchors.fill: parent
+            anchors.margins: -3
+            border.width: 2
+            border.color: "#F7931A"
+            radius: 13
+            color: "transparent"
+            opacity: 0.4
+        }
+    }
+    contentItem: ColumnLayout {
+        spacing: 3
+        Label {
+            Layout.fillWidth: true
+            Layout.preferredWidth: 0
+            font.family: "Inter"
+            font.styleName: "Semi Bold"
+            font.pointSize: 18
+            color: "white"
+            text: button.text
+            wrapMode: Text.WordWrap
+        }
+        Label {
+            Layout.fillWidth: true
+            Layout.preferredWidth: 0
+            font.family: "Inter"
+            font.styleName: "Regular"
+            font.pixelSize: 15
+            color: "white"
+            text: button.description
+            wrapMode: Text.WordWrap
+        }
+        Loader {
+            active: button.recommended
+            sourceComponent: Label {
+                background: Rectangle {
+                    color: "white"
+                    radius: 3
+                }
+                font.styleName: "Regular"
+                font.pixelSize: 13
+                padding: 4
+                color: "black"
+                text: qsTr("Recommended")
+            }
+        }
+    }
+}

--- a/src/qml/engine.cpp
+++ b/src/qml/engine.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/engine.h>
+
+#include <interfaces/node.h>
+#include <node/context.h>
+
+#include <QQmlContext>
+
+Engine::Engine(interfaces::Node& node)
+    : m_node(node)
+{
+}
+
+Engine::~Engine()
+{
+}
+
+interfaces::Node& Engine::node(QObject* object)
+{
+    auto context = Assert(QQmlEngine::contextForObject(object));
+    auto engine = Assert(context->engine());
+    return Assert(qobject_cast<Engine*>(engine))->node();
+}

--- a/src/qml/engine.cpp
+++ b/src/qml/engine.cpp
@@ -18,9 +18,19 @@ Engine::~Engine()
 {
 }
 
+interfaces::Chain& Engine::chain(QObject* object)
+{
+    return *Assert(Engine::nodeContext(object).chain);
+}
+
 interfaces::Node& Engine::node(QObject* object)
 {
     auto context = Assert(QQmlEngine::contextForObject(object));
     auto engine = Assert(context->engine());
     return Assert(qobject_cast<Engine*>(engine))->node();
+}
+
+NodeContext& Engine::nodeContext(QObject* object)
+{
+    return *Assert(Engine::node(object).context());
 }

--- a/src/qml/engine.h
+++ b/src/qml/engine.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_ENGINE_H
+#define BITCOIN_QML_ENGINE_H
+
+#include <QQmlApplicationEngine>
+
+namespace interfaces {
+class Node;
+}
+
+class Engine : public QQmlApplicationEngine
+{
+    Q_OBJECT
+
+public:
+    explicit Engine(interfaces::Node& node);
+    ~Engine();
+
+    interfaces::Node& node() const { return m_node; }
+
+    static interfaces::Node& node(QObject* object);
+
+private:
+    interfaces::Node& m_node;
+};
+
+#endif // BITCOIN_QML_ENGINE_H

--- a/src/qml/engine.h
+++ b/src/qml/engine.h
@@ -8,8 +8,11 @@
 #include <QQmlApplicationEngine>
 
 namespace interfaces {
+class Chain;
 class Node;
 }
+
+class NodeContext;
 
 class Engine : public QQmlApplicationEngine
 {
@@ -21,7 +24,9 @@ public:
 
     interfaces::Node& node() const { return m_node; }
 
+    static interfaces::Chain& chain(QObject* object);
     static interfaces::Node& node(QObject* object);
+    static NodeContext& nodeContext(QObject* object);
 
 private:
     interfaces::Node& m_node;

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -6,6 +6,7 @@
 
 #include <interfaces/node.h>
 #include <qml/engine.h>
+#include <qt/guiutil.h>
 #include <validation.h>
 
 #include <cassert>
@@ -34,6 +35,8 @@ void NodeModel::componentComplete()
     assert(!m_handler_notify_block_tip);
     m_handler_notify_block_tip = node.handleNotifyBlockTip(
         [this](SynchronizationState state, interfaces::BlockTip tip, double verification_progress) {
-            setBlockTipHeight(tip.block_height);
+            GUIUtil::ObjectInvoke(this, [=] {
+                setBlockTipHeight(tip.block_height);
+            });
         });
 }

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -5,14 +5,14 @@
 #include <qml/nodemodel.h>
 
 #include <interfaces/node.h>
+#include <qml/engine.h>
 #include <validation.h>
 
 #include <cassert>
 
-NodeModel::NodeModel(interfaces::Node& node)
-    : m_node{node}
+NodeModel::NodeModel(QObject* parent)
+    : QObject(parent)
 {
-    ConnectToBlockTipSignal();
 }
 
 void NodeModel::setBlockTipHeight(int new_height)
@@ -23,16 +23,16 @@ void NodeModel::setBlockTipHeight(int new_height)
     }
 }
 
-void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::BlockAndHeaderTipInfo tip_info)
+void NodeModel::classBegin()
 {
-    // TODO: Handle the `success` parameter,
-    setBlockTipHeight(tip_info.block_height);
 }
 
-void NodeModel::ConnectToBlockTipSignal()
+void NodeModel::componentComplete()
 {
+    auto& node = Engine::node(this);
+    setBlockTipHeight(node.getNumBlocks());
     assert(!m_handler_notify_block_tip);
-    m_handler_notify_block_tip = m_node.handleNotifyBlockTip(
+    m_handler_notify_block_tip = node.handleNotifyBlockTip(
         [this](SynchronizationState state, interfaces::BlockTip tip, double verification_progress) {
             setBlockTipHeight(tip.block_height);
         });

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -23,16 +23,6 @@ void NodeModel::setBlockTipHeight(int new_height)
     }
 }
 
-void NodeModel::startNodeInitializionThread()
-{
-    Q_EMIT requestedInitialize();
-}
-
-void NodeModel::startNodeShutdown()
-{
-    Q_EMIT requestedShutdown();
-}
-
 void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::BlockAndHeaderTipInfo tip_info)
 {
     // TODO: Handle the `success` parameter,

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -28,16 +28,11 @@ public:
     int blockTipHeight() const { return m_block_tip_height; }
     void setBlockTipHeight(int new_height);
 
-    Q_INVOKABLE void startNodeInitializionThread();
-    void startNodeShutdown();
-
 public Q_SLOTS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
 
 Q_SIGNALS:
     void blockTipHeightChanged();
-    void requestedInitialize();
-    void requestedShutdown();
 
 private:
     // Properties that are exposed to QML.

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -6,30 +6,32 @@
 #define BITCOIN_QML_NODEMODEL_H
 
 #include <interfaces/handler.h>
-#include <interfaces/node.h>
 
 #include <memory>
 
 #include <QObject>
+#include <QQmlParserStatus>
 
 namespace interfaces {
 class Node;
 }
 
 /** Model for Bitcoin network client. */
-class NodeModel : public QObject
+class NodeModel : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
     Q_PROPERTY(int blockTipHeight READ blockTipHeight NOTIFY blockTipHeightChanged)
 
 public:
-    explicit NodeModel(interfaces::Node& node);
+    explicit NodeModel(QObject* parent = nullptr);
 
     int blockTipHeight() const { return m_block_tip_height; }
     void setBlockTipHeight(int new_height);
 
-public Q_SLOTS:
-    void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
+    // QQmlParserStatus
+    void classBegin() override;
+    void componentComplete() override;
 
 Q_SIGNALS:
     void blockTipHeightChanged();
@@ -38,10 +40,7 @@ private:
     // Properties that are exposed to QML.
     int m_block_tip_height{0};
 
-    interfaces::Node& m_node;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;
-
-    void ConnectToBlockTipSignal();
 };
 
 #endif // BITCOIN_QML_NODEMODEL_H

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -17,17 +17,19 @@ ApplicationWindow {
 
     Component.onCompleted: nodeModel.startNodeInitializionThread();
 
-    Image {
-        id: appLogo
-        anchors.horizontalCenter: parent.horizontalCenter
-        source: "image://images/app"
-        sourceSize.width: 128
-        sourceSize.height: 128
-    }
-
-    BlockCounter {
-        id: blockCounter
+    ColumnLayout {
         anchors.centerIn: parent
-        blockHeight: nodeModel.blockTipHeight
+        spacing: 15
+        width: 400
+        Image {
+            Layout.alignment: Qt.AlignCenter
+            source: "image://images/app"
+            sourceSize.width: 64
+            sourceSize.height: 64
+        }
+        BlockCounter {
+            Layout.alignment: Qt.AlignCenter
+            blockHeight: nodeModel.blockTipHeight
+        }
     }
 }

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -29,7 +29,6 @@ ApplicationWindow {
     BitcoinCoreComponents.BlockCounter {
         id: blockCounter
         anchors.centerIn: parent
-        height: parent.height / 3
         blockHeight: nodeModel.blockTipHeight
     }
 }

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -13,9 +13,7 @@ ApplicationWindow {
     title: "Bitcoin Core TnG"
     minimumWidth: 750
     minimumHeight: 450
-    background: Rectangle {
-        color: "black"
-    }
+    color: "black"
     visible: true
 
     Component.onCompleted: nodeModel.startNodeInitializionThread();

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -5,8 +5,7 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.11
-import "../components" as BitcoinCoreComponents
-
+import "../components"
 
 ApplicationWindow {
     id: appWindow
@@ -26,7 +25,7 @@ ApplicationWindow {
         sourceSize.height: 128
     }
 
-    BitcoinCoreComponents.BlockCounter {
+    BlockCounter {
         id: blockCounter
         anchors.centerIn: parent
         blockHeight: nodeModel.blockTipHeight

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import BitcoinCore 1.0
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.11
@@ -17,27 +18,28 @@ ApplicationWindow {
 
     Component.onCompleted: initExecutor.initialize()
 
-    Connections {
-        target: initExecutor
-        onInitializeResult: nodeModel.initializeResult(success, tip_info)
-    }
-
-
-    ColumnLayout {
+    Loader {
+        id: loader
+        active: initExecutor.ready
         anchors.centerIn: parent
-        spacing: 15
-        width: 400
-        Image {
-            Layout.alignment: Qt.AlignCenter
-            source: "image://images/app"
-            sourceSize.width: 64
-            sourceSize.height: 64
-        }
-        BlockCounter {
-            Layout.alignment: Qt.AlignCenter
-            blockHeight: nodeModel.blockTipHeight
-        }
-        ConnectionOptions {
+        sourceComponent: ColumnLayout {
+            spacing: 15
+            width: 400
+            NodeModel {
+                id: node_model
+            }
+            Image {
+                Layout.alignment: Qt.AlignCenter
+                source: "image://images/app"
+                sourceSize.width: 64
+                sourceSize.height: 64
+            }
+            BlockCounter {
+                Layout.alignment: Qt.AlignCenter
+                blockHeight: nodeModel.blockTipHeight
+            }
+            ConnectionOptions {
+            }
         }
     }
 }

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -31,5 +31,7 @@ ApplicationWindow {
             Layout.alignment: Qt.AlignCenter
             blockHeight: nodeModel.blockTipHeight
         }
+        ConnectionOptions {
+        }
     }
 }

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -15,7 +15,13 @@ ApplicationWindow {
     color: "black"
     visible: true
 
-    Component.onCompleted: nodeModel.startNodeInitializionThread();
+    Component.onCompleted: initExecutor.initialize()
+
+    Connections {
+        target: initExecutor
+        onInitializeResult: nodeModel.initializeResult(success, tip_info)
+    }
+
 
     ColumnLayout {
         anchors.centerIn: parent

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -22,23 +22,31 @@ ApplicationWindow {
         id: loader
         active: initExecutor.ready
         anchors.centerIn: parent
-        sourceComponent: ColumnLayout {
+        sourceComponent: RowLayout {
             spacing: 15
-            width: 400
-            NodeModel {
-                id: node_model
+            ColumnLayout {
+                spacing: 15
+                Layout.preferredWidth: 400
+                NodeModel {
+                    id: nodeModel
+                }
+                Image {
+                    Layout.alignment: Qt.AlignCenter
+                    source: "image://images/app"
+                    sourceSize.width: 64
+                    sourceSize.height: 64
+                }
+                BlockCounter {
+                    Layout.alignment: Qt.AlignCenter
+                    blockHeight: nodeModel.blockTipHeight
+                }
+                ConnectionOptions {
+                }
             }
-            Image {
-                Layout.alignment: Qt.AlignCenter
-                source: "image://images/app"
-                sourceSize.width: 64
-                sourceSize.height: 64
-            }
-            BlockCounter {
-                Layout.alignment: Qt.AlignCenter
-                blockHeight: nodeModel.blockTipHeight
-            }
-            ConnectionOptions {
+            BlocksListView {
+                Layout.fillHeight: true
+                Layout.preferredHeight: 0
+                Layout.preferredWidth: 300
             }
         }
     }

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -21,6 +21,11 @@ InitExecutor::InitExecutor(interfaces::Node& node)
 {
     m_context.moveToThread(&m_thread);
     m_thread.start();
+
+    connect(this, &InitExecutor::initializeResult, this, [=](bool success, interfaces::BlockAndHeaderTipInfo tip_info) {
+        m_ready = success;
+        Q_EMIT readyChanged();
+    });
 }
 
 InitExecutor::~InitExecutor()

--- a/src/qt/initexecutor.h
+++ b/src/qt/initexecutor.h
@@ -22,15 +22,19 @@ QT_END_NAMESPACE
 class InitExecutor : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
 public:
     explicit InitExecutor(interfaces::Node& node);
     ~InitExecutor();
+
+    bool ready() const { return m_ready; }
 
 public Q_SLOTS:
     void initialize();
     void shutdown();
 
 Q_SIGNALS:
+    void readyChanged();
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
     void shutdownResult();
     void runawayException(const QString& message);
@@ -42,6 +46,7 @@ private:
     interfaces::Node& m_node;
     QObject m_context;
     QThread m_thread;
+    bool m_ready{false};
 };
 
 #endif // BITCOIN_QT_INITEXECUTOR_H


### PR DESCRIPTION
Based on #38. This PR adds and uses the `ChainModel`. This model exposes chain data, like block heights and hashes. Can be used as a source for list views and repeaters. The model uses a lazy load approach, ie, data is fetched from `interfaces::Chain` as needed.