### PR TITLE
Fix std::bad_optional_access in ChainModel

### DIFF
--- a/src/qml/chainmodel.cpp
+++ b/src/qml/chainmodel.cpp
@@ -62,6 +62,11 @@ void ChainModel::setTimeRatioListInitial()
     m_time_ratio_list.push_back(double(QDateTime::currentSecsSinceEpoch() - time_at_meridian) / SECS_IN_12_HOURS);
     m_time_ratio_list.push_back(0);
 
+    if (!m_chain.getHeight()) {
+        Q_EMIT timeRatioListChanged();
+        return;
+    }
+
     int first_block_height;
     int active_chain_height = m_chain.getHeight().value();
     bool success = m_chain.findFirstBlockWithTimeAndHeight(/*min_time=*/time_at_meridian, /*min_height=*/0, interfaces::FoundBlock().height(first_block_height));


### PR DESCRIPTION
During shutdown, ChainModel initial values are being set now. This short circuits the init if there is no height set and prevents an abort.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/285)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/285)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/285)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/285)