### PR TITLE
build, doc: Ditch QtQuick.Controls 1

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -140,14 +140,8 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       if test -d "$qt_plugin_path/platforms/android"; then
         QT_LIBS="$QT_LIBS -L$qt_plugin_path/platforms/android -lqtfreetype -lEGL"
       fi
-      if test -d "$qt_plugin_path/../qml/QtQuick/Controls"; then
-        QT_LIBS="$QT_LIBS -L$qt_plugin_path/../qml/QtQuick/Controls"
-      fi
       if test -d "$qt_plugin_path/../qml/QtQuick/Controls.2"; then
         QT_LIBS="$QT_LIBS -L$qt_plugin_path/../qml/QtQuick/Controls.2"
-      fi
-      if test -d "$qt_plugin_path/../qml/QtQuick/Dialogs"; then
-        QT_LIBS="$QT_LIBS -L$qt_plugin_path/../qml/QtQuick/Dialogs"
       fi
       if test -d "$qt_plugin_path/../qml/QtQuick/Layouts"; then
         QT_LIBS="$QT_LIBS -L$qt_plugin_path/../qml/QtQuick/Layouts"
@@ -193,10 +187,8 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       AC_DEFINE(QT_QPA_PLATFORM_ANDROID, 1, [Define this symbol if the qt platform is android])
     fi
     if test "x$use_qml" != xno; then
-      _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuick2DialogsPlugin], [-ldialogplugin])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuick2Plugin], [-lqtquick2plugin])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuick2WindowPlugin], [-lwindowplugin])
-      _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickControls1Plugin], [-lqtquickcontrolsplugin])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickControls2Plugin], [-lqtquickcontrols2plugin])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickLayoutsPlugin], [-lqquicklayoutsplugin])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickTemplates2Plugin], [-lqtquicktemplates2plugin])

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -21,9 +21,6 @@ $(package)_qtdeclarative_sha256_hash = 1267e029abc8424424c419bc1681db069ec76e512
 $(package)_qtgraphicaleffects_file_name = qtgraphicaleffects-$($(package)_suffix)
 $(package)_qtgraphicaleffects_sha256_hash = d84490104965fb5e831b3d1b9ce72786071e9bdd8080deb07ee1ed189f3eda0a
 
-$(package)_qtquickcontrols_file_name = qtquickcontrols-$($(package)_suffix)
-$(package)_qtquickcontrols_sha256_hash = cd6b81fda691ab15d25ac60b6a3437667a892e401438e07a64c88cadd3481389
-
 $(package)_qtquickcontrols2_file_name = qtquickcontrols2-$($(package)_suffix)
 $(package)_qtquickcontrols2_sha256_hash = c05585f42db7c17fb7f344f8a9cabd38a4e9dff17b3d04ec35e8edab7ead355c
 
@@ -35,7 +32,6 @@ $(package)_qttools_sha256_hash=98b2aaca230458f65996f3534fd471d2ffd038dd58ac997c0
 
 $(package)_extra_sources += $($(package)_qtdeclarative_file_name)
 $(package)_extra_sources += $($(package)_qtgraphicaleffects_file_name)
-$(package)_extra_sources += $($(package)_qtquickcontrols_file_name)
 $(package)_extra_sources += $($(package)_qtquickcontrols2_file_name)
 $(package)_extra_sources += $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)
@@ -201,7 +197,6 @@ define $(package)_fetch_cmds
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtdeclarative_file_name),$($(package)_qtdeclarative_file_name),$($(package)_qtdeclarative_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtgraphicaleffects_file_name),$($(package)_qtgraphicaleffects_file_name),$($(package)_qtgraphicaleffects_sha256_hash)) && \
-$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtquickcontrols_file_name),$($(package)_qtquickcontrols_file_name),$($(package)_qtquickcontrols_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtquickcontrols2_file_name),$($(package)_qtquickcontrols2_file_name),$($(package)_qtquickcontrols2_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttranslations_file_name),$($(package)_qttranslations_file_name),$($(package)_qttranslations_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttools_file_name),$($(package)_qttools_file_name),$($(package)_qttools_sha256_hash))
@@ -212,7 +207,6 @@ define $(package)_extract_cmds
   echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_qtdeclarative_sha256_hash)  $($(package)_source_dir)/$($(package)_qtdeclarative_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_qtgraphicaleffects_sha256_hash)  $($(package)_source_dir)/$($(package)_qtgraphicaleffects_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
-  echo "$($(package)_qtquickcontrols_sha256_hash)  $($(package)_source_dir)/$($(package)_qtquickcontrols_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_qtquickcontrols2_sha256_hash)  $($(package)_source_dir)/$($(package)_qtquickcontrols2_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_qttranslations_sha256_hash)  $($(package)_source_dir)/$($(package)_qttranslations_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_qttools_sha256_hash)  $($(package)_source_dir)/$($(package)_qttools_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
@@ -223,8 +217,6 @@ define $(package)_extract_cmds
   tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtdeclarative_file_name) -C qtdeclarative && \
   mkdir qtgraphicaleffects && \
   tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtgraphicaleffects_file_name) -C qtgraphicaleffects && \
