### PR TITLE
Refactor Init error window to fit to design spec

### DIFF
--- a/src/qml/pages/initerrormessage.qml
+++ b/src/qml/pages/initerrormessage.qml
@@ -4,22 +4,35 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../controls"
 
 ApplicationWindow {
-    title: "Bitcoin Core TnG"
+    id: root
     visible: true
+    title: "Bitcoin Core App"
     minimumWidth: 500
-    minimumHeight: 200
+    minimumHeight: 250
+    color: Theme.color.background
+    ColumnLayout {
+        spacing: 30
+        anchors.top: parent.top
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: 340
 
-    Dialog {
-        anchors.centerIn: parent
-        title: qsTr("Error")
-        contentItem:
-            Label {
-                text: message
-            }
-        visible: true
-        standardButtons: Dialog.Ok
-        onAccepted: Qt.quit()
+        Header {
+            Layout.topMargin: 30
+            Layout.fillWidth: true
+            bold: true
+            header: qsTr("There was an issue starting up.")
+            headerSize: 21
+            description: message
+            descriptionMargin: 3
+        }
+        OutlineButton {
+            Layout.alignment: Qt.AlignCenter
+            text: qsTr("Close")
+            onClicked: Qt.quit()
+        }
     }
 }


### PR DESCRIPTION
Refactors the init error window to fit to the design spec: [init error window design spec](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App?node-id=4204%3A85964)

| master | PR |
| --------- | ---- |
| <img width="612" alt="Screen Shot 2022-08-15 at 10 18 07 PM" src="https://user-images.githubusercontent.com/23396902/184787821-693e72aa-e4ac-4535-b6cb-b9b3f780e1ce.png"> | <img width="612" alt="Screen Shot 2023-01-16 at 1 53 50 AM" src="https://user-images.githubusercontent.com/23396902/212616368-688fc9b0-def8-442c-b976-e5592ae09881.png"> |

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/164)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/164)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/164)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/164)

closes  bitcoin-core/gui-qml#130
