### PR TITLE
Add NavButton interaction color animation states

### DIFF
--- a/src/qml/controls/NavButton.qml
+++ b/src/qml/controls/NavButton.qml
@@ -14,7 +14,32 @@ AbstractButton {
     property url iconSource: ""
 
     padding: 0
-    background: null
+    background: Rectangle {
+        id: bg
+        height: root.height
+        width: root.width
+        radius: 5
+        state:"DEFAULT"
+
+        states: [
+            State {
+                name: "DEFAULT"
+                PropertyChanges { target: bg; color: Theme.color.background }
+            },
+            State {
+                name: "HOVER"
+                PropertyChanges { target: bg; color: Theme.color.neutral2 }
+            },
+            State {
+                name: "PRESSED"
+                PropertyChanges { target: bg; color: Theme.color.neutral3 }
+            }
+        ]
+
+        Behavior on color {
+            ColorAnimation { duration: 150 }
+        }
+    }
     contentItem: RowLayout {
         anchors.fill: parent
         spacing: 0
@@ -33,7 +58,6 @@ AbstractButton {
                icon.height: root.iconHeight
                icon.width: root.iconWidth
                background: null
-               onClicked: root.clicked()
            }
         }
         Loader {
@@ -52,8 +76,24 @@ AbstractButton {
                    color: Theme.color.neutral9
                    text: root.text
               }
-              onClicked: root.clicked()
           }
-      }
+        }
+    }
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        onEntered: {
+            root.background.state = "HOVER"
+        }
+        onExited: {
+            root.background.state = "DEFAULT"
+        }
+        onPressed: {
+            root.background.state = "PRESSED"
+        }
+        onReleased: {
+            root.background.state = "DEFAULT"
+            root.clicked()
+        }
     }
 }

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -48,8 +48,11 @@ Item {
                 Setting {
                     Layout.fillWidth: true
                     header: qsTr("About")
-                    actionItem: NavButton {
-                        iconSource: "image://images/caret-right"
+                    actionItem: Button {
+                        icon.source: "image://images/caret-right"
+                        icon.color: Theme.color.neutral9
+                        icon.height: 18
+                        icon.width: 18
                         background: null
                         onClicked: {
                             nodeSettingsView.push(about_page)
@@ -59,8 +62,11 @@ Item {
                 Setting {
                     Layout.fillWidth: true
                     header: qsTr("Storage")
-                    actionItem: NavButton {
-                        iconSource: "image://images/caret-right"
+                    actionItem: Button {
+                        icon.source: "image://images/caret-right"
+                        icon.color: Theme.color.neutral9
+                        icon.height: 18
+                        icon.width: 18
                         background: null
                         onClicked: {
                             nodeSettingsView.push(storage_page)
@@ -70,8 +76,11 @@ Item {
                 Setting {
                     Layout.fillWidth: true
                     header: qsTr("Connection")
-                    actionItem: NavButton {
-                        iconSource: "image://images/caret-right"
+                    actionItem: Button {
+                        icon.source: "image://images/caret-right"
+                        icon.color: Theme.color.neutral9
+                        icon.height: 18
+                        icon.width: 18
                         background: null
                         onClicked: {
                             nodeSettingsView.push(connection_page)


### PR DESCRIPTION
Introduces the missing NavButton interaction color animation states as detailed in  https://github.com/bitcoin-core/gui-qml/issues/231, except there are issues with the sizing of the components themselves.

#### Dark Mode 

| Default | Hovered | Pressed |
| ------- | ------- | ------- |
| <img width="104" alt="Screen Shot 2023-01-29 at 4 41 48 AM" src="https://user-images.githubusercontent.com/23396902/215318084-676a8834-b7df-4ad0-8e0f-06bb763bf24f.png"> | <img width="104" alt="Screen Shot 2023-01-29 at 4 42 04 AM" src="https://user-images.githubusercontent.com/23396902/215318088-cab6d039-8532-4782-9198-e18be5cf1e78.png"> | <img width="104" alt="Screen Shot 2023-01-29 at 4 42 21 AM" src="https://user-images.githubusercontent.com/23396902/215318108-490d8bf6-5eb6-45c4-bc20-08b6cc4f854b.png"> |

#### Dark Mode 

| Default | Hovered | Pressed |
| ------- | ------- | ------- |
| <img width="104" alt="Screen Shot 2023-01-29 at 4 43 40 AM" src="https://user-images.githubusercontent.com/23396902/215318182-cd81e393-5b34-4100-a714-773fe7b7b232.png"> | <img width="104" alt="Screen Shot 2023-01-29 at 4 44 00 AM" src="https://user-images.githubusercontent.com/23396902/215318189-57029f83-db97-434c-9eb6-1c31fc4caac0.png"> | <img width="104" alt="Screen Shot 2023-01-29 at 4 44 12 AM" src="https://user-images.githubusercontent.com/23396902/215318192-d20e0ec5-a16b-4c23-bb2f-7fd94cf30a22.png"> |

As can be told from the screenshots the sizing of the component itself isn't correct; this needs to be addressed, potentially in a follow-up.


The first commit allows for us to use the NavButton correctly with these new background states but also fixes an issue where the Right Caret buttons in the NodeSettings page were much bigger than in the other areas we use this button. A follow-up can contain this button in a nice component.





[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/<PR>)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/<PR>)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/<PR>)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/<PR>)