### PR TITLE
Fix CaretRightButton padding

### DIFF
--- a/src/qml/components/CaretRightButton.qml
+++ b/src/qml/components/CaretRightButton.qml
@@ -8,6 +8,10 @@ import QtQuick.Controls 2.15
 Button {
     id: root
     required property color stateColor
+
+    leftPadding: 0
+    topPadding: 0
+    bottomPadding: 0
     icon.source: "image://images/caret-right"
     icon.color: root.stateColor
     icon.height: 18


### PR DESCRIPTION
Fixes the padding on the CaretRightButton which then fixes the height of a setting row within the NodeSettings page


| master | pr |
| ------ | -- |
| <img width="642" alt="Screen Shot 2023-02-09 at 2 48 11 PM" src="https://user-images.githubusercontent.com/23396902/217947132-526a900a-f85e-4bf4-8143-c32bcef59eea.png"> | <img width="642" alt="Screen Shot 2023-02-09 at 2 42 27 PM" src="https://user-images.githubusercontent.com/23396902/217947109-6b27b477-3e0a-4180-9d25-0778a7cdb2b8.png"> |



[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/253)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/253)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/253)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/253)

