### PR TITLE
qml: Add DropShadow to the OptionSwitch indicatorButton

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -42,6 +42,8 @@ QT_END_NAMESPACE
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
+Q_IMPORT_PLUGIN(QtGraphicalEffectsPlugin)
+Q_IMPORT_PLUGIN(QtGraphicalEffectsPrivatePlugin)
 Q_IMPORT_PLUGIN(QtQmlPlugin)
 Q_IMPORT_PLUGIN(QtQmlModelsPlugin)
 Q_IMPORT_PLUGIN(QtQuick2Plugin)

--- a/src/qml/controls/OptionSwitch.qml
+++ b/src/qml/controls/OptionSwitch.qml
@@ -4,6 +4,7 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtGraphicalEffects 1.15
 
 Switch {
     id: root
@@ -22,6 +23,17 @@ Switch {
             height: 20
             radius: 18
             color: "#ffffff"
+        }
+
+        DropShadow {
+            anchors.fill: indicatorButton
+            horizontalOffset: 0
+            verticalOffset: 5
+            radius: 10.0
+            spread: 0.0
+            samples: 21
+            color: "#00000040"
+            source: indicatorButton
         }
     }
 }


### PR DESCRIPTION
- This PR is a follow-up to #101 and addresses the suggestions given there after it was merged.
- This PR also adds the **DropShadow** for the **OptionSwitch**'s `indicatorButton`, as per the [main design file](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App-Main?node-id=1035%3A1883) of the project.

Some points to note:

- Used `===` instead of `==` to avoid type coercion.
- Chose sample value based on official recommended guidelines (sample = 2*radius + 1) https://doc.qt.io/qt-5/qml-qtgraphicaleffects-dropshadow.html#samples-prop
- Used rgba to hex convertor for shadow color: https://rgbacolorpicker.com/rgba-to-hex