-  mkdir qtquickcontrols && \
-  tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtquickcontrols_file_name) -C qtquickcontrols && \
   mkdir qtquickcontrols2 && \
   tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtquickcontrols2_file_name) -C qtquickcontrols2 && \
   mkdir qttranslations && \
@@ -297,7 +289,6 @@ define $(package)_stage_cmds
   export PATH && \
   $(MAKE) -C qtbase/src INSTALL_ROOT=$($(package)_staging_dir) $(addsuffix -install_subtargets,$(addprefix sub-,$($(package)_qt_libs))) && \
   $(MAKE) -C qtdeclarative INSTALL_ROOT=$($(package)_staging_dir) sub-src-install_subtargets && \
-  $(MAKE) -C qtquickcontrols INSTALL_ROOT=$($(package)_staging_dir) install && \
   $(MAKE) -C qtquickcontrols2 INSTALL_ROOT=$($(package)_staging_dir) sub-src-install_subtargets && \
   $(MAKE) -C qttools/src/linguist INSTALL_ROOT=$($(package)_staging_dir) $(addsuffix -install_subtargets,$(addprefix sub-,$($(package)_linguist_tools))) && \
   $(MAKE) -C qttranslations INSTALL_ROOT=$($(package)_staging_dir) install_subtargets

--- a/depends/patches/qt/qt.pro
+++ b/depends/patches/qt/qt.pro
@@ -8,11 +8,10 @@ CONFIG += $$prl
 cache(CONFIG, add stash, prl)
 
 TEMPLATE = subdirs
-SUBDIRS = qtbase qtdeclarative qtgraphicaleffects qtquickcontrols qtquickcontrols2 qttools qttranslations
+SUBDIRS = qtbase qtdeclarative qtgraphicaleffects qtquickcontrols2 qttools qttranslations
 
 qtdeclarative.depends = qtbase
 qtgraphicaleffects.depends = qtdeclarative
-qtquickcontrols.depends = qtdeclarative
 qtquickcontrols2.depends = qtgraphicaleffects
 qttools.depends = qtbase
 qttranslations.depends = qttools

--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -51,7 +51,7 @@ The following runtime dependencies are also required for dynamic builds;
 they are not needed for static builds:
 
 ```
-sudo apt install qml-module-qtquick2 qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-layouts qml-module-qtquick-window2
+sudo apt install qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qtquick-window2
 ```
 
 No additional dependencies, besides those in [build-osx.md](../../doc/build-osx.md), are needed for macOS.

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -42,10 +42,8 @@ QT_END_NAMESPACE
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
-Q_IMPORT_PLUGIN(QtQuick2DialogsPlugin);
 Q_IMPORT_PLUGIN(QtQuick2Plugin);
 Q_IMPORT_PLUGIN(QtQuick2WindowPlugin);
-Q_IMPORT_PLUGIN(QtQuickControls1Plugin);
 Q_IMPORT_PLUGIN(QtQuickControls2Plugin);
 Q_IMPORT_PLUGIN(QtQuickLayoutsPlugin);
 Q_IMPORT_PLUGIN(QtQuickTemplates2Plugin);

--- a/src/qml/pages/initerrormessage.qml
+++ b/src/qml/pages/initerrormessage.qml
@@ -3,13 +3,23 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import QtQuick 2.12
-import QtQuick.Dialogs 1.3
+import QtQuick.Controls 2.12
 
-MessageDialog {
-    id: messageDialog
+ApplicationWindow {
     title: "Bitcoin Core TnG"
-    icon: StandardIcon.Critical
-    text: message
-    onAccepted: Qt.quit()
-    Component.onCompleted: visible = true
+    visible: true
+    minimumWidth: 500
+    minimumHeight: 200
+
+    Dialog {
+        anchors.centerIn: parent
+        title: qsTr("Error")
+        contentItem:
+            Label {
+                text: message
+            }
+        visible: true
+        standardButtons: Dialog.Ok
+        onAccepted: Qt.quit()
+    }
 }


### PR DESCRIPTION
On the main branch (da6ae1ca919c0df861c5b0dab5c5ea5e77417eaf) the QtQuick.Controls 1 are required only in the `initerrormessage.qml`, which is certainly unimportant for the UX.

This PR suggests a new implementation of the `initerrormessage.qml` without dependencies on QtQuick.Controls 1.

Closes #39.
An alternative to #63.

[![Windows](https://svgshare.com/i/ZhY.svg)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/Win64%20\[unit%20tests,%20no%20gui%20tests,%20no%20boost::process,%20no%20functional%20tests\]%20\[focal\]/insecure_win_gui.zip?branch=pull/77)
[![macOS](https://svgshare.com/i/ZjP.svg)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macOS%2010.15%20\[gui,%20no%20tests\]%20\[focal\]/insecure_mac_gui.zip?branch=pull/77)
