### PR TITLE
Introduce the Peers page

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -40,6 +40,7 @@ QT_MOC_CPP = \
   qml/moc_chainmodel.cpp \
   qml/moc_nodemodel.cpp \
   qml/moc_options_model.cpp \
+  qml/moc_peerlistsortproxy.cpp \
   qt/moc_addressbookpage.cpp \
   qt/moc_addresstablemodel.cpp \
   qt/moc_askpassphrasedialog.cpp \
@@ -118,6 +119,7 @@ BITCOIN_QT_H = \
   qml/imageprovider.h \
   qml/nodemodel.h \
   qml/options_model.h \
+  qml/peerlistsortproxy.h \
   qml/util.h \
   qt/addressbookpage.h \
   qt/addresstablemodel.h \
@@ -300,6 +302,7 @@ BITCOIN_QML_BASE_CPP = \
   qml/imageprovider.cpp \
   qml/nodemodel.cpp \
   qml/options_model.cpp \
+  qml/peerlistsortproxy.cpp \
   qml/util.cpp
 
 QML_RES_FONTS = \
@@ -360,6 +363,7 @@ QML_RES_QML = \
   qml/pages/main.qml \
   qml/pages/node/NodeRunner.qml \
   qml/pages/node/NodeSettings.qml \
+  qml/pages/node/Peers.qml \
   qml/pages/onboarding/OnboardingBlockclock.qml \
   qml/pages/onboarding/OnboardingConnection.qml \
   qml/pages/onboarding/OnboardingCover.qml \

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -18,11 +18,13 @@
 #include <qml/imageprovider.h>
 #include <qml/nodemodel.h>
 #include <qml/options_model.h>
+#include <qml/peerlistsortproxy.h>
 #include <qml/util.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/initexecutor.h>
 #include <qt/networkstyle.h>
+#include <qt/peertablemodel.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
@@ -185,6 +187,10 @@ int QmlGuiMain(int argc, char* argv[])
         node->startShutdown();
     });
 
+    PeerTableModel peer_model{*node, nullptr};
+    PeerListSortProxy peer_model_sort_proxy{nullptr};
+    peer_model_sort_proxy.setSourceModel(&peer_model);
+
     GUIUtil::LoadFont(":/fonts/inter/regular");
     GUIUtil::LoadFont(":/fonts/inter/semibold");
 
@@ -196,6 +202,8 @@ int QmlGuiMain(int argc, char* argv[])
 
     engine.rootContext()->setContextProperty("nodeModel", &node_model);
     engine.rootContext()->setContextProperty("chainModel", &chain_model);
+    engine.rootContext()->setContextProperty("peerTableModel", &peer_model);
+    engine.rootContext()->setContextProperty("peerListModelProxy", &peer_model_sort_proxy);
 
     OptionsQmlModel options_model{*node};
     engine.rootContext()->setContextProperty("optionsModel", &options_model);

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -33,6 +33,7 @@
         <file>pages/main.qml</file>
         <file>pages/node/NodeRunner.qml</file>
         <file>pages/node/NodeSettings.qml</file>
+        <file>pages/node/Peers.qml</file>
         <file>pages/onboarding/OnboardingBlockclock.qml</file>
         <file>pages/onboarding/OnboardingConnection.qml</file>
         <file>pages/onboarding/OnboardingCover.qml</file>

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -85,6 +85,20 @@ Item {
                     }
                     onClicked: loadedItem.clicked()
                 }
+                Separator { Layout.fillWidth: true }
+                Setting {
+                    id: gotoPeers
+                    Layout.fillWidth: true
+                    header: qsTr("Peers")
+                    actionItem: CaretRightButton {
+                        stateColor: gotoPeers.stateColor
+                        onClicked: {
+                            peerTableModel.startAutoRefresh();
+                            nodeSettingsView.push(peers_page)
+                        }
+                    }
+                    onClicked: loadedItem.clicked()
+                }
             }
         }
     }
