### PR TITLE
refactor: Move `interfaces::BlockAndHeaderTipInfo` registration

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -96,6 +96,7 @@ int QmlGuiMain(int argc, char* argv[])
 #endif // WIN32
 
     Q_INIT_RESOURCE(bitcoin_qml);
+    qRegisterMetaType<interfaces::BlockAndHeaderTipInfo>("interfaces::BlockAndHeaderTipInfo");
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication::styleHints()->setTabFocusBehavior(Qt::TabFocusAllControls);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -88,6 +88,7 @@ static void RegisterMetaTypes()
 
     qRegisterMetaType<std::function<void()>>("std::function<void()>");
     qRegisterMetaType<QMessageBox::Icon>("QMessageBox::Icon");
+    qRegisterMetaType<interfaces::BlockAndHeaderTipInfo>("interfaces::BlockAndHeaderTipInfo");
 }
 
 static QString GetLangTerritory()

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -43,8 +43,6 @@ UrlDecodeFn* const URL_DECODE = urlDecode;
 
 int main(int argc, char* argv[])
 {
-    qRegisterMetaType<interfaces::BlockAndHeaderTipInfo>("interfaces::BlockAndHeaderTipInfo");
-
     // Subscribe to global signals from core.
     noui_connect();
 


### PR DESCRIPTION
This change is required for easier syncing with the main repo, and it partially reverts commit 3ead757f60434933a915b0c726e58b419ea8b8c4.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/122)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/122)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/122)