### PR TITLE
Fixed width for BlockCounter

### DIFF
--- a/src/qml/components/BlockCounter.qml
+++ b/src/qml/components/BlockCounter.qml
@@ -16,6 +16,6 @@ Label {
     padding: 16
     horizontalAlignment: Text.AlignHCenter
     verticalAlignment: Text.AlignVCenter
-    font.pixelSize: height / 3
+    font.pixelSize: (parent.height / 15 + parent.width / 15) / 2
     text: blockHeight
 }

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -20,6 +20,7 @@ ApplicationWindow {
         id: blockCounter
         anchors.centerIn: parent
         height: parent.height / 3
+        width: parent.width / 2.67
         blockHeight: nodeModel.blockTipHeight
     }
 }


### PR DESCRIPTION
Without this, BlockCounter is continuously changing width
unnecessarily. With a fixed width BlockCounter, visual output doesn't
change more than strictly necessary. At current window min size, this
width fits up to 9 digits, which is enough to fit all of main, test
and signature networks.

You can spot the difference these changes add by creating two dummy
data directories and bootstrapping one with this change and
bootstrapping the other one without this change.
