### PR TITLE
doc: add Fedora as supported platform, various README fixups

### DIFF
--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -9,7 +9,7 @@ To test the recent GUI from the main branch, insecure CI artifacts can be used:
 
 This directory contains the source code for an experimental Bitcoin Core graphical user interface (GUI) built using the [Qt Quick](https://doc.qt.io/qt-5/qtquick-index.html) framework.
 
-# Goals and Limitations
+## Goals and Limitations
 
 The current Bitcoin Core GUI has gathered enough technical debt and hacked on features; it is time to begin anew.
 This project will start from a clean slate to produce a feature-rich GUI with intuitive user flows and first-class design.
@@ -28,19 +28,19 @@ or improving relevant documentation.
 
 Note that this project will **not** accept pull requests making any significant changes unrelated to the GUI.
 
-# Development Process
+## Development Process
 
 This repo is synced with the [Bitcoin Core repo](https://github.com/bitcoin/bitcoin) on a weekly basis, or as needed to resolve conflicts.
 
 Contributions are welcome from all, developers and designers. If you are a new contributor, please read [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
-## Minimum Required Qt Version
+### Minimum Required Qt Version
 
 All development must adhere to the current upstream Qt Version to minimize our divergence from upstream and avoid costly changes. Review of open PR's must ensure that changes are compatible with this Qt version. Currently, the required version is [Qt 5.12.11](https://github.com/bitcoin-core/gui-qml/blob/a79a2249d027047f08dffe3f04951d52eac198f1/depends/packages/qt.mk#L2).
 
 As the Qt Version changes upstream, refactoring is allowed to use the now available features.
 
-# Compile and Run
+## Compile and Run
 
 The master branch is only guaranteed to work and build on Debian-based systems and macOS.
 Support for more systems will be confirmed and documented as the project matures.

--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -48,11 +48,15 @@ This project has custom policies for development, see:
 
 ## Compile and Run
 
-The master branch is only guaranteed to work and build on Debian-based systems and macOS.
+The master branch is only guaranteed to work and build on Debian-based systems, Fedora, and macOS.
 Support for more systems will be confirmed and documented as the project matures.
 
 ### Dependencies
-Aside from the dependencies listed in [build-unix.md](../../doc/build-unix.md), Debian based systems require the following additional dependencies to compile:
+No additional dependencies, besides those in [build-osx.md](../../doc/build-osx.md), are needed for macOS.
+
+Aside from the dependencies listed in [build-unix.md](../../doc/build-unix.md), the following additional dependencies are required to compile:
+
+#### Debian-based systems:
 
 ```
 sudo apt install qtdeclarative5-dev qtquickcontrols2-5-dev
@@ -65,7 +69,11 @@ they are not needed for static builds:
 sudo apt install qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qtquick-window2
 ```
 
-No additional dependencies, besides those in [build-osx.md](../../doc/build-osx.md), are needed for macOS.
+#### Fedora:
+
+```
+sudo dnf install qt5-qtdeclarative-devel qt5-qtquickcontrols2-devel
+```
 
 ### Build
 

--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -2,12 +2,12 @@
 
 **WARNING: THIS IS EXPERIMENTAL, DO NOT USE BUILDS FROM THIS REPO FOR REAL TRANSACTIONS!**
 
-To test the recent GUI from the main branch, insecure CI artifacts can be used:
+This directory contains the source code for an experimental Bitcoin Core graphical user interface (GUI) built using the [Qt Quick](https://doc.qt.io/qt-5/qtquick-index.html) framework.
+
+Insecure CI artifacts are available for local testing of the master branch, avoiding the need to build:
 - for Windows: [`insecure_win_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip)
 - for macOS: [`insecure_mac_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip)
 - for Android: [`insecure_android_apk.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip)
-
-This directory contains the source code for an experimental Bitcoin Core graphical user interface (GUI) built using the [Qt Quick](https://doc.qt.io/qt-5/qtquick-index.html) framework.
 
 ## Goals and Limitations
 
@@ -21,12 +21,12 @@ The primary goals of the project can be summed up as follows:
 - Work alongside the Bitcoin Design community to develop an aesthetic GUI
 - Develop a mobile-optimized GUI
 
-It is important that we stay as conflict-free as possible with the Bitcoin Core repo.
+We must avoid conflicts with the Bitcoin Core repo.
 As such, this project will aim to make very few changes outside of the qml directory.
 Pull requests must be focused on developing the GUI itself, adding build support,
 or improving relevant documentation.
 
-Note that this project will **not** accept pull requests making any significant changes unrelated to the GUI.
+This project will **not** accept pull requests making any significant changes unrelated to the GUI.
 
 ## Development Process
 
@@ -63,14 +63,15 @@ No additional dependencies, besides those in [build-osx.md](../../doc/build-osx.
 
 ### Build
 
-For instructions on how to build and compile Bitcoin Core, refer to your respective systems build docs.
+For instructions on how to build and compile Bitcoin Core, refer to your respective system's build doc.
 
-To add support for building the qml GUI,
-you must configure with the following option:
+As long as the required dependencies are installed, the qml GUI will be built.
+To ensure that you are in fact building the qml GUI, you can configure with the following option:
 
 ```
 ./configure --with-qml
 ```
+
 ### Run
 
 To run the qml GUI:

--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -40,6 +40,12 @@ All development must adhere to the current upstream Qt Version to minimize our d
 
 As the Qt Version changes upstream, refactoring is allowed to use the now available features.
 
+### Policies
+
+This project has custom policies for development, see:
+- [Icon Policy](./doc/icon-policy.md)
+- [Translator Comments Policy](./doc/translator-comments.md)
+
 ## Compile and Run
 
 The master branch is only guaranteed to work and build on Debian-based systems and macOS.


### PR DESCRIPTION
This adds Fedora as a supported platform and performs various improvements to the qml README. The changes can be summed as follows: 

- 446565de7b68da1ac024554cd718295536c93685
  - Refactor so that there is only one main heading and everything else to be children headings. 
  
- 78dcb133abbfa20e9493699fd53ee64f6ae7f24a
  - Move the sentence that describes what this repo contains to the top.
  - Improve wording around insecure CI artifacts and there availability.
  - Improve wording around avoiding conflicts with upstream.
  - Improve wording around build instructions.

- b7626b73dab51ab7ace66ee14eed2ee7bb5963c3
  - Mentions our documented policies in the README for visibility.

- 3105e95ed7a50e8017e44cb889526e7fc91c17f8
  - Adds Fedora as a supported platform, and documents the required packages.
  - Makes several cleanups to the dependencies section.

**Renders**
- [master render](https://github.com/bitcoin-core/gui-qml/blob/main/src/qml/README.md)
- [PR render](https://github.com/jarolrod/gui-qml/blob/qml-readme-fixup/src/qml/README.md)