### PR TITLE
Introduce OptionsModel backend, Wire up Storage Amount settings to backend

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -37,6 +37,7 @@ QT_FORMS_UI = \
 QT_MOC_CPP = \
   qml/moc_appmode.cpp \
   qml/moc_nodemodel.cpp \
+  qml/moc_options_model.cpp \
   qt/moc_addressbookpage.cpp \
   qt/moc_addresstablemodel.cpp \
   qt/moc_askpassphrasedialog.cpp \
@@ -112,6 +113,7 @@ BITCOIN_QT_H = \
   qml/bitcoin.h \
   qml/imageprovider.h \
   qml/nodemodel.h \
+  qml/options_model.h \
   qml/util.h \
   qt/addressbookpage.h \
   qt/addresstablemodel.h \
@@ -291,6 +293,7 @@ BITCOIN_QML_BASE_CPP = \
   qml/bitcoin.cpp \
   qml/imageprovider.cpp \
   qml/nodemodel.cpp \
+  qml/options_model.cpp \
   qml/util.cpp
 
 QML_RES_FONTS = \

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -14,6 +14,7 @@
 #include <qml/appmode.h>
 #include <qml/imageprovider.h>
 #include <qml/nodemodel.h>
+#include <qml/options_model.h>
 #include <qml/util.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
@@ -184,6 +185,9 @@ int QmlGuiMain(int argc, char* argv[])
     engine.addImageProvider(QStringLiteral("images"), new ImageProvider{network_style.data()});
 
     engine.rootContext()->setContextProperty("nodeModel", &node_model);
+
+    OptionsQmlModel options_model{*node};
+    engine.rootContext()->setContextProperty("optionsModel", &options_model);
 
 #ifdef __ANDROID__
     AppMode app_mode(AppMode::MOBILE);

--- a/src/qml/components/StorageOptions.qml
+++ b/src/qml/components/StorageOptions.qml
@@ -19,11 +19,18 @@ ColumnLayout {
         description: qsTr("Uses about 2GB. For simple wallet use.")
         recommended: true
         checked: true
+        onClicked: {
+            optionsModel.prune = true
+            optionsModel.pruneSizeGB = 2
+        }
     }
     OptionButton {
         Layout.fillWidth: true
         ButtonGroup.group: group
         text: qsTr("Store all data")
         description: qsTr("Uses about 550GB. Support the network.")
+        onClicked: {
+            optionsModel.prune = false
+        }
     }
 }

--- a/src/qml/components/StorageSettings.qml
+++ b/src/qml/components/StorageSettings.qml
@@ -11,21 +11,18 @@ ColumnLayout {
     spacing: 20
     Setting {
         Layout.fillWidth: true
-        header: qsTr("Store Recent blocks only")
-        actionItem: OptionSwitch {}
-    }
-    Setting {
-        Layout.fillWidth: true
-        header: qsTr("Storage limit")
-        actionItem: ValueInput {
-            description: qsTr("2 GB")
+        header: qsTr("Store recent blocks only")
+        actionItem: OptionSwitch {
+            checked: optionsModel.prune
+            onToggled: optionsModel.prune = checked
         }
     }
     Setting {
         Layout.fillWidth: true
-        header: qsTr("Data location")
+        header: qsTr("Storage limit (GB)")
         actionItem: ValueInput {
-            description: "c://.../data"
+            description: optionsModel.pruneSizeGB
+            onEditingFinished: optionsModel.pruneSizeGB = parseInt(text)
         }
     }
 }

--- a/src/qml/options_model.cpp
+++ b/src/qml/options_model.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/options_model.h>
+
+#include <interfaces/node.h>
+
+OptionsQmlModel::OptionsQmlModel(interfaces::Node& node)
+    : m_node{node}
+{
+}

--- a/src/qml/options_model.cpp
+++ b/src/qml/options_model.cpp
@@ -5,8 +5,42 @@
 #include <qml/options_model.h>
 
 #include <interfaces/node.h>
+#include <qt/guiconstants.h>
+#include <qt/optionsmodel.h>
+#include <univalue.h>
+#include <util/settings.h>
+#include <util/system.h>
+
+#include <cassert>
 
 OptionsQmlModel::OptionsQmlModel(interfaces::Node& node)
     : m_node{node}
 {
+    int64_t prune_value{SettingToInt(m_node.getPersistentSetting("prune"), 0)};
+    m_prune = (prune_value > 1);
+    m_prune_size_gb = m_prune ? PruneMiBtoGB(prune_value) : DEFAULT_PRUNE_TARGET_GB;
+}
+
+void OptionsQmlModel::setPrune(bool new_prune)
+{
+    if (new_prune != m_prune) {
+        m_prune = new_prune;
+        m_node.updateRwSetting("prune", pruneSetting());
+        Q_EMIT pruneChanged(new_prune);
+    }
+}
+
+void OptionsQmlModel::setPruneSizeGB(int new_prune_size_gb)
+{
+    if (new_prune_size_gb != m_prune_size_gb) {
+        m_prune_size_gb = new_prune_size_gb;
+        m_node.updateRwSetting("prune", pruneSetting());
+        Q_EMIT pruneSizeGBChanged(new_prune_size_gb);
+    }
+}
+
+util::SettingsValue OptionsQmlModel::pruneSetting() const
+{
+    assert(!m_prune || m_prune_size_gb >= 1);
+    return m_prune ? PruneGBtoMiB(m_prune_size_gb) : 0;
 }

--- a/src/qml/options_model.h
+++ b/src/qml/options_model.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_OPTIONS_MODEL_H
+#define BITCOIN_QML_OPTIONS_MODEL_H
+
+#include <QObject>
+
+namespace interfaces {
+class Node;
+}
+
+/** Model for Bitcoin client options. */
+class OptionsQmlModel : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit OptionsQmlModel(interfaces::Node& node);
+
+private:
+    interfaces::Node& m_node;
+};
+
+#endif // BITCOIN_QML_OPTIONS_MODEL_H

