### PR TITLE
Smart storage values based on assumed chain and chainstate values

### DIFF
--- a/src/qml/chainmodel.h
+++ b/src/qml/chainmodel.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_QML_CHAINMODEL_H
 #define BITCOIN_QML_CHAINMODEL_H
 
+#include <chainparams.h>
 #include <interfaces/chain.h>
 
 #include <QObject>
@@ -23,6 +24,8 @@ class ChainModel : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString currentNetworkName READ currentNetworkName WRITE setCurrentNetworkName NOTIFY currentNetworkNameChanged)
+    Q_PROPERTY(quint64 assumedBlockchainSize READ assumedBlockchainSize CONSTANT)
+    Q_PROPERTY(quint64 assumedChainstateSize READ assumedChainstateSize CONSTANT)
     Q_PROPERTY(QVariantList timeRatioList READ timeRatioList NOTIFY timeRatioListChanged)
 
 public:
@@ -30,6 +33,8 @@ public:
 
     QString currentNetworkName() const { return m_current_network_name; };
     void setCurrentNetworkName(QString network_name);
+    quint64 assumedBlockchainSize() const { return m_assumed_blockchain_size; };
+    quint64 assumedChainstateSize() const { return m_assumed_chainstate_size; };
     QVariantList timeRatioList() const { return m_time_ratio_list; };
 
     int timestampAtMeridian();
@@ -46,6 +51,8 @@ Q_SIGNALS:
 
 private:
     QString m_current_network_name;
+    quint64 m_assumed_blockchain_size{ Params().AssumedBlockchainSize() };
+    quint64 m_assumed_chainstate_size{ Params().AssumedChainStateSize() };
     /* time_ratio: Ratio between the time at which an event
      * happened and 12 hours. So, for example, if a block is
      * found at 4 am or pm, the time_ratio would be 0.3.

--- a/src/qml/components/StorageOptions.qml
+++ b/src/qml/components/StorageOptions.qml
@@ -5,6 +5,9 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+
+import org.bitcoincore.qt 1.0
+
 import "../controls"
 
 ColumnLayout {
@@ -19,7 +22,7 @@ ColumnLayout {
         Layout.fillWidth: true
         ButtonGroup.group: group
         text: qsTr("Reduce storage")
-        description: qsTr("Uses about 2GB. For simple wallet use.")
+        description: qsTr("Uses about %1GB. For simple wallet use.").arg(chainModel.assumedChainstateSize + 2)
         recommended: true
         checked: !root.customStorage && optionsModel.prune
         onClicked: {
@@ -36,7 +39,8 @@ ColumnLayout {
         ButtonGroup.group: group
         text: qsTr("Store all data")
         checked: !optionsModel.prune
-        description: qsTr("Uses about 550GB. Support the network.")
+        description: qsTr("Uses about %1GB. Support the network.").arg(
+            chainModel.assumedBlockchainSize + chainModel.assumedChainstateSize)
         onClicked: {
             optionsModel.prune = false
         }
@@ -49,7 +53,7 @@ ColumnLayout {
             ButtonGroup.group: group
             checked: root.customStorage && optionsModel.prune
             text: qsTr("Custom")
-            description: qsTr("Storing recent blocks up to %1GB").arg(root.customStorageAmount)
+            description: qsTr("Storing about %1GB of data.").arg(root.customStorageAmount + chainModel.assumedChainstateSize)
             onClicked: {
                 optionsModel.prune = true
                 optionsModel.pruneSizeGB = root.customStorageAmount

--- a/src/qml/components/StorageSettings.qml
+++ b/src/qml/components/StorageSettings.qml
@@ -35,7 +35,7 @@ ColumnLayout {
     Setting {
         id: pruneTargetSetting
         Layout.fillWidth: true
-        header: qsTr("Storage limit (GB)")
+        header: qsTr("Block Storage limit (GB)")
         errorText: qsTr("This is not a valid prune target. Please choose a value that is equal to or larger than 1GB")
         showErrorText: false
         actionItem: ValueInput {

--- a/src/qml/pages/onboarding/OnboardingStorageLocation.qml
+++ b/src/qml/pages/onboarding/OnboardingStorageLocation.qml
@@ -19,7 +19,7 @@ InformationPage {
     bold: true
     headerText: qsTr("Storage location")
     headerMargin: 0
-    description: qsTr("Where do you want to store the downloaded block data?\nYou need a minimum of 1GB of storage.")
+    description: qsTr("Where do you want to store the downloaded block data?\nYou need a minimum of %1GB of storage.").arg(chainModel.assumedChainstateSize + 1)
     descriptionMargin: 20
     detailActive: true
     detailItem: StorageLocations {}


### PR DESCRIPTION
When a prune target is set, that limits how much storage is taken up by blocks. But there is still other data such as the chainstate. This moves us away from wrongly conveying that the prune target is how much data will be taken up, and instead conveys how much data will be taken up considering the prune target, assumed blockchain size, and assumed chainstate size. The assumed sizes are updated every release cycle.

Changes:
- Storage Location
  - The text that shows what the minimum amount of space needed is now displays assumed chainstate size + 1GB instead of just 1GB

- Storage Options 
  - The default prune button is now 2GB + assumed chainstate size instead of just the prune target of 2GB
  - Store all data button is now the assumed blockchain size + assumed chainstate size instead of a hardcoded 550GB
  - Custom Prune button is now the prune target + assumed chainstate size instead of just the prune target set in detailed settings

- Storage Settings 
  - The text of the Setting which is used to set a custom prune target is changed from `"Storage limit (GB)"` to  `"Block Storage limit (GB)"` to convey this controls block storage specifically. The Custom prune button that then appears on the storage options page shows this prune target + assumed chainstate size


#### Master 
| Storage Location | Storage | Storage Settings | Custom Prune |
| ---------------- | ------- | ---------------- | ------------ |
| <img width="752" alt="storage-location-master" src="https://user-images.githubusercontent.com/23396902/222280393-301cb341-55a6-44b3-b4ff-225527e07d64.png"> | <img width="752" alt="storage-master" src="https://user-images.githubusercontent.com/23396902/222280426-eff403d6-b9c5-4c4c-85f0-e2423df0bd69.png"> | <img width="752" alt="storage-setting-master" src="https://user-images.githubusercontent.com/23396902/222280478-3071ed98-b3e1-448f-9c8b-2879a772d46f.png"> | <img width="752" alt="custom-prune-master" src="https://user-images.githubusercontent.com/23396902/222280523-32453595-1a6d-4dc5-b885-7f09126944ee.png"> |

## PR
| Storage Location | Storage | Storage Settings | Custom Prune |
| ---------------- | ------- | ---------------- | ------------ |
| <img width="752" alt="storage-location-pr" src="https://user-images.githubusercontent.com/23396902/222280732-3937b587-61eb-4889-8e6b-896f5df3a193.png"> |  <img width="752" alt="storage-pr" src="https://user-images.githubusercontent.com/23396902/222280906-114a3609-0a0b-4a49-90f6-f1336fa6108c.png"> |  <img width="752" alt="storage-settings-pr" src="https://user-images.githubusercontent.com/23396902/222280940-0bd860a7-62b1-44bc-8710-18343728ea1f.png"> |<img width="752" alt="custom-prune-pr" src="https://user-images.githubusercontent.com/23396902/222280983-e1b7beb3-392c-4c1b-aa16-1fefe52370a6.png"> |






[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/278)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/278)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/278)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/278)

