### PR TITLE
build: Fix compiling with GCC 11

### DIFF
--- a/depends/patches/qt/fix_limits_header.patch
+++ b/depends/patches/qt/fix_limits_header.patch
@@ -7,6 +7,17 @@ Upstream commits:
  - Qt 6.0: b2af6332ea37e45ab230a7a5d2d278f86d961b83
  - Qt 6.1: 9c56d4da2ff631a8c1c30475bd792f6c86bda53c
 
+Details of a patch for qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h:
+ - upstream bug: not submitted
+ - upstream commits:
+   - Qt 5.15 -- unavailable as open source
+   - Qt 6.1: 150bd8e33bc6f79906f711a74cf3fe6831bf05ac
+   - Qt 6.2: 367293b18ab0d0a0432c1c8ce445fee052e5eee5
+
+A patch for qtdeclarative/src/qml/jsruntime/qv4propertykey_p.h can be
+dropped after the commit 68b7a66a6e4d673d11aab44cb87b3f005cdff8ea
+in Qt 5.14.
+
 --- old/qtbase/src/corelib/global/qendian.h
 +++ new/qtbase/src/corelib/global/qendian.h
 @@ -44,6 +44,8 @@
@@ -42,3 +53,26 @@ Upstream commits:
  #include <math.h>
  #include <stdio.h>
  
+
+--- old/qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h
++++ old/qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h
+@@ -48,6 +48,7 @@
+ #include <QtCore/qmetatype.h>
+ 
+ #include <initializer_list>
++#include <limits>
+ #include <type_traits>
+ 
+ //
+
+--- old/qtdeclarative/src/qml/jsruntime/qv4propertykey_p.h
++++ new/qtdeclarative/src/qml/jsruntime/qv4propertykey_p.h
+@@ -52,6 +52,8 @@
+ 
+ #include <private/qv4global_p.h>
+ 
++#include <limits>
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QString


### PR DESCRIPTION
Currently (a8dbc010c57d1fc655ad8325e7f685954b950acc), building the `qt` package in depends with GCC 11 fails:
```
$ gcc --version
gcc (Ubuntu 11.1.0-1ubuntu1~21.04) 11.1.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ make -C depends qt
...
In file included from ../../include/QtQml/5.12.11/QtQml/private/qv4propertykey_p.h:1,
                 from ../../include/QtQml/5.12.11/QtQml/private/../../../../../src/qml/jsruntime/qv4internalclass_p.h:56,
                 from ../../include/QtQml/5.12.11/QtQml/private/qv4internalclass_p.h:1,
                 from ../qml/jsruntime/qv4value_p.h:59,
                 from ../qml/jsruntime/qv4managed_p.h:54,
                 from ../qml/jsruntime/qv4engine_p.h:54,
                 from ../qml/jsruntime/qv4engine.cpp:39:
../../include/QtQml/5.12.11/QtQml/private/../../../../../src/qml/jsruntime/qv4propertykey_p.h: In member function ‘uint QV4::PropertyKey::asArrayIndex() const’:
../../include/QtQml/5.12.11/QtQml/private/../../../../../src/qml/jsruntime/qv4propertykey_p.h:116:73: error: ‘numeric_limits’ is not a member of ‘std’
  116 |     uint asArrayIndex() const { return (isManaged() || val == 0) ? std::numeric_limits<uint>::max() : static_cast<uint>(val & 0xffffffff); }
      |                                                                         ^~~~~~~~~~~~~~
../../include/QtQml/5.12.11/QtQml/private/../../../../../src/qml/jsruntime/qv4propertykey_p.h:116:92: error: expected primary-expression before ‘>’ token
  116 |     uint asArrayIndex() const { return (isManaged() || val == 0) ? std::numeric_limits<uint>::max() : static_cast<uint>(val & 0xffffffff); }
      |                                                                                            ^
../../include/QtQml/5.12.11/QtQml/private/../../../../../src/qml/jsruntime/qv4propertykey_p.h:116:95: error: ‘::max’ has not been declared; did you mean ‘std::max’?
  116 |     uint asArrayIndex() const { return (isManaged() || val == 0) ? std::numeric_limits<uint>::max() : static_cast<uint>(val & 0xffffffff); }
      |                                                                                               ^~~
      |                                                                                               std::max
```

This is similar to the https://github.com/bitcoin/bitcoin/pull/22186.
