### PR TITLE
Fix qt_libbitcoinqt_a_SOURCES

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -328,11 +328,6 @@ endif
 
 nodist_qt_libbitcoinqt_a_SOURCES = $(QT_MOC_CPP) $(QT_MOC) $(QT_QRC_CPP) $(QT_QRC_LOCALE_CPP)
 
-if BUILD_WITH_QML
-  qt_libbitcoinqt_a_SOURCES += $(BITCOIN_QML_BASE_CPP) $(QML_QRC) $(QML_RES_FONTS) $(QML_RES_QML)
-  nodist_qt_libbitcoinqt_a_SOURCES += $(QML_QRC_CPP)
-endif # BUILD_WITH_QML
-
 # forms/foo.h -> forms/ui_foo.h
 QT_FORMS_H=$(join $(dir $(QT_FORMS_UI)),$(addprefix ui_, $(notdir $(QT_FORMS_UI:.ui=.h))))
 
@@ -406,6 +401,9 @@ if BUILD_WITH_QML
 $(QML_QRC_CPP): $(QML_QRC) $(QML_RES_FONTS) $(QML_RES_QML)
 	@test -f $(RCC)
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(RCC) --name bitcoin_qml --format-version 1 $< > $@
+
+qt_libbitcoinqt_a_SOURCES += $(BITCOIN_QML_BASE_CPP) $(QML_QRC_CPP)
+nodist_qt_libbitcoinqt_a_SOURCES += $(QML_QRC_CPP)
 endif # BUILD_WITH_QML
 
 CLEAN_QT = $(nodist_qt_libbitcoinqt_a_SOURCES) $(QT_QM) $(QT_FORMS_H) qt/*.gcda qt/*.gcno qt/temp_bitcoin_locale.qrc


### PR DESCRIPTION
The correct dependency is QML_QRC_CPP which already depends on QML_QRC 
and QML_RES_QML and probably others later on.