### PR TITLE
Set tab focus behavior

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -34,6 +34,7 @@
 #include <QQmlContext>
 #include <QQuickWindow>
 #include <QString>
+#include <QStyleHints>
 #include <QUrl>
 
 QT_BEGIN_NAMESPACE
@@ -98,6 +99,7 @@ int QmlGuiMain(int argc, char* argv[])
     Q_INIT_RESOURCE(bitcoin_qml);
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication::styleHints()->setTabFocusBehavior(Qt::TabFocusAllControls);
     QGuiApplication app(argc, argv);
 
     auto handler_message_box = ::uiInterface.ThreadSafeMessageBox_connect(InitErrorMessageBox);


### PR DESCRIPTION
Sets tab focus behavior to iterate all controls and widgets.

Can be tested after adding some controls to the scene.