### PR TITLE
Add node shutdownRequested detection

### DIFF
--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -39,6 +39,13 @@ void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::Bloc
     setBlockTipHeight(tip_info.block_height);
 }
 
+void NodeModel::detectShutdown()
+{
+    if (m_node.shutdownRequested()) {
+        startNodeShutdown();
+    }
+}
+
 void NodeModel::ConnectToBlockTipSignal()
 {
     assert(!m_handler_notify_block_tip);

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -33,6 +33,7 @@ public:
 
 public Q_SLOTS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
+    void detectShutdown();
 
 Q_SIGNALS:
     void blockTipHeightChanged();


### PR DESCRIPTION
Adds a function to our NodeModel QObject that asks the underlying `m_node` if `shutdownRequested` has been set. If it has been set then it calls `startNodeShutdown`, which emits `requestedShutdown`. The emitted signal can then be used to quit the GUI when a user has attempted to close the application through a terminal.

This is part of enabling the GUI to shutdown when a user has attempted to quit through the terminal. This part has been opened separately because I am opening two PR's with different visions on how to fully accomplish the task. Opening this separately helps keep the discussion focused on the location of the `QTimer` in the following PR's.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/95)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/95)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/95)
