### PR TITLE
doc: Add run information to README instructions

### DIFF
--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -71,3 +71,9 @@ you must configure with the following option:
 ```
 ./configure --with-qml
 ```
+### Run
+
+To run the qml GUI:
+```
+./src/qt/bitcoin-qt
+```


### PR DESCRIPTION
The README was missing the run step after the build information. When I was setting up my local environment I found this missing step a bit confusing as to how to actually get the QML GUI running, so I think it would be good to include here.

![image](https://user-images.githubusercontent.com/85003930/146577338-fda3387a-ad4e-455f-a8c0-6dca3f009752.png)

