### PR TITLE
Simplified version of Block Clock

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -36,6 +36,7 @@ QT_FORMS_UI = \
 
 QT_MOC_CPP = \
   qml/moc_appmode.cpp \
+  qml/moc_chainmodel.cpp \
   qml/moc_nodemodel.cpp \
   qt/moc_addressbookpage.cpp \
   qt/moc_addresstablemodel.cpp \
@@ -110,6 +111,7 @@ QT_QRC_LOCALE = qt/bitcoin_locale.qrc
 BITCOIN_QT_H = \
   qml/appmode.h \
   qml/bitcoin.h \
+  qml/chainmodel.h \
   qml/imageprovider.h \
   qml/nodemodel.h \
   qml/util.h \
@@ -289,6 +291,7 @@ BITCOIN_QT_WALLET_CPP = \
 
 BITCOIN_QML_BASE_CPP = \
   qml/bitcoin.cpp \
+  qml/chainmodel.cpp \
   qml/imageprovider.cpp \
   qml/nodemodel.cpp \
   qml/util.cpp

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -323,12 +323,14 @@ QML_QRC = qml/bitcoin_qml.qrc
 QML_RES_QML = \
   qml/components/AboutOptions.qml \
   qml/components/BlockCounter.qml \
+  qml/components/BlockClockComponent.qml \
   qml/components/ConnectionOptions.qml \
   qml/components/ConnectionSettings.qml \
   qml/components/DeveloperOptions.qml \
   qml/components/StorageLocations.qml \
   qml/components/StorageOptions.qml \
   qml/components/StorageSettings.qml \
+  qml/controls/BlockClock.qml \
   qml/controls/ContinueButton.qml \
   qml/controls/ExternalLink.qml \
   qml/controls/Header.qml \

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -128,6 +128,9 @@ public:
     //! Get block hash. Height must be valid or this function will abort.
     virtual uint256 getBlockHash(int height) = 0;
 
+    //! Get block time, Height must be valid or this function will abort.
+    virtual int64_t getBlockTime(int height) = 0;
+
     //! Check that the block is available on disk (i.e. has not been
     //! pruned), and contains transactions.
     virtual bool haveBlockOnDisk(int height) = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -514,6 +514,11 @@ public:
         LOCK(::cs_main);
         return Assert(chainman().ActiveChain()[height])->GetBlockHash();
     }
