### PR TITLE
Add Connection animation with delay timers

### DIFF
--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -30,6 +30,7 @@ Item {
         timeRatioList: chainModel.timeRatioList
         verificationProgress: nodeModel.verificationProgress
         paused: root.paused
+        connected: root.connected
         synced: nodeModel.verificationProgress > 0.999
         backgroundColor: Theme.color.neutral2
         timeTickColor: Theme.color.neutral5

--- a/src/qml/components/blockclockdial.cpp
+++ b/src/qml/components/blockclockdial.cpp
@@ -4,8 +4,10 @@
 
 #include <qml/components/blockclockdial.h>
 
+#include <QBrush>
 #include <QColor>
 #include <QPainterPath>
+#include <QConicalGradient>
 #include <QPen>
 #include <QtMath>
 
@@ -18,6 +20,26 @@ BlockClockDial::BlockClockDial(QQuickItem *parent)
 {
 }
 
+void BlockClockDial::setupConnectingGradient(const QPen & pen)
+{
+    m_connecting_gradient.setCenter(getBoundsForPen(pen).center());
+    m_connecting_gradient.setAngle(m_connecting_start_angle);
+    m_connecting_gradient.setColorAt(0, m_confirmation_colors[5]);
+    m_connecting_gradient.setColorAt(0.5, m_confirmation_colors[5]);
+    m_connecting_gradient.setColorAt(0.6, m_confirmation_colors[4]);
+    m_connecting_gradient.setColorAt(0.7, m_confirmation_colors[3]);
+    m_connecting_gradient.setColorAt(1, m_background_color);
+}
+
+qreal BlockClockDial::decrementGradientAngle(qreal angle)
+{
+    if (angle == -360) {
+        return 0;
+    } else {
+        return angle -= 4;
+    }
+}
+
 void BlockClockDial::setTimeRatioList(QVariantList new_list)
 {
     m_time_ratio_list = new_list;
@@ -27,6 +49,12 @@ void BlockClockDial::setTimeRatioList(QVariantList new_list)
 void BlockClockDial::setVerificationProgress(double progress)
 {
     m_verification_progress = progress;
+    update();
+}
+
+void BlockClockDial::setConnected(bool connected)
+{
+    m_is_connected = connected;
     update();
 }
 
@@ -139,6 +167,20 @@ void BlockClockDial::paintProgress(QPainter * painter)
     painter->drawArc(bounds, startAngle * 16, spanAngle * 16);
 }
 
+void BlockClockDial::paintConnectingAnimation(QPainter * painter)
+{
+    QPen pen;
+    pen.setWidthF(4);
+    setupConnectingGradient(pen);
+    pen.setBrush(QBrush(m_connecting_gradient));
+    pen.setCapStyle(Qt::RoundCap);
+    const QRectF bounds = getBoundsForPen(pen);
+    painter->setPen(pen);
+    painter->drawArc(bounds, m_connecting_start_angle * 16, m_connecting_end_angle * 16);
+    m_connecting_start_angle = decrementGradientAngle(m_connecting_start_angle);
+    update();
+}
+
 void BlockClockDial::paintBackground(QPainter * painter)
 {
     QPen pen(m_background_color);
@@ -185,6 +227,11 @@ void BlockClockDial::paint(QPainter * painter)
     paintTimeTicks(painter);
 
     if (paused()) return;
+
+    if (!(connected())) {
+        paintConnectingAnimation(painter);
+        return;
+    }
 
     if (synced()) {
         paintBlocks(painter);

--- a/src/qml/components/blockclockdial.cpp
+++ b/src/qml/components/blockclockdial.cpp
@@ -17,7 +17,19 @@ BlockClockDial::BlockClockDial(QQuickItem *parent)
 , m_background_color{QColor("#2D2D2D")}
 , m_confirmation_colors{QList<QColor>{}}
 , m_time_tick_color{QColor("#000000")}
+, m_animation_timer{QTimer(this)}
+, m_delay_timer{QTimer(this)}
 {
+    m_animation_timer.setTimerType(Qt::PreciseTimer);
+    m_animation_timer.setInterval(16);
+    m_delay_timer.setTimerType(Qt::PreciseTimer);
+    m_delay_timer.setSingleShot(true);
+    m_delay_timer.setInterval(5000);
+    connect(&m_animation_timer, &QTimer::timeout,
+            this, [=]() { this->update(); });
+    connect(&m_delay_timer, &QTimer::timeout,
+            this, [=]() { this->m_animation_timer.start(); });
+    m_delay_timer.start();
 }
 
 void BlockClockDial::setupConnectingGradient(const QPen & pen)
@@ -54,7 +66,15 @@ void BlockClockDial::setVerificationProgress(double progress)
 
 void BlockClockDial::setConnected(bool connected)
 {
-    m_is_connected = connected;
+    if (m_is_connected != connected) {
+        m_is_connected = connected;
+        m_delay_timer.stop();
+        if (m_is_connected) {
+            m_animation_timer.stop();
+        } else {
+            m_delay_timer.start();
+        }
+    }
     update();
 }
 
@@ -178,7 +198,6 @@ void BlockClockDial::paintConnectingAnimation(QPainter * painter)
     painter->setPen(pen);
     painter->drawArc(bounds, m_connecting_start_angle * 16, m_connecting_end_angle * 16);
     m_connecting_start_angle = decrementGradientAngle(m_connecting_start_angle);
-    update();
 }
 
 void BlockClockDial::paintBackground(QPainter * painter)
@@ -228,7 +247,7 @@ void BlockClockDial::paint(QPainter * painter)
 
     if (paused()) return;
 
-    if (!(connected())) {
+    if (m_animation_timer.isActive()) {
         paintConnectingAnimation(painter);
         return;
     }

--- a/src/qml/components/blockclockdial.h
+++ b/src/qml/components/blockclockdial.h
@@ -8,6 +8,7 @@
 #include <QQuickPaintedItem>
 #include <QConicalGradient>
 #include <QPainter>
+#include <QTimer>
 
 class BlockClockDial : public QQuickPaintedItem
 {
@@ -66,6 +67,8 @@ private:
     const qreal m_connecting_end_angle = -180;
     QList<QColor> m_confirmation_colors;
     QColor m_time_tick_color;
+    QTimer m_animation_timer;
+    QTimer m_delay_timer;
 };
 
 #endif // BITCOIN_QML_COMPONENTS_BLOCKCLOCKDIAL_H

--- a/src/qml/components/blockclockdial.h
+++ b/src/qml/components/blockclockdial.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QML_COMPONENTS_BLOCKCLOCKDIAL_H
 
 #include <QQuickPaintedItem>
+#include <QConicalGradient>
 #include <QPainter>
 
 class BlockClockDial : public QQuickPaintedItem
@@ -13,6 +14,7 @@ class BlockClockDial : public QQuickPaintedItem
     Q_OBJECT
     Q_PROPERTY(QVariantList timeRatioList READ timeRatioList WRITE setTimeRatioList)
     Q_PROPERTY(double verificationProgress READ verificationProgress WRITE setVerificationProgress)
+    Q_PROPERTY(bool connected READ connected WRITE setConnected)
     Q_PROPERTY(bool synced READ synced WRITE setSynced)
     Q_PROPERTY(bool paused READ paused WRITE setPaused)
     Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor)
@@ -25,6 +27,7 @@ public:
 
     QVariantList timeRatioList() const { return m_time_ratio_list; };
     double verificationProgress() const { return m_verification_progress; };
+    bool connected() const { return m_is_connected; };
     bool synced() const { return m_is_synced; };
     bool paused() const { return m_is_paused; };
     QColor backgroundColor() const { return m_background_color; };
@@ -34,6 +37,7 @@ public:
 public Q_SLOTS:
     void setTimeRatioList(QVariantList new_time);
     void setVerificationProgress(double progress);
+    void setConnected(bool connected);
     void setSynced(bool synced);
     void setPaused(bool paused);
     void setBackgroundColor(QColor color);
@@ -41,18 +45,25 @@ public Q_SLOTS:
     void setTimeTickColor(QColor color);
 
 private:
+    void paintConnectingAnimation(QPainter * painter);
     void paintProgress(QPainter * painter);
     void paintBlocks(QPainter * painter);
     void paintBackground(QPainter * painter);
     void paintTimeTicks(QPainter * painter);
     QRectF getBoundsForPen(const QPen & pen);
     double degreesPerPixel();
+    void setupConnectingGradient(const QPen & pen);
+    qreal decrementGradientAngle(qreal angle);
 
     QVariantList m_time_ratio_list;
     double m_verification_progress;
+    bool m_is_connected;
     bool m_is_synced;
     bool m_is_paused;
     QColor m_background_color;
+    QConicalGradient m_connecting_gradient;
+    qreal m_connecting_start_angle = 90;
+    const qreal m_connecting_end_angle = -180;
     QList<QColor> m_confirmation_colors;
     QColor m_time_tick_color;
 };


### PR DESCRIPTION
An extension of #261 with a 5 second delay and limited to 60fps

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/272)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/272)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/272)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/272)