### PR TITLE
Do not swallow QML error messages

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -6,6 +6,7 @@
 
 #include <init.h>
 #include <interfaces/node.h>
+#include <logging.h>
 #include <node/context.h>
 #include <node/ui_interface.h>
 #include <noui.h>
@@ -25,8 +26,13 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QQuickWindow>
+#include <QString>
 #include <QStringLiteral>
 #include <QUrl>
+
+QT_BEGIN_NAMESPACE
+class QMessageLogContext;
+QT_END_NAMESPACE
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
@@ -60,6 +66,17 @@ bool InitErrorMessageBox(
     }
     qGuiApp->exec();
     return false;
+}
+
+/* qDebug() message handler --> debug.log */
+void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg)
+{
+    Q_UNUSED(context);
+    if (type == QtDebugMsg) {
+        LogPrint(BCLog::QT, "GUI: %s\n", msg.toStdString());
+    } else {
+        LogPrintf("GUI: %s\n", msg.toStdString());
+    }
 }
 } // namespace
 
@@ -153,6 +170,9 @@ int QmlGuiMain(int argc, char* argv[])
     if (!window) {
         return EXIT_FAILURE;
     }
+
+    // Install qDebug() message handler to route to debug.log
+    qInstallMessageHandler(DebugMessageHandler);
 
     qInfo() << "Graphics API in use:" << QmlUtil::GraphicsApi(window);
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -187,6 +187,17 @@ static bool InitSettings()
     return true;
 }
 
+/* qDebug() message handler --> debug.log */
+void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &msg)
+{
+    Q_UNUSED(context);
+    if (type == QtDebugMsg) {
+        LogPrint(BCLog::QT, "GUI: %s\n", msg.toStdString());
+    } else {
+        LogPrintf("GUI: %s\n", msg.toStdString());
+    }
+}
+
 static int qt_argc = 1;
 static const char* qt_argv = "bitcoin-qt";
 
@@ -579,7 +590,8 @@ int GuiMain(int argc, char* argv[])
     // Install global event filter for processing Windows session related Windows messages (WM_QUERYENDSESSION and WM_ENDSESSION)
     qApp->installNativeEventFilter(new WinShutdownMonitor());
 #endif
-
+    // Install qDebug() message handler to route to debug.log
+    qInstallMessageHandler(DebugMessageHandler);
     // Allow parameter interaction before we create the options model
     app.parameterSetup();
     GUIUtil::LogQtInfo();

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -13,23 +13,17 @@
 #endif // USE_QML
 
 #include <interfaces/node.h>
-#include <logging.h>
 #include <noui.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
 #include <util/url.h>
 
+#include <QCoreApplication>
+
 #include <functional>
 #include <string>
 #include <tuple>
-
-#include <QCoreApplication>
-#include <QString>
-
-QT_BEGIN_NAMESPACE
-class QMessageLogContext;
-QT_END_NAMESPACE
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
@@ -48,19 +42,6 @@ extern const std::function<std::string(const char*)> G_TRANSLATION_FUN = [](cons
 };
 UrlDecodeFn* const URL_DECODE = urlDecode;
 
-namespace {
-/* qDebug() message handler --> debug.log */
-void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg)
-{
-    Q_UNUSED(context);
-    if (type == QtDebugMsg) {
-        LogPrint(BCLog::QT, "GUI: %s\n", msg.toStdString());
-    } else {
-        LogPrintf("GUI: %s\n", msg.toStdString());
-    }
-}
-} // namespace
-
 int main(int argc, char* argv[])
 {
     qRegisterMetaType<interfaces::BlockAndHeaderTipInfo>("interfaces::BlockAndHeaderTipInfo");
@@ -75,9 +56,6 @@ int main(int argc, char* argv[])
 
     // Subscribe to global signals from core.
     noui_connect();
-
-    // Install qDebug() message handler to route to debug.log
-    qInstallMessageHandler(DebugMessageHandler);
 
 #if USE_QML
     return QmlGuiMain(argc, argv);


### PR DESCRIPTION
After #25 error messages in `QQmlApplicationEngine::load` call are effectively swallowed because they are routed into our logging facility which has no chance to print them by `return EXIT_FAILURE;`.

The duplication of the `DebugMessageHandler` function could be addressed later, after integrating this repo into the main one.