### PR TITLE
doc: Add Fedora dependency packages

### DIFF
--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -46,10 +46,18 @@ The master branch is only guaranteed to work and build on Debian-based systems a
 Support for more systems will be confirmed and documented as the project matures.
 
 ### Dependencies
-Aside from the dependencies listed in [build-unix.md](../../doc/build-unix.md), Debian based systems require the following additional dependencies to compile:
+Aside from the dependencies listed in [build-unix.md](../../doc/build-unix.md), the following additional dependencies are required to compile:
+
+- on Debian-based systems:
 
 ```
 sudo apt install qtdeclarative5-dev qtquickcontrols2-5-dev
+```
+
+- on Fedora:
+
+```
+sudo dnf install qt5-qtdeclarative-devel qt5-qtquickcontrols2-devel
 ```
 
 The following runtime dependencies are also required for dynamic builds;


### PR DESCRIPTION
This PR adds build dependency package on Fedora.

On my system (Fedora 35) no additional runtime dependencies are required after successful build against system packages.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/92)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/92)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/92)
