### PR TITLE
Revert a commit from #5 to avoid merge conflict with bitcoin/bitcoin#22219

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -15,10 +15,12 @@
 #include <qt/guiutil.h>
 #include <qt/initexecutor.h>
 #include <util/system.h>
+#include <util/threadnames.h>
 #include <util/translation.h>
 
 #include <boost/signals2/connection.hpp>
 #include <memory>
+#include <tuple>
 
 #include <QDebug>
 #include <QGuiApplication>
@@ -66,6 +68,14 @@ bool InitErrorMessageBox(
 
 int QmlGuiMain(int argc, char* argv[])
 {
+#ifdef WIN32
+    util::WinCmdLineArgs winArgs;
+    std::tie(argc, argv) = winArgs.get();
+#endif // WIN32
+
+    SetupEnvironment();
+    util::ThreadSetInternalName("main");
+
     Q_INIT_RESOURCE(bitcoin_qml);
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -440,6 +440,13 @@ static void SetupUIArgs(ArgsManager& argsman)
 
 int GuiMain(int argc, char* argv[])
 {
+#ifdef WIN32
+    util::WinCmdLineArgs winArgs;
+    std::tie(argc, argv) = winArgs.get();
+#endif
+    SetupEnvironment();
+    util::ThreadSetInternalName("main");
+
     NodeContext node_context;
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode(&node_context);
 

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -15,14 +15,11 @@
 #include <interfaces/node.h>
 #include <logging.h>
 #include <noui.h>
-#include <util/system.h>
-#include <util/threadnames.h>
 #include <util/translation.h>
 #include <util/url.h>
 
 #include <functional>
 #include <string>
-#include <tuple>
 
 #include <QCoreApplication>
 #include <QString>
@@ -64,14 +61,6 @@ void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, cons
 int main(int argc, char* argv[])
 {
     qRegisterMetaType<interfaces::BlockAndHeaderTipInfo>("interfaces::BlockAndHeaderTipInfo");
-
-#ifdef WIN32
-    util::WinCmdLineArgs win_args;
-    std::tie(argc, argv) = win_args.get();
-#endif // WIN32
-
-    SetupEnvironment();
-    util::ThreadSetInternalName("main");
 
     // Subscribe to global signals from core.
     noui_connect();


### PR DESCRIPTION
This PR reverts the _"refactor: Move qwidget and qml common code into the main() function"_ commit (8efd330d54e75e4a5de36278299b5227e4e5bfdf) from #5, and it allows to sync with the main repo without a merge conflict with bitcoin/bitcoin#22219.