### PR TITLE
qml: Add DropShadow to the OptionSwitch indicatorButton

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -42,6 +42,8 @@ QT_END_NAMESPACE
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
+Q_IMPORT_PLUGIN(QtGraphicalEffectsPlugin)
+Q_IMPORT_PLUGIN(QtGraphicalEffectsPrivatePlugin)
 Q_IMPORT_PLUGIN(QtQmlPlugin)
 Q_IMPORT_PLUGIN(QtQmlModelsPlugin)
 Q_IMPORT_PLUGIN(QtQuick2Plugin)

--- a/src/qml/controls/OptionSwitch.qml
+++ b/src/qml/controls/OptionSwitch.qml
@@ -4,6 +4,7 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtGraphicalEffects 1.15
 
 Switch {
     id: root
@@ -22,6 +23,16 @@ Switch {
             height: 20
             radius: 18
             color: Theme.color.white
+        }
+        DropShadow {
+            anchors.fill: indicatorButton
+            horizontalOffset: 0
+            verticalOffset: 5
+            radius: 10.0
+            spread: 0.0
+            samples: 21
+            color: "#00000040"
+            source: indicatorButton
         }
     }
 }


### PR DESCRIPTION
Ported #111 to this PR.

This PR rebase #111 on the current master.

Notes:
- I successfully compiled the updated PR on Ubuntu 22.04 using `Qt version 5.15.3`.
- To successfully compile and run the PR, I had to install an additional library.
```
sudo apt install qml-module-qtgraphicaleffects
```
- I have created a convenient demo for checking that the drop shadow works correctly. [Drop Shadow onboarding test](https://github.com/shaavan/gui-qml/tree/Drop-Shadow-Onboarding-Test) branch cherry-picks this PR over the #124. 
- If, in the demo, the color of the drop shadow is too subtle to perceive, try experimenting with changing the color of the drop shadow to get high contrast. For example:
```diff
             spread: 0.0
             samples: 21
-            color: "#00000040"
+            color: "#7900fffc"
             source: indicatorButton
         }
     }
```