### PR TITLE
Properly relinquish activeFocus on ValueInput when editing is finished

### DIFF
--- a/src/qml/components/DeveloperOptions.qml
+++ b/src/qml/components/DeveloperOptions.qml
@@ -29,7 +29,10 @@ ColumnLayout {
         actionItem: ValueInput {
             parentState: dbcacheSetting.state
             description: optionsModel.dbcacheSizeMiB
-            onEditingFinished: optionsModel.dbcacheSizeMiB = parseInt(text)
+            onEditingFinished: {
+                optionsModel.dbcacheSizeMiB = parseInt(text)
+                dbcacheSetting.forceActiveFocus()
+            }
         }
         onClicked: loadedItem.forceActiveFocus()
     }
@@ -40,7 +43,10 @@ ColumnLayout {
         actionItem: ValueInput {
             parentState: parSetting.state
             description: optionsModel.scriptThreads
-            onEditingFinished: optionsModel.scriptThreads = parseInt(text)
+            onEditingFinished: {
+                optionsModel.scriptThreads = parseInt(text)
+                parSetting.forceActiveFocus()
+            }
         }
         onClicked: loadedItem.forceActiveFocus()
     }

--- a/src/qml/components/StorageSettings.qml
+++ b/src/qml/components/StorageSettings.qml
@@ -28,7 +28,10 @@ ColumnLayout {
         actionItem: ValueInput {
             parentState: pruneTargetSetting.state
             description: optionsModel.pruneSizeGB
-            onEditingFinished: optionsModel.pruneSizeGB = parseInt(text)
+            onEditingFinished: {
+                optionsModel.pruneSizeGB = parseInt(text)
+                pruneTargetSetting.forceActiveFocus()
+            }
         }
         onClicked: loadedItem.forceActiveFocus()
     }

--- a/src/qml/controls/ValueInput.qml
+++ b/src/qml/controls/ValueInput.qml
@@ -5,7 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-TextEdit {
+TextInput {
     id: root
     required property string parentState
     property string description: ""
@@ -32,7 +32,7 @@ TextEdit {
     font.styleName: "Regular"
     font.pixelSize: root.descriptionSize
     color: root.textColor
-    text: description
+    text: root.description
     horizontalAlignment: Text.AlignRight
     wrapMode: Text.WordWrap
 


### PR DESCRIPTION
On master, pressing `enter` while editing a setting that has a ValueInput does not properly relinquish focus from the ValueInput, still leaving it in an editing state. This fixes that by:

a. Making ValueInput a [TextInput](https://doc.qt.io/qt-5/qml-qtquick-textinput.html#text-prop) instead of a [TextEdit](https://doc.qt.io/qt-5/qml-qtquick-textedit.html)
  - TextEdit allows for multi-line input, so an `enter` in this would add a new line, which we don't want. There is no use case for a ValueInput to be multiple lines, it should only be one. Additionally, this prevents `enter` from signaling that editing is finished
  - TextInput is specifically for single line input. This QML type also allows us to do necessary validations with a [validator](https://doc.qt.io/qt-5/qml-qtquick-textinput.html#validator-prop), [inputMask](https://doc.qt.io/qt-5/qml-qtquick-textinput.html#inputMask-prop), and signal what kind of keyboard we want with [inputMethodHints](https://doc.qt.io/qt-5/qml-qtquick-textinput.html#inputMethodHints-prop). Additionally, this allows for `enter` to signal that editing is finished.

b. Relinquishing focus on the ValueInput itself, by forcing focus back to the parent Setting.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/255)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/255)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/255)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/255)
