### PR TITLE
Introduce Proxy settings view

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -336,6 +336,7 @@ QML_RES_QML = \
   qml/components/DeveloperOptions.qml \
   qml/components/PeersIndicator.qml \
   qml/components/NetworkIndicator.qml \
+  qml/components/ProxySettings.qml \
   qml/components/Separator.qml \
   qml/components/StorageLocations.qml \
   qml/components/StorageOptions.qml \
@@ -369,6 +370,7 @@ QML_RES_QML = \
   qml/pages/settings/SettingsAbout.qml \
   qml/pages/settings/SettingsConnection.qml \
   qml/pages/settings/SettingsDeveloper.qml \
+  qml/pages/settings/SettingsProxy.qml \
   qml/pages/settings/SettingsStorage.qml
 
 BITCOIN_QT_CPP = $(BITCOIN_QT_BASE_CPP)

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -9,6 +9,7 @@
         <file>components/PeersIndicator.qml</file>
         <file>components/DeveloperOptions.qml</file>
         <file>components/NetworkIndicator.qml</file>
+        <file>components/ProxySettings.qml</file>
         <file>components/StorageLocations.qml</file>
         <file>components/Separator.qml</file>
         <file>components/StorageOptions.qml</file>
@@ -42,6 +43,7 @@
         <file>pages/settings/SettingsAbout.qml</file>
         <file>pages/settings/SettingsConnection.qml</file>
         <file>pages/settings/SettingsDeveloper.qml</file>
+        <file>pages/settings/SettingsProxy.qml</file>
         <file>pages/settings/SettingsStorage.qml</file>
     </qresource>
     <qresource prefix="/icons">

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -70,5 +70,6 @@ ColumnLayout {
         actionItem: CaretRightButton {
             stateColor: gotoProxy.stateColor
         }
+        onClicked: connectionSwipe.incrementCurrentIndex()
     }
 }

--- a/src/qml/components/ProxySettings.qml
+++ b/src/qml/components/ProxySettings.qml
@@ -1,0 +1,82 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../controls"
+
+ColumnLayout {
+    spacing: 4
+    Header {
+        headerBold: true
+        center: false
+        header: qsTr("Default Proxy")
+        headerSize: 24
+        description: qsTr("Run peer connections through a proxy (SOCKS5) for improved privacy. The default proxy supports connections via IPv4, IPv6 and Tor. Tor connections can also be run through a separate Tor proxy.")
+        descriptionSize: 15
+        Layout.bottomMargin: 10
+    }
+    Separator { Layout.fillWidth: true }
+    Setting {
+        Layout.fillWidth: true
+        header: qsTr("Enable")
+        actionItem: OptionSwitch {}
+        onClicked: {
+            loadedItem.toggle()
+            loadedItem.toggled()
+        }
+    }
+    Separator { Layout.fillWidth: true }
+    Setting {
+        id: defaultProxy
+        Layout.fillWidth: true
+        header: qsTr("IP and Port")
+        actionItem: ValueInput {
+            parentState: defaultProxy.state
+            description: "127.0.0.1:9050"
+            onEditingFinished: {
+                defaultProxy.forceActiveFocus()
+            }
+        }
+        onClicked: loadedItem.forceActiveFocus()
+    }
+    Separator { Layout.fillWidth: true }
+    Header {
+        headerBold: true
+        center: false
+        header: qsTr("Tor Proxy")
+        headerSize: 24
+        description: qsTr("Enable to run Tor connections through a dedicated proxy.")
+        descriptionSize: 15
+        Layout.topMargin: 35
+        Layout.bottomMargin: 10
+    }
+    Separator { Layout.fillWidth: true }
+    Setting {
+        Layout.fillWidth: true
+        header: qsTr("Enable")
+        actionItem: OptionSwitch {}
+        description: qsTr("When disabled, Tor connections will use the default proxy (if enabled).")
+        onClicked: {
+            loadedItem.toggle()
+            loadedItem.toggled()
+        }
+    }
+    Separator { Layout.fillWidth: true }
+    Setting {
+        id: torProxy
+        Layout.fillWidth: true
+        header: qsTr("IP and Port")
+        actionItem: ValueInput {
+            parentState: torProxy.state
+            description: "127.0.0.1:9050"
+            onEditingFinished: {
+                torProxy.forceActiveFocus()
+            }
+        }
+        onClicked: loadedItem.forceActiveFocus()
+    }
+    Separator { Layout.fillWidth: true }
+}

--- a/src/qml/pages/settings/SettingsConnection.qml
+++ b/src/qml/pages/settings/SettingsConnection.qml
@@ -8,13 +8,40 @@ import QtQuick.Layouts 1.15
 import "../../controls"
 import "../../components"
 
-InformationPage {
-    background: null
-    clip: true
-    bannerActive: false
-    bold: true
-    headerText: qsTr("Connection settings")
-    headerMargin: 0
-    detailActive: true
-    detailItem: ConnectionSettings {}
+Item {
+    property alias navRightDetail: connectionSwipe.navRightDetail
+    property alias navLeftDetail: connectionSwipe.navLeftDetail
+    SwipeView {
+        id: connectionSwipe
+        property alias navRightDetail: connection_settings.navRightDetail
+        property alias navLeftDetail: connection_settings.navLeftDetail
+        anchors.fill: parent
+        interactive: false
+        orientation: Qt.Horizontal
+        InformationPage {
+            id: connection_settings
+            background: null
+            clip: true
+            bannerActive: false
+            bold: true
+            headerText: qsTr("Connection settings")
+            headerMargin: 0
+            detailActive: true
+            detailItem: ConnectionSettings {}
+        }
+        SettingsProxy {
+            navLeftDetail: NavButton {
+                iconSource: "image://images/caret-left"
+                text: qsTr("Back")
+                onClicked: {
+                    connectionSwipe.decrementCurrentIndex()
+                }
+            }
+            navMiddleDetail: Header {
+                headerBold: true
+                headerSize: 18
+                header: qsTr("Proxy Settings")
+            }
+        }
+    }
 }

--- a/src/qml/pages/settings/SettingsProxy.qml
+++ b/src/qml/pages/settings/SettingsProxy.qml
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../../controls"
+import "../../components"
+
+Page {
+    id: proxy_settings
+    property alias navLeftDetail: navbar.leftDetail
+    property alias navMiddleDetail: navbar.middleDetail
+
+    background: null
+    implicitWidth: 450
+    leftPadding: 20
+    rightPadding: 20
+    topPadding: 30
+
+    header: NavigationBar {
+        id: navbar
+    }
+    ProxySettings {
+        width: Math.min(parent.width, 450)
+        anchors.horizontalCenter: parent.horizontalCenter
+    }
+}


### PR DESCRIPTION
Introduces the components and views that make up the proxy settings page. Missing options handling wiring, as well as the gray box that signals the current status/activation of specified proxy settings. Based on these designs: [proxy designs](https://www.figma.com/file/ek8w3n3upbluw5UL2lGhRx/Bitcoin-Core-App-Design?node-id=6266%3A23933&t=fVYCyV3AXZLRXxpB-4)

| light | dark |
| ----- | ---- |
| <img width="752" alt="Screen Shot 2023-02-17 at 1 15 52 AM" src="https://user-images.githubusercontent.com/23396902/219564274-4156bdff-6d1e-48df-aad1-790800cd1622.png"> | <img width="752" alt="Screen Shot 2023-02-17 at 1 15 28 AM" src="https://user-images.githubusercontent.com/23396902/219564290-2fc83d8c-308d-496a-8de5-34c992701336.png"> |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/223)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/223)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/223)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/223)