### PR TITLE
Introduce `PeersIndicator` component

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -306,6 +306,7 @@ QML_RES_QML = \
   qml/components/BlockCounter.qml \
   qml/components/ConnectionOptions.qml \
   qml/components/ConnectionSettings.qml \
+  qml/components/PeersIndicator.qml \
   qml/components/StorageOptions.qml \
   qml/controls/ContinueButton.qml \
   qml/controls/Header.qml \

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -33,6 +33,7 @@ enum class SynchronizationState;
 enum class TransactionError;
 struct CNodeStateStats;
 struct bilingual_str;
+struct PeersNumByType;
 namespace node {
 struct NodeContext;
 } // namespace node
@@ -238,7 +239,7 @@ public:
     virtual std::unique_ptr<Handler> handleInitWallet(InitWalletFn fn) = 0;
 
     //! Register handler for number of connections changed messages.
-    using NotifyNumConnectionsChangedFn = std::function<void(int new_num_connections)>;
+    using NotifyNumConnectionsChangedFn = std::function<void(PeersNumByType new_num_connections)>;
     virtual std::unique_ptr<Handler> handleNotifyNumConnectionsChanged(NotifyNumConnectionsChangedFn fn) = 0;
 
     //! Register handler for network active messages.

--- a/src/net.h
+++ b/src/net.h
@@ -45,6 +45,7 @@ class BanMan;
 class CNode;
 class CScheduler;
 struct bilingual_str;
+struct PeersNumByType;
 
 /** Default for -whitelistrelay. */
 static const bool DEFAULT_WHITELISTRELAY = true;
@@ -1100,7 +1101,11 @@ private:
     std::list<CNode*> m_nodes_disconnected;
     mutable RecursiveMutex m_nodes_mutex;
     std::atomic<NodeId> nLastNodeId{0};
-    unsigned int nPrevNodeCount{0};
+    int m_num_outbound_full_relay{0};
+    int m_num_block_relay{0};
+    int m_num_manual{0};
+    int m_num_inbound{0};
+
 
     /**
      * Cache responses to addr requests to minimize privacy leak.

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -48,7 +48,7 @@ bool CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, cons
 bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, caption, style).value_or(false);}
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::InitWallet() { return g_ui_signals.InitWallet(); }
-void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
+void CClientUIInterface::NotifyNumConnectionsChanged(PeersNumByType newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
 void CClientUIInterface::NotifyNetworkActiveChanged(bool networkActive) { return g_ui_signals.NotifyNetworkActiveChanged(networkActive); }
 void CClientUIInterface::NotifyAlertChanged() { return g_ui_signals.NotifyAlertChanged(); }
 void CClientUIInterface::ShowProgress(const std::string& title, int nProgress, bool resume_possible) { return g_ui_signals.ShowProgress(title, nProgress, resume_possible); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -20,6 +20,14 @@ class connection;
 }
 } // namespace boost
 
+struct PeersNumByType {
+    int outbound_full_relay{0};
+    int block_relay{0};
+    int manual{0};
+    int inbound{0};
+    int total{0};
+};
+
 /** Signals for UI communication. */
 class CClientUIInterface
 {
@@ -85,7 +93,7 @@ public:
     ADD_SIGNALS_DECL_WRAPPER(InitWallet, void, );
 
     /** Number of network connections changed. */
-    ADD_SIGNALS_DECL_WRAPPER(NotifyNumConnectionsChanged, void, int newNumConnections);
+    ADD_SIGNALS_DECL_WRAPPER(NotifyNumConnectionsChanged, void, PeersNumByType newNumConnections);
 
     /** Network activity state changed. */
     ADD_SIGNALS_DECL_WRAPPER(NotifyNetworkActiveChanged, void, bool networkActive);

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -3,6 +3,7 @@
         <file>components/BlockCounter.qml</file>
         <file>components/ConnectionOptions.qml</file>
         <file>components/ConnectionSettings.qml</file>
+        <file>components/PeersIndicator.qml</file>
         <file>components/StorageOptions.qml</file>
         <file>controls/ContinueButton.qml</file>
         <file>controls/Header.qml</file>

--- a/src/qml/components/PeersIndicator.qml
+++ b/src/qml/components/PeersIndicator.qml
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// The PeersIndicator component.
+// See reference design: https://bitcoindesign.github.io/Bitcoin-Core-App/assets/images/block-clock-connection-states-big.png
+
+import QtQuick 2.15
+import "../controls"
+
+Item {
+    id: root
+    required property int numOutboundPeers
+    required property int maxNumOutboundPeers
+
+    implicitWidth: dots.childrenRect.width
+    implicitHeight: dots.childrenRect.height
+
+    Row {
+        id: dots
+        property int size: 5
+        spacing: 5
+        Repeater {
+            model: 5
+            Rectangle {
+                width: 3
+                height: 3
+                radius: width / 2
+                color: Theme.color.neutral9
+                opacity: (index === 0 && root.numOutboundPeers > 0) || (index + 1 <= dots.size * root.numOutboundPeers / root.maxNumOutboundPeers) ? 0.95 : 0.45
+                Behavior on opacity { OpacityAnimator { duration: 100 } }
+                SequentialAnimation on opacity {
+                    loops: Animation.Infinite
+                    running: numOutboundPeers === 0 && index === 0
+                    SmoothedAnimation { to: 0; velocity: 2.2 }
+                    SmoothedAnimation { to: 1; velocity: 2.2 }
+                }
+            }
+        }
+    }
+}

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -5,6 +5,8 @@
 #include <qml/nodemodel.h>
 
 #include <interfaces/node.h>
+#include <net.h>
+#include <node/ui_interface.h>
 #include <validation.h>
 
 #include <cassert>
@@ -16,6 +18,7 @@ NodeModel::NodeModel(interfaces::Node& node)
     : m_node{node}
 {
     ConnectToBlockTipSignal();
+    ConnectToNumConnectionsChangedSignal();
 }
 
 void NodeModel::setBlockTipHeight(int new_height)
@@ -23,6 +26,14 @@ void NodeModel::setBlockTipHeight(int new_height)
     if (new_height != m_block_tip_height) {
         m_block_tip_height = new_height;
         Q_EMIT blockTipHeightChanged();
+    }
+}
+
+void NodeModel::setNumOutboundPeers(int new_num)
+{
+    if (new_num != m_num_outbound_peers) {
+        m_num_outbound_peers = new_num;
+        Q_EMIT numOutboundPeersChanged();
     }
 }
 
