### PR TITLE
remove misuse of loader in onboarding views

### DIFF
--- a/src/qml/pages/onboarding/onboarding01a.qml
+++ b/src/qml/pages/onboarding/onboarding01a.qml
@@ -16,38 +16,35 @@ Page {
     Layout.fillWidth: true
     header: RowLayout {
         height: 50
-        Loader {
-            active: true
-            visible: active
+        Item {
             Layout.alignment: Qt.AlignRight
             Layout.margins: 11
-            sourceComponent: Item {
-                width: 24
-                height: 24
-                Rectangle {
+            width: 24
+            height: 24
+            Rectangle {
+                anchors.fill: parent
+                color: Theme.color.white
+                radius: width*0.5
+            }
+            Image {
+                id: icon
+                source: "qrc:/icons/info"
+                width: parent.width
+                height: parent.height
+                anchors.centerIn: parent
+                fillMode: Image.PreserveAspectFit
+                mipmap: true
+                MouseArea {
                     anchors.fill: parent
-                    color: Theme.color.white
-                    radius: width*0.5
-                }
-                Image {
-                    id: icon
-                    source: "qrc:/icons/info"
-                    width: parent.width
-                    height: parent.height
-                    anchors.centerIn: parent
-                    fillMode: Image.PreserveAspectFit
-                    mipmap: true
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            introductions.incrementCurrentIndex()
-                            swipeView.inSubPage = true
-                        }
+                    onClicked: {
+                        introductions.incrementCurrentIndex()
+                        swipeView.inSubPage = true
                     }
                 }
             }
         }
     }
+    
     ColumnLayout {
         width: 600
         spacing: 0

--- a/src/qml/pages/onboarding/onboarding01b.qml
+++ b/src/qml/pages/onboarding/onboarding01b.qml
@@ -15,42 +15,39 @@ Page {
     header: RowLayout {
         height: 50
         Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
+        Item {
+            width: 73
+            height: 46
+            RowLayout {
+                anchors.fill: parent
+                spacing: 0
+                Image {
+                    source: "qrc:/icons/caret-left"
+                    mipmap: true
+                    Layout.preferredWidth: 30
+                    Layout.preferredHeight: 30
+                    Layout.alignment: Qt.AlignVCenter
+                    fillMode: Image.PreserveAspectFit
                 }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        introductions.decrementCurrentIndex()
-                        swipeView.inSubPage = false
-                    }
+                Text {
+                    Layout.alignment: Qt.AlignVCenter
+                    text: "Back"
+                    color: Theme.color.neutral9
+                    font.family: "Inter"
+                    font.styleName: "Semi Bold"
+                    font.pixelSize: 18
+                }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    introductions.decrementCurrentIndex()
+                    swipeView.inSubPage = false
                 }
             }
         }
     }
+
     ColumnLayout {
         width: 600
         spacing: 0

--- a/src/qml/pages/onboarding/onboarding01c.qml
+++ b/src/qml/pages/onboarding/onboarding01c.qml
@@ -15,42 +15,39 @@ Page {
     header: RowLayout {
         height: 50
         Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
+        Item {
+            width: 73
+            height: 46
+            RowLayout {
+                anchors.fill: parent
+                spacing: 0
+                Image {
+                    source: "qrc:/icons/caret-left"
+                    mipmap: true
+                    Layout.preferredWidth: 30
+                    Layout.preferredHeight: 30
+                    Layout.alignment: Qt.AlignVCenter
+                    fillMode: Image.PreserveAspectFit
                 }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        introductions.decrementCurrentIndex()
-                        swipeView.inSubPage = true
-                    }
+                Text {
+                    Layout.alignment: Qt.AlignVCenter
+                    text: "Back"
+                    color: Theme.color.neutral9
+                    font.family: "Inter"
+                    font.styleName: "Semi Bold"
+                    font.pixelSize: 18
+                }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    introductions.decrementCurrentIndex()
+                    swipeView.inSubPage = true
                 }
             }
         }
     }
+    
     ColumnLayout {
         width: 600
         spacing: 0

--- a/src/qml/pages/onboarding/onboarding02.qml
+++ b/src/qml/pages/onboarding/onboarding02.qml
@@ -14,39 +14,36 @@ Page {
     header: RowLayout {
         height: 50
         Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
+        Item {
+            width: 73
+            height: 46
+            RowLayout {
+                anchors.fill: parent
+                spacing: 0
+                Image {
+                    source: "qrc:/icons/caret-left"
+                    mipmap: true
+                    Layout.preferredWidth: 30
+                    Layout.preferredHeight: 30
+                    Layout.alignment: Qt.AlignVCenter
+                    fillMode: Image.PreserveAspectFit
                 }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: swipeView.currentIndex -= 1
+                Text {
+                    Layout.alignment: Qt.AlignVCenter
+                    text: "Back"
+                    color: Theme.color.neutral9
+                    font.family: "Inter"
+                    font.styleName: "Semi Bold"
+                    font.pixelSize: 18
                 }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: swipeView.currentIndex -= 1
             }
         }
     }
+
     ColumnLayout {
         width: 600
         spacing: 0

--- a/src/qml/pages/onboarding/onboarding03.qml
+++ b/src/qml/pages/onboarding/onboarding03.qml
@@ -14,39 +14,36 @@ Page {
     header: RowLayout {
         height: 50
         Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
+        Item {
+            width: 73
+            height: 46
+            RowLayout {
+                anchors.fill: parent
+                spacing: 0
+                Image {
+                    source: "qrc:/icons/caret-left"
+                    mipmap: true
+                    Layout.preferredWidth: 30
+                    Layout.preferredHeight: 30
+                    Layout.alignment: Qt.AlignVCenter
+                    fillMode: Image.PreserveAspectFit
                 }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: swipeView.currentIndex -= 1
+                Text {
+                    Layout.alignment: Qt.AlignVCenter
+                    text: "Back"
+                    color: Theme.color.neutral9
+                    font.family: "Inter"
+                    font.styleName: "Semi Bold"
+                    font.pixelSize: 18
                 }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: swipeView.currentIndex -= 1
             }
         }
     }
+
     ColumnLayout {
         width: 600
         spacing: 0

--- a/src/qml/pages/onboarding/onboarding04.qml
+++ b/src/qml/pages/onboarding/onboarding04.qml
@@ -15,39 +15,36 @@ Page {
     header: RowLayout {
         height: 50
         Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
+        Item {
+            width: 73
+            height: 46
+            RowLayout {
+                anchors.fill: parent
+                spacing: 0
+                Image {
+                    source: "qrc:/icons/caret-left"
+                    mipmap: true
+                    Layout.preferredWidth: 30
+                    Layout.preferredHeight: 30
+                    Layout.alignment: Qt.AlignVCenter
+                    fillMode: Image.PreserveAspectFit
                 }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: swipeView.currentIndex -= 1
+                Text {
+                    Layout.alignment: Qt.AlignVCenter
+                    text: "Back"
+                    color: Theme.color.neutral9
+                    font.family: "Inter"
+                    font.styleName: "Semi Bold"
+                    font.pixelSize: 18
                 }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: swipeView.currentIndex -= 1
             }
         }
     }
+
     ColumnLayout {
         width: 600
         spacing: 0

--- a/src/qml/pages/onboarding/onboarding05a.qml
+++ b/src/qml/pages/onboarding/onboarding05a.qml
@@ -15,39 +15,36 @@ Page {
     header: RowLayout {
         height: 50
         Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
+        Item {
+            width: 73
+            height: 46
+            RowLayout {
+                anchors.fill: parent
+                spacing: 0
+                Image {
+                    source: "qrc:/icons/caret-left"
+                    mipmap: true
+                    Layout.preferredWidth: 30
+                    Layout.preferredHeight: 30
+                    Layout.alignment: Qt.AlignVCenter
+                    fillMode: Image.PreserveAspectFit
                 }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: swipeView.currentIndex -= 1
+                Text {
+                    Layout.alignment: Qt.AlignVCenter
+                    text: "Back"
+                    color: Theme.color.neutral9
+                    font.family: "Inter"
+                    font.styleName: "Semi Bold"
+                    font.pixelSize: 18
                 }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: swipeView.currentIndex -= 1
             }
         }
     }
+
     ColumnLayout {
         width: 600
         spacing: 0

--- a/src/qml/pages/onboarding/onboarding05b.qml
+++ b/src/qml/pages/onboarding/onboarding05b.qml
@@ -14,34 +14,31 @@ Page {
     clip: true
     header: RowLayout {
         height: 50
-        Loader {
-            active: true
-            visible: active
+        Item {
             Layout.alignment: Qt.AlignRight
             Layout.topMargin: 12
             Layout.rightMargin: -7
-            sourceComponent: Item {
-                Layout.fillWidth: true
-                width: 73
-                height: 46
-                Text {
-                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                    text: "Done"
-                    color: Theme.color.neutral9
-                    font.family: "Inter"
-                    font.styleName: "Semi Bold"
-                    font.pixelSize: 18
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        storages.decrementCurrentIndex()
-                        swipeView.inSubPage = false
-                    }
+            Layout.fillWidth: true
+            width: 73
+            height: 46
+            Text {
+                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                text: "Done"
+                color: Theme.color.neutral9
+                font.family: "Inter"
+                font.styleName: "Semi Bold"
+                font.pixelSize: 18
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    storages.decrementCurrentIndex()
+                    swipeView.inSubPage = false
                 }
             }
         }
     }
+
     ColumnLayout {
         width: 450
         spacing: 0

--- a/src/qml/pages/onboarding/onboarding06a.qml
+++ b/src/qml/pages/onboarding/onboarding06a.qml
@@ -15,39 +15,36 @@ Page {
     header: RowLayout {
         height: 50
         Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
+        Item {
+            width: 73
+            height: 46
+            RowLayout {
+                anchors.fill: parent
+                spacing: 0
+                Image {
+                    source: "qrc:/icons/caret-left"
+                    mipmap: true
+                    Layout.preferredWidth: 30
+                    Layout.preferredHeight: 30
+                    Layout.alignment: Qt.AlignVCenter
+                    fillMode: Image.PreserveAspectFit
                 }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: swipeView.currentIndex -= 1
+                Text {
+                    Layout.alignment: Qt.AlignVCenter
+                    text: "Back"
+                    color: Theme.color.neutral9
+                    font.family: "Inter"
+                    font.styleName: "Semi Bold"
+                    font.pixelSize: 18
                 }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: swipeView.currentIndex -= 1
             }
         }
     }
+
     ColumnLayout {
         width: 600
         spacing: 0

--- a/src/qml/pages/onboarding/onboarding06b.qml
+++ b/src/qml/pages/onboarding/onboarding06b.qml
@@ -14,34 +14,31 @@ Page {
     clip: true
     header: RowLayout {
         height: 50
-        Loader {
-            active: true
-            visible: active
+        Item {
             Layout.alignment: Qt.AlignRight
             Layout.topMargin: 12
             Layout.rightMargin: -7
-            sourceComponent: Item {
-                Layout.fillWidth: true
-                width: 73
-                height: 46
-                Text {
-                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                    text: "Done"
-                    color: Theme.color.neutral9
-                    font.family: "Inter"
-                    font.styleName: "Semi Bold"
-                    font.pixelSize: 18
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        connections.decrementCurrentIndex()
-                        swipeView.inSubPage = false
-                    }
+            Layout.fillWidth: true
+            width: 73
+            height: 46
+            Text {
+                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                text: "Done"
+                color: Theme.color.neutral9
+                font.family: "Inter"
+                font.styleName: "Semi Bold"
+                font.pixelSize: 18
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    connections.decrementCurrentIndex()
+                    swipeView.inSubPage = false
                 }
             }
         }
     }
+    
     ColumnLayout {
         width: 450
         spacing: 0


### PR DESCRIPTION
Loaders can be useful to constrain how much memory we are using at a certain time and to implement lazy loading techniques. Proper usage of loaders will allow the qml-gui to be performant when it comes to the UI, if they are used properly. Currently, loaders are used incorrectly and frequently within the onboarding views pages.

The Wizard control contains a Loader which loads all views when it's initialized. Loaders within the onboarding views pages should only be there to conditionally display a certain component. All of the onboarding views pages contain loaders with no purpose that have no condition for their loading function.

This removes the improper use of loaders within the views pages.

Note to reviewers: Please ensure that all layouts remain the same when comparing this PR branch and master.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/145)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/145)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/145)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/145)