+    int64_t getBlockTime(int height) override
+    {
+        LOCK(::cs_main);
+        return Assert(chainman().ActiveChain()[height])->GetBlockTime();
+    }
     bool haveBlockOnDisk(int height) override
     {
         LOCK(::cs_main);

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -1,6 +1,7 @@
 <!DOCTYPE RCC><RCC version="1.0">
     <qresource prefix="/qml">
         <file>components/AboutOptions.qml</file>
+        <file>components/BlockClockComponent.qml</file>
         <file>components/BlockCounter.qml</file>
         <file>components/ConnectionOptions.qml</file>
         <file>components/ConnectionSettings.qml</file>
@@ -8,6 +9,7 @@
         <file>components/StorageLocations.qml</file>
         <file>components/StorageOptions.qml</file>
         <file>components/StorageSettings.qml</file>
+        <file>controls/BlockClock.qml</file>
         <file>controls/ContinueButton.qml</file>
         <file>controls/ExternalLink.qml</file>
         <file>controls/Header.qml</file>

--- a/src/qml/chainmodel.cpp
+++ b/src/qml/chainmodel.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/chainmodel.h>
+
+#include <QDateTime>
+#include <QThread>
+#include <QTime>
+#include <interfaces/chain.h>
+
+ChainModel::ChainModel(interfaces::Chain& chain)
+    : m_chain{chain}
+{
+    timer = new QTimer();
+    connect(timer, &QTimer::timeout, this, &ChainModel::setCurrentTimeRatio);
+    timer->start(1000);
+
+    QThread* timer_thread = new QThread;
+    timer->moveToThread(timer_thread);
+    timer_thread->start();
+}
+
+void ChainModel::setTimeRatioList(int new_time)
+{
+    int timeAtMeridian = timestampAtMeridian();
+
+    if (new_time < timeAtMeridian) {
+        return;
+    }
+
+    m_time_ratio_list.push_back(double(new_time - timeAtMeridian) / SECS_IN_12_HOURS);
+
+    Q_EMIT timeRatioListChanged();
+}
+
+int ChainModel::timestampAtMeridian()
+{
+    int secsSinceMeridian = (QTime::currentTime().msecsSinceStartOfDay() / 1000) % SECS_IN_12_HOURS;
+    int currentTimestamp = QDateTime::currentSecsSinceEpoch();
+
+    return currentTimestamp - secsSinceMeridian;
+}
+
+void ChainModel::setTimeRatioListInitial()
+{
+    int timeAtMeridian = timestampAtMeridian();
+    int first_block_height;
+    int active_chain_height = m_chain.getHeight().value();
+    bool success = m_chain.findFirstBlockWithTimeAndHeight(/*min_time=*/timeAtMeridian, /*min_height=*/0, interfaces::FoundBlock().height(first_block_height));
+
+    if (!success) {
+        return;
+    }
+
+    m_time_ratio_list.clear();
+    m_time_ratio_list.push_back(double(QDateTime::currentSecsSinceEpoch() - timeAtMeridian) / SECS_IN_12_HOURS);
+
+    for (int height = first_block_height; height < active_chain_height + 1; height++) {
+        m_time_ratio_list.push_back(double(m_chain.getBlockTime(height) - timeAtMeridian) / SECS_IN_12_HOURS);
+    }
+
+    Q_EMIT timeRatioListChanged();
+}
+
+void ChainModel::setCurrentTimeRatio()
+{
+    int secsSinceMeridian = (QTime::currentTime().msecsSinceStartOfDay() / 1000) % SECS_IN_12_HOURS;
+    double currentTimeRatio = double(secsSinceMeridian) / SECS_IN_12_HOURS;
+
+    if (currentTimeRatio < m_time_ratio_list[0].toDouble()) { // That means time has crossed a meridian
+        m_time_ratio_list.erase(m_time_ratio_list.begin() + 1, m_time_ratio_list.end());
+    }
+    m_time_ratio_list[0] = currentTimeRatio;
+}

--- a/src/qml/chainmodel.h
+++ b/src/qml/chainmodel.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_CHAINMODEL_H
+#define BITCOIN_QML_CHAINMODEL_H
+
+#include <interfaces/chain.h>
+
+#include <QObject>
+#include <QTimer>
+#include <QVariant>
+
+namespace interfaces {
+class FoundBlock;
+class Chain;
+} // namespace interfaces
+
+static const int SECS_IN_12_HOURS = 43200;
+
+class ChainModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QVariantList timeRatioList READ timeRatioList NOTIFY timeRatioListChanged)
+
+public:
+    explicit ChainModel(interfaces::Chain& chain);
+
+    QVariantList timeRatioList() const { return m_time_ratio_list; };
+
+    int timestampAtMeridian();
+
+    void setCurrentTimeRatio();
+
+public Q_SLOTS:
+    void setTimeRatioList(int new_time);
+    void setTimeRatioListInitial();
+
+Q_SIGNALS:
+    void timeRatioListChanged();
+
+private:
+    QVariantList m_time_ratio_list{0.0};
+
+    QTimer* timer;
+
+    interfaces::Chain& m_chain;
+};
+
+#endif // BITCOIN_QML_CHAINMODEL_H

