### PR TITLE
Make header a required property in header control

### DIFF
--- a/src/qml/controls/Header.qml
+++ b/src/qml/controls/Header.qml
@@ -10,7 +10,7 @@ Control {
     id: root
     property bool bold: false
     property bool center: true
-    property string header
+    required property string header
     property int headerMargin
     property int headerSize: 28
     property string description


### PR DESCRIPTION
This makes qt enforce that the header property is required to use the header control, as is our intent. If no value is provided to the header property, the gui will not start.

From [Qt Docs](https://doc.qt.io/qt-5/qtqml-syntax-objectattributes.html#required-properties):
> As the name suggests, required properties must be set when an instance of the object is created. Violation of this rule will result in QML applications not starting if it can be detected statically.

Error message if no value provided: 
```
QObject::connect(QObject, QQmlApplicationEngine): invalid nullptr parameter
QObject::disconnect: Unexpected nullptr parameter
```

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/107)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/107)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/107)
