### PR TITLE
Refactor Init error window to fit to design spec (4/4) 

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -329,6 +329,7 @@ QML_RES_QML = \
   qml/controls/OnboardingNav.qml \
   qml/controls/OptionButton.qml \
   qml/controls/OptionSwitch.qml \
+  qml/controls/OutlineButton.qml \
   qml/controls/ProgressIndicator.qml \
   qml/controls/qmldir \
   qml/controls/Setting.qml \

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -67,6 +67,7 @@ bool InitErrorMessageBox(
 {
     QQmlApplicationEngine engine;
     engine.rootContext()->setContextProperty("message", QString::fromStdString(message.translated));
+    engine.addImageProvider(QStringLiteral("images"), new ImageProvider{NULL});
     engine.load(QUrl(QStringLiteral("qrc:///qml/pages/initerrormessage.qml")));
     if (engine.rootObjects().isEmpty()) {
         return EXIT_FAILURE;

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -17,6 +17,7 @@
         <file>controls/OnboardingNav.qml</file>
         <file>controls/OptionButton.qml</file>
         <file>controls/OptionSwitch.qml</file>
+        <file>controls/OutlineButton.qml</file>
         <file>controls/ProgressIndicator.qml</file>
         <file>controls/qmldir</file>
         <file>controls/Setting.qml</file>

--- a/src/qml/controls/OutlineButton.qml
+++ b/src/qml/controls/OutlineButton.qml
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Button {
+    font.family: "Inter"
+    font.styleName: "Semi Bold"
+    font.pixelSize: 18
+    contentItem: Text {
+        text: parent.text
+        font: parent.font
+        color: Theme.color.neutral9
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+    }
+    background: Rectangle {
+        implicitHeight: 46
+        implicitWidth: 340
+        color: Theme.color.background
+        radius: 5
+        border {
+            width: 1
+            color: Theme.color.neutral4
+        }
+    }
+}

--- a/src/qml/pages/initerrormessage.qml
+++ b/src/qml/pages/initerrormessage.qml
@@ -4,22 +4,73 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../controls"
 
 ApplicationWindow {
-    title: "Bitcoin Core TnG"
+    id: root
+    title: "Bitcoin Core App"
+    minimumWidth: 640
+    minimumHeight: 665
+    color: Theme.color.background
     visible: true
-    minimumWidth: 500
-    minimumHeight: 200
 
-    Dialog {
+    Page {
+        id: errorWindow
+        width: 400
+        height: 240
         anchors.centerIn: parent
-        title: qsTr("Error")
-        contentItem:
-            Label {
-                text: message
+        background: Rectangle {
+            color: Theme.color.background
+            radius: 10
+            border {
+                width: 1
+                color: Theme.color.neutral4
             }
-        visible: true
-        standardButtons: Dialog.Ok
-        onAccepted: Qt.quit()
+        }
+        header: RowLayout {
+            width: errorWindow.width
+            height: 55
+            Rectangle {
+                width: 55
+            }
+            Header {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignCenter
+                bold: true
+                header: "Error"
+                headerSize: 24
+            }
+            Button {
+                id: icon_button
+                implicitWidth: 55
+                icon.source: "image://images/cross"
+                icon.color: Theme.color.neutral9
+                icon.width: 20
+                background: null
+                onClicked: Qt.quit()
+            }
+        }
+        Rectangle {
+            anchors.bottom: errorWindow.header.bottom
+            width: errorWindow.width
+            height: 1
+            color: Theme.color.neutral5
+        }
+        ColumnLayout {
+            anchors.fill: parent
+            Header {
+                Layout.fillWidth: true
+                Layout.topMargin: 20
+                header: message
+                headerSize: 18
+            }
+            OutlineButton {
+                Layout.alignment: Qt.AlignCenter
+                Layout.bottomMargin: 20
+                text: "Quit"
+                onClicked: Qt.quit()
+            }
+        }
     }
 }


### PR DESCRIPTION
Refactors the init error window to fit one of the design proposals for the [init error window](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App?node-id=4680%3A105383)

Based on bitcoin-core/gui-qml#163

Alternative to bitcoin-core/gui-qml#164, bitcoin-core/gui-qml#165, and  bitcoin-core/gui-qml#166

## Linux
| master | PR |
| --------- | ---- |
| ![Screenshot from 2022-08-15 22-58-20](https://user-images.githubusercontent.com/23396902/184788928-ddacc619-2d8b-4f44-978c-0b4a5da8a42e.png) | ![init-error-window-4](https://user-images.githubusercontent.com/23396902/185288865-1c297dc5-ecbc-4198-b947-4cf4a570e3ee.png) |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/167)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/167)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/167)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/167)

closes bitcoin-core/gui-qml#130