### PR TITLE
doc: introduce icon policy documentation

### DIFF
--- a/src/qml/doc/icon-policy.md
+++ b/src/qml/doc/icon-policy.md
@@ -1,0 +1,39 @@
+# Icon policy
+This document provides guidelines for contributing icons to Bitcoin Core.
+
+## Preparing Icons
+Both an icon source file, in Scalable Vector Graphics (SVG) format,
+and an optimized production file, in Portable Network Graphics (PNG) format,
+are required for each icon.
+
+#### SVG Source File
+SVGs are used as source files because they can scale while retaining image quality.
+They are not used in production due to limited application support.
+If different-sized production (PNG) icons are required,
+they can be generated from the associated SVG source file in any vector-based tool.
+
+#### PNG Production File
+PNGs are used in production due to wide application support, transparency support,
+and better image quality compared to competing file types such as JPEG.
+
+#### Optimizing Production Files (PNG)
+Production (PNG) files must be processed by the [optimize-png.py](https://github.com/bitcoin-core/bitcoin-maintainer-tools/blob/master/optimise-pngs.py) script before their inclusion in Bitcoin Core.
+PNG optimization removes various unnecessary color profiles, ancillary data,
+and text chunks, resulting in a lossless file size reduction.
+
+## Contributing
+Bitcoin Core primarily uses icons from the [Bitcoin Icon set](https://github.com/BitcoinDesign/Bitcoin-Icons),
+an open source icon set made for Bitcoin applications.
+If a proposed feature requires an icon to be designed,
+an issue should be opened in the [Bitcoin Icons repo](https://github.com/BitcoinDesign/Bitcoin-Icons/issues)
+with the request.
+
+Icons are not to be added to Bitcoin Core prior to a production use case.
+If an icon is not being used, it should be removed.
+
+SVGs are to be included under the `src/qml/res/src` directory.
+Optimized PNGs are to be included under the `src/qml/res/icons` directory.
+
+## Attribution
+Icon additions must include appropriate attribution to the author, license information, and any comments relevant to the icon documented under the
+[contrib/debian/copyright](../../../contrib/debian/copyright) file.


### PR DESCRIPTION
Moved from https://github.com/bitcoin-core/gui/pull/310

Picking up https://github.com/bitcoin-core/gui/pull/178

This introduces documented policies for how icons should be prepared, optimized, styled, contributed, and attributed within Bitcoin Core. Having guidelines for iconography helps with making applications more consistent and efficient.


[document render](https://github.com/bitcoin-core/gui-qml/blob/23ad199b43e9068d0571eba5965752b03842a7f4/src/qml/doc/icon-policy.md)