### PR TITLE
Temporary dark mode button

### DIFF
--- a/src/qml/components/DeveloperOptions.qml
+++ b/src/qml/components/DeveloperOptions.qml
@@ -31,6 +31,13 @@ ColumnLayout {
     }
     Setting {
         Layout.fillWidth: true
+        header: qsTr("Dark Mode")
+        actionItem: OptionSwitch {
+            onToggled: Theme.toggleDark()
+        }
+    }
+    Setting {
+        Layout.fillWidth: true
         header: qsTr("Other option...")
         actionItem: ValueInput {
             description: qsTr("42")


### PR DESCRIPTION
A temporary placement for a button that toggles dark mode on and off within the entire UI. Necessary to visually ensure the UI is looking the way that the designers intend. For example, this rebased on top of #149:

![current-ui-darkmode](https://user-images.githubusercontent.com/23396902/184046910-953acfdc-c72c-4f34-956a-a7575e2f7c9e.png)



[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/150)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/150)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/150)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/150)
