### PR TITLE
Separate out Separator from Setting control

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -336,6 +336,7 @@ QML_RES_QML = \
   qml/components/DeveloperOptions.qml \
   qml/components/PeersIndicator.qml \
   qml/components/NetworkIndicator.qml \
+  qml/components/Separator.qml \
   qml/components/StorageLocations.qml \
   qml/components/StorageOptions.qml \
   qml/components/StorageSettings.qml \

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -10,6 +10,7 @@
         <file>components/DeveloperOptions.qml</file>
         <file>components/NetworkIndicator.qml</file>
         <file>components/StorageLocations.qml</file>
+        <file>components/Separator.qml</file>
         <file>components/StorageOptions.qml</file>
         <file>components/StorageSettings.qml</file>
         <file>controls/ContinueButton.qml</file>

--- a/src/qml/components/AboutOptions.qml
+++ b/src/qml/components/AboutOptions.qml
@@ -8,7 +8,7 @@ import QtQuick.Layouts 1.15
 import "../controls"
 
 ColumnLayout {
-    spacing: 20
+    spacing: 4
     Setting {
         id: websiteLink
         Layout.fillWidth: true
@@ -20,6 +20,7 @@ ColumnLayout {
         }
         onClicked: loadedItem.clicked()
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         id: sourceLink
         Layout.fillWidth: true
@@ -31,6 +32,7 @@ ColumnLayout {
         }
         onClicked: loadedItem.clicked()
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         id: licenseLink
         Layout.fillWidth: true
@@ -42,6 +44,7 @@ ColumnLayout {
         }
         onClicked: loadedItem.clicked()
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         id: versionLink
         Layout.fillWidth: true
@@ -56,6 +59,7 @@ ColumnLayout {
         }
         onClicked: loadedItem.clicked()
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         id: gotoDeveloper
         Layout.fillWidth: true

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -8,7 +8,7 @@ import QtQuick.Layouts 1.15
 import "../controls"
 
 ColumnLayout {
-    spacing: 20
+    spacing: 4
     Setting {
         Layout.fillWidth: true
         header: qsTr("Enable listening")
@@ -22,6 +22,7 @@ ColumnLayout {
           loadedItem.toggled()
         }
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         Layout.fillWidth: true
         header: qsTr("Map port using UPnP")
@@ -34,6 +35,7 @@ ColumnLayout {
           loadedItem.toggled()
         }
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         Layout.fillWidth: true
         header: qsTr("Map port using NAT-PMP")
@@ -46,6 +48,7 @@ ColumnLayout {
           loadedItem.toggled()
         }
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         Layout.fillWidth: true
         header: qsTr("Enable RPC server")
@@ -58,6 +61,7 @@ ColumnLayout {
           loadedItem.toggled()
         }
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         id: gotoProxy
         last: true

--- a/src/qml/components/DeveloperOptions.qml
+++ b/src/qml/components/DeveloperOptions.qml
@@ -8,7 +8,7 @@ import QtQuick.Layouts 1.15
 import "../controls"
 
 ColumnLayout {
-    spacing: 20
+    spacing: 4
     Setting {
         id: devDocsLink
         Layout.fillWidth: true
@@ -22,6 +22,7 @@ ColumnLayout {
         }
         onClicked: loadedItem.clicked()
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         id: dbcacheSetting
         Layout.fillWidth: true
@@ -33,6 +34,7 @@ ColumnLayout {
         }
         onClicked: loadedItem.forceActiveFocus()
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         id: parSetting
         Layout.fillWidth: true
@@ -44,6 +46,7 @@ ColumnLayout {
         }
         onClicked: loadedItem.forceActiveFocus()
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         Layout.fillWidth: true
         header: qsTr("Dark Mode")

--- a/src/qml/components/Separator.qml
+++ b/src/qml/components/Separator.qml
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import "../controls"
+
+Rectangle {
+    height: 1
+    color: Theme.color.neutral5
+}

--- a/src/qml/components/StorageSettings.qml
+++ b/src/qml/components/StorageSettings.qml
@@ -8,7 +8,7 @@ import QtQuick.Layouts 1.15
 import "../controls"
 
 ColumnLayout {
-    spacing: 20
+    spacing: 4
     Setting {
         Layout.fillWidth: true
         header: qsTr("Store recent blocks only")
@@ -21,6 +21,7 @@ ColumnLayout {
           loadedItem.toggled()
         }
     }
+    Separator { Layout.fillWidth: true }
     Setting {
         id: pruneTargetSetting
         Layout.fillWidth: true

--- a/src/qml/controls/Setting.qml
+++ b/src/qml/controls/Setting.qml
@@ -50,36 +50,24 @@ AbstractButton {
         }
     }
 
-    contentItem: ColumnLayout {
-        spacing: 20
-        width: parent.width
-        RowLayout {
-            Header {
-                Layout.fillWidth: true
-                center: false
-                header: root.header
-                headerSize: 18
-                headerColor: root.stateColor
-                description: root.description
-                descriptionSize: 15
-                descriptionMargin: 0
-            }
-            Loader {
-                id: action_loader
-                active: true
-                visible: active
-                sourceComponent: root.actionItem
-            }
+    contentItem: RowLayout {
+        Header {
+            Layout.topMargin: 14
+            Layout.bottomMargin: 14
+            Layout.fillWidth: true
+            center: false
+            header: root.header
+            headerSize: 18
+            headerColor: root.stateColor
+            description: root.description
+            descriptionSize: 15
+            descriptionMargin: 0
         }
         Loader {
-            Layout.fillWidth: true
-            Layout.columnSpan: 2
-            active: !last
+            id: action_loader
+            active: true
             visible: active
-            sourceComponent: Rectangle {
-                height: 1
-                color: Theme.color.neutral5
-            }
+            sourceComponent: root.actionItem
         }
     }
 }

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -34,7 +34,7 @@ Item {
                 id: navbar
             }
             ColumnLayout {
-                spacing: 20
+                spacing: 4
                 width: Math.min(parent.width, 450)
                 anchors.horizontalCenter: parent.horizontalCenter
                 Setting {
@@ -46,6 +46,7 @@ Item {
                     }
                     onClicked: loadedItem.toggled()
                 }
+                Separator { Layout.fillWidth: true }
                 Setting {
                     id: gotoAbout
                     Layout.fillWidth: true
@@ -58,6 +59,7 @@ Item {
                     }
                     onClicked: loadedItem.clicked()
                 }
+                Separator { Layout.fillWidth: true }
                 Setting {
                     id: gotoStorage
                     Layout.fillWidth: true
@@ -70,6 +72,7 @@ Item {
                     }
                     onClicked: loadedItem.clicked()
                 }
+                Separator { Layout.fillWidth: true }
                 Setting {
                     id: gotoConnection
                     Layout.fillWidth: true


### PR DESCRIPTION
This is required in order to properly support the feature attempted by https://github.com/bitcoin-core/gui-qml/pull/214

### Master

| About | Dev | Prune | Connection | Node |
| ----- | --- | ----- | ---------- | ---- |
| <img width="752" alt="about-master" src="https://user-images.githubusercontent.com/23396902/218625414-180b5a16-6a54-4c30-9f7f-6fd7ba667a6d.png"> |<img width="752" alt="dev-master" src="https://user-images.githubusercontent.com/23396902/218629878-7a1b1024-5b25-446e-9159-6160f0699a8a.png"> |<img width="752" alt="prune-master" src="https://user-images.githubusercontent.com/23396902/218629926-f61080f2-e20a-42f8-8f1c-7dac9ec494a9.png"> |<img width="752" alt="connection-master" src="https://user-images.githubusercontent.com/23396902/218629963-baebb34c-9615-435a-9f7c-24a1a88c8706.png"> |<img width="752" alt="node-master" src="https://user-images.githubusercontent.com/23396902/218629984-1d6a2b5e-d4a4-4baf-ba28-041f90214036.png"> |

### PR 

| About | Dev | Prune | Connection | Node |
| ----- | --- | ----- | ---------- | ---- |
| <img width="752" alt="about-pr" src="https://user-images.githubusercontent.com/23396902/218625012-4fb45c2c-4911-422d-a83c-471e64b05fd1.png"> |<img width="752" alt="dev-pr" src="https://user-images.githubusercontent.com/23396902/218625047-78e6ca4d-d900-4bf7-9f69-77c1a40e0920.png"> |<img width="752" alt="prune-pr" src="https://user-images.githubusercontent.com/23396902/218625067-a71ee530-60c9-4c6f-86eb-f3dccac4230e.png"> |<img width="752" alt="connection-pr" src="https://user-images.githubusercontent.com/23396902/218625084-3811d101-c67b-4f8a-89e7-fc19d58ae609.png"> |<img width="752" alt="node-pr" src="https://user-images.githubusercontent.com/23396902/218625114-ec06b0ec-e37c-403c-a9c5-68b919375cba.png"> |


This also gets us in line with the design file in regards to the height of a setting
| master | pr | design |
| ------ | -- | ------ |
| <img width="483" alt="Screen Shot 2023-02-13 at 7 30 58 PM" src="https://user-images.githubusercontent.com/23396902/218630233-cb861aad-9541-419a-9252-6fbbe697bad8.png"> | <img width="483" alt="Screen Shot 2023-02-13 at 7 21 49 PM" src="https://user-images.githubusercontent.com/23396902/218630255-e428a704-9b8c-41ee-a065-ebef73a9f75e.png"> | <img width="483" alt="Screen Shot 2023-02-13 at 7 31 54 PM" src="https://user-images.githubusercontent.com/23396902/218630286-6bb415a7-eca6-44d3-8d12-faf5dfe283b7.png"> |

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/263)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/263)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/263)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/263)