### PR TITLE
Onboarding views navigation bar cleanup

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -318,6 +318,7 @@ QML_RES_QML = \
   qml/controls/ContinueButton.qml \
   qml/controls/ExternalLink.qml \
   qml/controls/Header.qml \
+  qml/controls/NavButton.qml \
   qml/controls/PageIndicator.qml \
   qml/controls/OnboardingInfo.qml \
   qml/controls/OptionButton.qml \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -321,6 +321,7 @@ QML_RES_QML = \
   qml/controls/NavButton.qml \
   qml/controls/PageIndicator.qml \
   qml/controls/OnboardingInfo.qml \
+  qml/controls/OnboardingNav.qml \
   qml/controls/OptionButton.qml \
   qml/controls/OptionSwitch.qml \
   qml/controls/ProgressIndicator.qml \

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -11,6 +11,7 @@
         <file>controls/ContinueButton.qml</file>
         <file>controls/ExternalLink.qml</file>
         <file>controls/Header.qml</file>
+        <file>controls/NavButton.qml</file>
         <file>controls/PageIndicator.qml</file>
         <file>controls/OnboardingInfo.qml</file>
         <file>controls/OptionButton.qml</file>

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -14,6 +14,7 @@
         <file>controls/NavButton.qml</file>
         <file>controls/PageIndicator.qml</file>
         <file>controls/OnboardingInfo.qml</file>
+        <file>controls/OnboardingNav.qml</file>
         <file>controls/OptionButton.qml</file>
         <file>controls/OptionSwitch.qml</file>
         <file>controls/ProgressIndicator.qml</file>

--- a/src/qml/controls/NavButton.qml
+++ b/src/qml/controls/NavButton.qml
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+AbstractButton {
+    id: root
+    property int iconHeight: 30
+    property int iconWidth: 30
+    property int textSize: 18
+    property url iconSource: ""
+
+    padding: 0
+    background: null
+    contentItem: RowLayout {
+        anchors.fill: parent
+        spacing: 0
+        Loader {
+           id: button_background
+           active: root.iconSource.toString().length > 0
+           visible: active
+           sourceComponent: Button {
+               id: icon_button
+               padding: 0
+               display: AbstractButton.IconOnly
+               height: root.iconHeight
+               width: root.iconWidth
+               icon.source: root.iconSource
+               icon.color: Theme.color.neutral9
+               icon.height: root.iconHeight
+               icon.width: root.iconWidth
+               background: null
+               onClicked: root.clicked()
+           }
+        }
+        Loader {
+           active: root.text.length > 0
+           visible: active
+           sourceComponent: AbstractButton {
+               id: container
+               padding: 0
+               font.family: "Inter"
+               font.styleName: "Semi Bold"
+               font.pixelSize: root.textSize
+               background: null
+               contentItem: Text {
+                   anchors.verticalCenter: parent.verticalCenter
+                   font: container.font
+                   color: Theme.color.neutral9
+                   text: root.text
+              }
+              onClicked: root.clicked()
+          }
+      }
+    }
+}

--- a/src/qml/controls/OnboardingNav.qml
+++ b/src/qml/controls/OnboardingNav.qml
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Control {
+    id: root
+    property alias navButton: button_loader.sourceComponent
+    property bool alignLeft: true
+    height: 46
+    contentItem: RowLayout {
+        spacing: 0
+        Layout.fillWidth: true
+        Loader {
+            id: button_loader
+            Layout.rightMargin: 10
+            Layout.alignment: root.alignLeft ? Qt.AlignLeft : Qt.AlignRight
+            active: true
+            visible: active
+            sourceComponent: root.navButton
+        }
+    }
+}