--- a/src/qml/components/BlockClockComponent.qml
+++ b/src/qml/components/BlockClockComponent.qml
@@ -1,0 +1,64 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../controls"
+
+BlockClock {
+    id: blockClock
+    anchors.centerIn: parent
+    synced: nodeModel.verificationProgress > 0.999
+    pause: nodeModel.pause
+    // TODO: Modify following logic once nodeModel.numOutboundPeers property is incorporated.
+    conns: true
+
+    states: [
+        State {
+            name: "intialBlockDownload"; when: !synced && !pause && conns
+            PropertyChanges {
+                target: blockClock
+
+                ringProgress: nodeModel.verificationProgress
+                header: Math.round(ringProgress * 100) + "%"
+                subText: Math.round(nodeModel.remainingSyncTime/60000) > 0 ? Math.round(nodeModel.remainingSyncTime/60000) + "mins" : Math.round(nodeModel.remainingSyncTime/1000) + "secs"
+            }
+        },
+
+        State {
+            name: "blockClock"; when: synced && !pause && conns
+            PropertyChanges {
+                target: blockClock
+
+                ringProgress: blockList[0]
+                header: Math.floor(nodeModel.blockTipHeight / 1000) + "," + nodeModel.blockTipHeight % 1000
+                subText: "Blocktime"
+                blockList: chainModel.timeRatioList
+            }
+        },
+
+        State {
+            name: "Manual Pause"; when: pause
+            PropertyChanges {
+                target: blockClock
+
+                ringProgress: 0
+                header: "Paused"
+                headerSize: 24
+                subText: "Tap to start"
+                blockList: {}
+            }
+        },
+
+        State {
+            name: "Connecting"; when: !pause && !conns
+            PropertyChanges {
+                target: blockClock
+
+                ringProgress: 0
+                header: "Connecting"
+                headerSize: 24
+                subText: "Please Wait"
+                blockList: {}
+            }
+        }
+    ]
+}

