### PR TITLE
Allow user to quit GUI from terminal

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -170,7 +170,6 @@ int QmlGuiMain(int argc, char* argv[])
     qGuiApp->setQuitOnLastWindowClosed(false);
     QObject::connect(qGuiApp, &QGuiApplication::lastWindowClosed, [&] {
         node->startShutdown();
-        node_model.startNodeShutdown();
     });
 
     GUIUtil::LoadFont(":/fonts/inter/regular");
@@ -199,5 +198,6 @@ int QmlGuiMain(int argc, char* argv[])
 
     qInfo() << "Graphics API in use:" << QmlUtil::GraphicsApi(window);
 
+    node_model.startShutdownPolling();
     return qGuiApp->exec();
 }

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -31,11 +31,6 @@ void NodeModel::startNodeInitializionThread()
     Q_EMIT requestedInitialize();
 }
 
-void NodeModel::startNodeShutdown()
-{
-    Q_EMIT requestedShutdown();
-}
-
 void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::BlockAndHeaderTipInfo tip_info)
 {
     // TODO: Handle the `success` parameter,

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -8,6 +8,9 @@
 #include <validation.h>
 
 #include <cassert>
+#include <chrono>
+
+#include <QTimerEvent>
 
 NodeModel::NodeModel(interfaces::Node& node)
     : m_node{node}
@@ -37,6 +40,25 @@ void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::Bloc
 {
     // TODO: Handle the `success` parameter,
     setBlockTipHeight(tip_info.block_height);
+}
+
+void NodeModel::startShutdownPolling()
+{
+    m_shutdown_polling_timer_id = startTimer(200ms);
+}
+
+void NodeModel::stopShutdownPolling()
+{
+    killTimer(m_shutdown_polling_timer_id);
+}
+
+void NodeModel::timerEvent(QTimerEvent* event)
+{
+    Q_UNUSED(event)
+    if (m_node.shutdownRequested()) {
+        stopShutdownPolling();
+        Q_EMIT requestedShutdown();
+    }
 }
 
 void NodeModel::ConnectToBlockTipSignal()

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -33,7 +33,6 @@ public:
     void setBlockTipHeight(int new_height);
 
     Q_INVOKABLE void startNodeInitializionThread();
-    void startNodeShutdown();
 
     void startShutdownPolling();
     void stopShutdownPolling();

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -12,6 +12,10 @@
 
 #include <QObject>
 
+QT_BEGIN_NAMESPACE
+class QTimerEvent;
+QT_END_NAMESPACE
+
 namespace interfaces {
 class Node;
 }
@@ -31,6 +35,9 @@ public:
     Q_INVOKABLE void startNodeInitializionThread();
     void startNodeShutdown();
 
+    void startShutdownPolling();
+    void stopShutdownPolling();
+
 public Q_SLOTS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
 
@@ -39,9 +46,14 @@ Q_SIGNALS:
     void requestedInitialize();
     void requestedShutdown();
 
+protected:
+    void timerEvent(QTimerEvent* event) override;
+
 private:
     // Properties that are exposed to QML.
     int m_block_tip_height{0};
+
+    int m_shutdown_polling_timer_id{0};
 
     interfaces::Node& m_node;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;


### PR DESCRIPTION
This PR is an alternative to bitcoin-core/gui-qml#95, bitcoin-core/gui-qml#96, bitcoin-core/gui-qml#97.

Here are differences:
- used `QObject`'s timer support instead of `QTimer`, it is quite enough
- it works :) -- `node_model.startNodeShutdown()` leads to calling `Shutdown()` twice which is wrong

`NodeModel::startShutdownPolling()` and `NodeModel::stopShutdownPolling()` are parts of the `NodeModel` public interface to cope with `AbortShutdown()` in the future.