### PR TITLE
Constrain ContinueButton width to 300 pixels

### DIFF
--- a/src/qml/controls/InformationPage.qml
+++ b/src/qml/controls/InformationPage.qml
@@ -82,10 +82,12 @@ Page {
         id: continueButton
         visible: root.buttonText.length > 0
         enabled: visible
+        width: Math.min(300, parent.width - 2 * anchors.leftMargin)
         anchors.topMargin: 40
         anchors.bottomMargin: 60
         anchors.leftMargin: 20
         anchors.rightMargin: 20
+        anchors.horizontalCenter: parent.horizontalCenter
         text: root.buttonText
         onClicked: root.lastPage ? swipeView.finished = true : swipeView.incrementCurrentIndex()
     }
@@ -99,9 +101,6 @@ Page {
                 target: continueButton
                 anchors.top: undefined
                 anchors.bottom: continueButton.parent.bottom
-                anchors.right: continueButton.parent.right
-                anchors.left: continueButton.parent.left
-                anchors.horizontalCenter: undefined
             }
         },
         State {
@@ -110,9 +109,6 @@ Page {
                 target: continueButton
                 anchors.top: information.bottom
                 anchors.bottom: undefined
-                anchors.left: undefined
-                anchors.right: undefined
-                anchors.horizontalCenter: parent.horizontalCenter
             }
         }
     ]


### PR DESCRIPTION
Addresses the issue with the button stretching too far on a wide mobile/tablet.


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/190)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/190)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/190)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/190)