### PR TITLE
Adjust Onboarding's ContinueButton layout based on Mobile/Desktop target

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -35,6 +35,7 @@ QT_FORMS_UI = \
   qt/forms/transactiondescdialog.ui
 
 QT_MOC_CPP = \
+  qml/moc_appmode.cpp \
   qml/moc_nodemodel.cpp \
   qt/moc_addressbookpage.cpp \
   qt/moc_addresstablemodel.cpp \
@@ -107,6 +108,7 @@ QT_QRC_LOCALE_CPP = qt/qrc_bitcoin_locale.cpp
 QT_QRC_LOCALE = qt/bitcoin_locale.qrc
 
 BITCOIN_QT_H = \
+  qml/appmode.h \
   qml/bitcoin.h \
   qml/imageprovider.h \
   qml/nodemodel.h \

--- a/src/qml/appmode.h
+++ b/src/qml/appmode.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_APPMODE_H
+#define BITCOIN_QML_APPMODE_H
+
+#include <QObject>
+
+class AppMode : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool isDesktop READ isDesktop NOTIFY modeChanged)
+    Q_PROPERTY(bool isMobile READ isMobile NOTIFY modeChanged)
+    Q_PROPERTY(QString state READ state NOTIFY modeChanged)
+
+public:
+    enum Mode {
+        DESKTOP,
+        MOBILE
+    };
+
+    explicit AppMode(Mode mode) : m_mode(mode)
+    {
+    }
+
+    bool isMobile() { return m_mode == MOBILE; }
+    bool isDesktop() { return m_mode == DESKTOP; }
+    QString state()
+    {
+        switch (m_mode) {
+        case MOBILE:
+            return "MOBILE";
+        case DESKTOP:
+            return "DESKTOP";
+        default:
+            return "DESKTOP";
+        }
+    }
+    Mode mode() const { return m_mode; }
+
+Q_SIGNALS:
+    void modeChanged();
+
+private:
+    const Mode m_mode;
+};
+
+#endif // BITCOIN_QML_APPMODE_H

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -11,6 +11,7 @@
 #include <logging.h>
 #include <node/interface_ui.h>
 #include <noui.h>
+#include <qml/appmode.h>
 #include <qml/imageprovider.h>
 #include <qml/nodemodel.h>
 #include <qml/util.h>
@@ -183,6 +184,14 @@ int QmlGuiMain(int argc, char* argv[])
     engine.addImageProvider(QStringLiteral("images"), new ImageProvider{network_style.data()});
 
     engine.rootContext()->setContextProperty("nodeModel", &node_model);
