### PR TITLE
Fix TotalBytesIndicator Text

### DIFF
--- a/src/qml/components/TotalBytesIndicator.qml
+++ b/src/qml/components/TotalBytesIndicator.qml
@@ -9,8 +9,8 @@ import "../controls"
 
 RowLayout {
     id: root
+    property string indicatorText
     property color indicatorColor
-    property double totalBytes
 
     Rectangle {
         Layout.alignment: Qt.AlignVCenter
@@ -22,17 +22,7 @@ RowLayout {
     CoreText {
         Layout.alignment: Qt.AlignHCenter
         color: Theme.color.neutral9
-        text: qsTr("Received: %1").arg(formatBytes(root.totalBytes))
+        text: root.indicatorText
         font.pixelSize: 18
-    }
-
-    function formatBytes(bytes) {
-        var suffixes = ["Bytes", "KB", "MB", "GB", "TB", "PB"];
-        var index = 0;
-        while (bytes >= 1000 && index < suffixes.length - 1) {
-            bytes /= 1000;
-            index++;
-        }
-        return bytes.toFixed(0) + " " + suffixes[index];
     }
 }

--- a/src/qml/pages/node/NetworkTraffic.qml
+++ b/src/qml/pages/node/NetworkTraffic.qml
@@ -105,8 +105,8 @@ InformationPage {
 
         TotalBytesIndicator {
             Layout.alignment: Qt.AlignHCenter
+            indicatorText: qsTr("Received: %1").arg(formatBytes(networkTrafficTower.totalBytesReceived))
             indicatorColor: Theme.color.green
-            totalBytes: networkTrafficTower.totalBytesReceived
         }
 
         NetworkTrafficGraph {
@@ -125,8 +125,8 @@ InformationPage {
 
         TotalBytesIndicator {
             Layout.alignment: Qt.AlignHCenter
+            indicatorText: qsTr("Sent: %1").arg(formatBytes(networkTrafficTower.totalBytesSent))
             indicatorColor: Theme.color.blue
-            totalBytes: networkTrafficTower.totalBytesSent
         }
 
         NetworkTrafficGraph {
@@ -141,5 +141,15 @@ InformationPage {
             valueList: networkTrafficTower.sentRateList
             maxRateBps: networkTrafficTower.maxSentRateBps
         }
+    }
+
+    function formatBytes(bytes) {
+        var suffixes = ["Bytes", "KB", "MB", "GB", "TB", "PB"];
+        var index = 0;
+        while (bytes >= 1000 && index < suffixes.length - 1) {
+            bytes /= 1000;
+            index++;
+        }
+        return bytes.toFixed(0) + " " + suffixes[index];
     }
 }


### PR DESCRIPTION
Fix the text for the TotalBytesIndicator component, follow-up to https://github.com/bitcoin-core/gui-qml/pull/286

| master | pr |
| ------ | -- |
| <img width="752" alt="Screen Shot 2023-03-15 at 3 35 39 PM" src="https://user-images.githubusercontent.com/23396902/225436857-7b689f94-3516-441a-86d2-2b4078fb61b0.png"> | <img width="752" alt="Screen Shot 2023-03-15 at 4 37 42 PM" src="https://user-images.githubusercontent.com/23396902/225436887-1d56bffc-f694-452d-ac06-a4aad9723480.png"> |

In a follow-up, we can move all qml functions throughout the qml codebase into a guiutil singleton.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/293)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/293)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/293)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/293)
