### PR TITLE
ci: Make macOS static bitcoin-qt available from CI task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -267,6 +267,8 @@ task:
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_mac.sh"
+  macos_bitcoin_qt_artifacts:
+    path: "ci/scratch/build/bitcoin-x86_64-apple-darwin19/src/qt/bitcoin-qt"
 
 task:
   name: 'macOS 11 native [gui] [no depends]'


### PR DESCRIPTION
This PR makes `bitcoin-qt` available for downloading from CI for each PR.

Being downloaded it is required to make it executable with `chmod +x bitcoin-qt`.

Similar to #71.

A link to download: https://api.cirrus-ci.com/v1/artifact/build/5223626531143680/macos_bitcoin_qt.zip