@@ -73,5 +84,15 @@ void NodeModel::ConnectToBlockTipSignal()
         [this](SynchronizationState state, interfaces::BlockTip tip, double verification_progress) {
             setBlockTipHeight(tip.block_height);
             setVerificationProgress(verification_progress);
+        });
+}
+
+void NodeModel::ConnectToNumConnectionsChangedSignal()
+{
+    assert(!m_handler_notify_num_peers_changed);
+
+    m_handler_notify_num_peers_changed = m_node.handleNotifyNumConnectionsChanged(
+        [this](PeersNumByType new_num_peers) {
+            setNumOutboundPeers(new_num_peers.outbound_full_relay + new_num_peers.block_relay);
         });
 }

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -25,6 +25,8 @@ class NodeModel : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int blockTipHeight READ blockTipHeight NOTIFY blockTipHeightChanged)
+    Q_PROPERTY(int numOutboundPeers READ numOutboundPeers NOTIFY numOutboundPeersChanged)
+    Q_PROPERTY(int maxNumOutboundPeers READ maxNumOutboundPeers CONSTANT)
     Q_PROPERTY(double verificationProgress READ verificationProgress NOTIFY verificationProgressChanged)
 
 public:
@@ -32,6 +34,9 @@ public:
 
     int blockTipHeight() const { return m_block_tip_height; }
     void setBlockTipHeight(int new_height);
+    int numOutboundPeers() const { return m_num_outbound_peers; }
+    void setNumOutboundPeers(int new_num);
+    int maxNumOutboundPeers() const { return m_max_num_outbound_peers; }
     double verificationProgress() const { return m_verification_progress; }
     void setVerificationProgress(double new_progress);
 
@@ -45,6 +50,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void blockTipHeightChanged();
+    void numOutboundPeersChanged();
     void requestedInitialize();
     void requestedShutdown();
     void verificationProgressChanged();
@@ -55,14 +61,18 @@ protected:
 private:
     // Properties that are exposed to QML.
     int m_block_tip_height{0};
+    int m_num_outbound_peers{0};
+    static constexpr int m_max_num_outbound_peers{MAX_OUTBOUND_FULL_RELAY_CONNECTIONS + MAX_BLOCK_RELAY_ONLY_CONNECTIONS};
     double m_verification_progress{0.0};
 
     int m_shutdown_polling_timer_id{0};
 
     interfaces::Node& m_node;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;
+    std::unique_ptr<interfaces::Handler> m_handler_notify_num_peers_changed;
 
     void ConnectToBlockTipSignal();
+    void ConnectToNumConnectionsChangedSignal();
 };
 
 #endif // BITCOIN_QML_NODEMODEL_H

--- a/src/qml/pages/stub.qml
+++ b/src/qml/pages/stub.qml
@@ -44,6 +44,11 @@ ApplicationWindow {
             Layout.alignment: Qt.AlignCenter
             blockHeight: nodeModel.blockTipHeight
         }
+        PeersIndicator {
+            Layout.alignment: Qt.AlignCenter
+            numOutboundPeers: nodeModel.numOutboundPeers
+            maxNumOutboundPeers: nodeModel.maxNumOutboundPeers
+        }
         ProgressIndicator {
             id: indicator
             Layout.fillWidth: true

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -15,6 +15,7 @@
 #include <interfaces/node.h>
 #include <net.h>
 #include <netbase.h>
+#include <node/ui_interface.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 #include <util/time.h>
@@ -245,8 +246,8 @@ void ClientModel::subscribeToCoreSignals()
             Q_EMIT showProgress(QString::fromStdString(title), progress);
         });
     m_handler_notify_num_connections_changed = m_node.handleNotifyNumConnectionsChanged(
-        [this](int new_num_connections) {
-            Q_EMIT numConnectionsChanged(new_num_connections);
+        [this](PeersNumByType new_num_connections) {
+            Q_EMIT numConnectionsChanged(new_num_connections.total);
         });
     m_handler_notify_network_active_changed = m_node.handleNotifyNetworkActiveChanged(
         [this](bool network_active) {


### PR DESCRIPTION
The reference design: https://bitcoindesign.github.io/Bitcoin-Core-App/assets/images/block-clock-connection-states-big.png

Design features implementation:
- [x] a single blinking dot
- [x] dots are lit up proportional to the count of the outbound peers

Looking for designers' Concept (N)ACK, and developers' notes regarding QML code.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/127)
[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/127)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/127)