### PR TITLE
Handle undefined active state in Header control

### DIFF
--- a/src/qml/controls/Header.qml
+++ b/src/qml/controls/Header.qml
@@ -13,10 +13,10 @@ Control {
     required property string header
     property int headerMargin
     property int headerSize: 28
-    property string description
+    property string description: ""
     property int descriptionMargin: 10
     property int descriptionSize: 18
-    property string subtext
+    property string subtext: ""
     property int subtextMargin
     property int subtextSize: 15
     property bool wrap: true


### PR DESCRIPTION
Currently, when checking if the subtext or description labels should be active, the Header control doesn't  handle the case where, for example, root.description is undefined. Here, we handle the case by initializing description and subtext as empty strings.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/125)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/125)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/125)
