### PR TITLE
Make untranslatable values, untranslatable

### DIFF
--- a/src/qml/components/AboutOptions.qml
+++ b/src/qml/components/AboutOptions.qml
@@ -13,7 +13,7 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Website")
         actionItem: ExternalLink {
-            description: qsTr("bitcoincore.org")
+            description: "bitcoincore.org"
             link: "https://bitcoincore.org"
             iconSource: "image://images/caret-right"
         }
@@ -22,7 +22,7 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Source code")
         actionItem: ExternalLink {
-            description: qsTr("github.com/bitcoin/bitcoin")
+            description: "github.com/bitcoin/bitcoin"
             link: "https://github.com/bitcoin/bitcoin"
             iconSource: "image://images/caret-right"
         }
@@ -31,7 +31,7 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("License")
         actionItem: ExternalLink {
-            description: qsTr("MIT")
+            description: "MIT"
             link: "https://opensource.org/licenses/MIT"
             iconSource: "image://images/caret-right"
         }
@@ -40,7 +40,7 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Version")
         actionItem: ExternalLink {
-            description: qsTr("v22.99.0-1e7564eca8a6")
+            description: "v22.99.0-1e7564eca8a6"
             link: "https://bitcoin.org/en/download"
             iconSource: "image://images/caret-right"
         }

--- a/src/qml/components/StorageSettings.qml
+++ b/src/qml/components/StorageSettings.qml
@@ -25,7 +25,7 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Data location")
         actionItem: ValueInput {
-            description: qsTr("c://.../data")
+            description: "c://.../data"
         }
     }
 }


### PR DESCRIPTION
This picks up and replaces https://github.com/bitcoin-core/gui-qml/pull/140

Rebases and removes one more occurrence of a value qsTr() on an untranslatable value.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/217)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/217)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/217)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/217)
