### PR TITLE
Proper formatting of BlockClock's remaining sync time

### DIFF
--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -97,7 +97,7 @@ Item {
             PropertyChanges {
                 target: root
                 header: Math.round(nodeModel.verificationProgress * 100) + "%"
-                subText: Math.round(nodeModel.remainingSyncTime/60000) > 0 ? Math.round(nodeModel.remainingSyncTime/60000) + "mins" : Math.round(nodeModel.remainingSyncTime/1000) + "secs"
+                subText: formatRemainingSyncTime(nodeModel.remainingSyncTime)
             }
         },
 
@@ -146,4 +146,39 @@ Item {
             }
         }
     ]
+
+    function formatRemainingSyncTime(milliseconds) {
+        var minutes = Math.floor(milliseconds / 60000);
+        var seconds = Math.floor((milliseconds % 60000) / 1000);
+        var weeks = Math.floor(minutes / 10080);
+        minutes %= 10080;
+        var days = Math.floor(minutes / 1440);
+        minutes %= 1440;
+        var hours = Math.floor(minutes / 60);
+        minutes %= 60;
+
+        if (weeks > 0) {
+            return "~" + weeks + (weeks === 1 ? " week" : " weeks") + " left";
+        }
+        if (days > 0) {
+            return "~" + days + (days === 1 ? " day" : " days") + " left";
+        }
+        if (hours >= 5) {
+            return "~" + hours + (hours === 1 ? " hour" : " hours") + " left";
+        }
+        if (hours > 0) {
+            return "~" + hours + "h " + minutes + "m" + " left";
+        }
+        if (minutes >= 5) {
+            return "~" + minutes + (minutes === 1 ? " minute" : " minutes") + " left";
+        }
+        if (minutes > 0) {
+            return "~" + minutes + "m " + seconds + "s" + " left";
+        }
+        if (seconds > 0) {
+            return "~" + seconds + (seconds === 1 ? " second" : " seconds") + " left";
+        }
+
+        return "~0 seconds left";
+    }
 }


### PR DESCRIPTION
Applies proper formatting to the value obtained from `nodeModel.remainingSyncTime`, as specified in our [design docs](https://bitcoincore.app/block-clock/).

Displays the largest unit of time left until we get to less than 5 hours left, in which case it will shows both hours and minutes. When it reaches minutes, it only shows minutes until there is less than 5 minutes, which then it will display both minutes and seconds.

This works for now, but we'll probably want a different approach so that the units and the word "left" can be translated.

| weeks | days | hours | h & m | minutes | m & s | seconds |
| ----- | ---- | ----- | ----- | ------- | ----- | ------- |
| <img width="217" alt="Screen Shot 2023-02-05 at 9 21 37 PM" src="https://user-images.githubusercontent.com/23396902/216868784-54679ec6-9be2-40c0-8e3b-8b339b724fb0.png"> | <img width="217" alt="Screen Shot 2023-02-05 at 9 17 29 PM" src="https://user-images.githubusercontent.com/23396902/216868832-db71f629-8089-4b28-8a95-31b67df993ea.png"> | <img width="217" alt="Screen Shot 2023-02-05 at 9 17 33 PM" src="https://user-images.githubusercontent.com/23396902/216868895-3b4ad2e1-6ea5-4f9d-beb5-dd2d588ac8fd.png"> | <img width="217" alt="Screen Shot 2023-02-05 at 9 14 21 PM" src="https://user-images.githubusercontent.com/23396902/216868971-e37d2b87-faee-4d71-bbb1-c9782fb70336.png"> | <img width="217" alt="Screen Shot 2023-02-05 at 9 14 26 PM" src="https://user-images.githubusercontent.com/23396902/216869000-70909261-380a-4b2c-950b-9e1998358569.png"> | <img width="217" alt="Screen Shot 2023-02-05 at 9 15 10 PM" src="https://user-images.githubusercontent.com/23396902/216869019-4a7f8e46-629c-469d-8720-a477114fec89.png"> | <img width="217" alt="Screen Shot 2023-02-05 at 9 16 11 PM" src="https://user-images.githubusercontent.com/23396902/216869057-3c91e834-4df6-4fc9-b07c-4837f0d5dbf1.png"> |




Fixes https://github.com/bitcoin-core/gui-qml/issues/225

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/249)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/249)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/249)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/249)
