### PR TITLE
Initial support and wiring for developer settings

### DIFF
--- a/src/qml/components/DeveloperOptions.qml
+++ b/src/qml/components/DeveloperOptions.qml
@@ -39,7 +39,8 @@ ColumnLayout {
         header: qsTr("Script verification threads")
         actionItem: ValueInput {
             parentState: parSetting.state
-            description: ("0")
+            description: optionsModel.scriptThreads
+            onEditingFinished: optionsModel.scriptThreads = parseInt(text)
         }
         onClicked: loadedItem.forceActiveFocus()
     }

--- a/src/qml/components/DeveloperOptions.qml
+++ b/src/qml/components/DeveloperOptions.qml
@@ -25,10 +25,11 @@ ColumnLayout {
     Setting {
         id: dbcacheSetting
         Layout.fillWidth: true
-        header: qsTr("Database cache size")
+        header: qsTr("Database cache size (MiB)")
         actionItem: ValueInput {
             parentState: dbcacheSetting.state
-            description: ("450 MiB")
+            description: optionsModel.dbcacheSizeMiB
+            onEditingFinished: optionsModel.dbcacheSizeMiB = parseInt(text)
         }
         onClicked: loadedItem.forceActiveFocus()
     }

--- a/src/qml/options_model.cpp
+++ b/src/qml/options_model.cpp
@@ -7,6 +7,7 @@
 #include <interfaces/node.h>
 #include <qt/guiconstants.h>
 #include <qt/optionsmodel.h>
+#include <txdb.h>
 #include <univalue.h>
 #include <util/settings.h>
 #include <util/system.h>
@@ -16,9 +17,20 @@
 OptionsQmlModel::OptionsQmlModel(interfaces::Node& node)
     : m_node{node}
 {
+    m_dbcache_size_mib = SettingToInt(m_node.getPersistentSetting("dbcache"), nDefaultDbCache);
+
     int64_t prune_value{SettingToInt(m_node.getPersistentSetting("prune"), 0)};
     m_prune = (prune_value > 1);
     m_prune_size_gb = m_prune ? PruneMiBtoGB(prune_value) : DEFAULT_PRUNE_TARGET_GB;
+}
+
+void OptionsQmlModel::setDbcacheSizeMiB(int new_dbcache_size_mib)
+{
+    if (new_dbcache_size_mib != m_dbcache_size_mib) {
+        m_dbcache_size_mib = new_dbcache_size_mib;
+        m_node.updateRwSetting("dbcache", new_dbcache_size_mib);
+        Q_EMIT dbcacheSizeMiBChanged(new_dbcache_size_mib);
+    }
 }
 
 void OptionsQmlModel::setListen(bool new_listen)

--- a/src/qml/options_model.cpp
+++ b/src/qml/options_model.cpp
@@ -11,6 +11,7 @@
 #include <univalue.h>
 #include <util/settings.h>
 #include <util/system.h>
+#include <validation.h>
 
 #include <cassert>
 
@@ -22,6 +23,8 @@ OptionsQmlModel::OptionsQmlModel(interfaces::Node& node)
     int64_t prune_value{SettingToInt(m_node.getPersistentSetting("prune"), 0)};
     m_prune = (prune_value > 1);
     m_prune_size_gb = m_prune ? PruneMiBtoGB(prune_value) : DEFAULT_PRUNE_TARGET_GB;
+
+    m_script_threads = SettingToInt(m_node.getPersistentSetting("par"), DEFAULT_SCRIPTCHECK_THREADS);
 }
 
 void OptionsQmlModel::setDbcacheSizeMiB(int new_dbcache_size_mib)
@@ -66,6 +69,15 @@ void OptionsQmlModel::setPruneSizeGB(int new_prune_size_gb)
         m_prune_size_gb = new_prune_size_gb;
         m_node.updateRwSetting("prune", pruneSetting());
         Q_EMIT pruneSizeGBChanged(new_prune_size_gb);
