### PR TITLE
Use caret-right icon instead of greater-than text symbol

### DIFF
--- a/src/qml/components/AboutOptions.qml
+++ b/src/qml/components/AboutOptions.qml
@@ -13,42 +13,56 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Website")
         actionItem: ExternalLink {
-            description: qsTr("bitcoincore.org >")
+            description: qsTr("bitcoincore.org")
             link: "https://bitcoincore.org"
+            iconSource: "image://images/caret-right"
+            iconWidth: 18
+            iconHeight: 18
         }
     }
     Setting {
         Layout.fillWidth: true
         header: qsTr("Source code")
         actionItem: ExternalLink {
-            description: qsTr("github.com/bitcoin/bitcoin >")
+            description: qsTr("github.com/bitcoin/bitcoin")
             link: "https://github.com/bitcoin/bitcoin"
+            iconSource: "image://images/caret-right"
+            iconWidth: 18
+            iconHeight: 18
         }
     }
     Setting {
         Layout.fillWidth: true
         header: qsTr("License")
         actionItem: ExternalLink {
-            description: qsTr("MIT >")
+            description: qsTr("MIT")
             link: "https://opensource.org/licenses/MIT"
+            iconSource: "image://images/caret-right"
+            iconWidth: 18
+            iconHeight: 18
         }
     }
     Setting {
         Layout.fillWidth: true
         header: qsTr("Version")
         actionItem: ExternalLink {
-            description: qsTr("v22.99.0-1e7564eca8a6 >")
+            description: qsTr("v22.99.0-1e7564eca8a6")
             link: "https://bitcoin.org/en/download"
+            iconSource: "image://images/caret-right"
+            iconWidth: 18
+            iconHeight: 18
         }
     }
     Setting {
         Layout.fillWidth: true
         header: qsTr("Developer options")
         description: qsTr("Only use these if you have development experience")
-        actionItem: TextButton {
-            text: ">"
-            bold: false
-            rightalign: true
+        actionItem: Button {
+            icon.source: "image://images/caret-right"
+            icon.color: Theme.color.neutral9
+            icon.height: 18
+            icon.width: 18
+            background: null
             onClicked: {
                 introductions.incrementCurrentIndex()
                 swipeView.inSubPage = true

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -52,8 +52,12 @@ ColumnLayout {
         last: true
         Layout.fillWidth: true
         header: qsTr("Proxy settings")
-        actionItem: ValueInput {
-            description: qsTr(">")
+        actionItem: Button {
+            icon.source: "image://images/caret-right"
+            icon.color: Theme.color.neutral9
+            icon.height: 18
+            icon.width: 18
+            background: null
         }
     }
 }


### PR DESCRIPTION
Mainly only relevant in the `AboutOptions` component for now.

| master | pr |
| ------- | -- |
| <img width="752" alt="Screen Shot 2022-08-03 at 6 45 51 AM" src="https://user-images.githubusercontent.com/23396902/182590655-4e765f99-8de4-4782-bc12-6682b63b1eeb.png"> | <img width="752" alt="Screen Shot 2022-08-06 at 7 40 39 PM" src="https://user-images.githubusercontent.com/23396902/183269335-b8dd6894-14e9-47b5-8d43-6d2f540cbb27.png"> |



[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/144)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/144)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/144)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/144)

