### PR TITLE
Introduce PeersIndicator component, Add to BlockClock

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -333,6 +333,7 @@ QML_RES_QML = \
   qml/components/ConnectionOptions.qml \
   qml/components/ConnectionSettings.qml \
   qml/components/DeveloperOptions.qml \
+  qml/components/PeersIndicator.qml \
   qml/components/StorageLocations.qml \
   qml/components/StorageOptions.qml \
   qml/components/StorageSettings.qml \

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -33,6 +33,7 @@ enum class SynchronizationState;
 enum class TransactionError;
 struct CNodeStateStats;
 struct bilingual_str;
+struct PeersNumByType;
 namespace node {
 struct NodeContext;
 } // namespace node
@@ -238,7 +239,7 @@ public:
     virtual std::unique_ptr<Handler> handleInitWallet(InitWalletFn fn) = 0;
 
     //! Register handler for number of connections changed messages.
-    using NotifyNumConnectionsChangedFn = std::function<void(int new_num_connections)>;
+    using NotifyNumConnectionsChangedFn = std::function<void(PeersNumByType new_num_connections)>;
     virtual std::unique_ptr<Handler> handleNotifyNumConnectionsChanged(NotifyNumConnectionsChangedFn fn) = 0;
 
     //! Register handler for network active messages.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1133,15 +1133,47 @@ void CConnman::DisconnectNodes()
 
 void CConnman::NotifyNumConnectionsChanged()
 {
-    size_t nodes_size;
+    decltype(m_nodes) nodes_copy;
     {
         LOCK(m_nodes_mutex);
-        nodes_size = m_nodes.size();
+        nodes_copy = m_nodes;
     }
-    if(nodes_size != nPrevNodeCount) {
-        nPrevNodeCount = nodes_size;
+
+    int num_outbound_full_relay{0};
+    int num_block_relay{0};
+    int num_manual{0};
+    int num_inbound{0};
+    for (const auto* node : nodes_copy) {
+        switch (node->m_conn_type) {
+        case ConnectionType::OUTBOUND_FULL_RELAY:
+            ++num_outbound_full_relay;
+            break;
+        case ConnectionType::BLOCK_RELAY:
+            ++num_block_relay;
+            break;
+        case ConnectionType::MANUAL:
+            ++num_manual;
+            break;
+        case ConnectionType::INBOUND:
+            ++num_inbound;
+            break;
+        case ConnectionType::FEELER:
+        case ConnectionType::ADDR_FETCH:
+            break;
+        }
+    }
+
+    if (num_outbound_full_relay != m_num_outbound_full_relay ||
+        num_block_relay != m_num_block_relay ||
+        num_manual != m_num_manual ||
+        num_inbound != m_num_inbound) {
+        m_num_outbound_full_relay = num_outbound_full_relay;
+        m_num_block_relay = num_block_relay;
+        m_num_manual = num_manual;
+        m_num_inbound = num_inbound;
         if (m_client_interface) {
-            m_client_interface->NotifyNumConnectionsChanged(nodes_size);
+            m_client_interface->NotifyNumConnectionsChanged(
+                {num_outbound_full_relay, num_block_relay, num_manual, num_inbound, static_cast<int>(nodes_copy.size())});
         }
     }
 }

--- a/src/net.h
+++ b/src/net.h
@@ -46,6 +46,7 @@ class BanMan;
 class CNode;
 class CScheduler;
 struct bilingual_str;
+struct PeersNumByType;
 
 /** Default for -whitelistrelay. */
 static const bool DEFAULT_WHITELISTRELAY = true;
@@ -1010,7 +1011,11 @@ private:
     std::list<CNode*> m_nodes_disconnected;
     mutable RecursiveMutex m_nodes_mutex;
     std::atomic<NodeId> nLastNodeId{0};
-    unsigned int nPrevNodeCount{0};
+    int m_num_outbound_full_relay{0};
+    int m_num_block_relay{0};
+    int m_num_manual{0};
+    int m_num_inbound{0};
+
 
     /**
      * Cache responses to addr requests to minimize privacy leak.

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -48,7 +48,7 @@ bool CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, cons
 bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, caption, style).value_or(false);}
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::InitWallet() { return g_ui_signals.InitWallet(); }
-void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
+void CClientUIInterface::NotifyNumConnectionsChanged(PeersNumByType newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
 void CClientUIInterface::NotifyNetworkActiveChanged(bool networkActive) { return g_ui_signals.NotifyNetworkActiveChanged(networkActive); }
 void CClientUIInterface::NotifyAlertChanged() { return g_ui_signals.NotifyAlertChanged(); }
 void CClientUIInterface::ShowProgress(const std::string& title, int nProgress, bool resume_possible) { return g_ui_signals.ShowProgress(title, nProgress, resume_possible); }

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -20,6 +20,14 @@ class connection;
 }
 } // namespace boost
 
+struct PeersNumByType {
+    int outbound_full_relay{0};
+    int block_relay{0};
+    int manual{0};
+    int inbound{0};
+    int total{0};
+};
+
 /** Signals for UI communication. */
 class CClientUIInterface
 {
@@ -85,7 +93,7 @@ public:
     ADD_SIGNALS_DECL_WRAPPER(InitWallet, void, );
 
     /** Number of network connections changed. */
-    ADD_SIGNALS_DECL_WRAPPER(NotifyNumConnectionsChanged, void, int newNumConnections);
+    ADD_SIGNALS_DECL_WRAPPER(NotifyNumConnectionsChanged, void, PeersNumByType newNumConnections);
 
     /** Network activity state changed. */
     ADD_SIGNALS_DECL_WRAPPER(NotifyNetworkActiveChanged, void, bool networkActive);

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -5,6 +5,7 @@
         <file>components/BlockCounter.qml</file>
         <file>components/ConnectionOptions.qml</file>
         <file>components/ConnectionSettings.qml</file>
+        <file>components/PeersIndicator.qml</file>
         <file>components/DeveloperOptions.qml</file>
         <file>components/StorageLocations.qml</file>
         <file>components/StorageOptions.qml</file>

--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -66,21 +66,12 @@ Item {
         color: Theme.color.neutral4
     }
 
-    RowLayout {
-        id: peersIndicator
+    PeersIndicator {
         anchors.top: subText.bottom
         anchors.topMargin: 20
         anchors.horizontalCenter: root.horizontalCenter
-        spacing: 5
-        Repeater {
-            model: 5
-            Rectangle {
-                width: 3
-                height: width
-                radius: width/2
-                color: Theme.color.neutral9
-            }
-        }
+        numOutboundPeers: nodeModel.numOutboundPeers
+        maxNumOutboundPeers: nodeModel.maxNumOutboundPeers
     }
 
     MouseArea {

--- a/src/qml/components/PeersIndicator.qml
+++ b/src/qml/components/PeersIndicator.qml
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import "../controls"
+
+RowLayout {
+    id: root
+    required property int numOutboundPeers
+    required property int maxNumOutboundPeers
+    property int size: 5
+
+    spacing: 5
+    Repeater {
+        model: 5
+        Rectangle {
+            width: 3
+            height: 3
+            radius: width / 2
+            color: Theme.color.neutral9
+            opacity: (index === 0 && root.numOutboundPeers > 0) || (index + 1 <= root.size * root.numOutboundPeers / root.maxNumOutboundPeers) ? 0.95 : 0.45
+            Behavior on opacity { OpacityAnimator { duration: 100 } }
+            SequentialAnimation on opacity {
+                loops: Animation.Infinite
+                running: numOutboundPeers === 0 && index === 0
+                SmoothedAnimation { to: 0; velocity: 2.2 }
+                SmoothedAnimation { to: 1; velocity: 2.2 }
+            }
+        }
+    }
+}

--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -5,6 +5,8 @@
 #include <qml/nodemodel.h>
 
 #include <interfaces/node.h>
+#include <net.h>
+#include <node/interface_ui.h>
 #include <validation.h>
 
 #include <cassert>
@@ -18,6 +20,7 @@ NodeModel::NodeModel(interfaces::Node& node)
     : m_node{node}
 {
     ConnectToBlockTipSignal();
+    ConnectToNumConnectionsChangedSignal();
 }
 
 void NodeModel::setBlockTipHeight(int new_height)
@@ -25,6 +28,14 @@ void NodeModel::setBlockTipHeight(int new_height)
     if (new_height != m_block_tip_height) {
         m_block_tip_height = new_height;
         Q_EMIT blockTipHeightChanged();
+    }
+}
+
+void NodeModel::setNumOutboundPeers(int new_num)
+{
+    if (new_num != m_num_outbound_peers) {
+        m_num_outbound_peers = new_num;
+        Q_EMIT numOutboundPeersChanged();
     }
 }
 
@@ -127,5 +138,15 @@ void NodeModel::ConnectToBlockTipSignal()
 
                 Q_EMIT setTimeRatioList(tip.block_time);
             });
+        });
+}
+
+void NodeModel::ConnectToNumConnectionsChangedSignal()
+{
+    assert(!m_handler_notify_num_peers_changed);
+
+    m_handler_notify_num_peers_changed = m_node.handleNotifyNumConnectionsChanged(
+        [this](PeersNumByType new_num_peers) {
+            setNumOutboundPeers(new_num_peers.outbound_full_relay + new_num_peers.block_relay);
         });
 }

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -25,6 +25,8 @@ class NodeModel : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int blockTipHeight READ blockTipHeight NOTIFY blockTipHeightChanged)
+    Q_PROPERTY(int numOutboundPeers READ numOutboundPeers NOTIFY numOutboundPeersChanged)
+    Q_PROPERTY(int maxNumOutboundPeers READ maxNumOutboundPeers CONSTANT)
     Q_PROPERTY(int remainingSyncTime READ remainingSyncTime NOTIFY remainingSyncTimeChanged)
     Q_PROPERTY(double verificationProgress READ verificationProgress NOTIFY verificationProgressChanged)
     Q_PROPERTY(bool pause READ pause WRITE setPause NOTIFY pauseChanged)
