### PR TITLE
Use OnboardingInfo for all onboarding pages

### DIFF
--- a/src/qml/controls/OnboardingInfo.qml
+++ b/src/qml/controls/OnboardingInfo.qml
@@ -11,7 +11,7 @@ Item {
     id: root
     property alias bannerItem: banner_loader.sourceComponent
     property alias detailItem: detail_loader.sourceComponent
-    required property string buttonText
+    property string buttonText: ""
     property bool bannerActive: true
     property bool detailActive: false
     property bool lastPage: false
@@ -72,6 +72,8 @@ Item {
     }
     ContinueButton {
         id: continueButton
+        visible: root.buttonText.length > 0
+        enabled: visible
         anchors.topMargin: 40
         anchors.bottomMargin: 60
         anchors.leftMargin: 20

--- a/src/qml/controls/OnboardingInfo.qml
+++ b/src/qml/controls/OnboardingInfo.qml
@@ -28,8 +28,6 @@ Item {
     property int subtextMargin: 30
     property int subtextSize: 15
 
-    implicitWidth: 600
-
     ColumnLayout {
         anchors.horizontalCenter: parent.horizontalCenter
         width: parent.width
@@ -63,7 +61,7 @@ Item {
             id: detail_loader
             active: root.detailActive
             visible: active
-            Layout.alignment: Qt.AlignCenter
+            Layout.fillWidth: true
             Layout.topMargin: 30
             Layout.leftMargin: 20
             Layout.rightMargin: 20

--- a/src/qml/pages/onboarding/onboarding01b.qml
+++ b/src/qml/pages/onboarding/onboarding01b.qml
@@ -22,24 +22,23 @@ Page {
             }
         }
     }
-    ColumnLayout {
-        width: Math.min(parent.width, 490)
-        spacing: 0
-        anchors.top: parent.top
+    OnboardingInfo {
+        height: parent.height
+        width: Math.min(parent.width, 600)
         anchors.horizontalCenter: parent.horizontalCenter
-        Header {
-            Layout.fillWidth: true
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-            bold: true
-            header: "About"
-            description: qsTr("Bitcoin Core is an open source project.\nIf you find it useful, please contribute.\n\n This is experimental software.")
-            descriptionMargin: 20
-        }
-        AboutOptions {
-            Layout.topMargin: 30
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
+        bannerActive: false
+        bold: true
+        header: "About"
+        headerMargin: 0
+        description: qsTr("Bitcoin Core is an open source project.\nIf you find it useful, please contribute.\n\n This is experimental software.")
+        descriptionMargin: 20
+        detailActive: true
+        detailItem: ColumnLayout {
+            spacing: 0
+            AboutOptions {
+                Layout.maximumWidth: 450
+                Layout.alignment: Qt.AlignCenter
+            }
         }
     }
 }

--- a/src/qml/pages/onboarding/onboarding01c.qml
+++ b/src/qml/pages/onboarding/onboarding01c.qml
@@ -22,22 +22,21 @@ Page {
             }
         }
     }
-    ColumnLayout {
-        width: Math.min(parent.width, 490)
-        spacing: 0
-        anchors.top: parent.top
+    OnboardingInfo {
+        height: parent.height
+        width: Math.min(parent.width, 600)
         anchors.horizontalCenter: parent.horizontalCenter
-        Header {
-            Layout.fillWidth: true
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-            bold: true
-            header: "Developer options"
-        }
-        DeveloperOptions {
-            Layout.topMargin: 30
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
+        bannerActive: false
+        bold: true
+        header: "Developer options"
+        headerMargin: 0
+        detailActive: true
+        detailItem: ColumnLayout {
+            spacing: 0
+            DeveloperOptions {
+                Layout.maximumWidth: 450
+                Layout.alignment: Qt.AlignCenter
+            }
         }
     }
 }

--- a/src/qml/pages/onboarding/onboarding04.qml
+++ b/src/qml/pages/onboarding/onboarding04.qml
@@ -31,8 +31,12 @@ Page {
         description: qsTr("Where do you want to store the downloaded block data?")
         descriptionMargin: 20
         detailActive: true
-        detailItem: StorageLocations {
-            Layout.maximumWidth: 450
+        detailItem: ColumnLayout {
+            spacing: 0
+            StorageLocations {
+                Layout.maximumWidth: 450
+                Layout.alignment: Qt.AlignCenter
+            }
         }
         buttonText: qsTr("Next")
     }

--- a/src/qml/pages/onboarding/onboarding05a.qml
+++ b/src/qml/pages/onboarding/onboarding05a.qml
@@ -35,16 +35,11 @@ Page {
             spacing: 0
             StorageOptions {
                 Layout.maximumWidth: 450
-                Layout.fillWidth: true
-                Layout.leftMargin: 20
-                Layout.rightMargin: 20
+                Layout.alignment: Qt.AlignCenter
             }
             TextButton {
-                Layout.alignment: Qt.AlignCenter
                 Layout.topMargin: 30
                 Layout.fillWidth: true
-                Layout.leftMargin: 20
-                Layout.rightMargin: 20
                 text: "Detailed settings"
                 textSize: 18
                 textColor: "#F7931A"

--- a/src/qml/pages/onboarding/onboarding05b.qml
+++ b/src/qml/pages/onboarding/onboarding05b.qml
@@ -21,23 +21,21 @@ Page {
             }
         }
     }
-    ColumnLayout {
-        width: Math.min(parent.width, 490)
-        spacing: 0
-        anchors.top: parent.top
+    OnboardingInfo {
+        height: parent.height
+        width: Math.min(parent.width, 600)
         anchors.horizontalCenter: parent.horizontalCenter
-        Header {
-            Layout.fillWidth: true
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-            bold: true
-            header: "Storage settings"
-        }
-        StorageSettings {
-            Layout.fillWidth: true
-            Layout.topMargin: 30
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
+        bannerActive: false
+        bold: true
+        header: "Storage settings"
+        headerMargin: 0
+        detailActive: true
+        detailItem: ColumnLayout {
+            spacing: 0
+            StorageSettings {
+                Layout.maximumWidth: 450
+                Layout.alignment: Qt.AlignCenter
+            }
         }
     }
 }

--- a/src/qml/pages/onboarding/onboarding06b.qml
+++ b/src/qml/pages/onboarding/onboarding06b.qml
@@ -21,22 +21,21 @@ Page {
             }
         }
     }
-    ColumnLayout {
-        width: Math.min(parent.width, 490)
-        spacing: 0
-        anchors.top: parent.top
+    OnboardingInfo {
+        height: parent.height
+        width: Math.min(parent.width, 600)
         anchors.horizontalCenter: parent.horizontalCenter
-        Header {
-            Layout.fillWidth: true
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-            bold: true
-            header: "Connection settings"
-        }
-        ConnectionSettings {
-            Layout.topMargin: 30
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
+        bannerActive: false
+        bold: true
+        header: "Connection settings"
+        headerMargin: 0
+        detailActive: true
+        detailItem: ColumnLayout {
+            spacing: 0
+            ConnectionSettings {
+                Layout.maximumWidth: 450
+                Layout.alignment: Qt.AlignCenter
+            }
         }
     }
 }


### PR DESCRIPTION
This PR reworks the `OnboardingInfo` control so that we can use it for *all* onboarding pages.

The `OnboardingInfo` control doesn't work for the onboarding pages which represent the advanced settings views because the `OnboardingInfo` control always shows the continue button, which the advanced settings views do not use. We get around this here by making the buttonText value optional, making it so that the ContinueButton is not visible or enabled when the continueText value is not specified.

Additionally, this now changes the way that we fix the issue shown in https://github.com/bitcoin-core/gui-qml/pull/185. Instead of setting a maxwidth or 490 for the content, we give the `Setting` control an implicitWidth of 450. This is necessary in order to accommodate this change as we will no longer have an independent Header control which stretches out the width.

## Desktop
### master 

| a | b | c | d |
| - | - | - | - |
| <img width="752" alt="Screen Shot 2022-11-23 at 1 40 14 AM" src="https://user-images.githubusercontent.com/23396902/203560540-8766703f-f214-4d0c-bc07-27ae1fd244c8.png"> | <img width="752" alt="Screen Shot 2022-11-23 at 1 40 26 AM" src="https://user-images.githubusercontent.com/23396902/203560559-a58ff346-11be-4da4-8dbd-8f08adae7a7b.png"> | <img width="752" alt="Screen Shot 2022-11-23 at 1 40 40 AM" src="https://user-images.githubusercontent.com/23396902/203560582-582f404f-2c47-4609-9ac8-9b71c44567ef.png"> | <img width="752" alt="Screen Shot 2022-11-23 at 1 40 52 AM" src="https://user-images.githubusercontent.com/23396902/203560606-b04738c7-3e1a-4e77-a612-524bf85e58c1.png"> |


### pr

| a | b | c | d |
| - | - | - | - |
| <img width="752" alt="Screen Shot 2022-11-23 at 2 56 48 AM" src="https://user-images.githubusercontent.com/23396902/203560246-fd2137f3-8172-4fdb-9df9-fc7278777303.png"> | <img width="752" alt="Screen Shot 2022-11-23 at 2 56 55 AM" src="https://user-images.githubusercontent.com/23396902/203560306-3c4b064a-0054-4e0f-bfab-bddba5496a27.png"> | <img width="752" alt="Screen Shot 2022-11-23 at 2 57 10 AM" src="https://user-images.githubusercontent.com/23396902/203560333-0c962a39-9a52-4388-acdd-95ee517401db.png"> | <img width="752" alt="Screen Shot 2022-11-23 at 2 57 21 AM" src="https://user-images.githubusercontent.com/23396902/203560402-f54cb352-89df-4f33-8bc4-46021efcc52c.png"> |

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/192)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/192)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/192)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/192)
