### PR TITLE
Fix options switch alignment within settings

### DIFF
--- a/src/qml/controls/OptionSwitch.qml
+++ b/src/qml/controls/OptionSwitch.qml
@@ -7,9 +7,12 @@ import QtQuick.Controls 2.15
 
 Switch {
     id: root
+    padding: 0
+    width: 45
+    height: 28
     indicator: Rectangle {
-        implicitWidth: 45
-        implicitHeight: 28
+        implicitWidth: root.width
+        implicitHeight: root.height
         x: root.leftPadding
         y: Math.round((parent.height - height) / 2)
         radius: 18


### PR DESCRIPTION
Fixes alignment of the option switch within a settings row.

| master | PR |
| --------- | ---- |
| ![master-option](https://user-images.githubusercontent.com/23396902/184701651-89911f6c-5c9c-444e-8d37-93c7ba22e41b.png) | ![fix-option-pr](https://user-images.githubusercontent.com/23396902/184701668-44b61954-abe2-4af4-9c4e-76a7690ef466.png) |


Closes bitcoin-core/gui-qml#159

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/161)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/161)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/161)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/161)