@@ -34,6 +36,9 @@ public:
 
     int blockTipHeight() const { return m_block_tip_height; }
     void setBlockTipHeight(int new_height);
+    int numOutboundPeers() const { return m_num_outbound_peers; }
+    void setNumOutboundPeers(int new_num);
+    int maxNumOutboundPeers() const { return m_max_num_outbound_peers; }
     int remainingSyncTime() const { return m_remaining_sync_time; }
     void setRemainingSyncTime(double new_progress);
     double verificationProgress() const { return m_verification_progress; }
@@ -51,6 +56,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void blockTipHeightChanged();
+    void numOutboundPeersChanged();
     void remainingSyncTimeChanged();
     void requestedInitialize();
     void requestedShutdown();
@@ -66,6 +72,8 @@ protected:
 private:
     // Properties that are exposed to QML.
     int m_block_tip_height{0};
+    int m_num_outbound_peers{0};
+    static constexpr int m_max_num_outbound_peers{MAX_OUTBOUND_FULL_RELAY_CONNECTIONS + MAX_BLOCK_RELAY_ONLY_CONNECTIONS};
     int m_remaining_sync_time{0};
     double m_verification_progress{0.0};
     bool m_pause{false};
@@ -76,8 +84,10 @@ private:
 
     interfaces::Node& m_node;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;
