### PR TITLE
Introduce and use Theme singleton

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -307,8 +307,10 @@ QML_RES_QML = \
   qml/controls/OptionButton.qml \
   qml/controls/OptionSwitch.qml \
   qml/controls/ProgressIndicator.qml \
+  qml/controls/qmldir \
   qml/controls/Setting.qml \
   qml/controls/TextButton.qml \
+  qml/controls/Theme.qml \
   qml/pages/initerrormessage.qml \
   qml/pages/stub.qml
 

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -10,8 +10,10 @@
         <file>controls/OptionButton.qml</file>
         <file>controls/OptionSwitch.qml</file>
         <file>controls/ProgressIndicator.qml</file>
+        <file>controls/qmldir</file>
         <file>controls/Setting.qml</file>
         <file>controls/TextButton.qml</file>
+        <file>controls/Theme.qml</file>
         <file>pages/initerrormessage.qml</file>
         <file>pages/stub.qml</file>
     </qresource>

--- a/src/qml/components/BlockCounter.qml
+++ b/src/qml/components/BlockCounter.qml
@@ -6,13 +6,14 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import "../controls"
 
 Label {
     property int blockHeight: 0
     background: Rectangle {
-        color: "black"
+        color: Theme.color.background
     }
-    color: "orange"
+    color: Theme.color.orange
     padding: 16
     horizontalAlignment: Text.AlignHCenter
     verticalAlignment: Text.AlignVCenter

--- a/src/qml/controls/ContinueButton.qml
+++ b/src/qml/controls/ContinueButton.qml
@@ -12,14 +12,14 @@ Button {
     contentItem: Text {
         text: parent.text
         font: parent.font
-        color: "white"
+        color: Theme.color.white
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
     }
     background: Rectangle {
         implicitHeight: 46
         implicitWidth: 300
-        color: "#F7931A"
+        color: Theme.color.orange
         radius: 5
     }
 }

--- a/src/qml/controls/Header.qml
+++ b/src/qml/controls/Header.qml
@@ -28,7 +28,7 @@ Control {
             font.family: "Inter"
             font.styleName: root.bold ? "Semi Bold" : "Regular"
             font.pointSize: root.headerSize
-            color: "#FFFFFF"
+            color: Theme.color.neutral9
             text: root.header
             horizontalAlignment: center ? Text.AlignHCenter : Text.AlignLeft
             wrapMode: Text.WordWrap
@@ -43,7 +43,7 @@ Control {
                 font.family: "Inter"
                 font.styleName: "Regular"
                 font.pointSize: root.descriptionSize
-                color: "#DEDEDE"
+                color: Theme.color.neutral8
                 text: root.description
                 horizontalAlignment: root.center ? Text.AlignHCenter : Text.AlignLeft
                 wrapMode: Text.WordWrap
@@ -59,7 +59,7 @@ Control {
                 font.family: "Inter"
                 font.styleName: "Regular"
                 font.pixelSize: root.subtextSize
-                color: "#FFFFFF"
+                color: Theme.color.neutral9
                 text: root.subtext
                 horizontalAlignment: root.center ? Text.AlignHCenter : Text.AlignLeft
                 wrapMode: Text.WordWrap

--- a/src/qml/controls/OptionButton.qml
+++ b/src/qml/controls/OptionButton.qml
@@ -15,7 +15,7 @@ Button {
     property alias detail: detail_loader.sourceComponent
     background: Rectangle {
         border.width: 1
-        border.color: button.checked ? "#F7931A" : button.hovered ? "white" : "#999999"
+        border.color: button.checked ? Theme.color.orange : button.hovered ? Theme.color.neutral9 : Theme.color.neutral5
         radius: 10
         color: "transparent"
         Rectangle {
@@ -23,7 +23,7 @@ Button {
             anchors.fill: parent
             anchors.margins: -4
             border.width: 2
-            border.color: "#F7931A"
+            border.color: Theme.color.orange
             radius: 14
             color: "transparent"
             opacity: 0.4
@@ -50,7 +50,7 @@ Button {
                 visible: active
                 sourceComponent: Label {
                     background: Rectangle {
-                        color: "white"
+                        color: Theme.color.neutral9
                         radius: 3
                     }
                     font.styleName: "Regular"
@@ -59,7 +59,7 @@ Button {
                     rightPadding: 7
                     bottomPadding: 4
                     leftPadding: 7
-                    color: "black"
+                    color: Theme.color.neutral0
                     text: qsTr("Recommended")
                 }
             }

--- a/src/qml/controls/OptionSwitch.qml
+++ b/src/qml/controls/OptionSwitch.qml
@@ -13,7 +13,7 @@ Switch {
         x: root.leftPadding
         y: Math.round((parent.height - height) / 2)
         radius: 18
-        color: root.checked ? "#F7931A" : "#DDDDDD"
+        color: root.checked ? Theme.color.orange : Theme.color.neutral4
         Rectangle {
             id: indicatorButton
             y: parent.height / 2 - height / 2
@@ -21,7 +21,7 @@ Switch {
             width: 20
             height: 20
             radius: 18
-            color: "#ffffff"
+            color: Theme.color.white
         }
     }
 }

--- a/src/qml/controls/PageIndicator.qml
+++ b/src/qml/controls/PageIndicator.qml
@@ -11,7 +11,7 @@ PageIndicator {
         implicitWidth: 10
         implicitHeight: 10
         radius: Math.round(width / 2)
-        color: "white"
+        color: Theme.color.neutral9
         opacity: index === root.currentIndex ? 0.95 : pressed ? 0.7 : 0.45
         Behavior on opacity {
             OpacityAnimator {

--- a/src/qml/controls/ProgressIndicator.qml
+++ b/src/qml/controls/ProgressIndicator.qml
@@ -17,7 +17,7 @@ Control {
     contentItem: Rectangle {
         implicitHeight: 6
         radius: Math.floor(height / 2)
-        color: "#404040"
+        color: Theme.color.neutral3
         Item {
             width: Math.round(progress * contentItem.width)
             height: parent.height
@@ -26,7 +26,7 @@ Control {
                 width: contentItem.width
                 height: contentItem.height
                 radius: contentItem.radius
-                color: "orange"
+                color: Theme.color.orange
             }
         }
     }

--- a/src/qml/controls/Setting.qml
+++ b/src/qml/controls/Setting.qml
@@ -35,7 +35,7 @@ Control {
             visible: active
             sourceComponent: Rectangle {
                 height: 1
-                color: "#777777"
+                color: Theme.color.neutral5
             }
         }
     }

--- a/src/qml/controls/TextButton.qml
+++ b/src/qml/controls/TextButton.qml
@@ -8,7 +8,7 @@ import QtQuick.Controls 2.15
 Button {
     id: root
     property int textSize: 18
-    property string textColor: "white"
+    property string textColor: Theme.color.neutral9
     font.family: "Inter"
     font.styleName: "Semi Bold"
     font.pointSize: root.textSize

--- a/src/qml/controls/Theme.qml
+++ b/src/qml/controls/Theme.qml
@@ -1,0 +1,28 @@
+pragma Singleton
+import QtQuick 2.15
+
+QtObject {
+    property bool dark: false
+    property QtObject color: QtObject {
+        property color white: "#FFFFFF"
+        property color background: dark ? "black" : "white"
+        property color orange: dark ? "#F89B2A" : "#F7931A"
+        property color red: dark ? "#EC6363" : "#EB5757"
+        property color green: dark ? "#36B46B" : "#27AE60"
+        property color blue: dark ? "#3CA3DE" : "#2D9CDB"
+        property color purple: dark ? "#C075DC" : "#BB6BD9"
+        property color neutral0: dark ? "#000000" : "#FFFFFF"
+        property color neutral1: dark ? "#1A1A1A" : "#F8F8F8"
+        property color neutral2: dark ? "#2D2D2D" : "#F4F4F4"
+        property color neutral3: dark ? "#444444" : "#EDEDED"
+        property color neutral4: dark ? "#5C5C5C" : "#DEDEDE"
+        property color neutral5: dark ? "#787878" : "#BBBBBB"
+        property color neutral6: dark ? "#949494" : "#999999"
+        property color neutral7: dark ? "#B0B0B0" : "#777777"
+        property color neutral8: dark ? "#CCCCCC" : "#404040"
+        property color neutral9: dark ? "#FFFFFF" : "#000000"
+    }
+    function toggleDark() {
+        dark = !dark
+    }
+}

--- a/src/qml/controls/qmldir
+++ b/src/qml/controls/qmldir
@@ -1,0 +1,1 @@
+singleton Theme 1.0 Theme.qml

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -13,7 +13,7 @@ ApplicationWindow {
     title: "Bitcoin Core TnG"
     minimumWidth: 750
     minimumHeight: 450
-    color: "black"
+    color: Theme.color.background
     visible: true
 
     Component.onCompleted: nodeModel.startNodeInitializionThread();


### PR DESCRIPTION
Replaces #109 

This introduces a `Theme` singleton which contains color definitions so that colors can be used by name instead of by hex. Additionally, it adjusts color definitions depending on if the gui is in dark or light mode. 

Color definitions are based on our color palettes as defined in our [design system](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App-Main?node-id=2643%3A83514): 
![color-definitions](https://user-images.githubusercontent.com/23396902/148453667-bdaa347f-b4e9-4db9-9a82-027a10dc9e05.png)

A convenient demo of the changes can be found here: [theme singleton demo](https://github.com/jarolrod/gui-qml/tree/theme-singleton-demo)

This demo adds a `ThemeToggleButton` so that we can toggle between light and dark. Uses the `moon` and `sun` icon from [BitcoinIcons](https://github.com/BitcoinDesign/Bitcoin-Icons).
