### PR TITLE
Network Traffic Graph Option B

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ share/qt/Info.plist
 src/qt/*.moc
 src/qt/moc_*.cpp
 src/qml/components/moc_*.cpp
+src/qml/controls/moc_*.cpp
 src/qt/forms/ui_*.h
 
 src/qt/test/moc*.cpp

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -374,6 +374,7 @@ QML_RES_QML = \
   qml/controls/ValueInput.qml \
   qml/pages/initerrormessage.qml \
   qml/pages/main.qml \
+  qml/pages/node/NetworkTraffic.qml \
   qml/pages/node/NodeRunner.qml \
   qml/pages/node/NodeSettings.qml \
   qml/pages/node/Peers.qml \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -38,6 +38,7 @@ QT_MOC_CPP = \
   qml/components/moc_blockclockdial.cpp \
   qml/moc_appmode.cpp \
   qml/moc_chainmodel.cpp \
+  qml/moc_networktraffictower.cpp \
   qml/moc_nodemodel.cpp \
   qml/moc_options_model.cpp \
   qml/moc_peerlistsortproxy.cpp \
@@ -117,6 +118,7 @@ BITCOIN_QT_H = \
   qml/chainmodel.h \
   qml/components/blockclockdial.h \
   qml/imageprovider.h \
+  qml/networktraffictower.h \
   qml/nodemodel.h \
   qml/options_model.h \
   qml/peerlistsortproxy.h \
@@ -300,6 +302,7 @@ BITCOIN_QML_BASE_CPP = \
   qml/chainmodel.cpp \
   qml/components/blockclockdial.cpp \
   qml/imageprovider.cpp \
+  qml/networktraffictower.cpp \
   qml/nodemodel.cpp \
   qml/options_model.cpp \
   qml/peerlistsortproxy.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -352,6 +352,7 @@ QML_RES_QML = \
   qml/components/StorageLocations.qml \
   qml/components/StorageOptions.qml \
   qml/components/StorageSettings.qml \
+  qml/components/TotalBytesIndicator.qml \
   qml/controls/ContinueButton.qml \
   qml/controls/CoreText.qml \
   qml/controls/ExternalLink.qml \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -345,6 +345,7 @@ QML_RES_QML = \
   qml/components/ConnectionSettings.qml \
   qml/components/DeveloperOptions.qml \
   qml/components/PeersIndicator.qml \
+  qml/components/NetworkTrafficGraph.qml \
   qml/components/NetworkIndicator.qml \
   qml/components/ProxySettings.qml \
   qml/components/Separator.qml \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -36,6 +36,7 @@ QT_FORMS_UI = \
 
 QT_MOC_CPP = \
   qml/components/moc_blockclockdial.cpp \
+  qml/controls/moc_linegraph.cpp \
   qml/moc_appmode.cpp \
   qml/moc_chainmodel.cpp \
   qml/moc_networktraffictower.cpp \
@@ -117,6 +118,7 @@ BITCOIN_QT_H = \
   qml/bitcoin.h \
   qml/chainmodel.h \
   qml/components/blockclockdial.h \
+  qml/controls/linegraph.h \
   qml/imageprovider.h \
   qml/networktraffictower.h \
   qml/nodemodel.h \
@@ -301,6 +303,7 @@ BITCOIN_QML_BASE_CPP = \
   qml/bitcoin.cpp \
   qml/chainmodel.cpp \
   qml/components/blockclockdial.cpp \
+  qml/controls/linegraph.cpp \
   qml/imageprovider.cpp \
   qml/networktraffictower.cpp \
   qml/nodemodel.cpp \

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -15,6 +15,7 @@
 #include <qml/appmode.h>
 #include <qml/chainmodel.h>
 #include <qml/components/blockclockdial.h>
+#include <qml/controls/linegraph.h>
 #include <qml/networktraffictower.h>
 #include <qml/imageprovider.h>
 #include <qml/nodemodel.h>
@@ -249,6 +250,7 @@ int QmlGuiMain(int argc, char* argv[])
 
     qmlRegisterSingletonInstance<AppMode>("org.bitcoincore.qt", 1, 0, "AppMode", &app_mode);
     qmlRegisterType<BlockClockDial>("org.bitcoincore.qt", 1, 0, "BlockClockDial");
+    qmlRegisterType<LineGraph>("org.bitcoincore.qt", 1, 0, "LineGraph");
 
     engine.load(QUrl(QStringLiteral("qrc:///qml/pages/main.qml")));
     if (engine.rootObjects().isEmpty()) {

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -15,6 +15,7 @@
 #include <qml/appmode.h>
 #include <qml/chainmodel.h>
 #include <qml/components/blockclockdial.h>
+#include <qml/networktraffictower.h>
 #include <qml/imageprovider.h>
 #include <qml/nodemodel.h>
 #include <qml/options_model.h>
@@ -204,6 +205,8 @@ int QmlGuiMain(int argc, char* argv[])
     QObject::connect(&init_executor, &InitExecutor::shutdownResult, qGuiApp, &QGuiApplication::quit, Qt::QueuedConnection);
     // QObject::connect(&init_executor, &InitExecutor::runawayException, &node_model, &NodeModel::handleRunawayException);
 
+    NetworkTrafficTower network_traffic_tower{node_model};
+
     ChainModel chain_model{*chain};
     chain_model.setCurrentNetworkName(QString::fromStdString(gArgs.GetChainName()));
 
@@ -228,6 +231,7 @@ int QmlGuiMain(int argc, char* argv[])
     assert(!network_style.isNull());
     engine.addImageProvider(QStringLiteral("images"), new ImageProvider{network_style.data()});
 
+    engine.rootContext()->setContextProperty("networkTrafficTower", &network_traffic_tower);
     engine.rootContext()->setContextProperty("nodeModel", &node_model);
     engine.rootContext()->setContextProperty("chainModel", &chain_model);
     engine.rootContext()->setContextProperty("peerTableModel", &peer_model);

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -15,6 +15,7 @@
         <file>components/Separator.qml</file>
         <file>components/StorageOptions.qml</file>
         <file>components/StorageSettings.qml</file>
+        <file>components/TotalBytesIndicator.qml</file>
         <file>controls/ContinueButton.qml</file>
         <file>controls/CoreText.qml</file>
         <file>controls/ExternalLink.qml</file>

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -8,6 +8,7 @@
         <file>components/ConnectionSettings.qml</file>
         <file>components/PeersIndicator.qml</file>
         <file>components/DeveloperOptions.qml</file>
+        <file>components/NetworkTrafficGraph.qml</file>
         <file>components/NetworkIndicator.qml</file>
         <file>components/ProxySettings.qml</file>
         <file>components/StorageLocations.qml</file>

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -37,6 +37,7 @@
         <file>controls/ValueInput.qml</file>
         <file>pages/initerrormessage.qml</file>
         <file>pages/main.qml</file>
+        <file>pages/node/NetworkTraffic.qml</file>
         <file>pages/node/NodeRunner.qml</file>
         <file>pages/node/NodeSettings.qml</file>
         <file>pages/node/Peers.qml</file>

--- a/src/qml/components/NetworkTrafficGraph.qml
+++ b/src/qml/components/NetworkTrafficGraph.qml
@@ -1,0 +1,103 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../controls"
+import "../components"
+
+import org.bitcoincore.qt 1.0
+
+Item {
+    id: root
+    property alias backgroundColor: trafficGraph.backgroundColor
+    property alias borderColor: trafficGraph.borderColor
+    property alias drawFrame: trafficGraph.drawFrame
+    property alias fillColor: trafficGraph.fillColor
+    property alias lineColor: trafficGraph.lineColor
+    property alias markerLineColor: trafficGraph.markerLineColor
+    property alias maxSamples: trafficGraph.maxSamples
+    property alias maxValue: trafficGraph.maxValue
+    property alias valueList: trafficGraph.valueList
+    property double maxRateBps
+    property color unitLabelColor: Theme.color.neutral9
+    property bool alignLabelLeft: true
+
+    height: 250
+
+    LineGraph {
+        id: trafficGraph
+        height: root.height
+        width: root.width
+        backgroundColor: root.backgroundColor
+        borderColor: root.borderColor
+        drawFrame: root.drawFrame
+        fillColor: root.fillColor
+        lineColor: root.lineColor
+        markerLineColor: root.markerLineColor
+        maxSamples: root.maxSamples
+        maxValue: root.maxValue
+        valueList: root.valueList
+
+        Behavior on backgroundColor {
+            ColorAnimation { duration: 150 }
+        }
+
+        Behavior on borderColor {
+            ColorAnimation { duration: 150 }
+        }
+
+        Behavior on fillColor {
+            ColorAnimation { duration: 150 }
+        }
+
+        Behavior on lineColor {
+            ColorAnimation { duration: 150 }
+        }
+
+        Behavior on markerLineColor {
+            ColorAnimation { duration: 150 }
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        CoreText {
+            bold: true
+            text: formatBytes(formatMagnitude(root.maxRateBps)) + "/s"
+            color: root.unitLabelColor
+            font.pixelSize: 13
+            Layout.alignment: root.alignLabelLeft ? Qt.AlignLeft | Qt.AlignBottom : Qt.AlignRight | Qt.AlignBottom
+            Layout.leftMargin: root.alignLabelLeft ? 5 : 0
+            Layout.rightMargin: root.alignLabelLeft ? 0 : 5
+            Layout.bottomMargin: 6
+        }
+        CoreText {
+            bold: true
+            text: formatBytes(formatMagnitude(root.maxRateBps / 10)) + "/s"
+            color: root.unitLabelColor
+            font.pixelSize: 13
+            Layout.alignment: root.alignLabelLeft ? Qt.AlignLeft | Qt.AlignBottom : Qt.AlignRight | Qt.AlignBottom
+            Layout.leftMargin: root.alignLabelLeft ? 5 : 0
+            Layout.rightMargin: root.alignLabelLeft ? 0 : 5
+            Layout.bottomMargin: 5
+        }
+    }
+
+    function formatMagnitude(max_rate) {
+        var base = Math.floor(Math.log10(max_rate));
+        return Math.pow(10.0, base);
+    }
+
+    function formatBytes(bytes) {
+        var suffixes = ["Bytes", "KB", "MB", "GB", "TB", "PB"];
+        var index = 0;
+        while (bytes >= 1000 && index < suffixes.length - 1) {
+            bytes /= 1000;
+            index++;
+        }
+        return bytes.toFixed(0) + " " + suffixes[index];
+    }
+}

--- a/src/qml/components/TotalBytesIndicator.qml
+++ b/src/qml/components/TotalBytesIndicator.qml
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../controls"
+
+RowLayout {
+    id: root
+    property color indicatorColor
+    property double totalBytes
+
+    Rectangle {
+        Layout.alignment: Qt.AlignVCenter
+        height: 10
+        width: 10
+        radius: 5
+        color: root.indicatorColor
+    }
+    CoreText {
+        Layout.alignment: Qt.AlignHCenter
+        color: Theme.color.neutral9
+        text: qsTr("Received: %1").arg(formatBytes(root.totalBytes))
+        font.pixelSize: 18
+    }
+
+    function formatBytes(bytes) {
+        var suffixes = ["Bytes", "KB", "MB", "GB", "TB", "PB"];
+        var index = 0;
+        while (bytes >= 1000 && index < suffixes.length - 1) {
+            bytes /= 1000;
+            index++;
+        }
+        return bytes.toFixed(0) + " " + suffixes[index];
+    }
+}

--- a/src/qml/controls/ToggleButton.qml
+++ b/src/qml/controls/ToggleButton.qml
@@ -6,12 +6,14 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 
 Button {
+    property int bgRadius: 5
     property color bgDefaultColor: Theme.color.neutral2
     property color bgHoverColor: Theme.color.neutral2
     property color bgActiveColor: Theme.color.neutral5
     property color textColor: Theme.color.neutral7
     property color textHoverColor: Theme.color.orangeLight1
     property color textActiveColor: Theme.color.neutral9
+
     id: root
     checkable: true
     hoverEnabled: true
@@ -34,7 +36,7 @@ Button {
     background: Rectangle {
         id: bg
         color: root.bgDefaultColor
-        radius: 5
+        radius: root.bgRadius
 
         Behavior on color {
             ColorAnimation { duration: 150 }

--- a/src/qml/controls/linegraph.cpp
+++ b/src/qml/controls/linegraph.cpp
@@ -1,0 +1,167 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/controls/linegraph.h>
+
+#include <QBrush>
+#include <QColor>
+#include <QLinearGradient>
+#include <QObject>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPen>
+#include <QQueue>
+#include <QQuickPaintedItem>
+
+LineGraph::LineGraph(QQuickItem *parent)
+    : QQuickPaintedItem(parent)
+    , m_background_color{QColor("#2D2D2D")}
+    , m_border_color{QColor("#000000")}
+    , m_draw_frame{true}
+    , m_fill_color{QColor("#000000")}
+    , m_fill_gradient{QLinearGradient(0, 0, 0, 0)}
+    , m_line_color{QColor("#000000")}
+    , m_marker_line_color{("#000000")}
+    , m_max_samples{0}
+    , m_max_value{0}
+{
+    setFillColor(m_background_color);
+}
+
+void LineGraph::setBackgroundColor(QColor color)
+{
+    m_background_color = color;
+    setFillColor(color);
+}
+
+void LineGraph::setBorderColor(QColor color)
+{
+    m_border_color = color;
+    update();
+}
+
+void LineGraph::setDrawFrame(bool draw_frame)
+{
+    m_draw_frame = draw_frame;
+    update();
+}
+
+void LineGraph::setFillColor(QColor color)
+{
+    m_fill_color = color;
+    update();
+}
+
+void LineGraph::setLineColor(QColor color)
+{
+    m_line_color = color;
+    update();
+}
+
+void LineGraph::setMarkerLineColor(QColor color)
+{
+    m_marker_line_color = color;
+    update();
+}
+
+void LineGraph::setMaxSamples(int max_samples)
+{
+    m_max_samples = max_samples;
+    update();
+}
+
+void LineGraph::setMaxValue(float max_value)
+{
+    m_max_value = max_value;
+}
+
+void LineGraph::setValueList(QQueue<float> value_list)
+{
+    m_value_list = value_list;
+    update();
+}
+
+void LineGraph::paintGraphBorder(QPainter * painter)
+{
+    painter->setPen(QPen(m_border_color, 2));
+    QRectF rect(0, 0, width(), height());
+    painter->drawRect(rect);
+}
+
+void LineGraph::paintMarkerLines(QPainter * painter)
+{
+    painter->setPen(QPen(m_marker_line_color, 1));
+    qreal line_spacing = height() / 8;
+
+    for (int i = 0; i < 9; i++) {
+        qreal y = i * line_spacing;
+
+        if (i == 4) {
+            painter->setPen(QPen(m_border_color, 1));
+            painter->drawLine(0, y, width(), y);
+            painter->setPen(QPen(m_marker_line_color, 1));
+        } else {
+             painter->drawLine(0, y, width(), y);
+        }
+    }
+}
+
+void LineGraph::paintPath(QPainterPath * painter_path)
+{
+    int item_count = std::min(m_max_samples, m_value_list.size());
+    qreal h = height();
+    qreal w = width();
+
+    if(item_count > 0) {
+        int y_pos = h;
+        int x_pos = w;
+        painter_path->moveTo(x_pos, y_pos);
+
+        for(int i = 0; i < item_count; ++i) {
+            x_pos = w - w * i / m_max_samples;
+            y_pos = h - ((h - 10) * m_value_list.at(i) / m_max_value);
+            painter_path->lineTo(x_pos, y_pos);
+        }
+
+        painter_path->lineTo(x_pos - 2, h);
+        painter_path->lineTo(0, h);
+    }
+}
+
+void LineGraph::paintTraffic(QPainter * painter)
+{
+    painter->setRenderHint(QPainter::Antialiasing);
+
+    if (m_max_value == 0.0f) {
+        return;
+    }
+
+    if(!m_value_list.empty()) {
+        QPainterPath p;
+        paintPath(&p);
+        setupGradient(&p);
+        painter->setPen(QPen(m_line_color, 1));
+        painter->drawPath(p);
+        painter->fillPath(p, QBrush(m_fill_gradient));
+    }
+
+    update();
+}
+
+void LineGraph::setupGradient(QPainterPath * painter_path)
+{
+    QLinearGradient gradient(painter_path->boundingRect().topLeft(), painter_path->boundingRect().bottomLeft());
+    gradient.setColorAt(0, QColor(m_fill_color.red(), m_fill_color.green(), m_fill_color.blue(), 191));
+    gradient.setColorAt(1, QColor("transparent"));
+    m_fill_gradient = gradient;
+}
+
+void LineGraph::paint(QPainter *painter)
+{
+    if (m_draw_frame) {
+        paintMarkerLines(painter);
+    }
+    paintTraffic(painter);
+    paintGraphBorder(painter);
+}

--- a/src/qml/controls/linegraph.h
+++ b/src/qml/controls/linegraph.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_CONTROLS_LINEGRAPH_H
+#define BITCOIN_QML_CONTROLS_LINEGRAPH_H
+
+#include <QLinearGradient>
+#include <QPainter>
+#include <QPainterPath>
+#include <QQueue>
+#include <QQuickPaintedItem>
+
+class LineGraph : public QQuickPaintedItem
+{
+    Q_OBJECT
+    Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor)
+    Q_PROPERTY(QColor borderColor READ borderColor WRITE setBorderColor)
+    Q_PROPERTY(bool drawFrame READ drawFrame WRITE setDrawFrame)
+    Q_PROPERTY(QColor fillColor READ fillColor WRITE setFillColor)
+    Q_PROPERTY(QColor lineColor READ lineColor WRITE setLineColor)
+    Q_PROPERTY(QColor markerLineColor READ markerLineColor WRITE setMarkerLineColor)
+    Q_PROPERTY(int maxSamples READ maxSamples WRITE setMaxSamples)
+    Q_PROPERTY(float maxValue READ maxValue WRITE setMaxValue)
+    Q_PROPERTY(QQueue<float> valueList READ valueList WRITE setValueList)
+
+    public:
+        explicit LineGraph(QQuickItem * parent = nullptr);
+        void paint(QPainter * painter) override;
+
+        QColor backgroundColor() const { return m_background_color; };
+        QColor borderColor() const { return m_border_color; };
+        bool drawFrame() const { return m_draw_frame; };
+        QColor fillColor() const { return m_fill_color; };
+        QColor lineColor() const { return m_line_color; };
+        QColor markerLineColor() const { return m_marker_line_color; };
+        int maxSamples() const { return m_max_samples; };
+        float maxValue() const { return m_max_value; };
+        QQueue<float> valueList() const { return m_value_list; };
+
+    public Q_SLOTS:
+        void setBackgroundColor(QColor color);
+        void setBorderColor(QColor color);
+        void setDrawFrame(bool draw_frame);
+        void setFillColor(QColor color);
+        void setLineColor(QColor color);
+        void setMarkerLineColor(QColor color);
+        void setMaxSamples(int max_samples);
+        void setMaxValue(float max_value);
+        void setValueList(QQueue<float> value_list);
+
+    private:
+        void paintGraphBorder(QPainter * painter);
+        void paintMarkerLines(QPainter * painter);
+        void paintPath(QPainterPath * painter_path);
+        void paintTraffic(QPainter * painter);
+        void setupGradient(QPainterPath * painter);
+
+        QColor m_background_color;
+        QColor m_border_color;
+        bool m_draw_frame;
+        QColor m_fill_color;
+        QLinearGradient m_fill_gradient;
+        QColor m_line_color;
+        QColor m_marker_line_color;
+        int m_max_samples;
+        float m_max_value;
+        QQueue<float> m_value_list;
+};
+
+#endif // BITCOIN_QML_CONTROLS_LINEGRAPH_H

--- a/src/qml/networktraffictower.cpp
+++ b/src/qml/networktraffictower.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/networktraffictower.h>
+
+#include <QObject>
+#include <QThread>
+#include <QTimer>
+
+#define MAX_SAMPLES      86400
+
+NetworkTrafficTower::NetworkTrafficTower(NodeModel& node)
+    : m_node{node}
+    , m_total_bytes_received{0.0f}
+    , m_total_bytes_sent{0.0f}
+    , m_max_received_rate_bps{0.0f}
+    , m_max_sent_rate_bps{0.0f}
+{
+    QTimer* timer = new QTimer();
+    connect(timer, &QTimer::timeout, this, &NetworkTrafficTower::updateTrafficStats);
+    timer->start(1000);
+
+    QThread* timer_thread = new QThread;
+    timer->moveToThread(timer_thread);
+    timer_thread->start();
+
+    m_filter_window_size = 30;
+}
+
+void NetworkTrafficTower::setTotalBytesReceived(float new_total)
+{
+    m_total_bytes_received = new_total;
+    Q_EMIT totalBytesReceivedChanged();
+}
+
+void NetworkTrafficTower::setTotalBytesSent(float new_total)
+{
+    m_total_bytes_sent = new_total;
+    Q_EMIT totalBytesSentChanged();
+}
+
+void NetworkTrafficTower::setMaxReceivedRateBps(float new_max)
+{
+    m_max_received_rate_bps = new_max;
+    Q_EMIT maxReceivedRateBpsChanged();
+}
+
+void NetworkTrafficTower::setMaxSentRateBps(float new_max)
+{
+    m_max_sent_rate_bps = new_max;
+    Q_EMIT maxSentRateBpsChanged();
+}
+
+void NetworkTrafficTower::updateFilterWindowSize(int new_size)
+{
+    if (!(m_filter_window_size == new_size)) {
+        m_filter_window_size = new_size;
+
+        if (!m_received_rate_list.isEmpty()) {
+            recalculateSmoothedRateList(&m_received_rate_list, &m_smoothed_received_rate_list);
+            float new_max_received_rate = calculateMaxRateBps(&m_smoothed_received_rate_list);
+
+            setMaxReceivedRateBps(new_max_received_rate);
+            Q_EMIT receivedRateListChanged();
+        }
+        if (!m_sent_rate_list.isEmpty()) {
+            recalculateSmoothedRateList(&m_sent_rate_list, &m_smoothed_sent_rate_list);
+            float new_max_sent_rate = calculateMaxRateBps(&m_smoothed_sent_rate_list);
+
+            setMaxSentRateBps(new_max_sent_rate);
+            Q_EMIT sentRateListChanged();
+        }
+    }
+    Q_EMIT sentRateListChanged();
+}
+
+float NetworkTrafficTower::applyMovingAverageFilter(QQueue<float> * rate_list)
+{
+    int filter_window_size = std::min(rate_list->size(), m_filter_window_size);
+    float sum = 0.0f;
+    for (int i = 0; i < filter_window_size; ++i) {
+        sum += rate_list->at(i);
+    }
+
+    return sum / filter_window_size;
+}
+
+float NetworkTrafficTower::calculateMaxRateBps(QQueue<float> * smoothed_rate_list)
+{
+    float max_rate_bps = 0.0f;
+    int lookback = std::min(smoothed_rate_list->size() - 1, m_filter_window_size * 10);
+    for (int i = lookback; i > 0; --i) {
+        if (smoothed_rate_list->at(i) > max_rate_bps) {
+            max_rate_bps = smoothed_rate_list->at(i);
+        }
+    }
+    return max_rate_bps;
+}
+
+void NetworkTrafficTower::recalculateSmoothedRateList(QQueue<float> * rate_list, QQueue<float> * smoothed_rate_list)
+{
+    smoothed_rate_list->clear();
+    QQueue<float> temp_list;
+    for (int i = rate_list->size() - 1; i > 0; --i) {
+        temp_list.push_front(rate_list->at(i));
+        float smoothed_rate = applyMovingAverageFilter(&temp_list);
+        smoothed_rate_list->push_front(smoothed_rate);
+    }
+}
+
+void NetworkTrafficTower::updateTrafficStats()
+{
+    float new_total_bytes_received = m_node.getTotalBytesReceived();
+    float new_total_bytes_sent = m_node.getTotalBytesSent();
+
+    float rate_received_bps = (new_total_bytes_received - m_total_bytes_received);
+    float rate_sent_bps = (new_total_bytes_sent - m_total_bytes_sent);
+
+    setTotalBytesSent(new_total_bytes_sent);
+    setTotalBytesReceived(new_total_bytes_received);
+
+    m_received_rate_list.push_front(rate_received_bps);
+    m_sent_rate_list.push_front(rate_sent_bps);
+
+    float smoothed_received_rate_bps = applyMovingAverageFilter(&m_received_rate_list);
+    float smoothed_sent_rate_bps = applyMovingAverageFilter(&m_sent_rate_list);
+
+    m_smoothed_received_rate_list.push_front(smoothed_received_rate_bps);
+    m_smoothed_sent_rate_list.push_front(smoothed_sent_rate_bps);
+
+    while (m_received_rate_list.size() > MAX_SAMPLES) {
+        m_received_rate_list.pop_back();
+        m_smoothed_received_rate_list.pop_back();
+    }
+
+    while (m_sent_rate_list.size() > MAX_SAMPLES) {
+        m_sent_rate_list.pop_back();
+        m_smoothed_sent_rate_list.pop_back();
+    }
+
+    float new_max_received_rate_bps = calculateMaxRateBps(&m_smoothed_received_rate_list);
+    float new_max_sent_rate_bps = calculateMaxRateBps(&m_smoothed_sent_rate_list);
+
+    setTotalBytesSent(new_total_bytes_sent);
+    setTotalBytesReceived(new_total_bytes_received);
+    setMaxReceivedRateBps(new_max_received_rate_bps);
+    setMaxSentRateBps(new_max_sent_rate_bps);
+
+    Q_EMIT receivedRateListChanged();
+    Q_EMIT sentRateListChanged();
+}

--- a/src/qml/networktraffictower.h
+++ b/src/qml/networktraffictower.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_NETWORKTRAFFICTOWER_H
+#define BITCOIN_QML_NETWORKTRAFFICTOWER_H
+
+#include <qml/nodemodel.h>
+
+#include <QObject>
+#include <QQueue>
+
+class NetworkTrafficTower : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(float totalBytesReceived READ totalBytesReceived NOTIFY totalBytesReceivedChanged)
+    Q_PROPERTY(float totalBytesSent READ totalBytesSent NOTIFY totalBytesSentChanged)
+    Q_PROPERTY(float maxReceivedRateBps READ maxReceivedRateBps NOTIFY maxReceivedRateBpsChanged)
+    Q_PROPERTY(float maxSentRateBps READ maxSentRateBps NOTIFY maxSentRateBpsChanged)
+    Q_PROPERTY(QQueue<float> receivedRateList READ receivedRateList NOTIFY receivedRateListChanged)
+    Q_PROPERTY(QQueue<float> sentRateList READ sentRateList NOTIFY sentRateListChanged)
+
+public:
+    explicit NetworkTrafficTower(NodeModel& node);
+
+    float totalBytesReceived() const { return m_total_bytes_received; }
+    float totalBytesSent() const { return m_total_bytes_sent; }
+    float maxReceivedRateBps() const { return m_max_received_rate_bps; }
+    float maxSentRateBps() const { return m_max_sent_rate_bps; }
+    QQueue<float> receivedRateList() { return m_smoothed_received_rate_list; }
+    QQueue<float> sentRateList() { return m_smoothed_sent_rate_list; }
+
+public Q_SLOTS:
+    void setTotalBytesReceived(float new_total);
+    void setTotalBytesSent(float new_total);
+    void setMaxReceivedRateBps(float new_max);
+    void setMaxSentRateBps(float new_max);
+
+    Q_INVOKABLE void updateFilterWindowSize(int new_size);
+
+Q_SIGNALS:
+    void totalBytesReceivedChanged();
+    void totalBytesSentChanged();
+    void maxReceivedRateBpsChanged();
+    void maxSentRateBpsChanged();
+    void receivedRateListChanged();
+    void sentRateListChanged();
+
+private:
+    float applyMovingAverageFilter(QQueue<float> * rate_list);
+    float calculateMaxRateBps(QQueue<float> * smoothed_rate_list);
+    void recalculateSmoothedRateList(QQueue<float> * raw_rate_list, QQueue<float> * smoothed_rate_list);
+    void updateTrafficStats();
+
+    NodeModel& m_node;
+    int m_filter_window_size;
+    float m_total_bytes_received;
+    float m_total_bytes_sent;
+    float m_max_received_rate_bps;
+    float m_max_sent_rate_bps;
+    QQueue<float> m_received_rate_list;
+    QQueue<float> m_smoothed_received_rate_list;
+    QQueue<float> m_sent_rate_list;
+    QQueue<float> m_smoothed_sent_rate_list;
+};
+
+#endif // BITCOIN_QML_NETWORKTRAFFICTOWER_H

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -46,6 +46,9 @@ public:
     bool pause() const { return m_pause; }
     void setPause(bool new_pause);
 
+    Q_INVOKABLE float getTotalBytesReceived() const { return (float)m_node.getTotalBytesRecv(); }
+    Q_INVOKABLE float getTotalBytesSent() const { return (float)m_node.getTotalBytesSent(); }
+
     Q_INVOKABLE void startNodeInitializionThread();
 
     void startShutdownPolling();

--- a/src/qml/pages/node/NetworkTraffic.qml
+++ b/src/qml/pages/node/NetworkTraffic.qml
@@ -1,0 +1,158 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../../controls"
+import "../../components"
+
+import org.bitcoincore.qt 1.0
+
+InformationPage {
+    id: root
+    property int maxSamples: 300
+    bannerActive: false
+    bold: true
+    headerText: qsTr("Network Traffic")
+    headerMargin: 0
+    description: qsTr("How much data you have sent to and received from your peers.")
+    descriptionMargin: 15
+    detailActive: true
+    detailMaximumWidth: 600
+    detailItem: ColumnLayout {
+        width: parent.width
+        spacing: 15
+
+        Rectangle {
+            Layout.alignment: Qt.AlignHCenter
+            color: Theme.color.neutral3
+            width: childrenRect.width + 6
+            height: childrenRect.height + 6
+            radius: 3
+
+            Behavior on color {
+                ColorAnimation { duration: 150 }
+            }
+
+            RowLayout {
+                anchors.centerIn: parent
+                anchors.margins: 3
+                spacing: 5
+                ToggleButton {
+                    text: qsTr("5 min")
+                    autoExclusive: true
+                    checked: true
+                    bgRadius: 3
+                    textColor: Theme.color.neutral9
+                    textActiveColor: Theme.color.neutral0
+                    bgActiveColor: Theme.color.neutral9
+                    bgDefaultColor: Theme.color.neutral3
+
+                    onClicked: {
+                        root.maxSamples = 300
+                        networkTrafficTower.updateFilterWindowSize(root.maxSamples / 10)
+                    }
+                }
+
+                ToggleButton {
+                    text: qsTr("1 hour")
+                    autoExclusive: true
+                    bgRadius: 3
+                    textColor: Theme.color.neutral9
+                    textActiveColor: Theme.color.neutral0
+                    bgActiveColor: Theme.color.neutral9
+                    bgDefaultColor: Theme.color.neutral3
+
+                    onClicked: {
+                        root.maxSamples = 3600
+                        networkTrafficTower.updateFilterWindowSize(root.maxSamples / 10)
+                    }
+                }
+
+                ToggleButton {
+                    text: qsTr("12 hours")
+                    autoExclusive: true
+                    bgRadius: 3
+                    textColor: Theme.color.neutral9
+                    textActiveColor: Theme.color.neutral0
+                    bgActiveColor: Theme.color.neutral9
+                    bgDefaultColor: Theme.color.neutral3
+
+                    onClicked: {
+                        root.maxSamples = 3600 * 12
+                        networkTrafficTower.updateFilterWindowSize(root.maxSamples / 10)
+                    }
+                }
+
+                ToggleButton {
+                    text: qsTr("1 day")
+                    autoExclusive: true
+                    bgRadius: 3
+                    textColor: Theme.color.neutral9
+                    textActiveColor: Theme.color.neutral0
+                    bgActiveColor: Theme.color.neutral9
+                    bgDefaultColor: Theme.color.neutral3
+
+                    onClicked: {
+                        root.maxSamples = 3600 * 24
+                        networkTrafficTower.updateFilterWindowSize(root.maxSamples / 10)
+                    }
+                }
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
+            NetworkTrafficGraph {
+                width: parent.width
+                backgroundColor: Theme.color.background
+                borderColor: Theme.color.neutral5
+                drawFrame: true
+                fillColor: Theme.color.green
+                lineColor: Theme.color.green
+                unitLabelColor: Theme.color.green
+                markerLineColor: Theme.color.neutral2
+                maxSamples: root.maxSamples
+                maxValue: networkTrafficTower.maxReceivedRateBps
+                valueList: networkTrafficTower.receivedRateList
+                maxRateBps: networkTrafficTower.maxReceivedRateBps
+            }
+            NetworkTrafficGraph {
+                id: sentGraph
+                width: parent.width
+                alignLabelLeft: false
+                backgroundColor: Theme.color.background
+                borderColor: Theme.color.neutral5
+                drawFrame: false
+                fillColor: Theme.color.blue
+                lineColor: Theme.color.blue
+                unitLabelColor: Theme.color.blue
+                markerLineColor: Theme.color.neutral2
+                maxSamples: root.maxSamples
+                maxValue: networkTrafficTower.maxSentRateBps
+                valueList: networkTrafficTower.sentRateList
+                maxRateBps: networkTrafficTower.maxSentRateBps
+            }
+
+            RowLayout {
+                anchors.top: sentGraph.bottom
+                anchors.topMargin: 15
+                anchors.horizontalCenter: parent.horizontalCenter
+                spacing: 15
+
+                TotalBytesIndicator {
+                    Layout.alignment: Qt.AlignHCenter
+                    indicatorColor: Theme.color.green
+                    totalBytes: networkTrafficTower.totalBytesReceived
+                }
+                TotalBytesIndicator {
+                    Layout.alignment: Qt.AlignHCenter
+                    indicatorColor: Theme.color.blue
+                    totalBytes: networkTrafficTower.totalBytesSent
+                }
+            }
+        }
+    }
+}

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -99,6 +99,19 @@ Item {
                     }
                     onClicked: loadedItem.clicked()
                 }
+                Separator { Layout.fillWidth: true }
+                Setting {
+                    id: gotoNetworkTraffic
+                    Layout.fillWidth: true
+                    header: qsTr("Network Traffic")
+                    actionItem: CaretRightButton {
+                        stateColor: gotoNetworkTraffic.stateColor
+                        onClicked: {
+                            nodeSettingsView.push(networktraffic_page)
+                        }
+                    }
+                    onClicked: loadedItem.clicked()
+                }
             }
         }
     }
@@ -147,6 +160,18 @@ Item {
                 onClicked: {
                     nodeSettingsView.pop()
                     peerTableModel.stopAutoRefresh();
+                }
+            }
+        }
+    }
+    Component {
+        id: networktraffic_page
+        NetworkTraffic {
+            navLeftDetail: NavButton {
+                iconSource: "image://images/caret-left"
+                text: qsTr("Back")
+                onClicked: {
+                    nodeSettingsView.pop()
                 }
             }
         }


### PR DESCRIPTION
An alternative to https://github.com/bitcoin-core/gui-qml/pull/286 which only introduces one graph. Based on [this design](https://www.figma.com/file/GaCoOSNHB2yMB9ThiDtred/Bitcoin-Core-App-(Old)?node-id=6262%3A114217&t=g2nS7pSwgexYwcmp-4).

| dark | light |
| ---- | ----- |
| <img width="752" alt="Screen Shot 2023-03-15 at 6 17 04 AM" src="https://user-images.githubusercontent.com/23396902/225279978-b6cf371e-d4ce-43e2-a9f7-9f2a209bd3a1.png"> | <img width="752" alt="Screen Shot 2023-03-15 at 6 17 08 AM" src="https://user-images.githubusercontent.com/23396902/225280008-1169b3da-09aa-4da4-a7b3-9fe33955e509.png"> |

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/292)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/292)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/292)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/292)