+    std::unique_ptr<interfaces::Handler> m_handler_notify_num_peers_changed;
 
     void ConnectToBlockTipSignal();
+    void ConnectToNumConnectionsChangedSignal();
 };
 
 #endif // BITCOIN_QML_NODEMODEL_H

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -15,6 +15,7 @@
 #include <interfaces/node.h>
 #include <net.h>
 #include <netbase.h>
+#include <node/interface_ui.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 #include <util/time.h>
@@ -245,8 +246,8 @@ void ClientModel::subscribeToCoreSignals()
             Q_EMIT showProgress(QString::fromStdString(title), progress);
         });
     m_handler_notify_num_connections_changed = m_node.handleNotifyNumConnectionsChanged(
-        [this](int new_num_connections) {
-            Q_EMIT numConnectionsChanged(new_num_connections);
+        [this](PeersNumByType new_num_connections) {
+            Q_EMIT numConnectionsChanged(new_num_connections.total);
         });
     m_handler_notify_network_active_changed = m_node.handleNotifyNetworkActiveChanged(
         [this](bool network_active) {


### PR DESCRIPTION
This is a rebased version of, and replaces, https://github.com/bitcoin-core/gui-qml/pull/127

Introduces the actual `PeersIndicator` component and adds it to the `BlockClock`

| Dark Mode | Light Mode |
| --------- | ---------- |
| <img width="752" alt="Screen Shot 2023-01-31 at 12 48 23 AM" src="https://user-images.githubusercontent.com/23396902/215676831-6573a94f-2030-4bf2-b45b-9d325be42600.png"> | <img width="752" alt="Screen Shot 2023-01-31 at 12 49 09 AM" src="https://user-images.githubusercontent.com/23396902/215676882-96f82c03-43ff-449d-b5d9-d7016fb0540b.png"> |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/236)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/236)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/236)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/236)
