### PR TITLE
Format BlockClock progress percentage according to the design file

### DIFF
--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -88,7 +88,7 @@ Item {
             name: "IBD"; when: !synced && !paused && connected
             PropertyChanges {
                 target: root
-                header: Math.round(nodeModel.verificationProgress * 100) + "%"
+                header: formatProgressPercentage(nodeModel.verificationProgress * 100)
                 subText: formatRemainingSyncTime(nodeModel.remainingSyncTime)
             }
         },
@@ -138,6 +138,18 @@ Item {
             }
         }
     ]
+
+    function formatProgressPercentage(progress) {
+        if (progress >= 1) {
+            return Math.round(progress) + "%"
+        } else if (progress >= 0.1) {
+            return progress.toFixed(1) + "%"
+        } else if (progress >= 0.01) {
+            return progress.toFixed(2) + "%"
+        } else {
+            return "0%"
+        }
+    }
 
     function formatRemainingSyncTime(milliseconds) {
         var minutes = Math.floor(milliseconds / 60000);


### PR DESCRIPTION
This formats the BlockClock's progress percentage to fit with the [design file](https://www.figma.com/file/ek8w3n3upbluw5UL2lGhRx/Bitcoin-Core-App-Design?node-id=5986%3A17926&t=jywAOeHntrNKOEcG-4)

The design file shows: 
![Block clock-3](https://user-images.githubusercontent.com/23396902/221780498-aa576c90-f2b3-4a20-b88a-f03ef3c59654.png)


This PR implements 

| 0 | 0.01 | 0.1 | 1 |
| - | ---- | --- | - |
| <img width="752" alt="zero" src="https://user-images.githubusercontent.com/23396902/221780711-c8c31b20-cd5d-412b-af87-0060fb56eeec.png"> | <img width="752" alt="zero-dot-one" src="https://user-images.githubusercontent.com/23396902/221780804-ef35fa20-dd10-44ca-a22c-020404fdd775.png"> | <img width="752" alt="dot-one" src="https://user-images.githubusercontent.com/23396902/221780883-a20f865a-f22c-4a2c-a394-46537627dab9.png"> | <img width="752" alt="one" src="https://user-images.githubusercontent.com/23396902/221780949-57bb164d-dcb8-4e1c-a7b2-205b80073ddf.png"> |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/276)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/276)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/276)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/276)

