### PR TITLE
Introduce ImageProvider class

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -108,6 +108,7 @@ QT_QRC_LOCALE = qt/bitcoin_locale.qrc
 
 BITCOIN_QT_H = \
   qml/bitcoin.h \
+  qml/imageprovider.h \
   qml/nodemodel.h \
   qml/util.h \
   qt/addressbookpage.h \
@@ -285,6 +286,7 @@ BITCOIN_QT_WALLET_CPP = \
 
 BITCOIN_QML_BASE_CPP = \
   qml/bitcoin.cpp \
+  qml/imageprovider.cpp \
   qml/nodemodel.cpp \
   qml/util.cpp
 

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -4,6 +4,7 @@
 
 #include <qml/bitcoin.h>
 
+#include <chainparams.h>
 #include <init.h>
 #include <interfaces/init.h>
 #include <interfaces/node.h>
@@ -11,11 +12,13 @@
 #include <node/context.h>
 #include <node/ui_interface.h>
 #include <noui.h>
+#include <qml/imageprovider.h>
 #include <qml/nodemodel.h>
 #include <qml/util.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/initexecutor.h>
+#include <qt/networkstyle.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
@@ -173,6 +176,11 @@ int QmlGuiMain(int argc, char* argv[])
     });
 
     QQmlApplicationEngine engine;
+
+    QScopedPointer<const NetworkStyle> network_style{NetworkStyle::instantiate(Params().NetworkIDString())};
+    assert(!network_style.isNull());
+    engine.addImageProvider(QStringLiteral("images"), new ImageProvider{network_style.data()});
+
     engine.rootContext()->setContextProperty("nodeModel", &node_model);
 
     engine.load(QUrl(QStringLiteral("qrc:///qml/pages/stub.qml")));

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -4,4 +4,7 @@
         <file>pages/initerrormessage.qml</file>
         <file>pages/stub.qml</file>
     </qresource>
+    <qresource prefix="/icons">
+        <file alias="bitcoin">../qt/res/icons/bitcoin.png</file>
+    </qresource>
 </RCC>

--- a/src/qml/imageprovider.cpp
+++ b/src/qml/imageprovider.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/imageprovider.h>
+
+#include <qt/networkstyle.h>
+
+#include <QIcon>
+#include <QPixmap>
+#include <QQuickImageProvider>
+#include <QSize>
+#include <QString>
+
+ImageProvider::ImageProvider(const NetworkStyle* network_style)
+    : QQuickImageProvider{QQuickImageProvider::Pixmap},
+      m_network_style{network_style} {}
+
+QPixmap ImageProvider::requestPixmap(const QString& id, QSize* size, const QSize& requested_size)
+{
+    if (!size || !requested_size.isValid()) {
+        return {};
+    }
+
+    if (id == "app") {
+        *size = requested_size;
+        return m_network_style->getAppIcon().pixmap(requested_size);
+    }
+
+    return {};
+}

--- a/src/qml/imageprovider.h
+++ b/src/qml/imageprovider.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_IMAGEPROVIDER_H
+#define BITCOIN_QML_IMAGEPROVIDER_H
+
+#include <QPixmap>
+#include <QQuickImageProvider>
+
+class NetworkStyle;
+
+QT_BEGIN_NAMESPACE
+class QSize;
+class QString;
+QT_END_NAMESPACE
+
+class ImageProvider : public QQuickImageProvider
+{
+public:
+    explicit ImageProvider(const NetworkStyle* network_style);
+
+    QPixmap requestPixmap(const QString& id, QSize* size, const QSize& requested_size) override;
+
+private:
+    const NetworkStyle* m_network_style;
+};
+
+#endif // BITCOIN_QML_IMAGEPROVIDER_H

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -13,9 +13,20 @@ ApplicationWindow {
     title: "Bitcoin Core TnG"
     minimumWidth: 750
     minimumHeight: 450
+    background: Rectangle {
+        color: "black"
+    }
     visible: true
 
     Component.onCompleted: nodeModel.startNodeInitializionThread();
+
+    Image {
+        id: appLogo
+        anchors.horizontalCenter: parent.horizontalCenter
+        source: "image://images/app"
+        sourceSize.width: 128
+        sourceSize.height: 128
+    }
 
     BitcoinCoreComponents.BlockCounter {
         id: blockCounter


### PR DESCRIPTION
The new `ImageProvider` class allows images in QML to be loaded using `QPixmap`s.

The last commit is a demo for our fellow designers.

For testing this PR one can run `bitcoin-qt` with different values of the `-chain=...` command-line option.