### PR TITLE
Only "click" setting if released within its MouseArea

### DIFF
--- a/src/qml/controls/Setting.qml
+++ b/src/qml/controls/Setting.qml
@@ -68,8 +68,12 @@ AbstractButton {
             root.state = "ACTIVE"
         }
         onReleased: {
-            root.state = "HOVER"
-            root.clicked()
+            if (mouseArea.containsMouse) {
+                root.state = "HOVER"
+                root.clicked()
+            } else {
+                root.state = "FILLED"
+            }
         }
     }
 


### PR DESCRIPTION
Fixes issues with pressing a setting, holding mouse down, and releasing outside of the Setting's MouseArea

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/281)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/281)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/281)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/281)
