### PR TITLE
Drop erroneous `#include <QStringLiteral>`

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -33,7 +33,6 @@
 #include <QQmlContext>
 #include <QQuickWindow>
 #include <QString>
-#include <QStringLiteral>
 #include <QUrl>
 
 QT_BEGIN_NAMESPACE


### PR DESCRIPTION
To use the [`QStringLiteral`](https://doc.qt.io/qt-5.12/qstring.html#QStringLiteral) macro, the [`QString`](https://doc.qt.io/qt-5.12/qstring.html) header should be included, that is done already.

The wrong header was added in #5.