--- a/src/qml/pages/onboarding/onboarding01a.qml
+++ b/src/qml/pages/onboarding/onboarding01a.qml
@@ -14,37 +14,14 @@ Page {
     background: null
     clip: true
     Layout.fillWidth: true
-    header: RowLayout {
-        height: 50
-        Loader {
-            active: true
-            visible: active
-            Layout.alignment: Qt.AlignRight
-            Layout.margins: 11
-            sourceComponent: Item {
-                width: 24
-                height: 24
-                Rectangle {
-                    anchors.fill: parent
-                    color: Theme.color.white
-                    radius: width*0.5
-                }
-                Image {
-                    id: icon
-                    source: "qrc:/icons/info"
-                    width: parent.width
-                    height: parent.height
-                    anchors.centerIn: parent
-                    fillMode: Image.PreserveAspectFit
-                    mipmap: true
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            introductions.incrementCurrentIndex()
-                            swipeView.inSubPage = true
-                        }
-                    }
-                }
+    header: OnboardingNav {
+        alignLeft: false
+        navButton: NavButton {
+            iconSource: "image://images/info"
+            iconHeight: 24
+            onClicked: {
+                introductions.incrementCurrentIndex()
+                swipeView.inSubPage = true
             }
         }
     }

--- a/src/qml/pages/onboarding/onboarding01b.qml
+++ b/src/qml/pages/onboarding/onboarding01b.qml
@@ -12,42 +12,13 @@ Page {
     background: null
     clip: true
     Layout.fillWidth: true
-    header: RowLayout {
-        height: 50
-        Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        introductions.decrementCurrentIndex()
-                        swipeView.inSubPage = false
-                    }
-                }
+    header: OnboardingNav {
+        navButton: NavButton {
+            iconSource: "image://images/caret-left"
+            text: "Back"
+            onClicked: {
+                introductions.decrementCurrentIndex()
+                swipeView.inSubPage = false
             }
         }
     }

--- a/src/qml/pages/onboarding/onboarding01c.qml
+++ b/src/qml/pages/onboarding/onboarding01c.qml
@@ -12,42 +12,13 @@ Page {
     background: null
     clip: true
     Layout.fillWidth: true
-    header: RowLayout {
-        height: 50
-        Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        introductions.decrementCurrentIndex()
-                        swipeView.inSubPage = true
-                    }
-                }
+    header: OnboardingNav {
+        navButton: NavButton {
+            iconSource: "image://images/caret-left"
+            text: "Back"
+            onClicked: {
+                introductions.decrementCurrentIndex()
+                swipeView.inSubPage = true
             }
         }
     }

--- a/src/qml/pages/onboarding/onboarding02.qml
+++ b/src/qml/pages/onboarding/onboarding02.qml
@@ -11,40 +11,11 @@ Page {
     background: null
     clip: true
     Layout.fillWidth: true
-    header: RowLayout {
-        height: 50
-        Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: swipeView.currentIndex -= 1
-                }
-            }
+    header: OnboardingNav {
+        navButton: NavButton {
+            iconSource: "image://images/caret-left"
+            text: "Back"
+            onClicked: swipeView.currentIndex -= 1
         }
     }
     OnboardingInfo {

--- a/src/qml/pages/onboarding/onboarding03.qml
+++ b/src/qml/pages/onboarding/onboarding03.qml
@@ -11,40 +11,11 @@ Page {
     background: null
     clip: true
     Layout.fillWidth: true
-    header: RowLayout {
-        height: 50
-        Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: swipeView.currentIndex -= 1
-                }
-            }
+    header: OnboardingNav {
+        navButton: NavButton {
+            iconSource: "image://images/caret-left"
+            text: "Back"
+            onClicked: swipeView.currentIndex -= 1
         }
     }
     OnboardingInfo {

--- a/src/qml/pages/onboarding/onboarding04.qml
+++ b/src/qml/pages/onboarding/onboarding04.qml
@@ -12,40 +12,11 @@ Page {
     background: null
     Layout.fillWidth: true
     clip: true
-    header: RowLayout {
-        height: 50
-        Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: swipeView.currentIndex -= 1
-                }
-            }
+    header: OnboardingNav {
+        navButton: NavButton {
+            iconSource: "image://images/caret-left"
+            text: "Back"
+            onClicked: swipeView.currentIndex -= 1
         }
     }
     ColumnLayout {

--- a/src/qml/pages/onboarding/onboarding05a.qml
+++ b/src/qml/pages/onboarding/onboarding05a.qml
@@ -12,40 +12,11 @@ Page {
     background: null
     Layout.fillWidth: true
     clip: true
-    header: RowLayout {
-        height: 50
-        Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: swipeView.currentIndex -= 1
-                }
-            }
+    header: OnboardingNav {
+        navButton: NavButton {
+            iconSource: "image://images/caret-left"
+            text: "Back"
+            onClicked: swipeView.currentIndex -= 1
         }
     }
     ColumnLayout {

--- a/src/qml/pages/onboarding/onboarding05b.qml
+++ b/src/qml/pages/onboarding/onboarding05b.qml
@@ -12,33 +12,13 @@ Page {
     background: null
     Layout.fillWidth: true
     clip: true
-    header: RowLayout {
-        height: 50
-        Loader {
-            active: true
-            visible: active
-            Layout.alignment: Qt.AlignRight
-            Layout.topMargin: 12
-            Layout.rightMargin: -7
-            sourceComponent: Item {
-                Layout.fillWidth: true
-                width: 73
-                height: 46
-                Text {
-                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                    text: "Done"
-                    color: Theme.color.neutral9
-                    font.family: "Inter"
-                    font.styleName: "Semi Bold"
-                    font.pixelSize: 18
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        storages.decrementCurrentIndex()
-                        swipeView.inSubPage = false
-                    }
-                }
+    header: OnboardingNav {
+        alignLeft: false
+        navButton: NavButton {
+            text: "Done"
+            onClicked: {
+                storages.decrementCurrentIndex()
+                swipeView.inSubPage = false
             }
         }
     }

--- a/src/qml/pages/onboarding/onboarding06a.qml
+++ b/src/qml/pages/onboarding/onboarding06a.qml
@@ -12,40 +12,11 @@ Page {
     background: null
     Layout.fillWidth: true
     clip: true
-    header: RowLayout {
-        height: 50
-        Layout.leftMargin: 10
-        Loader {
-            active: true
-            visible: active
-            sourceComponent: Item {
-                width: 73
-                height: 46
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-                    Image {
-                        source: "qrc:/icons/caret-left"
-                        mipmap: true
-                        Layout.preferredWidth: 30
-                        Layout.preferredHeight: 30
-                        Layout.alignment: Qt.AlignVCenter
-                        fillMode: Image.PreserveAspectFit
-                    }
-                    Text {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: "Back"
-                        color: Theme.color.neutral9
-                        font.family: "Inter"
-                        font.styleName: "Semi Bold"
-                        font.pixelSize: 18
-                    }
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: swipeView.currentIndex -= 1
-                }
-            }
+    header: OnboardingNav {
+        navButton: NavButton {
+            iconSource: "image://images/caret-left"
+            text: "Back"
+            onClicked: swipeView.currentIndex -= 1
         }
     }
     ColumnLayout {

--- a/src/qml/pages/onboarding/onboarding06b.qml
+++ b/src/qml/pages/onboarding/onboarding06b.qml
@@ -12,33 +12,13 @@ Page {
     background: null
     Layout.fillWidth: true
     clip: true
-    header: RowLayout {
-        height: 50
-        Loader {
-            active: true
-            visible: active
-            Layout.alignment: Qt.AlignRight
-            Layout.topMargin: 12
-            Layout.rightMargin: -7
-            sourceComponent: Item {
-                Layout.fillWidth: true
-                width: 73
-                height: 46
-                Text {
-                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                    text: "Done"
-                    color: Theme.color.neutral9
-                    font.family: "Inter"
-                    font.styleName: "Semi Bold"
-                    font.pixelSize: 18
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        connections.decrementCurrentIndex()
-                        swipeView.inSubPage = false
-                    }
-                }
+    header: OnboardingNav {
+        alignLeft: false
+        navButton: NavButton {
+            text: "Done"
+            onClicked: {
+                connections.decrementCurrentIndex()
+                swipeView.inSubPage = false
             }
         }
     }


### PR DESCRIPTION
This reduces a bunch of duplicated code by properly abstracting the navigation bar of the onboarding view pages into components; the `OnboardingNav` and `NavButton` control.

These are extensible out of the box and will work for new types of elements that may be needed in the navigation bar in the future; extensibility is free for the future.

This and bitcoin-core/gui-qml#146 greatly simplify and correct the onboarding views.

This is also another way to fix the issue outlined in bitcoin-core/gui-qml#145 as we do away with the misuse of loaders.

Note to reviewers: please check the formatting of the UI with this change.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/147)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/147)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/147)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/147)