### PR TITLE
doc: Refer to CI assets as unsecure, instead of insecure

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -210,9 +210,9 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_win64.sh"
   copy_artifacts_script:
-    - cp ci/scratch/build/bitcoin-x86_64-w64-mingw32/release/bitcoin-qt.exe insecure_win_gui.exe
-  insecure_win_gui_artifacts:
-    path: "insecure_win_gui.exe"
+    - cp ci/scratch/build/bitcoin-x86_64-w64-mingw32/release/bitcoin-qt.exe unsecure_win_gui.exe
+  unsecure_win_gui_artifacts:
+    path: "unsecure_win_gui.exe"
 
 task:
   name: '32-bit + dash [gui] [CentOS 8]'
@@ -322,10 +322,10 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_mac.sh"
   copy_artifacts_script:
-    - cp ci/scratch/build/bitcoin-x86_64-apple-darwin/src/qt/bitcoin-qt insecure_mac_gui
-    - tar -czf insecure_mac_gui.tar.gz insecure_mac_gui
-  insecure_mac_gui_artifacts:
-    path: "insecure_mac_gui.tar.gz"
+    - cp ci/scratch/build/bitcoin-x86_64-apple-darwin/src/qt/bitcoin-qt unsecure_mac_gui
+    - tar -czf unsecure_mac_gui.tar.gz unsecure_mac_gui
+  unsecure_mac_gui_artifacts:
+    path: "unsecure_mac_gui.tar.gz"
     type: "application/gzip"
 
 task:
@@ -343,10 +343,10 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_mac_arm64.sh"
   copy_artifacts_script:
-    - cp ci/scratch/build/bitcoin-arm64-apple-darwin/src/qt/bitcoin-qt insecure_mac_arm64_gui
-    - tar -czf insecure_mac_arm64_gui.tar.gz insecure_mac_arm64_gui
-  insecure_mac_arm64_gui_artifacts:
-    path: "insecure_mac_arm64_gui.tar.gz"
+    - cp ci/scratch/build/bitcoin-arm64-apple-darwin/src/qt/bitcoin-qt unsecure_mac_arm64_gui
+    - tar -czf unsecure_mac_arm64_gui.tar.gz unsecure_mac_arm64_gui
+  unsecure_mac_arm64_gui_artifacts:
+    path: "unsecure_mac_arm64_gui.tar.gz"
     type: "application/gzip"
 
 task:
@@ -383,6 +383,6 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_android.sh"
   copy_artifacts_script:
-    - cp src/qt/android/build/outputs/apk/debug/android-debug.apk ${CIRRUS_WORKING_DIR}/insecure_android.apk
-  insecure_android_apk_artifacts:
-    path: "insecure_android.apk"
+    - cp src/qt/android/build/outputs/apk/debug/android-debug.apk ${CIRRUS_WORKING_DIR}/unsecure_android.apk
+  unsecure_android_apk_artifacts:
+    path: "unsecure_android.apk"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,8 +45,8 @@ patches often sit for a long time.
 <!--
 Links for Windows and macOS build artifacts. Replace <PR> with the assigned pull request number.
 
-[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/<PR>)
-[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/<PR>)
-[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/<PR>)
-[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/<PR>)
+[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/<PR>)
+[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/<PR>)
+[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/<PR>)
+[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/<PR>)
 -->

--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -4,17 +4,17 @@
 
 This directory contains the source code for an experimental Bitcoin Core graphical user interface (GUI) built using the [Qt Quick](https://doc.qt.io/qt-5/qtquick-index.html) framework.
 
-Insecure CI artifacts are available for local testing of the master branch, avoiding the need to build:
-- for Windows: [`insecure_win_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip)
-- for Intel macOS: [`insecure_mac_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip)
-- for Apple Silicon macOS: [`insecure_mac_arm64_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip)
-- for ARM64 Android: [`insecure_android_apk.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip)
+Unsecure CI artifacts are available for local testing of the master branch, avoiding the need to build:
+- for Windows: [`unsecure_win_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip)
+- for Intel macOS: [`unsecure_mac_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip)
+- for Apple Silicon macOS: [`unsecure_mac_arm64_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip)
+- for ARM64 Android: [`unsecure_android_apk.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip)
 
 Note: For Apple Silicon macOS machines, the binary must be signed before it can
 be ran. To apply a signature, run the following on the unzipped CI artifact:
 
 ```
-codesign -s - ./Downloads/insecure_mac_arm64_gui
+codesign -s - ./Downloads/unsecure_mac_arm64_gui
 ```
 
 ## Goals and Limitations


### PR DESCRIPTION
Fixes https://github.com/bitcoin-core/gui-qml/issues/297