+
+#ifdef __ANDROID__
+    AppMode app_mode(AppMode::MOBILE);
+#else
+    AppMode app_mode(AppMode::DESKTOP);
+#endif // __ANDROID__
+
+    qmlRegisterSingletonInstance<AppMode>("org.bitcoincore.qt", 1, 0, "AppMode", &app_mode);
 
     engine.load(QUrl(QStringLiteral("qrc:///qml/pages/main.qml")));
     if (engine.rootObjects().isEmpty()) {

--- a/src/qml/controls/Header.qml
+++ b/src/qml/controls/Header.qml
@@ -24,7 +24,6 @@ Control {
         spacing: 0
         Label {
             Layout.fillWidth: true
-            Layout.preferredWidth: 0
             topPadding: root.headerMargin
             font.family: "Inter"
             font.styleName: root.bold ? "Semi Bold" : "Regular"
@@ -36,7 +35,6 @@ Control {
         }
         Loader {
             Layout.fillWidth: true
-            Layout.preferredWidth: 0
             active: root.description.length > 0
             visible: active
             sourceComponent: Label {
@@ -52,7 +50,6 @@ Control {
         }
         Loader {
             Layout.fillWidth: true
-            Layout.preferredWidth: 0
             active: root.subtext.length > 0
             visible: active
             sourceComponent: Label {

--- a/src/qml/controls/OnboardingInfo.qml
+++ b/src/qml/controls/OnboardingInfo.qml
@@ -5,8 +5,9 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
 
-Control {
+Item {
     id: root
     property alias banner: banner_loader.sourceComponent
     required property string buttonText
@@ -25,7 +26,10 @@ Control {
 
     implicitWidth: 600
 
-    contentItem: ColumnLayout {
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: parent.width
+        id: information
         spacing: 0
         Loader {
             id: banner_loader
@@ -49,11 +53,40 @@ Control {
             subtextMargin: root.subtextMargin
             subtextSize: root.subtextSize
         }
-        ContinueButton {
-            Layout.alignment: Qt.AlignCenter
-            Layout.topMargin: 40
-            text: root.buttonText
-            onClicked: swipeView.incrementCurrentIndex()
-        }
     }
+    ContinueButton {
+        id: continueButton
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 40
+        anchors.bottomMargin: 60
+        anchors.leftMargin: 20
+        anchors.rightMargin: 20
+        text: root.buttonText
+        onClicked: swipeView.incrementCurrentIndex()
+    }
+
+    state: AppMode.state
+
+    states: [
+        State {
+            name: "MOBILE"
+            AnchorChanges {
+                target: continueButton
+                anchors.top: undefined
+                anchors.bottom: continueButton.parent.bottom
+                anchors.right: continueButton.parent.right
+                anchors.left: continueButton.parent.left
+            }
+        },
+        State {
+            name: "DESKTOP"
+            AnchorChanges {
+                target: continueButton
+                anchors.top: information.bottom
+                anchors.bottom: undefined
+                anchors.left: undefined
+                anchors.right: undefined
+            }
+        }
+    ]
 }

--- a/src/qml/pages/onboarding/onboarding01a.qml
+++ b/src/qml/pages/onboarding/onboarding01a.qml
@@ -26,7 +26,7 @@ Page {
         }
     }
     OnboardingInfo {
-        anchors.top: parent.top
+        height: parent.height
         anchors.horizontalCenter: parent.horizontalCenter
         banner: Image {
             Layout.fillWidth: true

--- a/src/qml/pages/onboarding/onboarding02.qml
+++ b/src/qml/pages/onboarding/onboarding02.qml
@@ -19,16 +19,16 @@ Page {
         }
     }
     OnboardingInfo {
-      anchors.top: parent.top
-      anchors.horizontalCenter: parent.horizontalCenter
-      banner: Image {
-          source: Theme.image.network
-          sourceSize.width: 200
-          sourceSize.height: 200
-      }
-      bold: true
-      header: qsTr("Strengthen bitcoin")
-      description: qsTr("Bitcoin Core runs a full Bitcoin node which verifies the rules of the network are being followed.\n\nUsers running nodes is what makes bitcoin\nso resilient and trustworthy.")
-      buttonText: "Next"
+        height: parent.height
+        anchors.horizontalCenter: parent.horizontalCenter
+        banner: Image {
+            source: Theme.image.network
+            sourceSize.width: 200
+            sourceSize.height: 200
+        }
+        bold: true
+        header: qsTr("Strengthen bitcoin")
+        description: qsTr("Bitcoin Core runs a full Bitcoin node which verifies the rules of the network are being followed.\n\nUsers running nodes is what makes bitcoin\nso resilient and trustworthy.")
+        buttonText: "Next"
     }
 }

--- a/src/qml/pages/onboarding/onboarding03.qml
+++ b/src/qml/pages/onboarding/onboarding03.qml
@@ -19,7 +19,7 @@ Page {
         }
     }
     OnboardingInfo {
-        anchors.top: parent.top
+        height: parent.height
         anchors.horizontalCenter: parent.horizontalCenter
         banner: Image {
             source: Theme.image.blocktime

--- a/src/qml/pages/onboarding/onboarding04.qml
+++ b/src/qml/pages/onboarding/onboarding04.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
 import "../../controls"
 import "../../components"
 
@@ -20,6 +21,7 @@ Page {
         }
     }
     ColumnLayout {
+        id: selections
         width: 600
         spacing: 0
         anchors.top: parent.top
@@ -35,11 +37,40 @@ Page {
             Layout.topMargin: 30
             Layout.alignment: Qt.AlignCenter
         }
-        ContinueButton {
-            Layout.alignment: Qt.AlignCenter
-            Layout.topMargin: 40
-            text: "Next"
-            onClicked: swipeView.incrementCurrentIndex()
-        }
     }
+    ContinueButton {
+        id: continueButton
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 40
+        anchors.bottomMargin: 60
+        anchors.rightMargin: 20
+        anchors.leftMargin: 20
+        text: "Next"
+        onClicked: swipeView.incrementCurrentIndex()
+    }
+
+    state: AppMode.state
+
+    states: [
+        State {
+            name: "MOBILE"
+            AnchorChanges {
+                target: continueButton
+                anchors.top: undefined
+                anchors.bottom: continueButton.parent.bottom
+                anchors.left: continueButton.parent.left
+                anchors.right: continueButton.parent.right
+            }
+        },
+        State {
+            name: "DESKTOP"
+            AnchorChanges {
+                target: continueButton
+                anchors.top: selections.bottom
+                anchors.bottom: undefined
+                anchors.left: undefined
+                anchors.right: undefined
+            }
+        }
+    ]
 }

--- a/src/qml/pages/onboarding/onboarding05a.qml
+++ b/src/qml/pages/onboarding/onboarding05a.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.11
+import org.bitcoincore.qt 1.0
 import "../../controls"
 import "../../components"
 
@@ -20,6 +21,7 @@ Page {
         }
     }
     ColumnLayout {
+        id: selections
         width: 600
         spacing: 0
         anchors.top: parent.top
@@ -45,11 +47,40 @@ Page {
               swipeView.inSubPage = true
             }
         }
-        ContinueButton {
-            Layout.alignment: Qt.AlignCenter
-            Layout.topMargin: 40
-            text: "Next"
-            onClicked: swipeView.incrementCurrentIndex()
-        }
     }
+    ContinueButton {
+        id: continueButton
+        anchors.topMargin: 40
+        anchors.leftMargin: 20
+        anchors.rightMargin: 20
+        anchors.bottomMargin: 60
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: "Next"
+        onClicked: swipeView.incrementCurrentIndex()
+    }
+
+    state: AppMode.state
+
+    states: [
+        State {
+            name: "MOBILE"
+            AnchorChanges {
+                target: continueButton
+                anchors.top: undefined
+                anchors.bottom: continueButton.parent.bottom
+                anchors.left: continueButton.parent.left
+                anchors.right: continueButton.parent.right
+            }
+        },
+        State {
+            name: "DESKTOP"
+            AnchorChanges {
+                target: continueButton
+                anchors.top: selections.bottom
+                anchors.bottom: undefined
+                anchors.left: undefined
+                anchors.right: undefined
+            }
+        }
+    ]
 }

--- a/src/qml/pages/onboarding/onboarding06a.qml
+++ b/src/qml/pages/onboarding/onboarding06a.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
 import "../../controls"
 import "../../components"
 
@@ -20,6 +21,7 @@ Page {
         }
     }
     ColumnLayout {
+        id: selections
         width: 600
         spacing: 0
         anchors.top: parent.top
@@ -50,11 +52,40 @@ Page {
               swipeView.inSubPage = true
             }
         }
-        ContinueButton {
-            Layout.alignment: Qt.AlignCenter
-            Layout.topMargin: 40
-            text: "Next"
-            onClicked: swipeView.finished = true
-        }
     }
+    ContinueButton {
+        id: continueButton
+        anchors.topMargin: 40
+        anchors.leftMargin: 20
+        anchors.rightMargin: 20
+        anchors.bottomMargin: 60
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: "Next"
+        onClicked: swipeView.finished = true
+    }
+
+    state: AppMode.state
+
+    states: [
+        State {
+            name: "MOBILE"
+            AnchorChanges {
+                target: continueButton
+                anchors.top: undefined
+                anchors.bottom: continueButton.parent.bottom
+                anchors.right: continueButton.parent.right
+                anchors.left: continueButton.parent.left
+            }
+        },
+        State {
+            name: "DESKTOP"
+            AnchorChanges {
+                target: continueButton
+                anchors.top: selections.bottom
+                anchors.bottom: undefined
+                anchors.right: undefined
+                anchors.left: undefined
+            }
+        }
+    ]
 }


### PR DESCRIPTION
This change registers a new QObject that can be used to check if the app is running in DESKTOP or MOBILE mode. Based on that value, adjustments to the ContinueButton's anchors will be made to match the spec for each configuration. 

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/171)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/171)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/171)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/171)