### PR TITLE
Initial support and wiring for currently implemented connection settings

### DIFF
--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -13,7 +13,10 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Enable listening")
         description: qsTr("Allows incoming connections")
-        actionItem: OptionSwitch {}
+        actionItem: OptionSwitch {
+            checked: optionsModel.listen
+            onToggled: optionsModel.listen = checked
+        }
     }
     Setting {
         Layout.fillWidth: true

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -21,7 +21,10 @@ ColumnLayout {
     Setting {
         Layout.fillWidth: true
         header: qsTr("Map port using UPnP")
-        actionItem: OptionSwitch {}
+        actionItem: OptionSwitch {
+            checked: optionsModel.upnp
+            onToggled: optionsModel.upnp = checked
+        }
     }
     Setting {
         Layout.fillWidth: true

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -37,7 +37,10 @@ ColumnLayout {
     Setting {
         Layout.fillWidth: true
         header: qsTr("Enable RPC server")
-        actionItem: OptionSwitch {}
+        actionItem: OptionSwitch {
+            checked: optionsModel.server
+            onToggled: optionsModel.server = checked
+        }
     }
     Setting {
         last: true

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -29,7 +29,10 @@ ColumnLayout {
     Setting {
         Layout.fillWidth: true
         header: qsTr("Map port using NAT-PMP")
-        actionItem: OptionSwitch {}
+        actionItem: OptionSwitch {
+            checked: optionsModel.natpmp
+            onToggled: optionsModel.natpmp = checked
+        }
     }
     Setting {
         Layout.fillWidth: true

--- a/src/qml/options_model.cpp
+++ b/src/qml/options_model.cpp
@@ -21,6 +21,15 @@ OptionsQmlModel::OptionsQmlModel(interfaces::Node& node)
     m_prune_size_gb = m_prune ? PruneMiBtoGB(prune_value) : DEFAULT_PRUNE_TARGET_GB;
 }
 
+void OptionsQmlModel::setListen(bool new_listen)
+{
+    if (new_listen != m_listen) {
+        m_listen = new_listen;
+        m_node.updateRwSetting("listen", new_listen);
+        Q_EMIT listenChanged(new_listen);
+    }
+}
+
 void OptionsQmlModel::setPrune(bool new_prune)
 {
     if (new_prune != m_prune) {

--- a/src/qml/options_model.cpp
+++ b/src/qml/options_model.cpp
@@ -57,6 +57,15 @@ void OptionsQmlModel::setPruneSizeGB(int new_prune_size_gb)
     }
 }
 
+void OptionsQmlModel::setServer(bool new_server)
+{
+    if (new_server != m_server) {
+        m_server = new_server;
+        m_node.updateRwSetting("server", new_server);
+        Q_EMIT serverChanged(new_server);
+    }
+}
+
 void OptionsQmlModel::setUpnp(bool new_upnp)
 {
     if (new_upnp != m_upnp) {

--- a/src/qml/options_model.cpp
+++ b/src/qml/options_model.cpp
@@ -30,6 +30,15 @@ void OptionsQmlModel::setListen(bool new_listen)
     }
 }
 
+void OptionsQmlModel::setNatpmp(bool new_natpmp)
+{
+    if (new_natpmp != m_natpmp) {
+        m_natpmp = new_natpmp;
+        m_node.updateRwSetting("natpmp", new_natpmp);
+        Q_EMIT natpmpChanged(new_natpmp);
+    }
+}
+
 void OptionsQmlModel::setPrune(bool new_prune)
 {
     if (new_prune != m_prune) {

--- a/src/qml/options_model.cpp
+++ b/src/qml/options_model.cpp
@@ -48,6 +48,15 @@ void OptionsQmlModel::setPruneSizeGB(int new_prune_size_gb)
     }
 }
 
+void OptionsQmlModel::setUpnp(bool new_upnp)
+{
+    if (new_upnp != m_upnp) {
+        m_upnp = new_upnp;
+        m_node.updateRwSetting("upnp", new_upnp);
+        Q_EMIT upnpChanged(new_upnp);
+    }
+}
+
 util::SettingsValue OptionsQmlModel::pruneSetting() const
 {
     assert(!m_prune || m_prune_size_gb >= 1);

--- a/src/qml/options_model.h
+++ b/src/qml/options_model.h
@@ -17,18 +17,22 @@ class Node;
 class OptionsQmlModel : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(bool listen READ listen WRITE setListen NOTIFY listenChanged)
     Q_PROPERTY(bool prune READ prune WRITE setPrune NOTIFY pruneChanged)
     Q_PROPERTY(int pruneSizeGB READ pruneSizeGB WRITE setPruneSizeGB NOTIFY pruneSizeGBChanged)
 
 public:
     explicit OptionsQmlModel(interfaces::Node& node);
 
+    bool listen() const { return m_listen; }
+    void setListen(bool new_listen);
     bool prune() const { return m_prune; }
     void setPrune(bool new_prune);
     int pruneSizeGB() const { return m_prune_size_gb; }
     void setPruneSizeGB(int new_prune_size);
 
 Q_SIGNALS:
+    void listenChanged(bool new_listen);
     void pruneChanged(bool new_prune);
     void pruneSizeGBChanged(int new_prune_size_gb);
 
@@ -36,6 +40,7 @@ private:
     interfaces::Node& m_node;
 
     // Properties that are exposed to QML.
+    bool m_listen;
     bool m_prune;
     int m_prune_size_gb;
 

--- a/src/qml/options_model.h
+++ b/src/qml/options_model.h
@@ -18,6 +18,7 @@ class OptionsQmlModel : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(bool listen READ listen WRITE setListen NOTIFY listenChanged)
+    Q_PROPERTY(bool natpmp READ natpmp WRITE setNatpmp NOTIFY natpmpChanged)
     Q_PROPERTY(bool prune READ prune WRITE setPrune NOTIFY pruneChanged)
     Q_PROPERTY(int pruneSizeGB READ pruneSizeGB WRITE setPruneSizeGB NOTIFY pruneSizeGBChanged)
     Q_PROPERTY(bool upnp READ upnp WRITE setUpnp NOTIFY upnpChanged)
@@ -27,6 +28,8 @@ public:
 
     bool listen() const { return m_listen; }
     void setListen(bool new_listen);
+    bool natpmp() const { return m_natpmp; }
+    void setNatpmp(bool new_natpmp);
     bool prune() const { return m_prune; }
     void setPrune(bool new_prune);
     int pruneSizeGB() const { return m_prune_size_gb; }
@@ -36,6 +39,7 @@ public:
 
 Q_SIGNALS:
     void listenChanged(bool new_listen);
+    void natpmpChanged(bool new_natpmp);
     void pruneChanged(bool new_prune);
     void pruneSizeGBChanged(int new_prune_size_gb);
     void upnpChanged(bool new_upnp);
@@ -45,6 +49,7 @@ private:
 
     // Properties that are exposed to QML.
     bool m_listen;
+    bool m_natpmp;
     bool m_prune;
     int m_prune_size_gb;
     bool m_upnp;

--- a/src/qml/options_model.h
+++ b/src/qml/options_model.h
@@ -20,6 +20,7 @@ class OptionsQmlModel : public QObject
     Q_PROPERTY(bool listen READ listen WRITE setListen NOTIFY listenChanged)
     Q_PROPERTY(bool prune READ prune WRITE setPrune NOTIFY pruneChanged)
     Q_PROPERTY(int pruneSizeGB READ pruneSizeGB WRITE setPruneSizeGB NOTIFY pruneSizeGBChanged)
+    Q_PROPERTY(bool upnp READ upnp WRITE setUpnp NOTIFY upnpChanged)
 
 public:
     explicit OptionsQmlModel(interfaces::Node& node);
@@ -30,11 +31,14 @@ public:
     void setPrune(bool new_prune);
     int pruneSizeGB() const { return m_prune_size_gb; }
     void setPruneSizeGB(int new_prune_size);
+    bool upnp() const { return m_upnp; }
+    void setUpnp(bool new_upnp);
 
 Q_SIGNALS:
     void listenChanged(bool new_listen);
     void pruneChanged(bool new_prune);
     void pruneSizeGBChanged(int new_prune_size_gb);
+    void upnpChanged(bool new_upnp);
 
 private:
     interfaces::Node& m_node;
@@ -43,6 +47,7 @@ private:
     bool m_listen;
     bool m_prune;
     int m_prune_size_gb;
+    bool m_upnp;
 
     util::SettingsValue pruneSetting() const;
 };

--- a/src/qml/options_model.h
+++ b/src/qml/options_model.h
@@ -21,6 +21,7 @@ class OptionsQmlModel : public QObject
     Q_PROPERTY(bool natpmp READ natpmp WRITE setNatpmp NOTIFY natpmpChanged)
     Q_PROPERTY(bool prune READ prune WRITE setPrune NOTIFY pruneChanged)
     Q_PROPERTY(int pruneSizeGB READ pruneSizeGB WRITE setPruneSizeGB NOTIFY pruneSizeGBChanged)
+    Q_PROPERTY(bool server READ server WRITE setServer NOTIFY serverChanged)
     Q_PROPERTY(bool upnp READ upnp WRITE setUpnp NOTIFY upnpChanged)
 
 public:
@@ -34,6 +35,8 @@ public:
     void setPrune(bool new_prune);
     int pruneSizeGB() const { return m_prune_size_gb; }
     void setPruneSizeGB(int new_prune_size);
+    bool server() const { return m_server; }
+    void setServer(bool new_server);
     bool upnp() const { return m_upnp; }
     void setUpnp(bool new_upnp);
 
@@ -42,6 +45,7 @@ Q_SIGNALS:
     void natpmpChanged(bool new_natpmp);
     void pruneChanged(bool new_prune);
     void pruneSizeGBChanged(int new_prune_size_gb);
+    void serverChanged(bool new_server);
     void upnpChanged(bool new_upnp);
 
 private:
@@ -52,6 +56,7 @@ private:
     bool m_natpmp;
     bool m_prune;
     int m_prune_size_gb;
+    bool m_server;
     bool m_upnp;
 
     util::SettingsValue pruneSetting() const;


### PR DESCRIPTION
This introduces initial support and wiring for the currently implemented settings that are part of the `ConnectionSettings.qml`. This does not set defaults for these, nor calls additionally necessary steps in the case of mapping to actually map the ports as that is left for a follow-up.


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/222)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/222)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/222)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/222)

