### PR TITLE
ci: temporarily disable failing ci task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -174,15 +174,15 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_win64.sh"
 
-task:
-  name: '32-bit + dash [gui] [CentOS 8]'
-  << : *GLOBAL_TASK_TEMPLATE
-  container:
-    image: centos:8
-  env:
-    << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    PACKAGE_MANAGER_INSTALL: "yum install -y"
-    FILE_ENV: "./ci/test/00_setup_env_i686_centos.sh"
+#task:
+#  name: '32-bit + dash [gui] [CentOS 8]'
+#  << : *GLOBAL_TASK_TEMPLATE
+#  container:
+#    image: centos:8
+#  env:
+#    << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
+#    PACKAGE_MANAGER_INSTALL: "yum install -y"
+#    FILE_ENV: "./ci/test/00_setup_env_i686_centos.sh"
 
 task:
   name: '[previous releases, uses qt5 dev package and some depends packages, DEBUG] [unsigned char] [bionic]'


### PR DESCRIPTION
Temporarily disable the `32-bit + dash [gui] [CentOS 8]` task. The task currently fails on master and needs a fix: https://cirrus-ci.com/task/4928128318439424

For now, and to not have this distract, let's disable the task. The PR that introduces a fix should also re-enable the task.
