### PR TITLE
Don't use hover effects when on mobile

### DIFF
--- a/src/qml/controls/ContinueButton.qml
+++ b/src/qml/controls/ContinueButton.qml
@@ -4,10 +4,11 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import org.bitcoincore.qt 1.0
 
 Button {
     id: root
-    hoverEnabled: true
+    hoverEnabled: AppMode.isDesktop
     contentItem: CoreText {
         text: parent.text
         bold: true

--- a/src/qml/controls/NavButton.qml
+++ b/src/qml/controls/NavButton.qml
@@ -6,6 +6,8 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import org.bitcoincore.qt 1.0
+
 AbstractButton {
     id: root
     property int iconHeight: 30
@@ -14,7 +16,7 @@ AbstractButton {
     property url iconSource: ""
     property Rectangle iconBackground: null
     property color iconColor: Theme.color.neutral9
-    hoverEnabled: true
+    hoverEnabled: AppMode.isDesktop
     topPadding: text_background.active ? 7 : 14
     bottomPadding: text_background.active ? 7 : 14
     rightPadding: text_background.active ? 22 : 14
@@ -94,7 +96,7 @@ AbstractButton {
     }
     MouseArea {
         anchors.fill: parent
-        hoverEnabled: true
+        hoverEnabled: AppMode.isDesktop
         onEntered: {
             root.background.state = "HOVER"
         }

--- a/src/qml/controls/OutlineButton.qml
+++ b/src/qml/controls/OutlineButton.qml
@@ -4,10 +4,11 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import org.bitcoincore.qt 1.0
 
 Button {
     id: root
-    hoverEnabled: true
+    hoverEnabled: AppMode.isDesktop
     contentItem: CoreText {
         text: parent.text
         bold: true

--- a/src/qml/controls/Setting.qml
+++ b/src/qml/controls/Setting.qml
@@ -6,6 +6,8 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import org.bitcoincore.qt 1.0
+
 AbstractButton {
     id: root
     property bool last: parent && root === parent.children[parent.children.length - 1]
@@ -16,7 +18,7 @@ AbstractButton {
     property string errorText: ""
     property bool showErrorText: false
     property color stateColor
-    hoverEnabled: true
+    hoverEnabled: AppMode.isDesktop
     state: "FILLED"
 
     states: [
@@ -57,7 +59,7 @@ AbstractButton {
     MouseArea {
         id: mouseArea
         anchors.fill: root
-        hoverEnabled: true
+        hoverEnabled: AppMode.isDesktop
         onEntered: {
             root.state = "HOVER"
         }

--- a/src/qml/controls/TextButton.qml
+++ b/src/qml/controls/TextButton.qml
@@ -5,6 +5,8 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
+import org.bitcoincore.qt 1.0
+
 Button {
     id: root
     property int textSize: 18
@@ -13,7 +15,7 @@ Button {
     property bool bold: true
     property bool rightalign: false
     padding: 15
-    hoverEnabled: true
+    hoverEnabled: AppMode.isDesktop
     contentItem: CoreText {
         text: root.text
         bold: root.bold

--- a/src/qml/controls/ToggleButton.qml
+++ b/src/qml/controls/ToggleButton.qml
@@ -4,6 +4,7 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import org.bitcoincore.qt 1.0
 
 Button {
     property int bgRadius: 5
@@ -16,7 +17,7 @@ Button {
 
     id: root
     checkable: true
-    hoverEnabled: true
+    hoverEnabled: AppMode.isDesktop
     leftPadding: 12
     rightPadding: 12
     topPadding: 5


### PR DESCRIPTION
[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/289)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/289)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/289)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/289)
[![ARM32 Android](https://img.shields.io/badge/OS-Android%2032bit-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android32/unsecure_android_32bit_apk.zip?branch=pull/289)