### PR TITLE
ci: Fix and re-enable "lint" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,19 +66,19 @@ compute_credits_template: &CREDITS_TEMPLATE
   # Only use credits for pull requests to the main repo
   use_compute_credits: $CIRRUS_REPO_FULL_NAME == 'bitcoin/bitcoin' && $CIRRUS_PR != ""
 
-# task:
-#   name: 'lint [bionic]'
-#   << : *BASE_TEMPLATE
-#   container:
-#     image: ubuntu:bionic  # For python 3.6, oldest supported version according to doc/dependencies.md
-#     cpu: 1
-#     memory: 1G
-#   # For faster CI feedback, immediately schedule the linters
-#   << : *CREDITS_TEMPLATE
-#   lint_script:
-#     - ./ci/lint_run_all.sh
-#   env:
-#     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
+task:
+  name: 'lint [bionic]'
+  << : *BASE_TEMPLATE
+  container:
+    image: ubuntu:bionic  # For python 3.6, oldest supported version according to doc/dependencies.md
+    cpu: 1
+    memory: 1G
+  # For faster CI feedback, immediately schedule the linters
+  << : *CREDITS_TEMPLATE
+  lint_script:
+    - ./ci/lint_run_all.sh
+  env:
+    << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
 task:
   name: 'tidy [jammy]'

--- a/test/lint/lint-git-commit-check.py
+++ b/test/lint/lint-git-commit-check.py
@@ -41,8 +41,8 @@ def main():
         if args.prev_commits:
             commit_range = "HEAD~" + args.prev_commits + "...HEAD"
         else:
-            # This assumes that the target branch of the pull request will be master.
-            merge_base = check_output(["git", "merge-base", "HEAD", "master"], universal_newlines=True, encoding="utf8").rstrip("\n")
+            # This assumes that the target branch of the pull request will be main.
+            merge_base = check_output(["git", "merge-base", "HEAD", "main"], universal_newlines=True, encoding="utf8").rstrip("\n")
             commit_range = merge_base + "..HEAD"
     else:
         commit_range = os.getenv("COMMIT_RANGE")

--- a/test/lint/lint-whitespace.py
+++ b/test/lint/lint-whitespace.py
@@ -92,8 +92,8 @@ def main():
         if args.prev_commits:
             commit_range = "HEAD~" + args.prev_commits + "...HEAD"
         else:
-            # This assumes that the target branch of the pull request will be master.
-            merge_base = check_output(["git", "merge-base", "HEAD", "master"], universal_newlines=True, encoding="utf8").rstrip("\n")
+            # This assumes that the target branch of the pull request will be main.
+            merge_base = check_output(["git", "merge-base", "HEAD", "main"], universal_newlines=True, encoding="utf8").rstrip("\n")
             commit_range = merge_base + "..HEAD"
     else:
         commit_range = os.getenv("COMMIT_RANGE")


### PR DESCRIPTION
In this repository the default branch name is "main", and it differs from the one in the [main](https://github.com/bitcoin/bitcoin) repository which is "master".