### PR TITLE
Make entire Setting clickable, and engage ActionItem when clicked

### DIFF
--- a/src/qml/components/AboutOptions.qml
+++ b/src/qml/components/AboutOptions.qml
@@ -17,6 +17,7 @@ ColumnLayout {
             link: "https://bitcoincore.org"
             iconSource: "image://images/caret-right"
         }
+        onClicked: loadedItem.clicked()
     }
     Setting {
         Layout.fillWidth: true
@@ -26,6 +27,7 @@ ColumnLayout {
             link: "https://github.com/bitcoin/bitcoin"
             iconSource: "image://images/caret-right"
         }
+        onClicked: loadedItem.clicked()
     }
     Setting {
         Layout.fillWidth: true
@@ -35,6 +37,7 @@ ColumnLayout {
             link: "https://opensource.org/licenses/MIT"
             iconSource: "image://images/caret-right"
         }
+        onClicked: loadedItem.clicked()
     }
     Setting {
         Layout.fillWidth: true
@@ -44,6 +47,7 @@ ColumnLayout {
             link: "https://bitcoin.org/en/download"
             iconSource: "image://images/caret-right"
         }
+        onClicked: loadedItem.clicked()
     }
     Setting {
         Layout.fillWidth: true
@@ -59,5 +63,6 @@ ColumnLayout {
                 aboutSwipe.incrementCurrentIndex()
             }
         }
+        onClicked: loadedItem.clicked()
     }
 }

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -17,6 +17,10 @@ ColumnLayout {
             checked: optionsModel.listen
             onToggled: optionsModel.listen = checked
         }
+        onClicked: {
+          loadedItem.toggle()
+          loadedItem.toggled()
+        }
     }
     Setting {
         Layout.fillWidth: true
@@ -24,6 +28,10 @@ ColumnLayout {
         actionItem: OptionSwitch {
             checked: optionsModel.upnp
             onToggled: optionsModel.upnp = checked
+        }
+        onClicked: {
+          loadedItem.toggle()
+          loadedItem.toggled()
         }
     }
     Setting {
@@ -33,6 +41,10 @@ ColumnLayout {
             checked: optionsModel.natpmp
             onToggled: optionsModel.natpmp = checked
         }
+        onClicked: {
+          loadedItem.toggle()
+          loadedItem.toggled()
+        }
     }
     Setting {
         Layout.fillWidth: true
@@ -40,6 +52,10 @@ ColumnLayout {
         actionItem: OptionSwitch {
             checked: optionsModel.server
             onToggled: optionsModel.server = checked
+        }
+        onClicked: {
+          loadedItem.toggle()
+          loadedItem.toggled()
         }
     }
     Setting {

--- a/src/qml/components/DeveloperOptions.qml
+++ b/src/qml/components/DeveloperOptions.qml
@@ -18,6 +18,7 @@ ColumnLayout {
             iconHeight: 30
             link: "https://bitcoin.org/en/bitcoin-core/contribute/documentation"
         }
+        onClicked: loadedItem.clicked()
     }
     Setting {
         Layout.fillWidth: true
@@ -25,6 +26,7 @@ ColumnLayout {
         actionItem: ValueInput {
             description: ("450 MiB")
         }
+        onClicked: loadedItem.forceActiveFocus()
     }
     Setting {
         Layout.fillWidth: true
@@ -32,6 +34,7 @@ ColumnLayout {
         actionItem: ValueInput {
             description: ("0")
         }
+        onClicked: loadedItem.forceActiveFocus()
     }
     Setting {
         Layout.fillWidth: true
@@ -40,5 +43,6 @@ ColumnLayout {
             checked: Theme.dark
             onToggled: Theme.toggleDark()
         }
+        onClicked: loadedItem.toggled()
     }
 }

--- a/src/qml/components/StorageSettings.qml
+++ b/src/qml/components/StorageSettings.qml
@@ -16,6 +16,10 @@ ColumnLayout {
             checked: optionsModel.prune
             onToggled: optionsModel.prune = checked
         }
+        onClicked: {
+          loadedItem.toggle()
+          loadedItem.toggled()
+        }
     }
     Setting {
         Layout.fillWidth: true
@@ -24,5 +28,6 @@ ColumnLayout {
             description: optionsModel.pruneSizeGB
             onEditingFinished: optionsModel.pruneSizeGB = parseInt(text)
         }
+        onClicked: loadedItem.forceActiveFocus()
     }
 }

--- a/src/qml/controls/ExternalLink.qml
+++ b/src/qml/controls/ExternalLink.qml
@@ -6,7 +6,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
-Control {
+AbstractButton {
     id: root
     required property string link
     property string description: ""
@@ -29,7 +29,6 @@ Control {
                 color: Theme.color.neutral7
                 textFormat: Text.RichText
                 text: "<style>a:link { color: " + Theme.color.neutral7 + "; text-decoration: none;}</style>" + "<a href=\"" + link + "\">" + root.description + "</a>"
-                onLinkActivated: Qt.openUrlExternally(link)
             }
         }
         Loader {
@@ -42,8 +41,9 @@ Control {
                 icon.height: root.iconHeight
                 icon.width: root.iconWidth
                 background: null
-                onClicked: Qt.openUrlExternally(link)
+                onClicked: root.clicked()
             }
         }
     }
+    onClicked: Qt.openUrlExternally(link)
 }

