### PR TITLE
Keep ContinueButton AnchorChanges inside of OnboardingInfo

### DIFF
--- a/src/qml/controls/OnboardingInfo.qml
+++ b/src/qml/controls/OnboardingInfo.qml
@@ -9,8 +9,9 @@ import org.bitcoincore.qt 1.0
 
 Item {
     id: root
-    property alias banner: banner_loader.sourceComponent
+    property alias bannerItem: banner_loader.sourceComponent
     required property string buttonText
+    property bool banner: true
     property bool bold: false
     property bool center: true
     property int bannerMargin: 20
@@ -33,11 +34,11 @@ Item {
         spacing: 0
         Loader {
             id: banner_loader
-            active: true
+            active: root.banner
             visible: active
             Layout.alignment: Qt.AlignCenter
             Layout.topMargin: root.bannerMargin
-            sourceComponent: root.actionItem
+            sourceComponent: root.bannerItem
         }
         Header {
             Layout.fillWidth: true

--- a/src/qml/controls/OnboardingInfo.qml
+++ b/src/qml/controls/OnboardingInfo.qml
@@ -10,8 +10,11 @@ import org.bitcoincore.qt 1.0
 Item {
     id: root
     property alias bannerItem: banner_loader.sourceComponent
+    property alias detailItem: detail_loader.sourceComponent
     required property string buttonText
     property bool banner: true
+    property bool detail: false
+    property bool finish: false
     property bool bold: false
     property bool center: true
     property int bannerMargin: 20
@@ -56,6 +59,16 @@ Item {
             subtextMargin: root.subtextMargin
             subtextSize: root.subtextSize
         }
+        Loader {
+            id: detail_loader
+            active: root.detail
+            visible: active
+            Layout.alignment: Qt.AlignCenter
+            Layout.topMargin: 30
+            Layout.leftMargin: 20
+            Layout.rightMargin: 20
+            sourceComponent: root.detailItem
+        }
     }
     ContinueButton {
         id: continueButton
@@ -64,7 +77,7 @@ Item {
         anchors.leftMargin: 20
         anchors.rightMargin: 20
         text: root.buttonText
-        onClicked: swipeView.incrementCurrentIndex()
+        onClicked: root.finish ? swipeView.finished = true : swipeView.incrementCurrentIndex()
     }
 
     state: AppMode.state

--- a/src/qml/pages/onboarding/onboarding01a.qml
+++ b/src/qml/pages/onboarding/onboarding01a.qml
@@ -28,7 +28,7 @@ Page {
         height: parent.height
         width: Math.min(parent.width, 600)
         anchors.horizontalCenter: parent.horizontalCenter
-        banner: Image {
+        bannerItem: Image {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignCenter
             source: "image://images/app"

--- a/src/qml/pages/onboarding/onboarding02.qml
+++ b/src/qml/pages/onboarding/onboarding02.qml
@@ -22,7 +22,7 @@ Page {
         height: parent.height
         width: Math.min(parent.width, 600)
         anchors.horizontalCenter: parent.horizontalCenter
-        banner: Image {
+        bannerItem: Image {
             source: Theme.image.network
             sourceSize.width: 200
             sourceSize.height: 200

--- a/src/qml/pages/onboarding/onboarding03.qml
+++ b/src/qml/pages/onboarding/onboarding03.qml
@@ -22,7 +22,7 @@ Page {
         height: parent.height
         width: Math.min(parent.width, 600)
         anchors.horizontalCenter: parent.horizontalCenter
-        banner: Image {
+        bannerItem: Image {
             source: Theme.image.blocktime
             sourceSize.width: 200
             sourceSize.height: 200

--- a/src/qml/pages/onboarding/onboarding04.qml
+++ b/src/qml/pages/onboarding/onboarding04.qml
@@ -36,6 +36,7 @@ Page {
             descriptionMargin: 20
         }
         StorageLocations {
+        banner: false
             Layout.maximumWidth: 450
             Layout.topMargin: 30
             Layout.leftMargin: 20

--- a/src/qml/pages/onboarding/onboarding04.qml
+++ b/src/qml/pages/onboarding/onboarding04.qml
@@ -20,64 +20,20 @@ Page {
             onClicked: swipeView.currentIndex -= 1
         }
     }
-    ColumnLayout {
-        id: selections
+    OnboardingInfo {
+        height: parent.height
         width: Math.min(parent.width, 600)
-        spacing: 0
-        anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
-        Header {
-            Layout.fillWidth: true
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-            bold: true
-            header: qsTr("Storage location")
-            description: qsTr("Where do you want to store the downloaded block data?")
-            descriptionMargin: 20
-        }
-        StorageLocations {
         banner: false
+        bold: true
+        header: qsTr("Storage location")
+        headerMargin: 0
+        description: qsTr("Where do you want to store the downloaded block data?")
+        descriptionMargin: 20
+        detail: true
+        detailItem: StorageLocations {
             Layout.maximumWidth: 450
-            Layout.topMargin: 30
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-            Layout.alignment: Qt.AlignCenter
         }
+        buttonText: qsTr("Next")
     }
-    ContinueButton {
-        id: continueButton
-        anchors.topMargin: 40
-        anchors.bottomMargin: 60
-        anchors.rightMargin: 20
-        anchors.leftMargin: 20
-        text: "Next"
-        onClicked: swipeView.incrementCurrentIndex()
-    }
-
-    state: AppMode.state
-
-    states: [
-        State {
-            name: "MOBILE"
-            AnchorChanges {
-                target: continueButton
-                anchors.top: undefined
-                anchors.bottom: continueButton.parent.bottom
-                anchors.left: continueButton.parent.left
-                anchors.right: continueButton.parent.right
-                anchors.horizontalCenter: undefined
-            }
-        },
-        State {
-            name: "DESKTOP"
-            AnchorChanges {
-                target: continueButton
-                anchors.top: selections.bottom
-                anchors.bottom: undefined
-                anchors.left: undefined
-                anchors.right: undefined
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-        }
-    ]
 }

--- a/src/qml/pages/onboarding/onboarding05a.qml
+++ b/src/qml/pages/onboarding/onboarding05a.qml
@@ -20,74 +20,40 @@ Page {
             onClicked: swipeView.currentIndex -= 1
         }
     }
-    ColumnLayout {
-        id: selections
+    OnboardingInfo {
+        height: parent.height
         width: Math.min(parent.width, 600)
-        spacing: 0
-        anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
-        Header {
-            Layout.fillWidth: true
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-            bold: true
-            header: qsTr("Storage")
-            description: qsTr("Data retrieved from the Bitcoin network is stored on your device.\nYou have 500GB of storage available.")
-        }
-        StorageOptions {
-            Layout.maximumWidth: 450
-            Layout.topMargin: 30
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-            Layout.alignment: Qt.AlignCenter
-        }
-        TextButton {
-            Layout.alignment: Qt.AlignCenter
-            Layout.topMargin: 30
-            text: "Detailed settings"
-            textSize: 18
-            textColor: "#F7931A"
-            onClicked: {
-              storages.incrementCurrentIndex()
-              swipeView.inSubPage = true
         banner: false
+        bold: true
+        header: qsTr("Storage")
+        headerMargin: 0
+        description: qsTr("Data retrieved from the Bitcoin network is stored on your device.\nYou have 500GB of storage available.")
+        descriptionMargin: 10
+        detail: true
+        detailItem: ColumnLayout {
+            spacing: 0
+            StorageOptions {
+                Layout.maximumWidth: 450
+                Layout.fillWidth: true
+                Layout.leftMargin: 20
+                Layout.rightMargin: 20
+            }
+            TextButton {
+                Layout.alignment: Qt.AlignCenter
+                Layout.topMargin: 30
+                Layout.fillWidth: true
+                Layout.leftMargin: 20
+                Layout.rightMargin: 20
+                text: "Detailed settings"
+                textSize: 18
+                textColor: "#F7931A"
+                onClicked: {
+                  storages.incrementCurrentIndex()
+                  swipeView.inSubPage = true
+                }
             }
         }
+        buttonText: qsTr("Next")
     }
-    ContinueButton {
-        id: continueButton
-        anchors.topMargin: 40
-        anchors.leftMargin: 20
-        anchors.rightMargin: 20
-        anchors.bottomMargin: 60
-        text: "Next"
-        onClicked: swipeView.incrementCurrentIndex()
-    }
-
-    state: AppMode.state
-
-    states: [
-        State {
-            name: "MOBILE"
-            AnchorChanges {
-                target: continueButton
-                anchors.top: undefined
-                anchors.bottom: continueButton.parent.bottom
-                anchors.left: continueButton.parent.left
-                anchors.right: continueButton.parent.right
-                anchors.horizontalCenter: undefined
-            }
-        },
-        State {
-            name: "DESKTOP"
-            AnchorChanges {
-                target: continueButton
-                anchors.top: selections.bottom
-                anchors.bottom: undefined
-                anchors.left: undefined
-                anchors.right: undefined
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-        }
-    ]
 }

--- a/src/qml/pages/onboarding/onboarding05a.qml
+++ b/src/qml/pages/onboarding/onboarding05a.qml
@@ -50,6 +50,7 @@ Page {
             onClicked: {
               storages.incrementCurrentIndex()
               swipeView.inSubPage = true
+        banner: false
             }
         }
     }

--- a/src/qml/pages/onboarding/onboarding06a.qml
+++ b/src/qml/pages/onboarding/onboarding06a.qml
@@ -26,7 +26,7 @@ Page {
         spacing: 0
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
-        Image {
+        bannerItem: Image {
             Layout.topMargin: 20
             Layout.alignment: Qt.AlignCenter
             source: Theme.image.storage

--- a/src/qml/pages/onboarding/onboarding06a.qml
+++ b/src/qml/pages/onboarding/onboarding06a.qml
@@ -20,11 +20,9 @@ Page {
             onClicked: swipeView.currentIndex -= 1
         }
     }
-    ColumnLayout {
-        id: selections
+    OnboardingInfo {
+        height: parent.height
         width: Math.min(parent.width, 600)
-        spacing: 0
-        anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
         bannerItem: Image {
             Layout.topMargin: 20
@@ -33,23 +31,13 @@ Page {
             sourceSize.width: 200
             sourceSize.height: 200
         }
-        Header {
-            Layout.fillWidth: true
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-
-            bold: true
-            header: qsTr("Starting initial download")
-            headerMargin: 30
-            description: qsTr("The application will connect to the Bitcoin network and start downloading and verifying transactions.\n\nThis may take several hours, or even days, based on your connection.")
-            descriptionMargin: 20
-        }
-        TextButton {
-            Layout.alignment: Qt.AlignCenter
-            Layout.topMargin: 30
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-
+        bold: true
+        header: qsTr("Starting initial download")
+        headerMargin: 30
+        description: qsTr("The application will connect to the Bitcoin network and start downloading and verifying transactions.\n\nThis may take several hours, or even days, based on your connection.")
+        descriptionMargin: 20
+        detail: true
+        detailItem: TextButton {
             text: "Connection settings"
             textSize: 18
             textColor: Theme.color.orange
@@ -58,41 +46,8 @@ Page {
               swipeView.inSubPage = true
             }
         }
-    }
-    ContinueButton {
-        id: continueButton
-        anchors.topMargin: 40
-        anchors.leftMargin: 20
-        anchors.rightMargin: 20
-        anchors.bottomMargin: 60
-        text: "Next"
-        onClicked: swipeView.finished = true
-    }
+        finish: true
+        buttonText: "Next"
 
-    state: AppMode.state
-
-    states: [
-        State {
-            name: "MOBILE"
-            AnchorChanges {
-                target: continueButton
-                anchors.top: undefined
-                anchors.bottom: continueButton.parent.bottom
-                anchors.right: continueButton.parent.right
-                anchors.left: continueButton.parent.left
-                anchors.horizontalCenter: undefined
-            }
-        },
-        State {
-            name: "DESKTOP"
-            AnchorChanges {
-                target: continueButton
-                anchors.top: selections.bottom
-                anchors.bottom: undefined
-                anchors.right: undefined
-                anchors.left: undefined
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-        }
-    ]
+    }
 }


### PR DESCRIPTION
The `OnboardingInfo` control is currently a control that represents, among other things, the type of onboarding page that contains a continue button. The `ContinueButton` is currently the only item that has `AnchorChanges` applied to it. This attempts to de-duplicate the code for `AnchorChanges` on the `ContinueButton` by keeping them inside of the `OnboardingInfo` control and refactoring so more of the onboarding pages can use the `OnboardingInfo`. control.

No visual change with this PR.


### Master

|   |   |   |   |   |   |
| - | - | - | - | - | - |
| <img width="708" alt="Screen Shot 2022-10-26 at 5 02 54 AM" src="https://user-images.githubusercontent.com/23396902/198012887-739b30d6-55bb-458f-bfd5-4653cdfbcbba.png"> | <img width="752" alt="Screen Shot 2022-10-26 at 5 03 07 AM" src="https://user-images.githubusercontent.com/23396902/198012936-02f1e05c-7059-435c-8506-60deb32dabf3.png"> | <img width="752" alt="Screen Shot 2022-10-26 at 5 03 44 AM" src="https://user-images.githubusercontent.com/23396902/198012970-8d20c3fc-8c22-4ce6-b291-6e119c84041e.png"> | <img width="752" alt="Screen Shot 2022-10-26 at 5 03 56 AM" src="https://user-images.githubusercontent.com/23396902/198013001-49c2823d-cc16-4ddf-9f21-4a61380d414e.png"> | <img width="752" alt="Screen Shot 2022-10-26 at 5 04 01 AM" src="https://user-images.githubusercontent.com/23396902/198013026-af08f6da-2ce7-472c-85b5-37ec91433327.png"> | <img width="752" alt="Screen Shot 2022-10-26 at 5 04 18 AM" src="https://user-images.githubusercontent.com/23396902/198013064-6db9e84e-5f3a-4674-97fc-5049751dc927.png"> |


### PR
|   |   |   |   |   |   |
| - | - | - | - | - | - |
| <img width="752" alt="Screen Shot 2022-10-26 at 5 04 46 AM" src="https://user-images.githubusercontent.com/23396902/198013304-4beaa199-ff51-4542-bbbf-2d1f6e2a7d30.png"> | <img width="752" alt="Screen Shot 2022-10-26 at 5 04 57 AM" src="https://user-images.githubusercontent.com/23396902/198013322-8645d24b-7406-441b-b89c-979506f2a8a7.png"> | <img width="752" alt="Screen Shot 2022-10-26 at 5 05 01 AM" src="https://user-images.githubusercontent.com/23396902/198013441-674c25a6-482a-4a28-aab5-4e74df6c8ed4.png"> | <img width="752" alt="Screen Shot 2022-10-26 at 5 05 10 AM" src="https://user-images.githubusercontent.com/23396902/198013478-56b34077-3975-4200-a150-0243e447b252.png"> | <img width="752" alt="Screen Shot 2022-10-26 at 5 05 16 AM" src="https://user-images.githubusercontent.com/23396902/198013505-5360a3e5-1df9-418e-ab51-a583a1d6cff3.png"> | <img width="752" alt="Screen Shot 2022-10-26 at 5 05 21 AM" src="https://user-images.githubusercontent.com/23396902/198013545-1da2346d-d109-4b04-aea2-f912ddfd84eb.png"> |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/183)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/183)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/183)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/183)

