### PR TITLE
doc: add arm macOS CI artifact link, document codesign step

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -46,6 +46,7 @@ patches often sit for a long time.
 Links for Windows and macOS build artifacts. Replace <PR> with the assigned pull request number.
 
 [![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/<PR>)
-[![macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/<PR>)
+[![Intel macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/<PR>)
+[![Apple Silicon macOS](https://img.shields.io/badge/OS-macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/<PR>)
 [![Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/<PR>)
 -->

--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -6,8 +6,16 @@ This directory contains the source code for an experimental Bitcoin Core graphic
 
 Insecure CI artifacts are available for local testing of the master branch, avoiding the need to build:
 - for Windows: [`insecure_win_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip)
-- for macOS: [`insecure_mac_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip)
+- for Intel macOS: [`insecure_mac_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip)
+- for Apple Silicon macOS: [`insecure_mac_arm64_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip)
 - for Android: [`insecure_android_apk.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip)
+
+Note: For Apple Silicon macOS machines, the binary must be signed before it can
+be ran. To apply a signature, run the following on the unzipped CI artifact:
+
+```
+codesign -s - ./Downloads/insecure_mac_arm64_gui
+```
 
 ## Goals and Limitations
 


### PR DESCRIPTION
Adds a link to the arm macOS CI artifact to the qml readme. Additionally, documents that signing the binary is a requirement before one can run it. Also provides an example command on how one could sign the artifact.