### PR TITLE
Remove extra layout properties

### DIFF
--- a/src/qml/pages/onboarding/onboarding01.qml
+++ b/src/qml/pages/onboarding/onboarding01.qml
@@ -11,7 +11,6 @@ import "../settings"
 
 Page {
     background: null
-    Layout.fillWidth: true
     clip: true
     SwipeView {
         id: introductions
@@ -19,7 +18,6 @@ Page {
         interactive: false
         orientation: Qt.Horizontal
         InformationPage {
-            Layout.fillWidth: true
             navRightDetail: NavButton {
                 iconSource: "image://images/info"
                 iconHeight: 24

--- a/src/qml/pages/onboarding/onboarding02.qml
+++ b/src/qml/pages/onboarding/onboarding02.qml
@@ -8,7 +8,6 @@ import QtQuick.Layouts 1.15
 import "../../controls"
 
 InformationPage {
-    Layout.fillWidth: true
     navLeftDetail: NavButton {
         iconSource: "image://images/caret-left"
         text: qsTr("Back")

--- a/src/qml/pages/onboarding/onboarding03.qml
+++ b/src/qml/pages/onboarding/onboarding03.qml
@@ -8,7 +8,6 @@ import QtQuick.Layouts 1.15
 import "../../controls"
 
 InformationPage {
-    Layout.fillWidth: true
     navLeftDetail: NavButton {
         iconSource: "image://images/caret-left"
         text: qsTr("Back")

--- a/src/qml/pages/onboarding/onboarding04.qml
+++ b/src/qml/pages/onboarding/onboarding04.qml
@@ -10,7 +10,6 @@ import "../../controls"
 import "../../components"
 
 InformationPage {
-    Layout.fillWidth: true
     navLeftDetail: NavButton {
         iconSource: "image://images/caret-left"
         text: qsTr("Back")

--- a/src/qml/pages/onboarding/onboarding05.qml
+++ b/src/qml/pages/onboarding/onboarding05.qml
@@ -11,7 +11,6 @@ import "../settings"
 
 Page {
     background: null
-    Layout.fillWidth: true
     clip: true
     SwipeView {
         id: storages
@@ -19,7 +18,6 @@ Page {
         interactive: false
         orientation: Qt.Vertical
         InformationPage {
-            Layout.fillWidth: true
             navLeftDetail: NavButton {
                 iconSource: "image://images/caret-left"
                 text: qsTr("Back")

--- a/src/qml/pages/onboarding/onboarding06.qml
+++ b/src/qml/pages/onboarding/onboarding06.qml
@@ -11,7 +11,6 @@ import "../settings"
 
 Page {
     background: null
-    Layout.fillWidth: true
     clip: true
     SwipeView {
         id: connections
@@ -19,7 +18,6 @@ Page {
         interactive: false
         orientation: Qt.Vertical
         InformationPage {
-            Layout.fillWidth: true
             navLeftDetail: NavButton {
                 iconSource: "image://images/caret-left"
                 text: qsTr("Back")

--- a/src/qml/pages/settings/SettingsAbout.qml
+++ b/src/qml/pages/settings/SettingsAbout.qml
@@ -9,7 +9,6 @@ import "../../controls"
 import "../../components"
 
 InformationPage {
-    Layout.fillWidth: true
     bannerActive: false
     bold: true
     headerText: qsTr("About")

--- a/src/qml/pages/settings/SettingsConnection.qml
+++ b/src/qml/pages/settings/SettingsConnection.qml
@@ -10,7 +10,6 @@ import "../../components"
 
 InformationPage {
     background: null
-    Layout.fillWidth: true
     clip: true
     bannerActive: false
     bold: true

--- a/src/qml/pages/settings/SettingsDeveloper.qml
+++ b/src/qml/pages/settings/SettingsDeveloper.qml
@@ -9,7 +9,6 @@ import "../../controls"
 import "../../components"
 
 InformationPage {
-    Layout.fillWidth: true
     bannerActive: false
     bold: true
     headerText: qsTr("Developer options")

--- a/src/qml/pages/settings/SettingsStorage.qml
+++ b/src/qml/pages/settings/SettingsStorage.qml
@@ -9,7 +9,6 @@ import "../../controls"
 import "../../components"
 
 InformationPage {
-    Layout.fillWidth: true
     bannerActive: false
     bold: true
     headerText: qsTr("Storage settings")


### PR DESCRIPTION
After consolidation of the Onboarding pages, there are some leftover Layout properties that are no longer needed.


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/201)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/201)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/201)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/201)
