### PR TITLE
Add and demo ConnectionSettings and ContinueButton components

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -299,6 +299,7 @@ QML_QRC = qml/bitcoin_qml.qrc
 QML_RES_QML = \
   qml/components/BlockCounter.qml \
   qml/components/ConnectionOptions.qml \
+  qml/components/ConnectionSettings.qml \
   qml/controls/ContinueButton.qml \
   qml/controls/Header.qml \
   qml/controls/OptionButton.qml \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -302,6 +302,7 @@ QML_RES_QML = \
   qml/controls/ContinueButton.qml \
   qml/controls/Header.qml \
   qml/controls/OptionButton.qml \
+  qml/controls/OptionSwitch.qml \
   qml/controls/ProgressIndicator.qml \
   qml/pages/initerrormessage.qml \
   qml/pages/stub.qml

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -299,6 +299,7 @@ QML_QRC = qml/bitcoin_qml.qrc
 QML_RES_QML = \
   qml/components/BlockCounter.qml \
   qml/components/ConnectionOptions.qml \
+  qml/controls/ContinueButton.qml \
   qml/controls/Header.qml \
   qml/controls/OptionButton.qml \
   qml/controls/ProgressIndicator.qml \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -304,6 +304,7 @@ QML_RES_QML = \
   qml/controls/OptionButton.qml \
   qml/controls/OptionSwitch.qml \
   qml/controls/ProgressIndicator.qml \
+  qml/controls/Setting.qml \
   qml/pages/initerrormessage.qml \
   qml/pages/stub.qml
 

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/qml">
         <file>components/BlockCounter.qml</file>
         <file>components/ConnectionOptions.qml</file>
+        <file>components/ConnectionSettings.qml</file>
         <file>controls/ContinueButton.qml</file>
         <file>controls/Header.qml</file>
         <file>controls/OptionButton.qml</file>

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -7,6 +7,7 @@
         <file>controls/OptionButton.qml</file>
         <file>controls/OptionSwitch.qml</file>
         <file>controls/ProgressIndicator.qml</file>
+        <file>controls/Setting.qml</file>
         <file>pages/initerrormessage.qml</file>
         <file>pages/stub.qml</file>
     </qresource>

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -5,6 +5,7 @@
         <file>controls/ContinueButton.qml</file>
         <file>controls/Header.qml</file>
         <file>controls/OptionButton.qml</file>
+        <file>controls/OptionSwitch.qml</file>
         <file>controls/ProgressIndicator.qml</file>
         <file>pages/initerrormessage.qml</file>
         <file>pages/stub.qml</file>

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/qml">
         <file>components/BlockCounter.qml</file>
         <file>components/ConnectionOptions.qml</file>
+        <file>controls/ContinueButton.qml</file>
         <file>controls/Header.qml</file>
         <file>controls/OptionButton.qml</file>
         <file>controls/ProgressIndicator.qml</file>

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../controls"
+
+ColumnLayout {
+    spacing: 20
+    Setting {
+        Layout.fillWidth: true
+        header: "Use cellular data"
+    }
+    Setting {
+        Layout.fillWidth: true
+        header: "Daily upload limit"
+    }
+    Setting {
+        Layout.fillWidth: true
+        header: "Connection limit"
+    }
+    Setting {
+        Layout.fillWidth: true
+        header: "Listening enabled"
+        description: "Reduces data usage."
+    }
+    Setting {
+        last: true
+        Layout.fillWidth: true
+        header: "Blocks Only"
+        description: "Do not transfer unconfirmed transactions. Also disabled listening."
+    }
+}

--- a/src/qml/controls/ContinueButton.qml
+++ b/src/qml/controls/ContinueButton.qml
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Button {
+    font.family: "Inter"
+    font.styleName: "Semi Bold"
+    font.pointSize: 18
+    contentItem: Text {
+        text: parent.text
+        font: parent.font
+        color: "white"
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+    }
+    background: Rectangle {
+        implicitHeight: 46
+        implicitWidth: 300
+        color: "#F7931A"
+        radius: 5
+    }
+}

--- a/src/qml/controls/OptionSwitch.qml
+++ b/src/qml/controls/OptionSwitch.qml
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Switch {
+    id: root
+    indicator: Rectangle {
+        implicitWidth: 45
+        implicitHeight: 28
+        x: root.leftPadding
+        y: parent.height / 2 - height / 2
+        radius: 18
+        color: root.checked ? "#F7931A" : "#DDDDDD"
+        Rectangle {
+            id: indicatorButton
+            y: parent.height / 2 - height / 2
+            x: root.checked ? parent.width - width - 4 : 0 + 4
+            width: 20
+            height: 20
+            radius: 18
+            color: "#ffffff"
+        }
+    }
+}

--- a/src/qml/controls/Setting.qml
+++ b/src/qml/controls/Setting.qml
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Control {
+    id: root
+    property bool last: false
+    property string header
+    property string description
+    contentItem: GridLayout {
+        columns: 2
+        rowSpacing: 20
+        width: parent.width
+        Header {
+            Layout.fillWidth: true
+            center: false
+            header: root.header
+            headerSize: 18
+            description: root.description
+            descriptionSize: 15
+            descriptionMargin: 0
+        }
+        OptionSwitch {
+            Layout.alignment: Qt.AlignRight
+        }
+        Loader {
+            Layout.fillWidth:true
+            Layout.columnSpan: 2
+            active: !last
+            visible: active
+            sourceComponent: Rectangle {
+                height: 1
+                color: "#777777"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This introduces the `ConnectionSettings` component, which represents the [detailed connections settings page](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App-Main?node-id=2777%3A67296) as designed in the [main design file](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App-Main?node-id=1035%3A1883). It also introduces the controls the component depends on, `Setting` and `OptionSwitch`.  Missing is the Text button that is used for settings which require an input value, because the functionality of that component needs to be discussed.

The `Setting` control represents an individual setting of the `ConnectionSettings` components, this component uses the `Header` control for its text. `OptionSwitch` represents the toggle button shown in the design.

To accomplish a proper demo of this component, this places our forms (ConnectionOptions and ConnectionSettings) into a StackLayout. The `ContinueButton` is introduced to advance/rewind the stack. A `PageIndicator` is added to highlight the functionality of the demo.

Additionally, to fix the annoying behavior of the stub currently, this makes the dimensions of the stub page dependent on it's contents width. 😄 

**Image of added components:**
<img width="529" alt="Screen Shot 2022-01-03 at 9 28 59 PM" src="https://user-images.githubusercontent.com/23396902/148001662-d374d6c7-5335-4406-a4fa-cbb205aa8d86.png">

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/101)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/101)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/101)
