### PR TITLE
ci: Set alias in tasks with artifacts in cirrus.yml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -181,6 +181,7 @@ task:
 task:
   name: 'Win64 [unit tests, no gui tests, no boost::process, no functional tests] [focal]'
   << : *GLOBAL_TASK_TEMPLATE
+  alias: win64
   container:
     image: ubuntu:focal
   env:
@@ -279,6 +280,7 @@ task:
   name: 'macOS 10.15 [gui, no tests] [focal]'
   << : *DEPENDS_SDK_CACHE_TEMPLATE
   << : *GLOBAL_TASK_TEMPLATE
+  alias: macos
   container:
     image: ubuntu:focal
   env:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,6 +45,6 @@ patches often sit for a long time.
 <!--
 Links for Windows and macOS build artifacts. Replace <PR> with the assigned pull request number.
 
-[![Windows](https://svgshare.com/i/ZhY.svg)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/Win64%20\[unit%20tests,%20no%20gui%20tests,%20no%20boost::process,%20no%20functional%20tests\]%20\[focal\]/insecure_win_gui.zip?branch=pull/<PR>)
-[![macOS](https://svgshare.com/i/ZjP.svg)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macOS%2010.15%20\[gui,%20no%20tests\]%20\[focal\]/insecure_mac_gui.zip?branch=pull/<PR>)
+[![Windows](https://svgshare.com/i/ZhY.svg)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/<PR>)
+[![macOS](https://svgshare.com/i/ZjP.svg)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/<PR>)
 -->

--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -3,8 +3,8 @@
 **WARNING: THIS IS EXPERIMENTAL, DO NOT USE BUILDS FROM THIS REPO FOR REAL TRANSACTIONS!**
 
 To test the recent GUI from the main branch, insecure CI artifacts can be used:
-- for Windows: [`insecure_win_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/Win64%20\[unit%20tests,%20no%20gui%20tests,%20no%20boost::process,%20no%20functional%20tests\]%20\[focal\]/insecure_win_gui.zip)
-- for macOS: [`insecure_mac_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macOS%2010.15%20\[gui,%20no%20tests\]%20\[focal\]/insecure_mac_gui.zip)
+- for Windows: [`insecure_win_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip)
+- for macOS: [`insecure_mac_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip)
 
 This directory contains the source code for an experimental Bitcoin Core graphical user interface (GUI) built using the [Qt Quick](https://doc.qt.io/qt-5/qtquick-index.html) framework.
 


### PR DESCRIPTION
This change simplifies artifact links by using the task alias. It also allows changing the task name without breaking artifact links.

[![Windows](https://svgshare.com/i/ZhY.svg)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/79)
[![macOS](https://svgshare.com/i/ZjP.svg)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/79)