### PR TITLE
Avoid applying of a patch with fuzz 1

### DIFF
--- a/depends/patches/qt/fix_limits_header.patch
+++ b/depends/patches/qt/fix_limits_header.patch
@@ -55,7 +55,7 @@ in Qt 5.14.
  
 
 --- old/qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h
-+++ old/qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h
++++ new/qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h
 @@ -48,6 +48,7 @@
  #include <QtCore/qmetatype.h>
  
@@ -67,12 +67,11 @@ in Qt 5.14.
 
 --- old/qtdeclarative/src/qml/jsruntime/qv4propertykey_p.h
 +++ new/qtdeclarative/src/qml/jsruntime/qv4propertykey_p.h
-@@ -52,6 +52,8 @@
+@@ -51,6 +51,7 @@
+ //
  
  #include <private/qv4global_p.h>
- 
 +#include <limits>
-+
+ 
  QT_BEGIN_NAMESPACE
  
- class QString


### PR DESCRIPTION
On 48a13bf2a6f5c709392a1a2893614ff77f952a53:
```
$ make -j 9 -C depends qt_preprocessed
make: Entering directory '/home/hebasto/GitHub/gui-qml/depends'
Extracting qt...
/home/hebasto/GitHub/gui-qml/depends/sources/qtbase-everywhere-src-5.12.11.tar.xz: OK
/home/hebasto/GitHub/gui-qml/depends/sources/qtdeclarative-everywhere-src-5.12.11.tar.xz: OK
/home/hebasto/GitHub/gui-qml/depends/sources/qtgraphicaleffects-everywhere-src-5.12.11.tar.xz: OK
/home/hebasto/GitHub/gui-qml/depends/sources/qtquickcontrols-everywhere-src-5.12.11.tar.xz: OK
/home/hebasto/GitHub/gui-qml/depends/sources/qtquickcontrols2-everywhere-src-5.12.11.tar.xz: OK
/home/hebasto/GitHub/gui-qml/depends/sources/qttranslations-everywhere-src-5.12.11.tar.xz: OK
/home/hebasto/GitHub/gui-qml/depends/sources/qttools-everywhere-src-5.12.11.tar.xz: OK
Preprocessing qt...
patching file qtbase/configure
patching file qtbase/mkspecs/features/qt_module.prf
patching file qtbase/src/plugins/platforms/cocoa/qprintengine_mac_p.h
patching file qtbase/src/plugins/plugins.pro
patching file qtbase/mkspecs/android-clang/qmake.conf
patching file qtbase/mkspecs/common/android-base-head.conf
patching file qtbase/mkspecs/common/android-base-tail.conf
patching file qtbase/src/plugins/platforms/android/androidjnimain.cpp
patching file qtbase/mkspecs/common/android-base-head.conf
patching file qtbase/src/plugins/platforms/xcb/qxcbcursor.cpp
patching file qtbase/mkspecs/features/mac/default_post.prf
patching file qtbase/mkspecs/common/mac.conf
patching file qtbase/mkspecs/features/qmake_use.prf
patching file qtbase/mkspecs/features/qt_configure.prf
patching file qtbase/src/tools/moc/main.cpp
patching file qtbase/src/corelib/global/qendian.h
patching file qtbase/src/corelib/tools/qbytearraymatcher.h
patching file qtbase/src/tools/moc/generator.cpp
patching file qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h
patching file qtdeclarative/src/qml/jsruntime/qv4propertykey_p.h
Hunk #1 succeeded at 52 with fuzz 1.
patching file qtdeclarative/qtdeclarative.pro
patching file qtdeclarative/src/3rdparty/masm/masm.pri
patching file qtdeclarative/src/qml/configure.json
patching file qtdeclarative/src/qml/configure.pri
patching file qtdeclarative/src/qml/qml.pro
patching file qtbase/src/corelib/global/archdetect.cpp
patching file qtbase/src/corelib/global/qprocessordetection.h
patching file qtdeclarative/src/qml/qml.pro
make: Leaving directory '/home/hebasto/GitHub/gui-qml/depends'
```

The ARM CI task just [fails](https://api.cirrus-ci.com/v1/task/5152205419315200/logs/ci.log):
```
Hunk 1 FAILED 52/52.
 
 #include <private/qv4global_p.h>
 
+#include <limits>
+
 QT_BEGIN_NAMESPACE
 
 class QString
```

This PR fixes this issue.
Also a typo fixed.