--- a/src/qml/controls/BlockClock.qml
+++ b/src/qml/controls/BlockClock.qml
@@ -1,0 +1,175 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtGraphicalEffects 1.0
+
+import "../components"
+
+Item {
+    id: root
+
+    Layout.alignment: Qt.AlignCenter
+    width: size
+    height: size
+
+    property real ringProgress: 0
+    property string header
+    property string subText
+    property bool synced
+    property bool pause
+    property bool conns
+
+    property int headerSize: 32
+
+    property int size: 200
+    property real arcBegin: 0
+    property real arcEnd: ringProgress * 360
+    property real lineWidth: 4
+    property string colorCircle: "#f1d54a"
+    property string colorBackground: Theme.color.neutral2
+
+    property variant blockList: []
+    property variant colorList: ["#EC5445", "#ED6E46", "#EE8847", "#EFA148", "#F0BB49", "#F1D54A"]
+
+    property alias beginAnimation: animationArcBegin.enabled
+    property alias endAnimation: animationArcEnd.enabled
+
+    property int animationDuration: 250
+
+    onArcBeginChanged: canvas.requestPaint()
+    onArcEndChanged: canvas.requestPaint()
+    onSyncedChanged: canvas.requestPaint()
+    onBlockListChanged: canvas.requestPaint()
+
+    Behavior on arcBegin {
+       id: animationArcBegin
+       enabled: true
+       NumberAnimation {
+           duration: root.animationDuration
+           easing.type: Easing.InOutCubic
+       }
+    }
+
+    Behavior on arcEnd {
+       id: animationArcEnd
+       enabled: true
+       NumberAnimation {
+            easing.type: Easing.Bezier
+            easing.bezierCurve: [0.5, 0.0, 0.2, 1, 1, 1]
+            duration: root.animationDuration
+        }
+    }
+
+    Canvas {
+        id: canvas
+        anchors.fill: parent
+        rotation: -90
+
+        onPaint: {
+            var ctx = getContext("2d")
+            var x = width / 2
+            var y = height / 2
+
+            ctx.reset()
+
+            // Paint background
+            ctx.beginPath();
+            ctx.arc(x, y, (width / 2) - parent.lineWidth / 2, 0, Math.PI * 2, false)
+            ctx.lineWidth = root.lineWidth
+            ctx.strokeStyle = root.colorBackground
+            ctx.stroke()
+
+            if (!synced) {
+                var start = Math.PI * (parent.arcBegin / 180)
+                var end = Math.PI * (parent.arcEnd / 180)
+                // Paint foreground arc
+                ctx.beginPath();
+                ctx.arc(x, y, (width / 2) - parent.lineWidth / 2, start, end, false)
+                ctx.lineWidth = root.lineWidth
+                ctx.strokeStyle = root.colorCircle
+                ctx.stroke()
+            }
+
+            else {
+                var del = 0.0025
+                // Paint Block time points
+                for (var i=1; i<parent.blockList.length - 1; i++) {
+                    var starts = Math.PI * ((parent.blockList[i]) * 360 / 180)
+                    var ends = Math.PI * ((parent.blockList[i + 1]) * 360 / 180)
+                    var conf = blockList.length - i - 1
+                    ctx.beginPath();
+                    ctx.arc(x, y, (width / 2) - parent.lineWidth / 2, starts, ends, false)
+                    ctx.lineWidth = root.lineWidth
+                    ctx.strokeStyle = conf > 5 ? colorList[5] : colorList[conf]
+                    ctx.stroke()
+
+                    // Paint dark segments
+                    var start = Math.PI * ((parent.blockList[i + 1] - del) * 360 / 180)
+                    ctx.beginPath();
+                    ctx.arc(x, y, (width / 2) - parent.lineWidth/2, start, ends, false)
+                    ctx.lineWidth = 4
+                    ctx.strokeStyle = root.colorBackground
+                    ctx.stroke();
+                }
+
+                // Print last segment
+                var starts = Math.PI * ((parent.blockList[parent.blockList.length - 1]) * 360 / 180)
+                var ends = Math.PI * (ringProgress * 360 / 180)
+
+                ctx.beginPath();
+                ctx.arc(x, y, (width / 2) - parent.lineWidth / 2, starts, ends, false)
+                ctx.lineWidth = root.lineWidth
+                ctx.strokeStyle = colorList[0];
+                ctx.stroke()
+            }
+        }
+    }
+
+    ColumnLayout {
+        anchors.centerIn: root
+        Image {
+            Layout.alignment: Qt.AlignCenter
+            source: "image://images/bitcoin-circle"
+            sourceSize.width: 40
+            sourceSize.height: 40
+            Layout.bottomMargin: 7
+            ColorOverlay {
+                anchors.fill: parent
+                source: parent
+                color: Theme.color.neutral9
+            }
+        }
+        Header {
+            Layout.fillWidth: true
+            header: root.header
+            headerSize: root.headerSize
+            headerBold: true
+            description: root.subText
+            descriptionMargin: 2
+            descriptionColor: Theme.color.neutral4
+            descriptionBold: true
+            Layout.bottomMargin: 14
+        }
+        // TODO: Replace following with PeersIndicator{} once it is incorporated.
+        RowLayout {
+            Layout.alignment: Qt.AlignCenter
+            spacing: 5
+            Repeater {
+                model: 5
+                Rectangle {
+                    width: 3
+                    height: width
+                    radius: width/2
+                    color: Theme.color.neutral9
+                }
+            }
+        }
+    }
+
+    MouseArea {
+        anchors.fill: canvas
+        onClicked: {
+            nodeModel.pause = !pause
+        }
+    }
+}

