### PR TITLE
[1/2] Allow user to quit GUI from terminal

### DIFF
--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -39,6 +39,13 @@ void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::Bloc
     setBlockTipHeight(tip_info.block_height);
 }
 
+void NodeModel::detectShutdown()
+{
+    if (m_node.shutdownRequested()) {
+        startNodeShutdown();
+    }
+}
+
 void NodeModel::ConnectToBlockTipSignal()
 {
     assert(!m_handler_notify_block_tip);

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -33,6 +33,7 @@ public:
 
 public Q_SLOTS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
+    void detectShutdown();
 
 Q_SIGNALS:
     void blockTipHeightChanged();


### PR DESCRIPTION
Based on #95

This allows a user to quit the GUI from the terminal. It introduces a QTimer in `bitcoin.cpp` to periodically call the NodeModel detectShutdown function. 

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/96)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/96)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/96)

