### PR TITLE
The Setting control should just be of type ColumnLayout

### DIFF
--- a/src/qml/controls/Setting.qml
+++ b/src/qml/controls/Setting.qml
@@ -6,41 +6,39 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
-Control {
+ColumnLayout {
     id: root
     property bool last: parent && root === parent.children[parent.children.length - 1]
     required property string header
     property alias actionItem: action_loader.sourceComponent
     property string description
-    contentItem: ColumnLayout {
-        spacing: 20
-        width: parent.width
-        RowLayout {
-            Header {
-                Layout.fillWidth: true
-                center: false
-                header: root.header
-                headerSize: 18
-                description: root.description
-                descriptionSize: 15
-                descriptionMargin: 0
-            }
-            Loader {
-                id: action_loader
-                active: true
-                visible: active
-                sourceComponent: root.actionItem
-            }
+
+    spacing: 20
+    RowLayout {
+        Header {
+            Layout.fillWidth: true
+            center: false
+            header: root.header
+            headerSize: 18
+            description: root.description
+            descriptionSize: 15
+            descriptionMargin: 0
         }
         Loader {
-            Layout.fillWidth: true
-            Layout.columnSpan: 2
-            active: !last
+            id: action_loader
+            active: true
             visible: active
-            sourceComponent: Rectangle {
-                height: 1
-                color: Theme.color.neutral5
-            }
+            sourceComponent: root.actionItem
+        }
+    }
+    Loader {
+        Layout.fillWidth: true
+        Layout.columnSpan: 2
+        active: !last
+        visible: active
+        sourceComponent: Rectangle {
+            height: 1
+            color: Theme.color.neutral5
         }
     }
 }


### PR DESCRIPTION
There isn't a good reason for the Setting control to be of type Control, when it could be simplified to just be a ColumnLayout; so this does that.


## Desktop
### Master

| master-1 | master-2 | master-3 | master-4 |
| -------- | -------- | -------- | -------- |
| <img width="752" alt="master-1" src="https://user-images.githubusercontent.com/23396902/206318929-8a0a4432-9e94-4178-8d89-b72a60c485fd.png"> | <img width="752" alt="master-2" src="https://user-images.githubusercontent.com/23396902/206318940-e69e8317-a924-4622-bf7e-aec2a5ffea37.png"> | <img width="752" alt="master-3" src="https://user-images.githubusercontent.com/23396902/206318958-e945ca52-b9a7-48d3-a159-de2529bb4b80.png"> | <img width="752" alt="master-4" src="https://user-images.githubusercontent.com/23396902/206318971-35ec707a-1443-491b-b2c9-a5a1b211ec8e.png"> |

### PR

| pr-1 | pr-2 | pr-3 | pr-4 |
| ---- | ---- | ---- | ---- |
| <img width="752" alt="pr-1" src="https://user-images.githubusercontent.com/23396902/206319064-3ef3f19a-29bd-42ea-8689-6e4d1ef75f21.png"> | <img width="752" alt="pr-2" src="https://user-images.githubusercontent.com/23396902/206319077-9b8ac47c-4868-44fb-931c-f1fc7d851546.png"> | <img width="752" alt="pr-3" src="https://user-images.githubusercontent.com/23396902/206319087-3bb1784a-4d56-42d9-ae47-fc628361b92a.png"> | <img width="752" alt="pr-4" src="https://user-images.githubusercontent.com/23396902/206319097-01d48778-6b5f-40f3-a536-a860eae7881a.png"> |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/195)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/195)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/195)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/195)