### PR TITLE
Fix layout issue with checkmark in OptionButton

### DIFF
--- a/src/qml/controls/OptionButton.qml
+++ b/src/qml/controls/OptionButton.qml
@@ -33,6 +33,7 @@ Button {
         spacing: 3
         ColumnLayout {
             spacing: 3
+            Layout.fillWidth: true
             Header {
                 Layout.fillWidth: true
                 Layout.preferredWidth: 0
@@ -64,11 +65,12 @@ Button {
                 }
             }
         }
-        Loader {
-            id: detail_loader
-            visible: button.checked
-            active: true
-            sourceComponent: Button {
+        Item {
+            height: parent.height
+            width: 40
+            Button {
+                anchors.centerIn: parent
+                visible: button.checked
                 icon.source: "image://images/check"
                 icon.color: Theme.color.neutral9
                 icon.height: 24


### PR DESCRIPTION
This fixes a UI issue within the OptionButton, when the option button is smaller than 450px; the checkmark will cause the text to wrap to be smaller. The issue then is that they UI is toggling in a distracting manner between two different widths for text within the OptionButton.

The issue is illustrated below:
### Master
| select 1 | select 2 |
| -------- | -------- |
| <img width="412" alt="Screen Shot 2023-01-30 at 8 10 13 PM" src="https://user-images.githubusercontent.com/23396902/215639049-fc58461d-a2e9-48f1-b40c-d1ad711f6530.png"> | <img width="412" alt="Screen Shot 2023-01-30 at 8 10 26 PM" src="https://user-images.githubusercontent.com/23396902/215639070-2e80f09e-1c13-4c72-8dfb-625244b9243e.png"> |

### PR
This PR fixes this by setting the box containing the Header to take up 90% of the internal width of the OptionButton and giving the remaining 10% to the Checkmark icon button. The math for this is as follows:
- given a width of 450, and padding of 15, we have an internal max width of 420 🔥
- The design file specifies that when the OptionButton has a width of 450, the box containing the header has a width of 380
- 380/420 = ~0.9
<img width="1193" alt="Screen Shot 2023-01-30 at 7 50 34 PM" src="https://user-images.githubusercontent.com/23396902/215640099-45b96f36-2934-479b-a11d-bde0ee794e31.png">

| select 1 | select 2 |
| -------- | -------- |
| <img width="412" alt="Screen Shot 2023-01-30 at 8 06 43 PM" src="https://user-images.githubusercontent.com/23396902/215640303-61418447-2ddf-436b-a68d-8aa43c9d47e2.png"> | <img width="412" alt="Screen Shot 2023-01-30 at 8 06 55 PM" src="https://user-images.githubusercontent.com/23396902/215640358-07228387-cf82-4deb-ac8a-74ae7a68b28d.png"> |

### Why a 15pt Right Margin

This sets `Layout.rightMargin: 15` on the box containing the header because otherwise the header text would get too close to the checkmark

| without | with |
| ------- | ---- |
| <img width="459" alt="Screen Shot 2023-01-30 at 8 04 54 PM" src="https://user-images.githubusercontent.com/23396902/215640654-a9870102-30b1-419d-ae17-8a313bbaec5b.png"> | <img width="513" alt="Screen Shot 2023-01-30 at 8 03 59 PM" src="https://user-images.githubusercontent.com/23396902/215640670-dc546290-9cb2-4251-900a-033068d0036f.png"> |



[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/235)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/235)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/235)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/235)