@@ -120,6 +134,19 @@ Item {
                 text: qsTr("Back")
                 onClicked: {
                     nodeSettingsView.pop()
+                }
+            }
+        }
+    }
+    Component {
+        id: peers_page
+        Peers {
+            navLeftDetail: NavButton {
+                iconSource: "image://images/caret-left"
+                text: qsTr("Back")
+                onClicked: {
+                    nodeSettingsView.pop()
+                    peerTableModel.stopAutoRefresh();
                 }
             }
         }

--- a/src/qml/pages/node/Peers.qml
+++ b/src/qml/pages/node/Peers.qml
@@ -1,0 +1,100 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../../controls"
+import "../../components"
+
+Page {
+    background: null
+    property alias navLeftDetail: navbar.leftDetail
+
+    header: NavigationBar {
+        id: navbar
+    }
+
+    Text {
+        anchors.top: parent.top
+        anchors.horizontalCenter: parent.horizontalCenter
+        id: description
+        height: 75
+        width: Math.min(parent.width - 40, 450)
+        wrapMode: Text.WordWrap
+        text: qsTr("Peers are nodes you are connected to. You want to ensure that you are connected to x, y and z, but not a, b, and c. Learn more.")
+        font.family: "Inter"
+        font.styleName: "Regular"
+        font.pixelSize: 13
+        color: Theme.color.neutral7
+        horizontalAlignment: Text.AlignHCenter
+    }
+
+    ListView {
+        id: listView
+        clip: true
+        width: Math.min(parent.width - 40, 450)
+        anchors.top: description.bottom
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        model: peerListModelProxy
+        spacing: 15
+
+        delegate: Item {
+            required property int nodeId;
+            required property string address;
+            required property string subversion;
+            required property string direction;
+            implicitHeight: 65
+            implicitWidth: listView.width
+
+            ColumnLayout {
+                anchors.left: parent.left
+                Label {
+                    Layout.alignment: Qt.AlignLeft
+                    id: primary
+                    text: "#" + nodeId
+                    font.family: "Inter"
+                    font.styleName: "Regular"
+                    font.pixelSize: 18
+                    color: Theme.color.neutral9
+                }
+                Label {
+                    Layout.alignment: Qt.AlignLeft
+                    id: tertiary
+                    text: address
+                    font.family: "Inter"
+                    font.styleName: "Regular"
+                    font.pixelSize: 15
+                    color: Theme.color.neutral7
+                }
+            }
+            ColumnLayout {
+                anchors.right: parent.right
+                Label {
+                    Layout.alignment: Qt.AlignRight
+                    id:secondary
+                    text: direction
+                    font.family: "Inter"
+                    font.styleName: "Regular"
+                    font.pixelSize: 18
+                    color: Theme.color.neutral9
+                }
+                Label {
+                    Layout.alignment: Qt.AlignRight
+                    id: quaternary
+                    text: subversion
+                    font.family: "Inter"
+                    font.styleName: "Regular"
+                    font.pixelSize: 15
+                    color: Theme.color.neutral7
+                }
+            }
+            Separator {
+                anchors.bottom: parent.bottom
+                width: parent.width
+            }
+        }
+    }
+}

--- a/src/qml/pages/node/Peers.qml
+++ b/src/qml/pages/node/Peers.qml
@@ -41,6 +41,30 @@ Page {
         model: peerListModelProxy
         spacing: 15
 
+        footer: Loader {
+            anchors.centerIn: parent
+            height: 75
+            active: nodeModel.numOutboundPeers < nodeModel.maxNumOutboundPeers
+            visible: active
+            sourceComponent: RowLayout {
+                spacing: 20
+                PeersIndicator {
+                    Layout.alignment: Qt.AlignHCenter
+                    numOutboundPeers: nodeModel.numOutboundPeers
+                    maxNumOutboundPeers: nodeModel.maxNumOutboundPeers
+                }
+                Text {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: qsTr("Looking for %1 more peer(s)").arg(
+                            nodeModel.maxNumOutboundPeers - nodeModel.numOutboundPeers)
+                    font.family: "Inter"
+                    font.styleName: "Regular"
+                    font.pixelSize: 15
+                    color: Theme.color.neutral7
+                }
+            }
+        }
+
         delegate: Item {
             required property int nodeId;
             required property string address;

--- a/src/qml/peerlistsortproxy.cpp
+++ b/src/qml/peerlistsortproxy.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/peerlistsortproxy.h>
+#include <qt/peertablemodel.h>
+
+PeerListSortProxy::PeerListSortProxy(QObject* parent)
+    : PeerTableSortProxy(parent)
+{
+}
+
+QHash<int, QByteArray> PeerListSortProxy::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[PeerTableModel::NetNodeId] = "nodeId";
+    roles[PeerTableModel::Age] = "age";
+    roles[PeerTableModel::Address] = "address";
+    roles[PeerTableModel::Direction] = "direction";
+    roles[PeerTableModel::ConnectionType] = "connectionType";
+    roles[PeerTableModel::Network] = "network";
+    roles[PeerTableModel::Ping] = "ping";
+    roles[PeerTableModel::Sent] = "sent";
+    roles[PeerTableModel::Received] = "received";
+    roles[PeerTableModel::Subversion] = "subversion";
+    return roles;
+}
+
+QVariant PeerListSortProxy::data(const QModelIndex& index, int role) const
+{
+    if (role == PeerTableModel::StatsRole) {
+        return PeerTableSortProxy::data(index, role);
+    }
+
+    QModelIndex converted_index = PeerTableSortProxy::index(index.row(), role);
+    return PeerTableSortProxy::data(converted_index, Qt::DisplayRole);
+}

--- a/src/qml/peerlistsortproxy.h
+++ b/src/qml/peerlistsortproxy.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_PEERLISTSORTPROXY_H
+#define BITCOIN_QML_PEERLISTSORTPROXY_H
+
+#include <qt/peertablesortproxy.h>
+#include <QByteArray>
+#include <QHash>
+#include <QModelIndex>
+#include <QVariant>
+
+class PeerListSortProxy : public PeerTableSortProxy
+{
+    Q_OBJECT
+
+public:
+    explicit PeerListSortProxy(QObject* parent);
+    ~PeerListSortProxy() = default;
+
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
+};
+
+#endif // BITCOIN_QML_PEERLISTSORTPROXY_H

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -42,8 +42,8 @@ class PeerTableModel : public QAbstractTableModel
 public:
     explicit PeerTableModel(interfaces::Node& node, QObject* parent);
     ~PeerTableModel();
-    void startAutoRefresh();
-    void stopAutoRefresh();
+    Q_INVOKABLE void startAutoRefresh();
+    Q_INVOKABLE void stopAutoRefresh();
 
     enum ColumnIndex {
         NetNodeId = 0,


### PR DESCRIPTION
Adds a new page under Node settings that shows a list of connected peers.  A ProxyModel is added to translate the original PeerTableModel into a model that the ListView can handle.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/259)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/259)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/259)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/259)


![Screenshot from 2023-02-12 22-38-10](https://user-images.githubusercontent.com/985648/218367663-54a31931-cd25-49b6-80b6-2b17a99edd76.png)
![Screenshot from 2023-02-12 22-38-30](https://user-images.githubusercontent.com/985648/218367593-f8b693d7-0f37-48f7-a7f0-996566697a9d.png)
