### PR TITLE
Android foregound service to allow background syncing

### DIFF
--- a/src/qt/android/AndroidManifest.xml
+++ b/src/qt/android/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
     <uses-feature android:glEsVersion="0x00020000" android:required="true" />
 
@@ -34,6 +35,8 @@
             <meta-data android:name="android.app.extract_android_style" android:value="default"/>
             <meta-data android:name="android.app.load_local_libs_resource_id" android:resource="@array/load_local_libs"/>
         </activity>
-
+        <service android:name="org.bitcoincore.qt.BitcoinQtService" android:exported="true">
+            <meta-data android:name="android.app.background_running" android:value="true"/>
+        </service>
     </application>
 </manifest>

--- a/src/qt/android/src/org/bitcoincore/qt/BitcoinQtActivity.java
+++ b/src/qt/android/src/org/bitcoincore/qt/BitcoinQtActivity.java
@@ -1,5 +1,8 @@
 package org.bitcoincore.qt;
 
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.system.ErrnoException;
 import android.system.Os;
@@ -17,6 +20,13 @@ public class BitcoinQtActivity extends QtActivity
         final File bitcoinDir = new File(getFilesDir().getAbsolutePath() + "/.bitcoin");
         if (!bitcoinDir.exists()) {
             bitcoinDir.mkdir();
+        }
+
+        Intent intent = new Intent(this, BitcoinQtService.class);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                startForegroundService(intent);
+        } else {
+                startService(intent);
         }
 
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);

--- a/src/qt/android/src/org/bitcoincore/qt/BitcoinQtService.java
+++ b/src/qt/android/src/org/bitcoincore/qt/BitcoinQtService.java
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+package org.bitcoincore.qt;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Intent;
+import android.util.Log;
+import org.qtproject.qt5.android.bindings.QtService;
+
+public class BitcoinQtService extends QtService
+{
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        CharSequence name = "Bitcoin Core";
+        String description = "Bitcoin Core App notifications";
+        int importance = NotificationManager.IMPORTANCE_DEFAULT;
+        NotificationChannel channel = new NotificationChannel("bitcoin_channel_id", name, importance);
+        channel.setDescription(description);
+
+        NotificationManager notificationManager = getSystemService(NotificationManager.class);
+        notificationManager.createNotificationChannel(channel);
+
+        Notification notification = new Notification.Builder(this, "bitcoin_channel_id")
+            .setSmallIcon(R.drawable.bitcoin)
+            .setContentTitle("Running bitcoin")
+            .setOngoing(true)
+            .build();
+
+        startForeground(1, notification);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        super.onStartCommand(intent, flags, startId);
+        return START_NOT_STICKY;
+    }
+}


### PR DESCRIPTION
The idea here is to start a foreground notification service so that the process manager on android won't kill our application when in the background so that we can continue to sync without requiring the device to be awake and our activity in the foreground at all times. 

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/296)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/296)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/296)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/296)
