### PR TITLE
Disable prune target setting when prune is disabled, introduce Disabled Setting color animation state

### DIFF
--- a/src/qml/components/StorageSettings.qml
+++ b/src/qml/components/StorageSettings.qml
@@ -15,6 +15,13 @@ ColumnLayout {
         actionItem: OptionSwitch {
             checked: optionsModel.prune
             onToggled: optionsModel.prune = checked
+            onCheckedChanged: {
+                if (checked == false) {
+                    pruneTargetSetting.state = "DISABLED"
+                } else {
+                    pruneTargetSetting.state = "FILLED"
+                }
+            }
         }
         onClicked: {
           loadedItem.toggle()

--- a/src/qml/controls/Setting.qml
+++ b/src/qml/controls/Setting.qml
@@ -19,7 +19,11 @@ AbstractButton {
     states: [
         State {
             name: "FILLED"
-            PropertyChanges { target: root; stateColor: Theme.color.neutral9 }
+            PropertyChanges {
+                target: root
+                enabled: true
+                stateColor: Theme.color.neutral9
+            }
         },
         State {
             name: "HOVER"
@@ -28,6 +32,14 @@ AbstractButton {
         State {
             name: "ACTIVE"
             PropertyChanges { target: root; stateColor: Theme.color.orange }
+        },
+        State {
+            name: "DISABLED"
+            PropertyChanges {
+                target: root
+                enabled: false
+                stateColor: Theme.color.neutral4
+            }
         }
     ]
 

--- a/src/qml/controls/ValueInput.qml
+++ b/src/qml/controls/ValueInput.qml
@@ -16,7 +16,11 @@ TextEdit {
     states: [
         State {
             name: "FILLED"
-            PropertyChanges { target: root; textColor: Theme.color.neutral9 }
+            PropertyChanges {
+                target: root
+                enabled: true
+                textColor: Theme.color.neutral9
+            }
         },
         State {
             name: "HOVER"
@@ -25,6 +29,14 @@ TextEdit {
         State {
             name: "ACTIVE"
             PropertyChanges { target: root; textColor: Theme.color.orange }
+        },
+        State {
+            name: "DISABLED"
+            PropertyChanges {
+                target: root
+                enabled: false
+                textColor: Theme.color.neutral4
+            }
         }
     ]
 


### PR DESCRIPTION
This disables the prune target ValueInput setting when the prune enabled/disabled Switch Setting is disabled. Also introduces the "DISABLED" state in accordance with the design file.

light

| enabled | disabled |
| ------- | -------- |
| <img width="468" alt="Screen Shot 2023-02-01 at 4 44 37 AM" src="https://user-images.githubusercontent.com/23396902/216008005-f72e92a4-3411-4bbc-88b2-03c0c91e7684.png"> | <img width="468" alt="Screen Shot 2023-02-01 at 4 44 42 AM" src="https://user-images.githubusercontent.com/23396902/216008040-085debd3-c1cb-4df9-8498-35d21959d811.png"> |

dark
| enabled | disabled |
| ------- | -------- |
| <img width="468" alt="Screen Shot 2023-02-01 at 4 44 03 AM" src="https://user-images.githubusercontent.com/23396902/216008151-897f672b-0768-419d-87a3-77174b747c5e.png"> | <img width="468" alt="Screen Shot 2023-02-01 at 4 44 14 AM" src="https://user-images.githubusercontent.com/23396902/216008191-031e93fc-6fba-48e0-b9bd-cfbd4c102a0d.png"> |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/<PR>)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/<PR>)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/<PR>)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/<PR>)

