### PR TITLE
ci: Prefix artifacts names with insecure_ as CI cannot be trusted

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -186,8 +186,10 @@ task:
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_win64.sh"
-  bitcoin_qt_artifacts:
-    path: "ci/scratch/build/bitcoin-x86_64-w64-mingw32/release/bitcoin-qt.exe"
+  copy_artifacts_script:
+    - cp ci/scratch/build/bitcoin-x86_64-w64-mingw32/release/bitcoin-qt.exe insecure_win_gui.exe
+  insecure_win_gui_artifacts:
+    path: "insecure_win_gui.exe"
 
 #task:
 #  name: '32-bit + dash [gui] [CentOS 8]'
@@ -282,8 +284,12 @@ task:
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_mac.sh"
-  macos_bitcoin_qt_artifacts:
-    path: "ci/scratch/build/bitcoin-x86_64-apple-darwin19/src/qt/bitcoin-qt"
+  copy_artifacts_script:
+    - cp ci/scratch/build/bitcoin-x86_64-apple-darwin19/src/qt/bitcoin-qt insecure_mac_gui
+    - tar -czf insecure_mac_gui.tar.gz insecure_mac_gui
+  insecure_mac_gui_artifacts:
+    path: "insecure_mac_gui.tar.gz"
+    type: "application/gzip"
 
 task:
   name: 'macOS 11 native [gui] [no depends]'


### PR DESCRIPTION
https://github.com/bitcoin-core/gui-qml/pull/73#discussion_r738302994:
> wouldn't it be good to prefix the artifact name with `insecure_`, as the CI can't be trusted?

https://github.com/bitcoin-core/gui-qml/pull/73#discussion_r738303781:
> Wouldn't it be a better UX to move the file to a top level directory first?
> 
> Wouldn't it be better to name the file `insecure_gui.exe` or so?

All of the comments above are addressed in this PR.

Links to compressed executable binaries for this PR:
- Windows: https://api.cirrus-ci.com/v1/artifact/build/4507530693967872/insecure_win_gui.zip
- macOS: https://api.cirrus-ci.com/v1/artifact/build/4507530693967872/macOS%2010.15%20[gui,%20no%20tests]%20[focal]/insecure_mac_gui/insecure_mac_gui.tar.gz

