### PR TITLE
Allow user to quit GUI from terminal

### DIFF
--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -9,9 +9,14 @@
 
 #include <cassert>
 
+#include <QTimer>
+
 NodeModel::NodeModel(interfaces::Node& node)
     : m_node{node}
 {
+    m_poll_shutdown_timer = new QTimer(this);
+    connect(m_poll_shutdown_timer, &QTimer::timeout, this, &NodeModel::detectShutdown);
+    m_poll_shutdown_timer->start(200);
     ConnectToBlockTipSignal();
 }
 

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -39,6 +39,13 @@ void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::Bloc
     setBlockTipHeight(tip_info.block_height);
 }
 
+void NodeModel::detectShutdown()
+{
+    if (m_node.shutdownRequested()) {
+        Q_EMIT requestedShutdown();
+    }
+}
+
 void NodeModel::ConnectToBlockTipSignal()
 {
     assert(!m_handler_notify_block_tip);

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include <QObject>
+#include <QTimer>
 
 namespace interfaces {
 class Node;
@@ -46,6 +47,7 @@ private:
 
     interfaces::Node& m_node;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;
+    QTimer* m_poll_shutdown_timer{nullptr};
 
     void ConnectToBlockTipSignal();
 };

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -33,6 +33,7 @@ public:
 
 public Q_SLOTS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
+    void detectShutdown();
 
 Q_SIGNALS:
     void blockTipHeightChanged();


### PR DESCRIPTION
Based on #95

This allows a user to quit the GUI from the terminal. It introduces a QTimer in the NodeModel QObject to periodically call the object's `detectShutdown` function.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/97)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/97)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/97)