--- a/src/qml/controls/Setting.qml
+++ b/src/qml/controls/Setting.qml
@@ -6,39 +6,42 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
-ColumnLayout {
+AbstractButton {
     id: root
     property bool last: parent && root === parent.children[parent.children.length - 1]
     required property string header
     property alias actionItem: action_loader.sourceComponent
     property string description
 
-    spacing: 20
-    RowLayout {
-        Header {
-            Layout.fillWidth: true
-            center: false
-            header: root.header
-            headerSize: 18
-            description: root.description
-            descriptionSize: 15
-            descriptionMargin: 0
+    contentItem: ColumnLayout {
+        spacing: 20
+        width: parent.width
+        RowLayout {
+            Header {
+                Layout.fillWidth: true
+                center: false
+                header: root.header
+                headerSize: 18
+                description: root.description
+                descriptionSize: 15
+                descriptionMargin: 0
+            }
+            Loader {
+                id: action_loader
+                active: true
+                visible: active
+                sourceComponent: root.actionItem
+            }
         }
         Loader {
-            id: action_loader
-            active: true
+            Layout.fillWidth: true
+            Layout.columnSpan: 2
+            active: !last
             visible: active
-            sourceComponent: root.actionItem
-        }
-    }
-    Loader {
-        Layout.fillWidth: true
-        Layout.columnSpan: 2
-        active: !last
-        visible: active
-        sourceComponent: Rectangle {
-            height: 1
-            color: Theme.color.neutral5
+            sourceComponent: Rectangle {
+                height: 1
+                color: Theme.color.neutral5
+            }
         }
     }
 }

--- a/src/qml/controls/Setting.qml
+++ b/src/qml/controls/Setting.qml
@@ -11,6 +11,7 @@ AbstractButton {
     property bool last: parent && root === parent.children[parent.children.length - 1]
     required property string header
     property alias actionItem: action_loader.sourceComponent
+    property alias loadedItem: action_loader.item
     property string description
 
     contentItem: ColumnLayout {

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -44,6 +44,7 @@ Item {
                         checked: Theme.dark
                         onToggled: Theme.toggleDark()
                     }
+                    onClicked: loadedItem.toggled()
                 }
                 Setting {
                     Layout.fillWidth: true
@@ -58,6 +59,7 @@ Item {
                             nodeSettingsView.push(about_page)
                         }
                     }
+                    onClicked: loadedItem.clicked()
                 }
                 Setting {
                     Layout.fillWidth: true
@@ -72,6 +74,7 @@ Item {
                             nodeSettingsView.push(storage_page)
                         }
                     }
+                    onClicked: loadedItem.clicked()
                 }
                 Setting {
                     Layout.fillWidth: true
@@ -86,6 +89,7 @@ Item {
                             nodeSettingsView.push(connection_page)
                         }
                     }
+                    onClicked: loadedItem.clicked()
                 }
             }
         }


### PR DESCRIPTION
This makes the entire Setting a clickable object, and when it is clicked it will engage its actionItem. This means:
- For ExternalLinks, it will go to the link
- Will toggle options with have a Switch
- Will give focus to ValueInputs

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/240)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/240)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/240)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/240)
