### PR TITLE
Introduce and use Onboardinginfo control

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -318,6 +318,7 @@ QML_RES_QML = \
   qml/controls/ExternalLink.qml \
   qml/controls/Header.qml \
   qml/controls/PageIndicator.qml \
+  qml/controls/OnboardingInfo.qml \
   qml/controls/OptionButton.qml \
   qml/controls/OptionSwitch.qml \
   qml/controls/ProgressIndicator.qml \

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -12,6 +12,7 @@
         <file>controls/ExternalLink.qml</file>
         <file>controls/Header.qml</file>
         <file>controls/PageIndicator.qml</file>
+        <file>controls/OnboardingInfo.qml</file>
         <file>controls/OptionButton.qml</file>
         <file>controls/OptionSwitch.qml</file>
         <file>controls/ProgressIndicator.qml</file>

--- a/src/qml/controls/OnboardingInfo.qml
+++ b/src/qml/controls/OnboardingInfo.qml
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Control {
+    id: root
+    property alias banner: banner_loader.sourceComponent
+    required property string buttonText
+    property bool bold: false
+    property bool center: true
+    property int bannerMargin: 20
+    required property string header
+    property int headerMargin: 30
+    property int headerSize: 28
+    property string description: ""
+    property int descriptionMargin: 20
+    property int descriptionSize: 18
+    property string subtext: ""
+    property int subtextMargin: 30
+    property int subtextSize: 15
+
+    implicitWidth: 600
+
+    contentItem: ColumnLayout {
+        spacing: 0
+        Loader {
+            id: banner_loader
+            active: true
+            visible: active
+            Layout.alignment: Qt.AlignCenter
+            Layout.topMargin: root.bannerMargin
+            sourceComponent: root.actionItem
+        }
+        Header {
+            Layout.fillWidth: true
+            bold: root.bold
+            center: root.center
+            header: root.header
+            headerMargin: root.headerMargin
+            headerSize: root.headerSize
+            description: root.description
+            descriptionMargin: root.descriptionMargin
+            descriptionSize: root.descriptionSize
+            subtext: root.subtext
+            subtextMargin: root.subtextMargin
+            subtextSize: root.subtextSize
+        }
+        ContinueButton {
+            Layout.alignment: Qt.AlignCenter
+            Layout.topMargin: 40
+            text: root.buttonText
+            onClicked: swipeView.incrementCurrentIndex()
+        }
+    }
+}

--- a/src/qml/pages/onboarding/onboarding01a.qml
+++ b/src/qml/pages/onboarding/onboarding01a.qml
@@ -48,35 +48,24 @@ Page {
             }
         }
     }
-    ColumnLayout {
-        width: 600
-        spacing: 0
-        anchors.horizontalCenter: parent.horizontalCenter
+    OnboardingInfo {
         anchors.top: parent.top
-        Image {
+        anchors.horizontalCenter: parent.horizontalCenter
+        banner: Image {
+            Layout.fillWidth: true
             Layout.alignment: Qt.AlignCenter
             source: "image://images/app"
             sourceSize.width: 100
             sourceSize.height: 100
         }
-        Header {
-            Layout.fillWidth: true
-            implicitWidth: childrenRect.width
-            bold: true
-            header: qsTr("Bitcoin Core App")
-            headerSize: 36
-            headerMargin: 30
-            description: qsTr("Be part of the Bitcoin network.")
-            descriptionSize: 24
-            descriptionMargin: 10
-            subtext: qsTr("100% open-source & open-design")
-            subtextMargin: 30
-        }
-        ContinueButton {
-            Layout.alignment: Qt.AlignCenter
-            Layout.topMargin: 40
-            text: "Start"
-            onClicked: swipeView.incrementCurrentIndex()
-        }
+        bannerMargin: 0
+        bold: true
+        header: qsTr("Bitcoin Core App")
+        headerSize: 36
+        description: qsTr("Be part of the Bitcoin network.")
+        descriptionMargin: 10
+        descriptionSize: 24
+        subtext: qsTr("100% open-source & open-design")
+        buttonText: "Start"
     }
 }

--- a/src/qml/pages/onboarding/onboarding02.qml
+++ b/src/qml/pages/onboarding/onboarding02.qml
@@ -47,31 +47,17 @@ Page {
             }
         }
     }
