### PR TITLE
ci: Add "macOS arm64" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -319,6 +319,27 @@ task:
     type: "application/gzip"
 
 task:
+  name: 'macOS arm64 [gui, no tests] [jammy]'
+  << : *BASE_TEMPLATE
+  macos_sdk_cache:
+    folder: "depends/SDKs/$MACOS_SDK"
+    fingerprint_key: "$MACOS_SDK"
+  << : *MAIN_TEMPLATE
+  alias: macos_arm64
+  container:
+    image: ubuntu:jammy
+  env:
+    MACOS_SDK: "Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers"
+    << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
+    FILE_ENV: "./ci/test/00_setup_env_mac_arm64.sh"
+  copy_artifacts_script:
+    - cp ci/scratch/build/bitcoin-arm64-apple-darwin/src/qt/bitcoin-qt insecure_mac_arm64_gui
+    - tar -czf insecure_mac_arm64_gui.tar.gz insecure_mac_arm64_gui
+  insecure_mac_arm64_gui_artifacts:
+    path: "insecure_mac_arm64_gui.tar.gz"
+    type: "application/gzip"
+
+task:
   name: 'macOS 12 native [gui, system sqlite only] [no depends]'
   brew_install_script:
     - brew install boost libevent qt@5 miniupnpc libnatpmp ccache zeromq qrencode libtool automake gnu-getopt

--- a/ci/test/00_setup_env_mac_arm64.sh
+++ b/ci/test/00_setup_env_mac_arm64.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_macos_cross
+export DOCKER_NAME_TAG=ubuntu:22.04
+export HOST=arm64-apple-darwin
+export PACKAGES="cmake libz-dev libtinfo5 python3-setuptools xorriso"
+export XCODE_VERSION=12.2
+export XCODE_BUILD_ID=12B45b
+export RUN_UNIT_TESTS=false
+export RUN_FUNCTIONAL_TESTS=false
+export GOAL="deploy"
+export BITCOIN_CONFIG="--with-gui --enable-reduce-exports"


### PR DESCRIPTION
This PR adds "macOS arm64" task which creates a downloadable binary for macOS systems based on Apple M1.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/133)
[![macOS x86_64](https://img.shields.io/badge/OS-macOS%2C%20x86__64-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/133)
[![macOS arm64_64](https://img.shields.io/badge/OS-macOS%2C%20arm64-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/133)
[![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/133)

The downloaded file on macOS M1:
```
% lipo -info ./Downloads/insecure_mac_arm64_gui
Non-fat file: ./Downloads/insecure_mac_arm64_gui is architecture: arm64
```

---

### IMPORTANT NOTE

macOS M1 requires all binaries must be signed. To apply ad-hoc code signing to the downloaded `insecure_mac_arm64_gui`, run:
```
% codesign -s - ./Downloads/insecure_mac_arm64_gui  
```