--- a/src/qml/controls/Header.qml
+++ b/src/qml/controls/Header.qml
@@ -8,14 +8,16 @@ import QtQuick.Layouts 1.15
 
 ColumnLayout {
     id: root
-    property bool bold: false
     property bool center: true
     required property string header
     property int headerMargin
     property int headerSize: 28
+    property bool headerBold: false
     property string description: ""
     property int descriptionMargin: 10
     property int descriptionSize: 18
+    property string descriptionColor: Theme.color.neutral8
+    property bool descriptionBold: false
     property string subtext: ""
     property int subtextMargin
     property int subtextSize: 15
@@ -26,7 +28,7 @@ ColumnLayout {
         Layout.fillWidth: true
         topPadding: root.headerMargin
         font.family: "Inter"
-        font.styleName: root.bold ? "Semi Bold" : "Regular"
+        font.styleName: root.headerBold ? "Semi Bold" : "Regular"
         font.pixelSize: root.headerSize
         color: Theme.color.neutral9
         text: root.header
@@ -40,9 +42,9 @@ ColumnLayout {
         sourceComponent: Label {
             topPadding: root.descriptionMargin
             font.family: "Inter"
-            font.styleName: "Regular"
+            font.styleName: root.descriptionBold ? "Semi Bold" : "Regular"
             font.pixelSize: root.descriptionSize
-            color: Theme.color.neutral8
+            color: root.descriptionColor
             text: root.description
             horizontalAlignment: root.center ? Text.AlignHCenter : Text.AlignLeft
             wrapMode: wrap ? Text.WordWrap : Text.NoWrap

--- a/src/qml/controls/InformationPage.qml
+++ b/src/qml/controls/InformationPage.qml
@@ -55,7 +55,7 @@ Page {
             Layout.fillWidth: true
             Layout.leftMargin: 20
             Layout.rightMargin: 20
-            bold: root.bold
+            headerBold: root.bold
             center: root.center
             header: root.headerText
             headerMargin: root.headerMargin

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <chrono>
 
+#include <QDateTime>
 #include <QMetaObject>
 #include <QTimerEvent>
 
@@ -27,11 +28,57 @@ void NodeModel::setBlockTipHeight(int new_height)
     }
 }
 
+void NodeModel::setRemainingSyncTime(double new_progress)
+{
+    int currentTime = QDateTime::currentDateTime().toMSecsSinceEpoch();
+
+    // keep a vector of samples of verification progress at height
+    m_block_process_time.push_front(qMakePair(currentTime, new_progress));
+
+    // show progress speed if we have more than one sample
+    if (m_block_process_time.size() >= 2) {
+        double progressDelta = 0;
+        int timeDelta = 0;
+        int remainingMSecs = 0;
+        double remainingProgress = 1.0 - new_progress;
+        for (int i = 1; i < m_block_process_time.size(); i++) {
+            QPair<int, double> sample = m_block_process_time[i];
+
+            // take first sample after 500 seconds or last available one
+            if (sample.first < (currentTime - 500 * 1000) || i == m_block_process_time.size() - 1) {
+                progressDelta = m_block_process_time[0].second - sample.second;
+                timeDelta = m_block_process_time[0].first - sample.first;
+                remainingMSecs = (progressDelta > 0) ? remainingProgress / progressDelta * timeDelta : -1;
+                break;
+            }
+        }
+        if (remainingMSecs > 0 && m_block_process_time.count() % 1000 == 0) {
+            m_remaining_sync_time = remainingMSecs;
+
+            Q_EMIT remainingSyncTimeChanged();
+        }
+        static const int MAX_SAMPLES = 5000;
+        if (m_block_process_time.count() > MAX_SAMPLES) {
+            m_block_process_time.remove(1, m_block_process_time.count() - 1);
+        }
+    }
+}
 void NodeModel::setVerificationProgress(double new_progress)
 {
     if (new_progress != m_verification_progress) {
+        setRemainingSyncTime(new_progress);
+
         m_verification_progress = new_progress;
         Q_EMIT verificationProgressChanged();
+    }
+}
+
+void NodeModel::setPause(bool new_pause)
+{
+    if(m_pause != new_pause) {
+        m_pause = new_pause;
+        m_node.setNetworkActive(!new_pause);
+        Q_EMIT pauseChanged(new_pause);
     }
 }
 
@@ -45,6 +92,8 @@ void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::Bloc
     // TODO: Handle the `success` parameter,
     setBlockTipHeight(tip_info.block_height);
     setVerificationProgress(tip_info.verification_progress);
+
+    Q_EMIT setTimeRatioListInitial();
 }
 
 void NodeModel::startShutdownPolling()
@@ -75,6 +124,8 @@ void NodeModel::ConnectToBlockTipSignal()
             QMetaObject::invokeMethod(this, [=] {
                 setBlockTipHeight(tip.block_height);
                 setVerificationProgress(verification_progress);
+
+                Q_EMIT setTimeRatioList(tip.block_time);
             });
         });
 }

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -25,15 +25,21 @@ class NodeModel : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int blockTipHeight READ blockTipHeight NOTIFY blockTipHeightChanged)
+    Q_PROPERTY(int remainingSyncTime READ remainingSyncTime NOTIFY remainingSyncTimeChanged)
     Q_PROPERTY(double verificationProgress READ verificationProgress NOTIFY verificationProgressChanged)
