### PR TITLE
Make working progress bar

### DIFF
--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -23,6 +23,14 @@ void NodeModel::setBlockTipHeight(int new_height)
     }
 }
 
+void NodeModel::setVerificationProgress(double new_progress)
+{
+    if (new_progress != m_verification_progress) {
+        m_verification_progress = new_progress;
+        Q_EMIT verificationProgressChanged();
+    }
+}
+
 void NodeModel::startNodeInitializionThread()
 {
     Q_EMIT requestedInitialize();
@@ -37,13 +45,16 @@ void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::Bloc
 {
     // TODO: Handle the `success` parameter,
     setBlockTipHeight(tip_info.block_height);
+    setVerificationProgress(tip_info.verification_progress);
 }
 
 void NodeModel::ConnectToBlockTipSignal()
 {
     assert(!m_handler_notify_block_tip);
+
     m_handler_notify_block_tip = m_node.handleNotifyBlockTip(
         [this](SynchronizationState state, interfaces::BlockTip tip, double verification_progress) {
             setBlockTipHeight(tip.block_height);
+            setVerificationProgress(verification_progress);
         });
 }

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -21,12 +21,15 @@ class NodeModel : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int blockTipHeight READ blockTipHeight NOTIFY blockTipHeightChanged)
+    Q_PROPERTY(double verificationProgress READ verificationProgress NOTIFY verificationProgressChanged)
 
 public:
     explicit NodeModel(interfaces::Node& node);
 
     int blockTipHeight() const { return m_block_tip_height; }
     void setBlockTipHeight(int new_height);
+    double verificationProgress() const { return m_verification_progress; }
+    void setVerificationProgress(double new_progress);
 
     Q_INVOKABLE void startNodeInitializionThread();
     void startNodeShutdown();
@@ -38,10 +41,12 @@ Q_SIGNALS:
     void blockTipHeightChanged();
     void requestedInitialize();
     void requestedShutdown();
+    void verificationProgressChanged();
 
 private:
     // Properties that are exposed to QML.
     int m_block_tip_height{0};
+    double m_verification_progress{0.0};
 
     interfaces::Node& m_node;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -35,10 +35,7 @@ ApplicationWindow {
         ProgressIndicator {
             id: indicator
             Layout.fillWidth: true
-            progress: 0.666
-            background: MouseArea {
-                onClicked: indicator.progress = mouseX / width
-            }
+            progress: nodeModel.verificationProgress
         }
         ConnectionOptions {
             Layout.preferredWidth: 400


### PR DESCRIPTION
- This PR makes the progress bar on the block sync page work.
- This was done by introducing a new private member in the NodeModel class.

**Screenshots:**

**Master**

![Screenshot from 2021-12-28 11-38-51](https://user-images.githubusercontent.com/85434418/147533861-a040157a-7d5a-48b8-a3ce-452d98108613.png)

**PR (at different instances)**

|60680 Blocks|65344 Blocks|69744 Blocks|
|----|----|----|
|![Screenshot from 2021-12-28 11-35-27](https://user-images.githubusercontent.com/85434418/147533879-fb7693be-3bce-43bf-9b85-0f8008a6291d.png)|![Screenshot from 2021-12-28 11-35-34](https://user-images.githubusercontent.com/85434418/147533893-6c99a97d-a9c0-44bb-bf8a-d629949fb18b.png)|![Screenshot from 2021-12-28 11-35-41](https://user-images.githubusercontent.com/85434418/147533914-53718f20-112a-43ed-aae4-9306158a39b1.png)|