+    }
+}
+
+void OptionsQmlModel::setScriptThreads(int new_script_threads)
+{
+    if (new_script_threads != m_script_threads) {
+        m_script_threads = new_script_threads;
+        m_node.updateRwSetting("par", new_script_threads);
+        Q_EMIT scriptThreadsChanged(new_script_threads);
     }
 }
 

--- a/src/qml/options_model.h
+++ b/src/qml/options_model.h
@@ -17,6 +17,7 @@ class Node;
 class OptionsQmlModel : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(int dbcacheSizeMiB READ dbcacheSizeMiB WRITE setDbcacheSizeMiB NOTIFY dbcacheSizeMiBChanged)
     Q_PROPERTY(bool listen READ listen WRITE setListen NOTIFY listenChanged)
     Q_PROPERTY(bool natpmp READ natpmp WRITE setNatpmp NOTIFY natpmpChanged)
     Q_PROPERTY(bool prune READ prune WRITE setPrune NOTIFY pruneChanged)
@@ -27,6 +28,8 @@ class OptionsQmlModel : public QObject
 public:
     explicit OptionsQmlModel(interfaces::Node& node);
 
+    int dbcacheSizeMiB() const { return m_dbcache_size_mib; }
+    void setDbcacheSizeMiB(int new_dbcache_size_mib);
     bool listen() const { return m_listen; }
     void setListen(bool new_listen);
     bool natpmp() const { return m_natpmp; }
@@ -41,6 +44,7 @@ public:
     void setUpnp(bool new_upnp);
 
 Q_SIGNALS:
+    void dbcacheSizeMiBChanged(int new_dbcache_size_mib);
     void listenChanged(bool new_listen);
     void natpmpChanged(bool new_natpmp);
     void pruneChanged(bool new_prune);
@@ -52,6 +56,7 @@ private:
     interfaces::Node& m_node;
 
     // Properties that are exposed to QML.
+    int m_dbcache_size_mib;
     bool m_listen;
     bool m_natpmp;
     bool m_prune;

--- a/src/qml/options_model.h
+++ b/src/qml/options_model.h
@@ -22,6 +22,7 @@ class OptionsQmlModel : public QObject
     Q_PROPERTY(bool natpmp READ natpmp WRITE setNatpmp NOTIFY natpmpChanged)
     Q_PROPERTY(bool prune READ prune WRITE setPrune NOTIFY pruneChanged)
     Q_PROPERTY(int pruneSizeGB READ pruneSizeGB WRITE setPruneSizeGB NOTIFY pruneSizeGBChanged)
+    Q_PROPERTY(int scriptThreads READ scriptThreads WRITE setScriptThreads NOTIFY scriptThreadsChanged)
     Q_PROPERTY(bool server READ server WRITE setServer NOTIFY serverChanged)
     Q_PROPERTY(bool upnp READ upnp WRITE setUpnp NOTIFY upnpChanged)
 
@@ -38,6 +39,8 @@ public:
     void setPrune(bool new_prune);
     int pruneSizeGB() const { return m_prune_size_gb; }
     void setPruneSizeGB(int new_prune_size);
+    int scriptThreads() const { return m_script_threads; }
+    void setScriptThreads(int new_script_threads);
     bool server() const { return m_server; }
     void setServer(bool new_server);
     bool upnp() const { return m_upnp; }
@@ -49,6 +52,7 @@ Q_SIGNALS:
     void natpmpChanged(bool new_natpmp);
     void pruneChanged(bool new_prune);
     void pruneSizeGBChanged(int new_prune_size_gb);
+    void scriptThreadsChanged(int new_script_threads);
     void serverChanged(bool new_server);
     void upnpChanged(bool new_upnp);
 
@@ -61,6 +65,7 @@ private:
     bool m_natpmp;
     bool m_prune;
     int m_prune_size_gb;
+    int m_script_threads;
     bool m_server;
     bool m_upnp;
 


### PR DESCRIPTION
This introduces initial support and wiring for the currently implemented settings that are part of the `DeveloperSettings.qml`.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/224)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/224)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/224)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/224)
