### PR TITLE
Remove unused inSubPage bool from Wizard control

### DIFF
--- a/src/qml/components/AboutOptions.qml
+++ b/src/qml/components/AboutOptions.qml
@@ -65,7 +65,6 @@ ColumnLayout {
             background: null
             onClicked: {
                 introductions.incrementCurrentIndex()
-                swipeView.inSubPage = true
             }
         }
     }

--- a/src/qml/controls/Wizard.qml
+++ b/src/qml/controls/Wizard.qml
@@ -13,7 +13,6 @@ Page {
     background: null
     SwipeView {
         id: swipeView
-        property bool inSubPage: false
         property bool finished: false
         anchors.fill: parent
         interactive: false

--- a/src/qml/pages/onboarding/onboarding01a.qml
+++ b/src/qml/pages/onboarding/onboarding01a.qml
@@ -20,7 +20,6 @@ Page {
             iconHeight: 24
             onClicked: {
                 introductions.incrementCurrentIndex()
-                swipeView.inSubPage = true
             }
         }
     }

--- a/src/qml/pages/onboarding/onboarding01b.qml
+++ b/src/qml/pages/onboarding/onboarding01b.qml
@@ -18,7 +18,6 @@ Page {
             text: "Back"
             onClicked: {
                 introductions.decrementCurrentIndex()
-                swipeView.inSubPage = false
             }
         }
     }

--- a/src/qml/pages/onboarding/onboarding01c.qml
+++ b/src/qml/pages/onboarding/onboarding01c.qml
@@ -18,7 +18,6 @@ Page {
             text: "Back"
             onClicked: {
                 introductions.decrementCurrentIndex()
-                swipeView.inSubPage = true
             }
         }
     }

--- a/src/qml/pages/onboarding/onboarding05a.qml
+++ b/src/qml/pages/onboarding/onboarding05a.qml
@@ -50,7 +50,6 @@ Page {
                 textColor: "#F7931A"
                 onClicked: {
                   storages.incrementCurrentIndex()
-                  swipeView.inSubPage = true
                 }
             }
         }

--- a/src/qml/pages/onboarding/onboarding05b.qml
+++ b/src/qml/pages/onboarding/onboarding05b.qml
@@ -17,7 +17,6 @@ Page {
             text: "Done"
             onClicked: {
                 storages.decrementCurrentIndex()
-                swipeView.inSubPage = false
             }
         }
     }

--- a/src/qml/pages/onboarding/onboarding06a.qml
+++ b/src/qml/pages/onboarding/onboarding06a.qml
@@ -43,7 +43,6 @@ Page {
             textColor: Theme.color.orange
             onClicked: {
               connections.incrementCurrentIndex()
-              swipeView.inSubPage = true
             }
         }
         lastPage: true

--- a/src/qml/pages/onboarding/onboarding06b.qml
+++ b/src/qml/pages/onboarding/onboarding06b.qml
@@ -17,7 +17,6 @@ Page {
             text: "Done"
             onClicked: {
                 connections.decrementCurrentIndex()
-                swipeView.inSubPage = false
             }
         }
     }


### PR DESCRIPTION
This is not used at all. This is a remnant from a time where the idea was to have the navbar encapsulated within the Wizard control, and this bool would dictate what navbutton to display. We have since moved to each page provides its navbar and its navbuttons.


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/196)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/196)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/196)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/196)

