### PR TITLE
Add basic system theme detection

### DIFF
--- a/src/qml/controls/Theme.qml
+++ b/src/qml/controls/Theme.qml
@@ -4,8 +4,13 @@ import QtQuick.Controls 2.15
 
 Control {
     property bool dark: true
+    property color windowColor: systemColor.window
     readonly property ColorSet color: dark ? darkColorSet : lightColorSet
     readonly property ImageSet image: dark ? darkImageSet : lightImageSet
+
+    SystemPalette {
+        id: systemColor
+    }
 
     component ColorSet: QtObject {
         required property color white
@@ -117,5 +122,19 @@ Control {
 
     function toggleDark() {
         dark = !dark
+    }
+
+    onWindowColorChanged: {
+        dark = isSystemDarkMode(windowColor)
+    }
+
+    function isSystemDarkMode(windowColor) {
+        var luminance = 0.2126 * windowColor.r + 0.7152 * windowColor.g + 0.0722 * windowColor.b;
+
+        if (luminance <= 0.5) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
This adds basic system theme detection by asking qt what color would it be using for the background right now through [SystemPalette](https://doc.qt.io/qt-6/qml-qtquick-systempalette.html#details). Then we do some math on it to calculate it's luminance, which tells us if the color Qt wants to use for the background is dark or not. This implies to us wether the system is in dark mode or not. From my understanding, Qt6.2 is able to expose an enum on system theme but we use qt 5.15

| system light | system dark |
| ------------ | ----------- |
| <img width="752" alt="Screen Shot 2023-02-20 at 8 28 12 PM" src="https://user-images.githubusercontent.com/23396902/220225471-23d31d48-7d50-4028-a4c1-44fd680bfee9.png"> | <img width="752" alt="Screen Shot 2023-02-20 at 8 28 18 PM" src="https://user-images.githubusercontent.com/23396902/220225482-7ba0b19e-12b4-4cd4-bb6d-2cc0d82bec2f.png"> |

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/270)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/270)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/270)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/270)

