### PR TITLE
Add focus outlines to controls used during onboarding

### DIFF
--- a/src/qml/controls/ContinueButton.qml
+++ b/src/qml/controls/ContinueButton.qml
@@ -43,6 +43,16 @@ Button {
         Behavior on color {
             ColorAnimation { duration: 150 }
         }
+
+        Rectangle {
+            visible: root.visualFocus
+            anchors.fill: parent
+            anchors.margins: -4
+            border.width: 2
+            border.color: Theme.color.purple
+            radius: 9
+            color: "transparent"
+        }
     }
     MouseArea {
         anchors.fill: parent

--- a/src/qml/controls/ExternalLink.qml
+++ b/src/qml/controls/ExternalLink.qml
@@ -85,4 +85,14 @@ AbstractButton {
         }
     }
     onClicked: Qt.openUrlExternally(link)
+
+    background: Rectangle {
+        visible: root.visualFocus
+        anchors.fill: parent
+        anchors.margins: -4
+        border.width: 2
+        border.color: Theme.color.purple
+        radius: 9
+        color: "transparent"
+    }
 }

--- a/src/qml/controls/NavButton.qml
+++ b/src/qml/controls/NavButton.qml
@@ -39,7 +39,18 @@ AbstractButton {
         Behavior on color {
             ColorAnimation { duration: 150 }
         }
+
+        Rectangle {
+            visible: root.visualFocus
+            anchors.fill: parent
+            anchors.margins: -4
+            border.width: 2
+            border.color: Theme.color.purple
+            radius: 9
+            color: "transparent"
+        }
     }
+
     contentItem: RowLayout {
         anchors.fill: parent
         spacing: 0
@@ -77,7 +88,7 @@ AbstractButton {
                    text: root.text
               }
           }
-        }
+       }
     }
     MouseArea {
         anchors.fill: parent

--- a/src/qml/controls/OptionButton.qml
+++ b/src/qml/controls/OptionButton.qml
@@ -23,10 +23,9 @@ Button {
             anchors.fill: parent
             anchors.margins: -4
             border.width: 2
-            border.color: Theme.color.orange
+            border.color: Theme.color.purple
             radius: 14
             color: "transparent"
-            opacity: 0.4
         }
     }
     contentItem: RowLayout {

--- a/src/qml/controls/OptionSwitch.qml
+++ b/src/qml/controls/OptionSwitch.qml
@@ -12,6 +12,16 @@ Switch {
     background: Rectangle {
         radius: Math.floor(height / 2)
         color: root.checked ? Theme.color.orange : Theme.color.neutral4
+
+        Rectangle {
+            visible: root.visualFocus
+            anchors.fill: parent
+            anchors.margins: -4
+            border.width: 2
+            border.color: Theme.color.purple
+            radius: 9
+            color: "transparent"
+        }
     }
     indicator: Rectangle {
         property real _margin: Math.round((parent.height - height) / 2)

--- a/src/qml/controls/ValueInput.qml
+++ b/src/qml/controls/ValueInput.qml
@@ -5,13 +5,26 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-TextEdit {
+Control {
     id: root
     required property string parentState
     property string description: ""
     property int descriptionSize: 18
     property color textColor
     state: root.parentState
+    signal editingFinished()
+    focusPolicy: Qt.StrongFocus
+
+    contentItem: TextEdit {
+        font.family: "Inter"
+        font.styleName: "Regular"
+        font.pixelSize: root.descriptionSize
+        color: root.textColor
+        text: root.description
+        horizontalAlignment: Text.AlignRight
+        wrapMode: Text.WordWrap
+        onEditingFinished: editingFinished()
+    }
 
     states: [
         State {
@@ -28,15 +41,17 @@ TextEdit {
         }
     ]
 
-    font.family: "Inter"
-    font.styleName: "Regular"
-    font.pixelSize: root.descriptionSize
-    color: root.textColor
-    text: description
-    horizontalAlignment: Text.AlignRight
-    wrapMode: Text.WordWrap
-
-    Behavior on color {
+    Behavior on textColor {
         ColorAnimation { duration: 150 }
+    }
+
+    background: Rectangle {
+        visible: root.visualFocus
+        anchors.fill: parent
+        anchors.margins: -4
+        border.width: 2
+        border.color: Theme.color.purple
+        radius: 9
+        color: "transparent"
     }
 }


### PR DESCRIPTION
Changes to the controls within the Onboarding flows to show which control is in active focus. This will be the main indicator when navigating with a keyboard/tabbing.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/214)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/214)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/214)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/214)
