### PR TITLE
Update block tip in the gui thread

### DIFF
--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <chrono>
 
+#include <QMetaObject>
 #include <QTimerEvent>
 
 NodeModel::NodeModel(interfaces::Node& node)
@@ -71,7 +72,9 @@ void NodeModel::ConnectToBlockTipSignal()
 
     m_handler_notify_block_tip = m_node.handleNotifyBlockTip(
         [this](SynchronizationState state, interfaces::BlockTip tip, double verification_progress) {
-            setBlockTipHeight(tip.block_height);
-            setVerificationProgress(verification_progress);
+            QMetaObject::invokeMethod(this, [=] {
+                setBlockTipHeight(tip.block_height);
+                setVerificationProgress(verification_progress);
+            });
         });
 }


### PR DESCRIPTION
This takes commit https://github.com/bitcoin-core/gui-qml/pull/38/commits/cf8a278e7a8bb5aaabef60b9345deff4c3d3c792 from https://github.com/bitcoin-core/gui-qml/pull/38/ and rebases it over changes on master; namely that we've dropped `GUIUtil::ObjectInvoke` in favor of `QMetaObject::invokeMethod`.

This avoids non-thread-safe errors. I ran into a segfault here while running some data intensive monkey-code related to blocks, this change prevented it. I'm not going to actually use the code that caused the segfault, just to illustrate that this is useful here anyways. 

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/177)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/177)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/177)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/177)

