### PR TITLE
Fix NavButton padding

### DIFF
--- a/src/qml/controls/NavButton.qml
+++ b/src/qml/controls/NavButton.qml
@@ -15,7 +15,10 @@ AbstractButton {
     property Rectangle iconBackground: null
     property color iconColor: Theme.color.neutral9
 
-    padding: 0
+    topPadding: text_background.active ? 7 : 14
+    bottomPadding: text_background.active ? 7 : 14
+    rightPadding: text_background.active ? 22 : 14
+    leftPadding: text_background.active ? 2 : 14
     background: Rectangle {
         id: bg
         height: root.height
@@ -43,7 +46,6 @@ AbstractButton {
         }
     }
     contentItem: RowLayout {
-        anchors.fill: parent
         spacing: 0
         Loader {
            id: button_background
@@ -63,22 +65,25 @@ AbstractButton {
            }
         }
         Loader {
-           active: root.text.length > 0
-           visible: active
-           sourceComponent: AbstractButton {
-               id: container
-               padding: 0
-               font.family: "Inter"
-               font.styleName: "Semi Bold"
-               font.pixelSize: root.textSize
-               background: null
-               contentItem: Text {
-                   anchors.verticalCenter: parent.verticalCenter
-                   font: container.font
-                   color: Theme.color.neutral9
-                   text: root.text
-              }
-          }
+            id: text_background
+            active: root.text.length > 0
+            visible: active
+            sourceComponent: AbstractButton {
+                id: container
+                topPadding: button_background.active ? 0 : 4
+                bottomPadding: button_background.active ? 0 : 4
+                rightPadding: 0
+                leftPadding: button_background.active ? 0 : 20
+                font.family: "Inter"
+                font.styleName: "Semi Bold"
+                font.pixelSize: root.textSize
+                contentItem: Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    font: container.font
+                    color: Theme.color.neutral9
+                    text: root.text
+                }
+            }
         }
     }
     MouseArea {

--- a/src/qml/controls/NavigationBar.qml
+++ b/src/qml/controls/NavigationBar.qml
@@ -39,7 +39,6 @@ RowLayout {
         Layout.preferredWidth: parent.width / 3
         Loader {
             id: right_detail
-            Layout.rightMargin: 10
             Layout.alignment: Qt.AlignRight
             active: true
             visible: active


### PR DESCRIPTION
Applies proper padding values to NavButton so that it can fit the specifications in the design file for [icon buttons](https://www.figma.com/file/ek8w3n3upbluw5UL2lGhRx/Bitcoin-Core-App-Design?node-id=4998%3A117938&t=fZfJaPNYvvK1gzU4-4), [icon and text buttons](https://www.figma.com/file/ek8w3n3upbluw5UL2lGhRx/Bitcoin-Core-App-Design?node-id=4998%3A117920&t=fZfJaPNYvvK1gzU4-4), and [text buttons](https://www.figma.com/file/ek8w3n3upbluw5UL2lGhRx/Bitcoin-Core-App-Design?node-id=4998%3A117908&t=fZfJaPNYvvK1gzU4-4).


| master | 
| ------ |
| ![master](https://user-images.githubusercontent.com/23396902/218366429-d99d9bc9-c040-4d75-948b-65d6db290b12.png) |


|   pr   | 
| ------ |
| ![pr](https://user-images.githubusercontent.com/23396902/218366479-50b706d8-6c26-410e-9e78-75066e4534bd.png) |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/260)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/260)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/260)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/260)

