### PR TITLE
Fix sizing, add background to OnboardingCover info icon button

### DIFF
--- a/src/qml/controls/NavButton.qml
+++ b/src/qml/controls/NavButton.qml
@@ -12,6 +12,7 @@ AbstractButton {
     property int iconWidth: 30
     property int textSize: 18
     property url iconSource: ""
+    property Rectangle iconBackground: null
 
     padding: 0
     background: Rectangle {
@@ -57,7 +58,7 @@ AbstractButton {
                icon.color: Theme.color.neutral9
                icon.height: root.iconHeight
                icon.width: root.iconWidth
-               background: null
+               background: root.iconBackground
            }
         }
         Loader {

--- a/src/qml/controls/NavButton.qml
+++ b/src/qml/controls/NavButton.qml
@@ -13,6 +13,7 @@ AbstractButton {
     property int textSize: 18
     property url iconSource: ""
     property Rectangle iconBackground: null
+    property color iconColor: Theme.color.neutral9
 
     padding: 0
     background: Rectangle {
@@ -55,7 +56,7 @@ AbstractButton {
                height: root.iconHeight
                width: root.iconWidth
                icon.source: root.iconSource
-               icon.color: Theme.color.neutral9
+               icon.color: root.iconColor
                icon.height: root.iconHeight
                icon.width: root.iconWidth
                background: root.iconBackground

--- a/src/qml/pages/main.qml
+++ b/src/qml/pages/main.qml
@@ -53,6 +53,7 @@ ApplicationWindow {
                 navRightDetail: NavButton {
                     iconSource: "image://images/gear"
                     iconHeight: 24
+                    iconWidth: 24
                     onClicked: node_swipe.incrementCurrentIndex()
                 }
             }

--- a/src/qml/pages/onboarding/OnboardingCover.qml
+++ b/src/qml/pages/onboarding/OnboardingCover.qml
@@ -22,6 +22,11 @@ Page {
                 iconSource: "image://images/info"
                 iconHeight: 24
                 iconWidth: 24
+                iconColor: Theme.color.neutral0
+                iconBackground: Rectangle {
+                    radius: 12
+                    color: Theme.color.neutral9
+                }
                 onClicked: {
                     introductions.incrementCurrentIndex()
                 }

--- a/src/qml/pages/onboarding/OnboardingCover.qml
+++ b/src/qml/pages/onboarding/OnboardingCover.qml
@@ -21,6 +21,7 @@ Page {
             navRightDetail: NavButton {
                 iconSource: "image://images/info"
                 iconHeight: 24
+                iconWidth: 24
                 onClicked: {
                     introductions.incrementCurrentIndex()
                 }


### PR DESCRIPTION
This fixes the sizing for both the info and gear icon used as NavButtons in OnboardingCover and NodeSettings. The screenshots below add a red rectangle to the background of these icons to clearly show what their dimensions are:

### master
| info | gear |
| ---- | ---- |
| <img width="150" alt="info-master" src="https://user-images.githubusercontent.com/23396902/218290267-c2abd2db-6952-43dd-a7e9-a2d7a9a17243.png"> | <img width="150" alt="gear-master" src="https://user-images.githubusercontent.com/23396902/218290285-d8c32368-a2a0-4b70-928b-753e632ddafe.png"> |

### pr
| info | gear |
| ---- | ---- |
| <img width="150" alt="info-pr" src="https://user-images.githubusercontent.com/23396902/218290394-7d97c07b-f7a7-4133-82a7-2b6c4ef62e72.png"> | <img width="150" alt="gear-pr" src="https://user-images.githubusercontent.com/23396902/218290405-dba088ce-de0d-41bc-9066-11ae827fd624.png"> |

And also adds a circle as a background for the info icon used in OnboardingCover as specified in the [design file](https://www.figma.com/file/ek8w3n3upbluw5UL2lGhRx/Bitcoin-Core-App-Design?node-id=3288%3A70698&t=TcsZHjnnq01uAQEK-4)

| light |  dark  |
| ----- | ------ |
| <img width="150" alt="Screen Shot 2023-02-11 at 8 04 19 PM" src="https://user-images.githubusercontent.com/23396902/218290602-87412816-753d-441c-9038-16cfe7ea7edf.png"> | <img width="150" alt="Screen Shot 2023-02-11 at 8 04 32 PM" src="https://user-images.githubusercontent.com/23396902/218290615-3c3aa09a-c8c2-4de9-8c8c-1299365ba21f.png"> |

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/258)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/258)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/258)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/258)

