### PR TITLE
Add Header Control

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -299,6 +299,7 @@ QML_QRC = qml/bitcoin_qml.qrc
 QML_RES_QML = \
   qml/components/BlockCounter.qml \
   qml/components/ConnectionOptions.qml \
+  qml/controls/Header.qml \
   qml/controls/OptionButton.qml \
   qml/controls/ProgressIndicator.qml \
   qml/pages/initerrormessage.qml \

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/qml">
         <file>components/BlockCounter.qml</file>
         <file>components/ConnectionOptions.qml</file>
+        <file>controls/Header.qml</file>
         <file>controls/OptionButton.qml</file>
         <file>controls/ProgressIndicator.qml</file>
         <file>pages/initerrormessage.qml</file>

--- a/src/qml/controls/Header.qml
+++ b/src/qml/controls/Header.qml
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Control {
+    id: root
+    property bool bold: false
+    property bool center: true
+    property string header
+    property int headerMargin
+    property int headerSize: 28
+    property string description
+    property int descriptionMargin: 10
+    property int descriptionSize: 18
+    property string subtext
+    property int subtextMargin
+    property int subtextSize: 15
+    contentItem: ColumnLayout {
+        spacing: 0
+        Label {
+            Layout.fillWidth: true
+            Layout.preferredWidth: 0
+            topPadding: root.headerMargin
+            font.family: "Inter"
+            font.styleName: root.bold ? "Semi Bold" : "Regular"
+            font.pointSize: root.headerSize
+            color: "#FFFFFF"
+            text: root.header
+            horizontalAlignment: center ? Text.AlignHCenter : Text.AlignLeft
+            wrapMode: Text.WordWrap
+        }
+        Loader {
+            Layout.fillWidth: true
+            Layout.preferredWidth: 0
+            active: root.description.length > 0
+            visible: active
+            sourceComponent: Label {
+                topPadding: root.descriptionMargin
+                font.family: "Inter"
+                font.styleName: "Regular"
+                font.pointSize: root.descriptionSize
+                color: "#DEDEDE"
+                text: root.description
+                horizontalAlignment: root.center ? Text.AlignHCenter : Text.AlignLeft
+                wrapMode: Text.WordWrap
+            }
+        }
+        Loader {
+            Layout.fillWidth: true
+            Layout.preferredWidth: 0
+            active: root.subtext.length > 0
+            visible: active
+            sourceComponent: Label {
+                topPadding: root.subtextMargin
+                font.family: "Inter"
+                font.styleName: "Regular"
+                font.pixelSize: root.subtextSize
+                color: "#FFFFFF"
+                text: root.subtext
+                horizontalAlignment: root.center ? Text.AlignHCenter : Text.AlignLeft
+                wrapMode: Text.WordWrap
+            }
+        }
+    }
+}

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -28,6 +28,18 @@ ApplicationWindow {
             sourceSize.width: 64
             sourceSize.height: 64
         }
+        Header {
+            Layout.fillWidth: true
+            bold: true
+            header: qsTr("Bitcoin Core App")
+            headerSize: 36
+            headerMargin: 30
+            description: qsTr("Be part of the Bitcoin network.")
+            descriptionSize: 24
+            descriptionMargin: 0
+            subtext: qsTr("100% open-source & open-design")
+            subtextMargin: 25
+        }
         BlockCounter {
             Layout.alignment: Qt.AlignCenter
             blockHeight: nodeModel.blockTipHeight


### PR DESCRIPTION
This introduces and demos the `Header` control. This component is to be used as the main text component for wizard pages; it implements the style for [wizard text](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App-Main?node-id=2777%3A66555) set in the [main design file](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App-Main?node-id=1035%3A1883). It's properties allows for a good level of customization, so this can be extended to any page (wizard or not) that needs a header.

The `header` control consists of a required **header** text, and optional **description** and **subtext** strings. This allows the control to be reused for all currently designed wizard pages. The **description** label will only be shown if the `description` property is given a value. Similarly, the **subtext** label will only be shown if the `subtext` property is given a value.

The `bold`, `headerSize`, `descriptionSize`, `descriptionMargin` and `subtextSize` properties have been given default values that represent the most common sizes in our wizard pages. Looking at the designed wizard pages; All headers have a size of 28 except the first one. Also, only one header is bold. Therefore, the `bold` property has been given a default value of false and `headerSize` a default value of 28. Similarly, all descriptions have a size of 18 and a margin of 10 except the first one; set 18 as default value for `descriptionSize` and 10 as default value for `descriptionMargin`. There is only one page with subtext, and it sets the size for the subtext to 15; set the default value for `subtextSize` to 15.

This means that the code to represent header text can be condensed. For example, the following code represents the header text for the [onboarding connections page](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App-Main?node-id=2777%3A66830):

```qml

Header {
    header: "Connections"
    description: "Communicating with the Bitcoin network can use a lot of data."
}
```

The diagram below shows a breakdown of the control and how it works/example usage:

![header-diagram-png](https://user-images.githubusercontent.com/23396902/147905255-e3cd145e-6e09-41ff-8a2f-f287bfd8c478.png)

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/100)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/100)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/100)