### PR TITLE
Better TextButton control default values

### DIFF
--- a/src/qml/controls/TextButton.qml
+++ b/src/qml/controls/TextButton.qml
@@ -8,7 +8,7 @@ import QtQuick.Controls 2.15
 Button {
     id: root
     property int textSize: 18
-    property string textColor: Theme.color.neutral9
+    property string textColor: Theme.color.orange
     property bool bold: true
     property bool rightalign: false
     font.family: "Inter"

--- a/src/qml/pages/onboarding/OnboardingConnection.qml
+++ b/src/qml/pages/onboarding/OnboardingConnection.qml
@@ -38,11 +38,7 @@ Page {
             detailActive: true
             detailItem: TextButton {
                 text: qsTr("Connection settings")
-                textSize: 18
-                textColor: Theme.color.orange
-                onClicked: {
-                    connections.incrementCurrentIndex()
-                }
+                onClicked: connections.incrementCurrentIndex()
             }
             lastPage: true
             buttonText: qsTr("Next")

--- a/src/qml/pages/onboarding/OnboardingStorageAmount.qml
+++ b/src/qml/pages/onboarding/OnboardingStorageAmount.qml
@@ -40,11 +40,7 @@ Page {
                     Layout.topMargin: 30
                     Layout.fillWidth: true
                     text: qsTr("Detailed settings")
-                    textSize: 18
-                    textColor: "#F7931A"
-                    onClicked: {
-                        storages.incrementCurrentIndex()
-                    }
+                    onClicked: storages.incrementCurrentIndex()
                 }
             }
             buttonText: qsTr("Next")


### PR DESCRIPTION
This makes the default values of the TextButton control more usable to it's actual usage.
## Desktop

| master | pr |
| ------ | -- |
| <img width="752" alt="master-7" src="https://user-images.githubusercontent.com/23396902/206324636-ba5d9192-45e2-4e8b-9095-898832e53b16.png"> | <img width="752" alt="Screen Shot 2022-12-07 at 7 09 23 PM" src="https://user-images.githubusercontent.com/23396902/206324655-5f2a26c1-5595-4a19-acbb-1886c2e5278a.png"> |

| master | pr |
| ------ | -- |
| <img width="752" alt="master-9" src="https://user-images.githubusercontent.com/23396902/206324735-f5417dd2-3719-4c16-9e41-b07fd414dbea.png"> | <img width="752" alt="Screen Shot 2022-12-07 at 7 09 29 PM" src="https://user-images.githubusercontent.com/23396902/206324747-657084ce-a26e-44fe-8599-b2210a8c83d0.png"> |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/199)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/199)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/199)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/199)