+    Q_PROPERTY(bool pause READ pause WRITE setPause NOTIFY pauseChanged)
 
 public:
     explicit NodeModel(interfaces::Node& node);
 
     int blockTipHeight() const { return m_block_tip_height; }
     void setBlockTipHeight(int new_height);
+    int remainingSyncTime() const { return m_remaining_sync_time; }
+    void setRemainingSyncTime(double new_progress);
     double verificationProgress() const { return m_verification_progress; }
     void setVerificationProgress(double new_progress);
+    bool pause() const { return m_pause; }
+    void setPause(bool new_pause);
 
     Q_INVOKABLE void startNodeInitializionThread();
 
@@ -45,9 +51,14 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void blockTipHeightChanged();
+    void remainingSyncTimeChanged();
     void requestedInitialize();
     void requestedShutdown();
     void verificationProgressChanged();
+    void pauseChanged(bool new_pause);
+
+    void setTimeRatioList(int new_time);
+    void setTimeRatioListInitial();
 
 protected:
     void timerEvent(QTimerEvent* event) override;
@@ -55,9 +66,13 @@ protected:
 private:
     // Properties that are exposed to QML.
     int m_block_tip_height{0};
+    int m_remaining_sync_time{0};
     double m_verification_progress{0.0};
+    bool m_pause{false};
 
     int m_shutdown_polling_timer_id{0};
+
+    QVector<QPair<int, double>> m_block_process_time;
 
     interfaces::Node& m_node;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;

--- a/src/qml/pages/main.qml
+++ b/src/qml/pages/main.qml
@@ -59,7 +59,7 @@ ApplicationWindow {
             }
             NodeSettings {
                 navMiddleDetail: Header {
-                    bold: true
+                    headerBold: true
                     headerSize: 18
                     header: "Settings"
                 }

--- a/src/qml/pages/node/NodeRunner.qml
+++ b/src/qml/pages/node/NodeRunner.qml
@@ -18,26 +18,9 @@ Page {
     ColumnLayout {
         spacing: 0
         anchors.fill: parent
-        ColumnLayout {
-            width: 600
-            spacing: 0
-            anchors.centerIn: parent
-            Component.onCompleted: nodeModel.startNodeInitializionThread();
-            Image {
-                Layout.alignment: Qt.AlignCenter
-                source: "image://images/app"
-                sourceSize.width: 64
-                sourceSize.height: 64
-            }
-            BlockCounter {
-                Layout.alignment: Qt.AlignCenter
-                blockHeight: nodeModel.blockTipHeight
-            }
-            ProgressIndicator {
-                width: 200
-                Layout.alignment: Qt.AlignCenter
-                progress: nodeModel.verificationProgress
-            }
-        }
+
+        Component.onCompleted: nodeModel.startNodeInitializionThread();
+
+        BlockClockComponent{}
     }
 }


### PR DESCRIPTION
This PR is the simplified version of #148. And removes commits in #127 to allow easier upstream commit merges.

Functional changes from the original version:

1. The **PeersIndicator** has been replaced with plain rectangles to keep the UI intact.
2. The `conns` property representing if the number of connections is greater than 0, has been set to always positive. With this change, the "connecting" page, though implemented, becomes inaccessible through the UI.