### PR TITLE
Temporarily set dark mode as default

### DIFF
--- a/src/qml/components/DeveloperOptions.qml
+++ b/src/qml/components/DeveloperOptions.qml
@@ -33,6 +33,7 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Dark Mode")
         actionItem: OptionSwitch {
+            checked: Theme.dark
             onToggled: Theme.toggleDark()
         }
     }

--- a/src/qml/controls/Theme.qml
+++ b/src/qml/controls/Theme.qml
@@ -2,7 +2,7 @@ pragma Singleton
 import QtQuick 2.15
 
 QtObject {
-    property bool dark: false
+    property bool dark: true
     property QtObject color: QtObject {
         property color white: "#FFFFFF"
         property color background: dark ? "black" : "white"


### PR DESCRIPTION
Necessary to accommodate for static backups of elements that are supposed to be lottie animations. Can be reverted when we have developed proper lottie elements and have OS detection for light/dark mode.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/155)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/155)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/155)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/155)