### PR TITLE
Fix anchor warning in ContinueButton

### DIFF
--- a/src/qml/controls/OnboardingInfo.qml
+++ b/src/qml/controls/OnboardingInfo.qml
@@ -58,7 +58,6 @@ Item {
     }
     ContinueButton {
         id: continueButton
-        anchors.horizontalCenter: parent.horizontalCenter
         anchors.topMargin: 40
         anchors.bottomMargin: 60
         anchors.leftMargin: 20
@@ -78,6 +77,7 @@ Item {
                 anchors.bottom: continueButton.parent.bottom
                 anchors.right: continueButton.parent.right
                 anchors.left: continueButton.parent.left
+                anchors.horizontalCenter: undefined
             }
         },
         State {
@@ -88,6 +88,7 @@ Item {
                 anchors.bottom: undefined
                 anchors.left: undefined
                 anchors.right: undefined
+                anchors.horizontalCenter: parent.horizontalCenter
             }
         }
     ]

--- a/src/qml/pages/onboarding/onboarding04.qml
+++ b/src/qml/pages/onboarding/onboarding04.qml
@@ -45,7 +45,6 @@ Page {
     }
     ContinueButton {
         id: continueButton
-        anchors.horizontalCenter: parent.horizontalCenter
         anchors.topMargin: 40
         anchors.bottomMargin: 60
         anchors.rightMargin: 20
@@ -65,6 +64,7 @@ Page {
                 anchors.bottom: continueButton.parent.bottom
                 anchors.left: continueButton.parent.left
                 anchors.right: continueButton.parent.right
+                anchors.horizontalCenter: undefined
             }
         },
         State {
@@ -75,6 +75,7 @@ Page {
                 anchors.bottom: undefined
                 anchors.left: undefined
                 anchors.right: undefined
+                anchors.horizontalCenter: parent.horizontalCenter
             }
         }
     ]

--- a/src/qml/pages/onboarding/onboarding05a.qml
+++ b/src/qml/pages/onboarding/onboarding05a.qml
@@ -59,7 +59,6 @@ Page {
         anchors.leftMargin: 20
         anchors.rightMargin: 20
         anchors.bottomMargin: 60
-        anchors.horizontalCenter: parent.horizontalCenter
         text: "Next"
         onClicked: swipeView.incrementCurrentIndex()
     }
@@ -75,6 +74,7 @@ Page {
                 anchors.bottom: continueButton.parent.bottom
                 anchors.left: continueButton.parent.left
                 anchors.right: continueButton.parent.right
+                anchors.horizontalCenter: undefined
             }
         },
         State {
@@ -85,6 +85,7 @@ Page {
                 anchors.bottom: undefined
                 anchors.left: undefined
                 anchors.right: undefined
+                anchors.horizontalCenter: parent.horizontalCenter
             }
         }
     ]

--- a/src/qml/pages/onboarding/onboarding06a.qml
+++ b/src/qml/pages/onboarding/onboarding06a.qml
@@ -65,7 +65,6 @@ Page {
         anchors.leftMargin: 20
         anchors.rightMargin: 20
         anchors.bottomMargin: 60
-        anchors.horizontalCenter: parent.horizontalCenter
         text: "Next"
         onClicked: swipeView.finished = true
     }
@@ -81,6 +80,7 @@ Page {
                 anchors.bottom: continueButton.parent.bottom
                 anchors.right: continueButton.parent.right
                 anchors.left: continueButton.parent.left
+                anchors.horizontalCenter: undefined
             }
         },
         State {
@@ -91,6 +91,7 @@ Page {
                 anchors.bottom: undefined
                 anchors.right: undefined
                 anchors.left: undefined
+                anchors.horizontalCenter: parent.horizontalCenter
             }
         }
     ]


### PR DESCRIPTION
anchors.horizontalCenter should be undefined when anchors.left and/or anchors.right is set.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/<PR>)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/<PR>)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/<PR>)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/<PR>)
