### PR TITLE
Handle pre & headers sync states, add header verification to Block Clock verification progress

### DIFF
--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -24,7 +24,7 @@ Item {
     property alias subText: subText.text
     property int headerSize: 32
     property bool connected: nodeModel.numOutboundPeers > 0
-    property bool synced: nodeModel.verificationProgress > 0.999
+    property bool synced: !nodeModel.inIBD
     property string syncProgress: formatProgressPercentage(nodeModel.verificationProgress * 100)
     property bool paused: false
     property var syncState: formatRemainingSyncTime(nodeModel.remainingSyncTime)
@@ -49,7 +49,7 @@ Item {
         verificationProgress: nodeModel.verificationProgress
         paused: root.paused
         connected: root.connected
-        synced: nodeModel.verificationProgress > 0.999
+        synced: root.synced
         backgroundColor: Theme.color.neutral2
         timeTickColor: Theme.color.neutral5
         confirmationColors: Theme.color.confirmationColors

--- a/src/qml/models/nodemodel.cpp
+++ b/src/qml/models/nodemodel.cpp
@@ -32,6 +32,15 @@ void NodeModel::setBlockTipHeight(int new_height)
     }
 }
 
+
+void NodeModel::setInIBD(bool new_ibd)
+{
+    if (new_ibd != m_in_ibd) {
+        m_in_ibd = new_ibd;
+        Q_EMIT inIBDChanged();
+    }
+}
+
 void NodeModel::setNumOutboundPeers(int new_num)
 {
     if (new_num != m_num_outbound_peers) {
@@ -188,6 +197,7 @@ void NodeModel::ConnectToBlockTipSignal()
         [this](SynchronizationState state, interfaces::BlockTip tip, double verification_progress) {
             QMetaObject::invokeMethod(this, [=] {
                 setBlockTipHeight(tip.block_height);
+                setInIBD(m_node.isInitialBlockDownload());
                 setVerificationProgress(verification_progress);
                 setInHeaderSync(false);
                 setInPreHeaderSync(false);
@@ -202,6 +212,7 @@ void NodeModel::ConnectToHeaderTipSignal()
 
     m_handler_notify_header_tip = m_node.handleNotifyHeaderTip(
         [this](SynchronizationState sync_state, interfaces::BlockTip tip, bool presync) {
+            setInIBD(m_node.isInitialBlockDownload());
             QMetaObject::invokeMethod(this, [=] {
                 if (presync) {
                     setInHeaderSync(false);

--- a/src/qml/models/nodemodel.h
+++ b/src/qml/models/nodemodel.h
@@ -30,6 +30,10 @@ class NodeModel : public QObject
     Q_PROPERTY(QString fullClientVersion READ fullClientVersion CONSTANT)
     Q_PROPERTY(int numOutboundPeers READ numOutboundPeers NOTIFY numOutboundPeersChanged)
     Q_PROPERTY(int maxNumOutboundPeers READ maxNumOutboundPeers CONSTANT)
+    Q_PROPERTY(bool inHeaderSync READ inHeaderSync WRITE setInHeaderSync NOTIFY inHeaderSyncChanged)
+    Q_PROPERTY(double headerSyncProgress READ headerSyncProgress NOTIFY headerSyncProgressChanged)
+    Q_PROPERTY(bool inPreHeaderSync READ inPreHeaderSync WRITE setInPreHeaderSync NOTIFY inPreHeaderSyncChanged)
+    Q_PROPERTY(double preHeaderSyncProgress READ preHeaderSyncProgress NOTIFY preHeaderSyncProgressChanged)
     Q_PROPERTY(int remainingSyncTime READ remainingSyncTime NOTIFY remainingSyncTimeChanged)
     Q_PROPERTY(double verificationProgress READ verificationProgress NOTIFY verificationProgressChanged)
     Q_PROPERTY(bool pause READ pause WRITE setPause NOTIFY pauseChanged)
@@ -43,6 +47,14 @@ public:
     int numOutboundPeers() const { return m_num_outbound_peers; }
     void setNumOutboundPeers(int new_num);
     int maxNumOutboundPeers() const { return m_max_num_outbound_peers; }
+    bool inHeaderSync() const { return m_in_header_sync; }
+    void setInHeaderSync(bool new_in_header_sync);
+    double headerSyncProgress() const { return m_header_sync_progress; }
+    void setHeaderSyncProgress(int64_t header_height, const QDateTime& block_date);
+    bool inPreHeaderSync() const { return m_in_pre_header_sync; }
+    void setInPreHeaderSync(bool new_in_pre_header_sync);
+    double preHeaderSyncProgress() const { return m_pre_header_sync_progress; }
+    void setPreHeaderSyncProgress(int64_t header_height, const QDateTime& block_date);
     int remainingSyncTime() const { return m_remaining_sync_time; }
     void setRemainingSyncTime(double new_progress);
     double verificationProgress() const { return m_verification_progress; }
@@ -65,6 +77,10 @@ public Q_SLOTS:
 Q_SIGNALS:
     void blockTipHeightChanged();
     void numOutboundPeersChanged();
+    void inHeaderSyncChanged();
+    void headerSyncProgressChanged();
+    void inPreHeaderSyncChanged();
+    void preHeaderSyncProgressChanged();
     void remainingSyncTimeChanged();
     void requestedInitialize();
     void requestedShutdown();
@@ -82,6 +98,10 @@ private:
     int m_block_tip_height{0};
     int m_num_outbound_peers{0};
     static constexpr int m_max_num_outbound_peers{MAX_OUTBOUND_FULL_RELAY_CONNECTIONS + MAX_BLOCK_RELAY_ONLY_CONNECTIONS};
+    bool m_in_header_sync;
+    double m_header_sync_progress;
+    bool m_in_pre_header_sync;
+    double m_pre_header_sync_progress;
     int m_remaining_sync_time{0};
     double m_verification_progress{0.0};
     bool m_pause{false};
@@ -92,9 +112,11 @@ private:
 
     interfaces::Node& m_node;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;
+    std::unique_ptr<interfaces::Handler> m_handler_notify_header_tip;
     std::unique_ptr<interfaces::Handler> m_handler_notify_num_peers_changed;
 
     void ConnectToBlockTipSignal();
+    void ConnectToHeaderTipSignal();
     void ConnectToNumConnectionsChangedSignal();
 };
 

--- a/src/qml/models/nodemodel.h
+++ b/src/qml/models/nodemodel.h
@@ -28,6 +28,7 @@ class NodeModel : public QObject
     Q_OBJECT
     Q_PROPERTY(int blockTipHeight READ blockTipHeight NOTIFY blockTipHeightChanged)
     Q_PROPERTY(QString fullClientVersion READ fullClientVersion CONSTANT)
+    Q_PROPERTY(bool inIBD READ inIBD NOTIFY inIBDChanged)
     Q_PROPERTY(int numOutboundPeers READ numOutboundPeers NOTIFY numOutboundPeersChanged)
     Q_PROPERTY(int maxNumOutboundPeers READ maxNumOutboundPeers CONSTANT)
     Q_PROPERTY(bool inHeaderSync READ inHeaderSync WRITE setInHeaderSync NOTIFY inHeaderSyncChanged)
@@ -44,6 +45,8 @@ public:
     int blockTipHeight() const { return m_block_tip_height; }
     void setBlockTipHeight(int new_height);
     QString fullClientVersion() const { return QString::fromStdString(FormatFullVersion()); }
+    bool inIBD() const { return m_in_ibd; }
+    void setInIBD(bool new_ibd);
     int numOutboundPeers() const { return m_num_outbound_peers; }
     void setNumOutboundPeers(int new_num);
     int maxNumOutboundPeers() const { return m_max_num_outbound_peers; }
@@ -76,6 +79,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void blockTipHeightChanged();
+    void inIBDChanged();
     void numOutboundPeersChanged();
     void inHeaderSyncChanged();
     void headerSyncProgressChanged();
@@ -96,6 +100,7 @@ protected:
 private:
     // Properties that are exposed to QML.
     int m_block_tip_height{0};
+    bool m_in_ibd;
     int m_num_outbound_peers{0};
     static constexpr int m_max_num_outbound_peers{MAX_OUTBOUND_FULL_RELAY_CONNECTIONS + MAX_BLOCK_RELAY_ONLY_CONNECTIONS};
     bool m_in_header_sync;


### PR DESCRIPTION
This connects us to the header tip signal so that we can handle when the node is in pre & or headers sync. This calculates the progress of the pre or headers sync and adds it to our verification progress. Pre and headers sync take up 1% of verification progress each, then IBD begins at 2% progress as displayed on the block clock.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/277)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/277)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/277)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/277)

