### PR TITLE
Storage options text fixups

### DIFF
--- a/src/qml/components/ConnectionOptions.qml
+++ b/src/qml/components/ConnectionOptions.qml
@@ -31,13 +31,5 @@ ColumnLayout {
         ButtonGroup.group: group
         text: qsTr("Only when on Wi-Fi")
         description: qsTr("Loads quickly when on wi-fi and pauses when on cellular data.")
-        detail: ProgressIndicator {
-            implicitWidth: 50
-            SequentialAnimation on progress {
-                loops: Animation.Infinite
-                SmoothedAnimation { to: 1; velocity: 1; }
-                SmoothedAnimation { to: 0; velocity: 1; }
-            }
-        }
     }
 }

--- a/src/qml/components/StorageLocations.qml
+++ b/src/qml/components/StorageLocations.qml
@@ -15,15 +15,15 @@ ColumnLayout {
     OptionButton {
         Layout.fillWidth: true
         ButtonGroup.group: group
-        text: qsTr("Default directory")
-        description: qsTr("The downloaded block data will be saved to the default data directory for your OS.")
+        text: qsTr("Default")
+        description: qsTr("Your application directory.")
         recommended: true
         checked: true
     }
     OptionButton {
         Layout.fillWidth: true
         ButtonGroup.group: group
-        text: qsTr("Custom directory")
-        description: qsTr("The downloaded block data will be saved to the chosen directory.")
+        text: qsTr("Custom")
+        description: qsTr("Choose the directory and storage device.")
     }
 }

--- a/src/qml/components/StorageOptions.qml
+++ b/src/qml/components/StorageOptions.qml
@@ -19,19 +19,11 @@ ColumnLayout {
         description: qsTr("Uses about 2GB.")
         recommended: true
         checked: true
-        detail: ProgressIndicator {
-            implicitWidth: 75
-            progress: 0.25
-        }
     }
     OptionButton {
         Layout.fillWidth: true
         ButtonGroup.group: group
         text: qsTr("Default")
         description: qsTr("Uses about 423GB.")
-        detail: ProgressIndicator {
-            implicitWidth: 75
-            progress: 0.8
-        }
     }
 }

--- a/src/qml/components/StorageOptions.qml
+++ b/src/qml/components/StorageOptions.qml
@@ -16,14 +16,14 @@ ColumnLayout {
         Layout.fillWidth: true
         ButtonGroup.group: group
         text: qsTr("Reduce storage")
-        description: qsTr("Uses about 2GB.")
+        description: qsTr("Uses about 2GB. For simple wallet use.")
         recommended: true
         checked: true
     }
     OptionButton {
         Layout.fillWidth: true
         ButtonGroup.group: group
-        text: qsTr("Default")
-        description: qsTr("Uses about 423GB.")
+        text: qsTr("Store all data")
+        description: qsTr("Uses about 550GB. Support the network.")
     }
 }

--- a/src/qml/controls/OptionButton.qml
+++ b/src/qml/controls/OptionButton.qml
@@ -12,7 +12,6 @@ Button {
     id: button
     padding: 15
     checkable: true
-    property alias detail: detail_loader.sourceComponent
     implicitWidth: 450
     background: Rectangle {
         border.width: 1
@@ -67,7 +66,15 @@ Button {
         }
         Loader {
             id: detail_loader
-            visible: item
+            visible: button.checked
+            active: true
+            sourceComponent: Button {
+                icon.source: "image://images/check"
+                icon.color: Theme.color.neutral9
+                icon.height: 24
+                icon.width: 24
+                background: null
+            }
         }
     }
 }

--- a/src/qml/pages/onboarding/OnboardingStorageLocation.qml
+++ b/src/qml/pages/onboarding/OnboardingStorageLocation.qml
@@ -19,7 +19,7 @@ InformationPage {
     bold: true
     headerText: qsTr("Storage location")
     headerMargin: 0
-    description: qsTr("Where do you want to store the downloaded block data?")
+    description: qsTr("Where do you want to store the downloaded block data?\nYou need a minimum of 1GB of storage.")
     descriptionMargin: 20
     detailActive: true
     detailItem: ColumnLayout {


### PR DESCRIPTION
Based on https://github.com/bitcoin-core/gui-qml/pull/205 so as to not conflict. Only PR commit is ac13dc1da3088099ca9c020f980d3245ac2a3084

Performs small text fixups to the storage options to fall in line with the designs. Only differs from the [figma designs](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App?node-id=3288%3A72160&t=ttpjexCKgAerUbB2-0) by changing `For regular wallet use.` to `For simple wallet use.` in the StorageAmount OptionsButton control.


### Master 

| a | b |
| - | - |
| <img width="752" alt="Screen Shot 2022-12-14 at 2 12 47 AM" src="https://user-images.githubusercontent.com/23396902/207529947-346fcd7b-4a7c-42bd-aee6-4784b1fbb43a.png"> | <img width="752" alt="Screen Shot 2022-12-14 at 2 12 52 AM" src="https://user-images.githubusercontent.com/23396902/207529982-e4e3faa1-7e24-4460-b5da-1d87ee69dc17.png"> |


### PR

| a | b |
| - | - |
| <img width="752" alt="Screen Shot 2022-12-14 at 2 08 00 AM" src="https://user-images.githubusercontent.com/23396902/207530072-3da9a872-7a76-4ba7-86b0-ba7b3fc48287.png"> | <img width="752" alt="Screen Shot 2022-12-14 at 2 08 18 AM" src="https://user-images.githubusercontent.com/23396902/207530101-5503aa6b-ac23-4d95-976d-7f37f4fb50f0.png"> |

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/206)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/206)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/206)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/206)

