### PR TITLE
Include missed <cassert> headers

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -24,6 +24,7 @@
 #include <util/translation.h>
 
 #include <boost/signals2/connection.hpp>
+#include <cassert>
 #include <memory>
 #include <tuple>
 

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -7,6 +7,8 @@
 #include <interfaces/node.h>
 #include <validation.h>
 
+#include <cassert>
+
 NodeModel::NodeModel(interfaces::Node& node)
     : m_node{node}
 {

--- a/src/qml/util.cpp
+++ b/src/qml/util.cpp
@@ -4,6 +4,7 @@
 
 #include <qml/util.h>
 
+#include <cassert>
 #include <string>
 
 #include <QQuickWindow>


### PR DESCRIPTION
CI log [excerpt](https://api.cirrus-ci.com/v1/task/5482291775406080/logs/ci.log) from #54:
```
qml/util.cpp: In function ‘QString QmlUtil::GraphicsApi(QQuickWindow*)’:
qml/util.cpp:31:5: error: ‘assert’ was not declared in this scope
     assert(false);
     ^~~~~~
qml/util.cpp:31:5: note: ‘assert’ is defined in header ‘<cassert>’; did you forget to ‘#include <cassert>’?
```