### PR TITLE
build: Fix `make distdir`

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -292,7 +292,10 @@ BITCOIN_QML_BASE_CPP = \
 
 QML_QRC_CPP = qml/qrc_bitcoin.cpp
 QML_QRC = qml/bitcoin_qml.qrc
-RES_QML = $(wildcard $(srcdir)/qml/pages/*.qml)
+QML_RES_QML = \
+  qml/components/BlockCounter.qml \
+  qml/pages/initerrormessage.qml \
+  qml/pages/stub.qml
 
 BITCOIN_QT_CPP = $(BITCOIN_QT_BASE_CPP)
 if TARGET_WINDOWS
@@ -322,7 +325,7 @@ endif
 nodist_qt_libbitcoinqt_a_SOURCES = $(QT_MOC_CPP) $(QT_MOC) $(QT_QRC_CPP) $(QT_QRC_LOCALE_CPP)
 
 if BUILD_WITH_QML
-  qt_libbitcoinqt_a_SOURCES += $(BITCOIN_QML_BASE_CPP) $(QML_QRC) $(RES_QML)
+  qt_libbitcoinqt_a_SOURCES += $(BITCOIN_QML_BASE_CPP) $(QML_QRC) $(QML_RES_QML)
   nodist_qt_libbitcoinqt_a_SOURCES += $(QML_QRC_CPP)
 endif # BUILD_WITH_QML
 
@@ -396,7 +399,7 @@ $(QT_QRC_CPP): $(QT_QRC) $(QT_FORMS_H) $(RES_FONTS) $(RES_ICONS) $(RES_ANIMATION
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(RCC) -name bitcoin --format-version 1 $< > $@
 
 if BUILD_WITH_QML
-$(QML_QRC_CPP): $(QML_QRC) $(RES_QML)
+$(QML_QRC_CPP): $(QML_QRC) $(QML_RES_QML)
 	@test -f $(RCC)
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(RCC) --name bitcoin_qml --format-version 1 $< > $@
 endif # BUILD_WITH_QML


### PR DESCRIPTION
Currently (a8dbc010c57d1fc655ad8325e7f685954b950acc):
```
$ make distdir
make  distdir-am
make[1]: Entering directory '/home/hebasto/GitHub/gui-qml'
if test -d "bitcoin-22.99.0"; then find "bitcoin-22.99.0" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "bitcoin-22.99.0" || { sleep 5 && rm -rf "bitcoin-22.99.0"; }; else :; fi
test -d "bitcoin-22.99.0" || mkdir "bitcoin-22.99.0"
 (cd src && make  top_distdir=../bitcoin-22.99.0 distdir=../bitcoin-22.99.0/src \
     am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
make[2]: Entering directory '/home/hebasto/GitHub/gui-qml/src'
make  distdir-am
make[3]: Entering directory '/home/hebasto/GitHub/gui-qml/src'
make[3]: *** No rule to make target 'qml/pages/*.qml)', needed by 'distdir-am'.  Stop.
make[3]: Leaving directory '/home/hebasto/GitHub/gui-qml/src'
make[2]: *** [Makefile:16725: distdir] Error 2
make[2]: Leaving directory '/home/hebasto/GitHub/gui-qml/src'
make[1]: *** [Makefile:932: distdir-am] Error 1
make[1]: Leaving directory '/home/hebasto/GitHub/gui-qml'
make: *** [Makefile:926: distdir] Error 2
```