--- a/src/qml/options_model.h
+++ b/src/qml/options_model.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_QML_OPTIONS_MODEL_H
 #define BITCOIN_QML_OPTIONS_MODEL_H
 
+#include <util/settings.h>
+
 #include <QObject>
 
 namespace interfaces {
@@ -15,12 +17,29 @@ class Node;
 class OptionsQmlModel : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(bool prune READ prune WRITE setPrune NOTIFY pruneChanged)
+    Q_PROPERTY(int pruneSizeGB READ pruneSizeGB WRITE setPruneSizeGB NOTIFY pruneSizeGBChanged)
 
 public:
     explicit OptionsQmlModel(interfaces::Node& node);
 
+    bool prune() const { return m_prune; }
+    void setPrune(bool new_prune);
+    int pruneSizeGB() const { return m_prune_size_gb; }
+    void setPruneSizeGB(int new_prune_size);
+
+Q_SIGNALS:
+    void pruneChanged(bool new_prune);
+    void pruneSizeGBChanged(int new_prune_size_gb);
+
 private:
     interfaces::Node& m_node;
+
+    // Properties that are exposed to QML.
+    bool m_prune;
+    int m_prune_size_gb;
+
+    util::SettingsValue pruneSetting() const;
 };
 
 #endif // BITCOIN_QML_OPTIONS_MODEL_H

--- a/src/qml/pages/settings/SettingsStorage.qml
+++ b/src/qml/pages/settings/SettingsStorage.qml
@@ -14,5 +14,11 @@ InformationPage {
     headerText: qsTr("Storage settings")
     headerMargin: 0
     detailActive: true
-    detailItem: StorageSettings {}
+    detailItem: StorageSettings {
+        // Set default prune values
+        Component.onCompleted: {
+            optionsModel.prune = true
+            optionsModel.pruneSizeGB = 2
+        }
+    }
 }


### PR DESCRIPTION
This re-uses https://github.com/bitcoin-core/gui-qml/pull/184, with changes, to introduce an OptionsModel backend, while also wiring the Storage Amount settings; as the first settings to be wired to the options backend.

Both the "easy configuration" and "advanced configuration" methods for configuring the storage amount are wired to the backend. While on the fifth view of the onboarding wizard, the view with the header "Storage", if you click on the "Reduce Storage" button, your `Settings.json` file will show:

```
{
    "prune": 1907
}
```

and if you click on the "Store all data" button, your `Settings.json` file will show:

```
{
    "prune": 0
}
```

Within "Detailed Settings", you can examine that the prune target specified within the `Settings.json` file will only be non-zero if a non-zero value is set in storage limit and if the "Store recent blocks only" switch is enabled, as it should be.

The values you configure while onboarding will then be visible within the NodeSettings view when you click on "Storage".

**Note:** This doesn't complete the entire feature set around the setting, enabling, or disabling of this feature. There is still work to be done, this is the initial introduction and wiring.

The screenshots below highlight the functionality of this PR.
| configuring while onboarding | correct values available within the node settings window |
| ---------------------------- | -------------------------------------------------------- |
| <img width="752" alt="Screen Shot 2022-12-14 at 4 32 48 AM" src="https://user-images.githubusercontent.com/23396902/207559204-76eeac23-8d6d-4234-8f97-122dc58b2bd5.png"> |  <img width="752" alt="Screen Shot 2022-12-14 at 4 32 57 AM" src="https://user-images.githubusercontent.com/23396902/207559250-6d77b672-7d28-4743-9d08-138dcc152c8d.png"> |




[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/207)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/207)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/207)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/207)
