### PR TITLE
qml: fix Bitcoin icon size to match spec

### DIFF
--- a/src/qml/pages/onboarding/onboarding01a.qml
+++ b/src/qml/pages/onboarding/onboarding01a.qml
@@ -32,8 +32,9 @@ Page {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignCenter
             source: "image://images/app"
-            sourceSize.width: 100
-            sourceSize.height: 100
+            // Bitcoin icon has ~11% padding
+            sourceSize.width: 112
+            sourceSize.height: 112
         }
         bannerMargin: 0
         bold: true


### PR DESCRIPTION
The included asset has padding around the icon so the width/height of the image component should be slightly larger to match the spec.