### PR TITLE
Discard QtQuickControls1Plugin since it is not used

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -140,9 +140,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       if test -d "$qt_plugin_path/platforms/android"; then
         QT_LIBS="$QT_LIBS -L$qt_plugin_path/platforms/android -lqtfreetype -lEGL"
       fi
-      if test -d "$qt_plugin_path/../qml/QtQuick/Controls"; then
-        QT_LIBS="$QT_LIBS -L$qt_plugin_path/../qml/QtQuick/Controls"
-      fi
       if test -d "$qt_plugin_path/../qml/QtQuick/Controls.2"; then
         QT_LIBS="$QT_LIBS -L$qt_plugin_path/../qml/QtQuick/Controls.2"
       fi
@@ -196,7 +193,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuick2DialogsPlugin], [-ldialogplugin])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuick2Plugin], [-lqtquick2plugin])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuick2WindowPlugin], [-lwindowplugin])
-      _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickControls1Plugin], [-lqtquickcontrolsplugin])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickControls2Plugin], [-lqtquickcontrols2plugin])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickLayoutsPlugin], [-lqquicklayoutsplugin])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickTemplates2Plugin], [-lqtquicktemplates2plugin])

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -45,7 +45,6 @@ QT_END_NAMESPACE
 Q_IMPORT_PLUGIN(QtQuick2DialogsPlugin);
 Q_IMPORT_PLUGIN(QtQuick2Plugin);
 Q_IMPORT_PLUGIN(QtQuick2WindowPlugin);
-Q_IMPORT_PLUGIN(QtQuickControls1Plugin);
 Q_IMPORT_PLUGIN(QtQuickControls2Plugin);
 Q_IMPORT_PLUGIN(QtQuickLayoutsPlugin);
 Q_IMPORT_PLUGIN(QtQuickTemplates2Plugin);


### PR DESCRIPTION
I don't think we want to use/mix QtQuick controls version 1 and version 2.