### PR TITLE
qml: split background and indicator on option switch

### DIFF
--- a/src/qml/controls/OptionSwitch.qml
+++ b/src/qml/controls/OptionSwitch.qml
@@ -7,21 +7,23 @@ import QtQuick.Controls 2.15
 
 Switch {
     id: root
-    indicator: Rectangle {
-        implicitWidth: 45
-        implicitHeight: 28
-        x: root.leftPadding
-        y: Math.round((parent.height - height) / 2)
-        radius: 18
+    implicitWidth: 45
+    implicitHeight: 28
+    background: Rectangle {
+        radius: Math.floor(height / 2)
         color: root.checked ? Theme.color.orange : Theme.color.neutral4
-        Rectangle {
-            id: indicatorButton
-            y: parent.height / 2 - height / 2
-            x: root.checked ? parent.width - width - 4 : 0 + 4
-            width: 20
-            height: 20
-            radius: 18
-            color: Theme.color.white
+    }
+    indicator: Rectangle {
+        property real _margin: Math.round((parent.height - height) / 2)
+        y: Math.round(parent.height - height) / 2
+        x: root.checked ? parent.width - width - _margin : _margin
+        radius: 10
+        width: 20
+        height: 20
+        color: Theme.color.white
+        Behavior on x {
+            SmoothedAnimation {
+            }
         }
     }
 }


### PR DESCRIPTION
Alternative to bitcoin-core/gui-qml#161.

nit, it also animates the indicator.

Links for Windows and macOS build artifacts

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/169)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/169)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/169)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/169)
