### PR TITLE
ValueInput "EMPTY" state

### DIFF
--- a/src/qml/components/DeveloperOptions.qml
+++ b/src/qml/components/DeveloperOptions.qml
@@ -35,7 +35,10 @@ ColumnLayout {
                 dbcacheSetting.forceActiveFocus()
             }
         }
-        onClicked: loadedItem.forceActiveFocus()
+        onClicked: {
+            loadedItem.filled = true
+            loadedItem.forceActiveFocus()
+        }
     }
     Separator { Layout.fillWidth: true }
     Setting {
@@ -50,7 +53,10 @@ ColumnLayout {
                 parSetting.forceActiveFocus()
             }
         }
-        onClicked: loadedItem.forceActiveFocus()
+        onClicked: {
+            loadedItem.filled = true
+            loadedItem.forceActiveFocus()
+        }
     }
     Separator { Layout.fillWidth: true }
     Setting {

--- a/src/qml/components/StorageSettings.qml
+++ b/src/qml/components/StorageSettings.qml
@@ -41,6 +41,9 @@ ColumnLayout {
                 pruneTargetSetting.forceActiveFocus()
             }
         }
-        onClicked: loadedItem.forceActiveFocus()
+        onClicked: {
+            loadedItem.filled = true
+            loadedItem.forceActiveFocus()
+        }
     }
 }

--- a/src/qml/controls/ValueInput.qml
+++ b/src/qml/controls/ValueInput.qml
@@ -9,8 +9,9 @@ TextInput {
     id: root
     required property string parentState
     property string description: ""
+    property bool filled: false
     property int descriptionSize: 18
-    property color textColor: Theme.color.neutral9
+    property color textColor: root.filled ? Theme.color.neutral9 : Theme.color.neutral5
     enabled: true
     state: root.parentState
 
@@ -21,7 +22,10 @@ TextInput {
         },
         State {
             name: "HOVER"
-            PropertyChanges { target: root; textColor: Theme.color.orangeLight1 }
+            PropertyChanges {
+                target: root
+                textColor: root.filled ? Theme.color.orangeLight1 : Theme.color.neutral5
+            }
         },
         State {
             name: "DISABLED"


### PR DESCRIPTION
This adds an `"EMPTY"` state to `ValueInput`, as specified in the [design file](https://www.figma.com/file/ek8w3n3upbluw5UL2lGhRx/Bitcoin-Core-App-Design?node-id=6079%3A166395&t=zvbm4HW9rxQf4iBb-4).

This state is only added to `ValueInput` because the `Setting` control should not care about this. All other states continue to function as normal*.

### Light

| EMPTY | FILLED | HOVER | ACTIVE |
| ----- | ------ | ----- | ------ |
| <img width="463" alt="Screen Shot 2023-02-10 at 5 26 04 PM" src="https://user-images.githubusercontent.com/23396902/218226249-e1ce6012-33d5-4362-bd1e-7620bbe9ed85.png"> | <img width="463" alt="Screen Shot 2023-02-10 at 5 24 42 PM" src="https://user-images.githubusercontent.com/23396902/218226265-94b2d5ae-fb7e-41b1-a477-3e9cdc7f9b95.png"> | <img width="463" alt="Screen Shot 2023-02-10 at 5 24 57 PM" src="https://user-images.githubusercontent.com/23396902/218226276-c3fbd0a4-08fc-4302-afe6-c3b187cb4095.png"> | <img width="463" alt="Screen Shot 2023-02-10 at 5 25 18 PM" src="https://user-images.githubusercontent.com/23396902/218226286-4cd43650-9121-4899-9bab-4d844e1efb03.png"> |

### Dark

| EMPTY | FILLED | HOVER | ACTIVE |
| ----- | ------ | ----- | ------ |
| <img width="463" alt="Screen Shot 2023-02-10 at 5 23 43 PM" src="https://user-images.githubusercontent.com/23396902/218226406-9be869ee-0eb1-412c-b5ed-426d35ca9341.png"> | <img width="463" alt="Screen Shot 2023-02-10 at 5 24 00 PM" src="https://user-images.githubusercontent.com/23396902/218226415-59b2c42d-80e4-4a6d-a7dc-631a7f195ce9.png"> | <img width="463" alt="Screen Shot 2023-02-10 at 5 24 11 PM" src="https://user-images.githubusercontent.com/23396902/218226432-34b6cc5f-e0d0-48e1-af11-a2e59d0bd0e5.png"> | <img width="463" alt="Screen Shot 2023-02-10 at 5 24 28 PM" src="https://user-images.githubusercontent.com/23396902/218226448-d0c801a8-c232-449a-82e7-282108e9e44a.png"> |

*the Setting control loses the active state when the mouse moves away from it, will be addressed in a follow-up.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/256)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/256)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/256)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/256)

