### PR TITLE
Various BlockClock followups

### DIFF
--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -85,6 +85,7 @@ Item {
 
     MouseArea {
         anchors.fill: dial
+        cursorShape: Qt.PointingHandCursor
         onClicked: {
             root.paused = !root.paused
             nodeModel.pause = root.paused

--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -94,7 +94,7 @@ Item {
 
     states: [
         State {
-            name: "intialBlockDownload"; when: !synced && !paused && conns
+            name: "IBD"; when: !synced && !paused && conns
             PropertyChanges {
                 target: root
                 header: Math.round(nodeModel.verificationProgress * 100) + "%"
@@ -103,7 +103,7 @@ Item {
         },
 
         State {
-            name: "blockClock"; when: synced && !paused && conns
+            name: "BLOCKCLOCK"; when: synced && !paused && conns
             PropertyChanges {
                 target: root
                 header: Number(nodeModel.blockTipHeight).toLocaleString(Qt.locale(), 'f', 0)
@@ -112,7 +112,7 @@ Item {
         },
 
         State {
-            name: "Manual Pause"; when: paused
+            name: "PAUSE"; when: paused
             PropertyChanges {
                 target: root
                 header: "Paused"
@@ -130,7 +130,7 @@ Item {
         },
 
         State {
-            name: "Connecting"; when: !paused && !conns
+            name: "CONNECTING"; when: !paused && !conns
             PropertyChanges {
                 target: root
                 header: "Connecting"

--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -34,6 +34,7 @@ Item {
         synced: nodeModel.verificationProgress > 0.999
         backgroundColor: Theme.color.neutral2
         timeTickColor: Theme.color.neutral5
+        confirmationColors: Theme.color.confirmationColors
     }
 
     Button {

--- a/src/qml/components/blockclockdial.cpp
+++ b/src/qml/components/blockclockdial.cpp
@@ -13,6 +13,7 @@ BlockClockDial::BlockClockDial(QQuickItem *parent)
 : QQuickPaintedItem(parent)
 , m_time_ratio_list{0.0}
 , m_background_color{QColor("#2D2D2D")}
+, m_confirmation_colors{QList<QColor>{}}
 , m_time_tick_color{QColor("#000000")}
 {
 }
@@ -44,6 +45,12 @@ void BlockClockDial::setPaused(bool paused)
 void BlockClockDial::setBackgroundColor(QColor color)
 {
     m_background_color = color;
+    update();
+}
+
+void BlockClockDial::setConfirmationColors(QList<QColor> colorList)
+{
+    m_confirmation_colors = colorList;
     update();
 }
 
@@ -80,20 +87,11 @@ void BlockClockDial::paintBlocks(QPainter * painter)
         return;
     }
 
-    QPen pen(QColor("#F1D54A"));
+    QPen pen(m_confirmation_colors[5]);
     pen.setWidth(4);
     pen.setCapStyle(Qt::FlatCap);
     const QRectF bounds = getBoundsForPen(pen);
     painter->setPen(pen);
-
-    QColor confirmationColors[] = {
-        QColor("#FF1C1C"), // red
-        QColor("#ED6E46"),
-        QColor("#EE8847"),
-        QColor("#EFA148"),
-        QColor("#F0BB49"),
-        QColor("#F1D54A"), // yellow
-    };
 
     // The gap is calculated here and is used to create a
     // one pixel spacing between each block
@@ -102,7 +100,7 @@ void BlockClockDial::paintBlocks(QPainter * painter)
     // Paint blocks
     for (int i = 1; i < numberOfBlocks; i++) {
         if (numberOfBlocks - i <= 6) {
-            QPen pen(confirmationColors[numberOfBlocks - i - 1]);
+            QPen pen(m_confirmation_colors[numberOfBlocks - i - 1]);
             pen.setWidth(4);
             pen.setCapStyle(Qt::FlatCap);
             painter->setPen(pen);
@@ -125,7 +123,7 @@ void BlockClockDial::paintBlocks(QPainter * painter)
 
 void BlockClockDial::paintProgress(QPainter * painter)
 {
-    QPen pen(QColor("#F1D54A"));
+    QPen pen(m_confirmation_colors[5]);
     pen.setWidthF(4);
     pen.setCapStyle(Qt::RoundCap);
     const QRectF bounds = getBoundsForPen(pen);

--- a/src/qml/components/blockclockdial.h
+++ b/src/qml/components/blockclockdial.h
@@ -16,6 +16,7 @@ class BlockClockDial : public QQuickPaintedItem
     Q_PROPERTY(bool synced READ synced WRITE setSynced)
     Q_PROPERTY(bool paused READ paused WRITE setPaused)
     Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor)
+    Q_PROPERTY(QList<QColor> confirmationColors READ confirmationColors WRITE setConfirmationColors )
     Q_PROPERTY(QColor timeTickColor READ timeTickColor WRITE setTimeTickColor)
 
 public:
@@ -27,6 +28,7 @@ public:
     bool synced() const { return m_is_synced; };
     bool paused() const { return m_is_paused; };
     QColor backgroundColor() const { return m_background_color; };
+    QList<QColor> confirmationColors() const { return m_confirmation_colors; };
     QColor timeTickColor() const { return m_time_tick_color; };
 
 public Q_SLOTS:
@@ -35,6 +37,7 @@ public Q_SLOTS:
     void setSynced(bool synced);
     void setPaused(bool paused);
     void setBackgroundColor(QColor color);
+    void setConfirmationColors(QList<QColor> colorList);
     void setTimeTickColor(QColor color);
 
 private:
@@ -50,6 +53,7 @@ private:
     bool m_is_synced;
     bool m_is_paused;
     QColor m_background_color;
+    QList<QColor> m_confirmation_colors;
     QColor m_time_tick_color;
 };
 

--- a/src/qml/controls/Theme.qml
+++ b/src/qml/controls/Theme.qml
@@ -27,6 +27,7 @@ Control {
         required property color neutral7
         required property color neutral8
         required property color neutral9
+        required property var confirmationColors
     }
 
     component ImageSet: QtObject {
@@ -56,6 +57,14 @@ Control {
         neutral7: "#B0B0B0"
         neutral8: "#CCCCCC"
         neutral9: "#FFFFFF"
+        confirmationColors: [
+            "#FF1C1C", // red
+            "#ED6E46",
+            "#EE8847",
+            "#EFA148",
+            "#F0BB49",
+            "#F1D54A", // yellow
+        ]
     }
 
     ColorSet {
@@ -79,6 +88,14 @@ Control {
         neutral7: "#777777"
         neutral8: "#404040"
         neutral9: "#000000"
+        confirmationColors: [
+            "#FF1C1C", // red
+            "#ED6E46",
+            "#EE8847",
+            "#EFA148",
+            "#F0BB49",
+            "#F1D54A", // yellow
+        ]
     }
 
     ImageSet {


### PR DESCRIPTION
This implements the following review comments from https://github.com/bitcoin-core/gui-qml/pull/220#pullrequestreview-1274061991
- Make cursor into pointing cursor when over the BlockClock to make the BlockClock look like it's clickable https://github.com/bitcoin-core/gui-qml/pull/220#discussion_r1089873774
- Make BlockClock state names capital https://github.com/bitcoin-core/gui-qml/pull/220#discussion_r1089866349
- Move out BlockClock confirmation colors into our Theme.qml https://github.com/bitcoin-core/gui-qml/pull/220#discussion_r1089853030


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/250)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/250)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/250)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/250)