-    ColumnLayout {
-        width: 600
-        spacing: 0
-        anchors.top: parent.top
-        anchors.horizontalCenter: parent.horizontalCenter
-        Image {
-            Layout.topMargin: 20
-            Layout.alignment: Qt.AlignCenter
-            source: "image://images/app"
-            sourceSize.width: 200
-            sourceSize.height: 200
-        }
-        Header {
-            Layout.fillWidth: true
-            bold: true
-            header: qsTr("Strengthen bitcoin")
-            headerMargin: 30
-            description: qsTr("Bitcoin Core runs a full Bitcoin node which verifies the rules of the network are being followed.\n\nUsers running nodes is what makes bitcoin\nso resilient and trustworthy.")
-            descriptionMargin: 20
-        }
-        ContinueButton {
-            Layout.alignment: Qt.AlignCenter
-            Layout.topMargin: 40
-            text: "Next"
-            onClicked: swipeView.incrementCurrentIndex()
-        }
+    OnboardingInfo {
+      anchors.top: parent.top
+      anchors.horizontalCenter: parent.horizontalCenter
+      banner: Image {
+          source: "image://images/app"
+          sourceSize.width: 200
+          sourceSize.height: 200
+      }
+      bold: true
+      header: qsTr("Strengthen bitcoin")
+      description: qsTr("Bitcoin Core runs a full Bitcoin node which verifies the rules of the network are being followed.\n\nUsers running nodes is what makes bitcoin\nso resilient and trustworthy.")
+      buttonText: "Next"
     }
 }

--- a/src/qml/pages/onboarding/onboarding03.qml
+++ b/src/qml/pages/onboarding/onboarding03.qml
@@ -47,31 +47,17 @@ Page {
             }
         }
     }
-    ColumnLayout {
-        width: 600
-        spacing: 0
+    OnboardingInfo {
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
-        Image {
-            Layout.topMargin: 20
-            Layout.alignment: Qt.AlignCenter
+        banner: Image {
             source: "image://images/app"
             sourceSize.width: 200
             sourceSize.height: 200
         }
-        Header {
-            Layout.fillWidth: true
-            bold: true
-            header: qsTr("The block clock")
-            headerMargin: 30
-            description: qsTr("The Bitcoin network targets a new block every\n10 minutes. Sometimes it's faster and sometimes slower.\n\nThe block clock indicates each block on a dial\nthat represents the current day.")
-            descriptionMargin: 20
-        }
-        ContinueButton {
-            Layout.alignment: Qt.AlignCenter
-            Layout.topMargin: 40
-            text: "Next"
-            onClicked: swipeView.incrementCurrentIndex()
-        }
+        bold: true
+        header: qsTr("The block clock")
+        description: qsTr("The Bitcoin network targets a new block every\n10 minutes. Sometimes it's faster and sometimes slower.\n\nThe block clock indicates each block on a dial\nthat represents the current day.")
+        buttonText: "Next"
     }
 }


### PR DESCRIPTION
This introduces the `OnboardingInfo` control which represents the contents of an onboarding page that displays an image, some body text, and the continue button. This type of onboarding page is thus categorized as in info page. This is a nice simplification for the onboarding views pages which display this type of info.

Extensible now with a loader for when the current temp images are replaced with Lottie animations.

no visual difference, comparison between master and pr below for reference:

**master**
| onboarding01a.qml | onboarding02.qml | onboarding03.qml |
| ------------------- | ------------------ | ------------------- |
| <img width="708" alt="Screen Shot 2022-08-08 at 1 09 27 AM" src="https://user-images.githubusercontent.com/23396902/183359912-629c1152-3d1e-46ab-8dfd-b69d543e34f5.png"> | <img width="752" alt="Screen Shot 2022-08-08 at 1 09 33 AM" src="https://user-images.githubusercontent.com/23396902/183359948-8ede57ff-80f0-4dfc-933e-b2bbeb10bf84.png"> | <img width="752" alt="Screen Shot 2022-08-08 at 1 09 46 AM" src="https://user-images.githubusercontent.com/23396902/183359973-9c80d61d-4f3a-45dc-b79b-88e23b80109a.png"> |

**pr**
| onboarding01a.qml | onboarding02.qml | onboarding03.qml |
| ------------------- | ------------------ | ------------------- |
| <img width="708" alt="Screen Shot 2022-08-08 at 1 08 30 AM" src="https://user-images.githubusercontent.com/23396902/183360053-091a898b-a216-46e3-8ea4-bbdaf250b442.png"> | <img width="752" alt="Screen Shot 2022-08-08 at 1 08 38 AM" src="https://user-images.githubusercontent.com/23396902/183360077-bf165055-e3a0-4c5f-86c3-daebb2aac794.png"> | <img width="752" alt="Screen Shot 2022-08-08 at 1 08 43 AM" src="https://user-images.githubusercontent.com/23396902/183360097-69958c50-d2bb-402c-a663-5feab82bd48c.png"> |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/146)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/146)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/<PR>)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/146)

