### PR TITLE
Show a check icon when an OptionButton is selected

### DIFF
--- a/src/qml/components/ConnectionOptions.qml
+++ b/src/qml/components/ConnectionOptions.qml
@@ -31,13 +31,5 @@ ColumnLayout {
         ButtonGroup.group: group
         text: qsTr("Only when on Wi-Fi")
         description: qsTr("Loads quickly when on wi-fi and pauses when on cellular data.")
-        detail: ProgressIndicator {
-            implicitWidth: 50
-            SequentialAnimation on progress {
-                loops: Animation.Infinite
-                SmoothedAnimation { to: 1; velocity: 1; }
-                SmoothedAnimation { to: 0; velocity: 1; }
-            }
-        }
     }
 }

--- a/src/qml/components/StorageOptions.qml
+++ b/src/qml/components/StorageOptions.qml
@@ -19,19 +19,11 @@ ColumnLayout {
         description: qsTr("Uses about 2GB.")
         recommended: true
         checked: true
-        detail: ProgressIndicator {
-            implicitWidth: 75
-            progress: 0.25
-        }
     }
     OptionButton {
         Layout.fillWidth: true
         ButtonGroup.group: group
         text: qsTr("Default")
         description: qsTr("Uses about 423GB.")
-        detail: ProgressIndicator {
-            implicitWidth: 75
-            progress: 0.8
-        }
     }
 }

--- a/src/qml/controls/OptionButton.qml
+++ b/src/qml/controls/OptionButton.qml
@@ -12,7 +12,6 @@ Button {
     id: button
     padding: 15
     checkable: true
-    property alias detail: detail_loader.sourceComponent
     implicitWidth: 450
     background: Rectangle {
         border.width: 1
@@ -67,7 +66,15 @@ Button {
         }
         Loader {
             id: detail_loader
-            visible: item
+            visible: button.checked
+            active: true
+            sourceComponent: Button {
+                icon.source: "image://images/check"
+                icon.color: Theme.color.neutral9
+                icon.height: 24
+                icon.width: 24
+                background: null
+            }
         }
     }
 }


### PR DESCRIPTION
This does away with the current detail loader and replaces it with a `check` icon. We no longer have a use case for a customizable detail within the `OptionButton` control, only a need for the check icon when the button is selected.

| a | b |
| - | - |
| <img width="752" alt="Screen Shot 2022-12-14 at 1 21 10 AM" src="https://user-images.githubusercontent.com/23396902/207523321-16c12aca-af95-493b-9870-e6916d836ece.png"> | <img width="752" alt="Screen Shot 2022-12-14 at 1 21 21 AM" src="https://user-images.githubusercontent.com/23396902/207523343-5935d940-eadf-47d8-9266-60107ec7a292.png"> |

| a | b |
| - | - |
| <img width="752" alt="Screen Shot 2022-12-14 at 1 21 42 AM" src="https://user-images.githubusercontent.com/23396902/207523425-f68617c3-dee1-45d6-abe9-19cd9ead58f7.png"> |  <img width="752" alt="Screen Shot 2022-12-14 at 1 21 48 AM" src="https://user-images.githubusercontent.com/23396902/207523466-fed59c46-11db-4bb7-8ea5-529894b2d365.png"> |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/205)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/205)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/205)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/205)
