### PR TITLE
Introduce Wizard control

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -317,6 +317,7 @@ QML_RES_QML = \
   qml/controls/Setting.qml \
   qml/controls/TextButton.qml \
   qml/controls/Theme.qml \
+  qml/controls/Wizard.qml \
   qml/pages/initerrormessage.qml \
   qml/pages/stub.qml
 

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -14,6 +14,7 @@
         <file>controls/Setting.qml</file>
         <file>controls/TextButton.qml</file>
         <file>controls/Theme.qml</file>
+        <file>controls/Wizard.qml</file>
         <file>pages/initerrormessage.qml</file>
         <file>pages/stub.qml</file>
     </qresource>

--- a/src/qml/controls/Wizard.qml
+++ b/src/qml/controls/Wizard.qml
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Page {
+    id: root
+    property var views
+    property alias finished: swipeView.finished
+    background: null
+    header: RowLayout {
+        height: 50
+        Layout.leftMargin: 10
+        Loader {
+            active: swipeView.currentIndex > 0 ? true : false
+            visible: active
+            sourceComponent: TextButton {
+                text: "‹ Back"
+                onClicked: swipeView.currentIndex -= 1
+            }
+        }
+    }
+    SwipeView {
+        id: swipeView
+        property bool inSubPage: false
+        property bool finished: false
+        anchors.fill: parent
+        interactive: false
+        Repeater {
+            model: views.length
+            Loader {
+                source: "../pages/" + views[index]
+            }
+        }
+    }
+    footer: Page {
+        background: Rectangle {
+            color: "black"
+        }
+        contentItem: RowLayout {
+            PageIndicator {
+                Layout.alignment: Qt.AlignCenter
+                count: swipeView.count
+                currentIndex: swipeView.currentIndex
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduces the wizard control which will hold all of the onboarding views. A convenient demo can be found here: [onboarding-wizard-demo](https://github.com/jarolrod/gui-qml/tree/onboarding-wizard-demo)

The demo shows the following views: 
![onboarding-flow](https://user-images.githubusercontent.com/23396902/148246185-5e2a3b7b-9960-43c3-9f34-850b9cdf8457.png)


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/106)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/106)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/106)

