### PR TITLE
android: Use signet instead of testnet

### DIFF
--- a/src/qt/android/AndroidManifest.xml
+++ b/src/qt/android/AndroidManifest.xml
@@ -22,7 +22,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
 
-            <meta-data android:name="android.app.arguments" android:value="-testnet"/>
+            <meta-data android:name="android.app.arguments" android:value="-signet"/>
             <meta-data android:name="android.app.lib_name" android:value="bitcoin-qt"/>
             <meta-data android:name="android.app.repository" android:value="default"/>
             <meta-data android:name="android.app.bundle_local_qt_libs" android:value="1"/>


### PR DESCRIPTION
For ease of testing, syncing with signet is quicker than testnet. When the app is finished, we can remove the network argument, opening up the app on main net. 

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/294)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/294)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/294)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/294)
