### PR TITLE
Introduce PageIndicator control

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -303,6 +303,7 @@ QML_RES_QML = \
   qml/components/StorageOptions.qml \
   qml/controls/ContinueButton.qml \
   qml/controls/Header.qml \
+  qml/controls/PageIndicator.qml \
   qml/controls/OptionButton.qml \
   qml/controls/OptionSwitch.qml \
   qml/controls/ProgressIndicator.qml \

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -6,6 +6,7 @@
         <file>components/StorageOptions.qml</file>
         <file>controls/ContinueButton.qml</file>
         <file>controls/Header.qml</file>
+        <file>controls/PageIndicator.qml</file>
         <file>controls/OptionButton.qml</file>
         <file>controls/OptionSwitch.qml</file>
         <file>controls/ProgressIndicator.qml</file>

--- a/src/qml/controls/PageIndicator.qml
+++ b/src/qml/controls/PageIndicator.qml
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+PageIndicator {
+    id: root
+    delegate: Rectangle {
+        implicitWidth: 10
+        implicitHeight: 10
+        radius: Math.round(width / 2)
+        color: "white"
+        opacity: index === root.currentIndex ? 0.95 : pressed ? 0.7 : 0.45
+        Behavior on opacity {
+            OpacityAnimator {
+                duration: 100
+            }
+        }
+    }
+}


### PR DESCRIPTION
Broken off from #106 

Introduces a PageIndicator control which lets the user know where they are within a Wizard or similar flow. 

Note: There is no current design file documentation of the specifics for the PageIndicator; therefore, the implementation provided here could be subject to change.

A demo of the control can be found here: [pageindicator-demo](https://github.com/jarolrod/gui-qml/tree/pageindicator-demo)

| Screenshot of PageIndicator |
|-----------------------------|
| <img width="95" alt="Screen Shot 2022-02-06 at 4 28 25 AM" src="https://user-images.githubusercontent.com/23396902/152674844-54ad0116-3e07-47ac-82a9-07a932f6513b.png"> |

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/113)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/113)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/113)

