### PR TITLE
Blockclock connecting state

### DIFF
--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -20,9 +20,9 @@ Item {
     property alias headerSize: mainText.font.pixelSize
     property alias subText: subText.text
     property int headerSize: 32
+    property bool connected: nodeModel.numOutboundPeers > 0
     property bool synced: nodeModel.verificationProgress > 0.999
     property bool paused: false
-    property bool conns: true
 
     BlockClockDial {
         id: dial
@@ -85,7 +85,7 @@ Item {
 
     states: [
         State {
-            name: "IBD"; when: !synced && !paused && conns
+            name: "IBD"; when: !synced && !paused && connected
             PropertyChanges {
                 target: root
                 header: Math.round(nodeModel.verificationProgress * 100) + "%"
@@ -94,7 +94,7 @@ Item {
         },
 
         State {
-            name: "BLOCKCLOCK"; when: synced && !paused && conns
+            name: "BLOCKCLOCK"; when: synced && !paused && connected
             PropertyChanges {
                 target: root
                 header: Number(nodeModel.blockTipHeight).toLocaleString(Qt.locale(), 'f', 0)
@@ -121,7 +121,7 @@ Item {
         },
 
         State {
-            name: "CONNECTING"; when: !paused && !conns
+            name: "CONNECTING"; when: !paused && !connected
             PropertyChanges {
                 target: root
                 header: "Connecting"


### PR DESCRIPTION
Wires logic so that the connecting state for the block clock will actually show when the node is finding peers


<img width="400" alt="Screen Shot 2023-02-08 at 11 52 38 PM" src="https://user-images.githubusercontent.com/23396902/217739279-4f4d85e0-38e9-4139-ada7-4f9e72acc5df.png">


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/252)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/252)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/252)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/252)
