### PR TITLE
Better ExternalLink control defaults

### DIFF
--- a/src/qml/components/AboutOptions.qml
+++ b/src/qml/components/AboutOptions.qml
@@ -16,8 +16,6 @@ ColumnLayout {
             description: qsTr("bitcoincore.org")
             link: "https://bitcoincore.org"
             iconSource: "image://images/caret-right"
-            iconWidth: 18
-            iconHeight: 18
         }
     }
     Setting {
@@ -27,8 +25,6 @@ ColumnLayout {
             description: qsTr("github.com/bitcoin/bitcoin")
             link: "https://github.com/bitcoin/bitcoin"
             iconSource: "image://images/caret-right"
-            iconWidth: 18
-            iconHeight: 18
         }
     }
     Setting {
@@ -38,8 +34,6 @@ ColumnLayout {
             description: qsTr("MIT")
             link: "https://opensource.org/licenses/MIT"
             iconSource: "image://images/caret-right"
-            iconWidth: 18
-            iconHeight: 18
         }
     }
     Setting {
@@ -49,8 +43,6 @@ ColumnLayout {
             description: qsTr("v22.99.0-1e7564eca8a6")
             link: "https://bitcoin.org/en/download"
             iconSource: "image://images/caret-right"
-            iconWidth: 18
-            iconHeight: 18
         }
     }
     Setting {

--- a/src/qml/components/DeveloperOptions.qml
+++ b/src/qml/components/DeveloperOptions.qml
@@ -14,6 +14,8 @@ ColumnLayout {
         header: qsTr("Developer documentation")
         actionItem: ExternalLink {
             iconSource: "qrc:/icons/export"
+            iconWidth: 30
+            iconHeight: 30
             link: "https://bitcoin.org/en/bitcoin-core/contribute/documentation"
         }
     }

--- a/src/qml/controls/ExternalLink.qml
+++ b/src/qml/controls/ExternalLink.qml
@@ -12,8 +12,8 @@ Control {
     property string description: ""
     property int descriptionSize: 18
     property url iconSource: ""
-    property int iconWidth: 30
-    property int iconHeight: 30
+    property int iconWidth: 18
+    property int iconHeight: 18
 
     contentItem: RowLayout {
         spacing: 0


### PR DESCRIPTION
This makes the default values of the ExternalLink control more usable to it's actual usage. 

Not based on anything as there are no conflicts with any open pr. No visual difference between master and pr.

| master | pr |
| ------ | -- |
| <img width="474" alt="master" src="https://user-images.githubusercontent.com/23396902/206305215-8270a3a1-411a-4e87-9d0c-44685222305d.png"> |<img width="474" alt="pr" src="https://user-images.githubusercontent.com/23396902/206305256-8362aa26-ec25-45ed-b30c-49978481b1c4.png"> | 

| master | pr |
| ------ | -- |
<img width="474" alt="Screen Shot 2022-12-07 at 4 55 02 PM" src="https://user-images.githubusercontent.com/23396902/206305379-be116798-1bc7-4597-ac66-d60e01bdea96.png"> | <img width="474" alt="Screen Shot 2022-12-07 at 4 55 33 PM" src="https://user-images.githubusercontent.com/23396902/206305403-0a30ceb3-a972-4114-9a94-23335873726a.png"> |



[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/200)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/200)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/200)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/200)

