### PR TITLE
Support detail item inside option button

### DIFF
--- a/src/qml/components/ConnectionOptions.qml
+++ b/src/qml/components/ConnectionOptions.qml
@@ -31,5 +31,13 @@ ColumnLayout {
         Layout.fillWidth: true
         text: qsTr("Only when on Wi-Fi")
         description: qsTr("Loads quickly when on wi-fi and pauses when on cellular data.")
+        detail: ProgressIndicator {
+            implicitWidth: 50
+            SequentialAnimation on progress {
+                loops: Animation.Infinite
+                SmoothedAnimation { to: 1; velocity: 1; }
+                SmoothedAnimation { to: 0; velocity: 1; }
+            }
+        }
     }
 }

--- a/src/qml/controls/OptionButton.qml
+++ b/src/qml/controls/OptionButton.qml
@@ -12,6 +12,7 @@ Button {
     id: button
     padding: 15
     checkable: true
+    property alias detail: detail_loader.sourceComponent
     background: Rectangle {
         border.width: 1
         border.color: button.checked ? "#F7931A" : button.hovered ? "white" : "#999999"
@@ -28,46 +29,53 @@ Button {
             opacity: 0.4
         }
     }
-    contentItem: ColumnLayout {
+    contentItem: RowLayout {
         spacing: 3
-        Label {
-            Layout.fillWidth: true
-            Layout.preferredWidth: 0
-            font.family: "Inter"
-            font.styleName: "Regular"
-            font.pointSize: 18
-            color: "white"
-            text: button.text
-            wrapMode: Text.WordWrap
-        }
-        Label {
-            Layout.fillWidth: true
-            Layout.preferredWidth: 0
-            font.family: "Inter"
-            font.styleName: "Regular"
-            font.pixelSize: 15
-            color: "#DEDEDE"
-            text: button.description
-            wrapMode: Text.WordWrap
+        ColumnLayout {
+            spacing: 3
+            Label {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 0
+                font.family: "Inter"
+                font.styleName: "Regular"
+                font.pointSize: 18
+                color: "white"
+                text: button.text
+                wrapMode: Text.WordWrap
+            }
+            Label {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 0
+                font.family: "Inter"
+                font.styleName: "Regular"
+                font.pixelSize: 15
+                color: "#DEDEDE"
+                text: button.description
+                wrapMode: Text.WordWrap
+            }
+            Loader {
+                Layout.topMargin: 2
+                active: button.recommended
+                visible: active
+                sourceComponent: Label {
+                    background: Rectangle {
+                        color: "white"
+                        radius: 3
+                    }
+                    font.styleName: "Regular"
+                    font.pixelSize: 13
+                    topPadding: 3
+                    rightPadding: 7
+                    bottomPadding: 4
+                    leftPadding: 7
+                    color: "black"
+                    text: qsTr("Recommended")
+                }
+            }
         }
         Loader {
-            Layout.topMargin: 2
-            active: button.recommended
-            visible: active
-            sourceComponent: Label {
-                background: Rectangle {
-                    color: "white"
-                    radius: 3
-                }
-                font.styleName: "Regular"
-                font.pixelSize: 13
-                topPadding: 3
-                rightPadding: 7
-                bottomPadding: 4
-                leftPadding: 7
-                color: "black"
-                text: qsTr("Recommended")
-            }
+            id: detail_loader
+            visible: item
         }
     }
 }


### PR DESCRIPTION
Allow a custom inlined item on the right-hand side of the `OptionButton`:

https://user-images.githubusercontent.com/3534524/148144944-165f657a-e918-47ab-92f7-5641faf095f8.mov

Links for Windows, macOS, and Android build artifacts.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/103)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/103)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/103)
