### PR TITLE
Handle Android back button presses

### DIFF
--- a/src/qml/nodemodel.cpp
+++ b/src/qml/nodemodel.cpp
@@ -98,6 +98,11 @@ void NodeModel::startNodeInitializionThread()
     Q_EMIT requestedInitialize();
 }
 
+void NodeModel::requestShutdown()
+{
+    Q_EMIT requestedShutdown();
+}
+
 void NodeModel::initializeResult([[maybe_unused]] bool success, interfaces::BlockAndHeaderTipInfo tip_info)
 {
     // TODO: Handle the `success` parameter,

--- a/src/qml/nodemodel.h
+++ b/src/qml/nodemodel.h
@@ -50,6 +50,7 @@ public:
     Q_INVOKABLE float getTotalBytesSent() const { return (float)m_node.getTotalBytesSent(); }
 
     Q_INVOKABLE void startNodeInitializionThread();
+    Q_INVOKABLE void requestShutdown();
 
     void startShutdownPolling();
     void stopShutdownPolling();

--- a/src/qml/pages/main.qml
+++ b/src/qml/pages/main.qml
@@ -23,6 +23,13 @@ ApplicationWindow {
         id: main
         initialItem: needOnboarding ? onboardingWizard : node
         anchors.fill: parent
+        focus: true
+        Keys.onReleased: {
+            if (event.key == Qt.Key_Back) {
+                nodeModel.requestShutdown()
+                event.accepted = true
+            }
+        }
     }
 
     Connections {


### PR DESCRIPTION
When the user presses the back button, send a signal to our node to begin shutdown. This will allow closure of resources and the chainstate to flush to disk properly.
 
[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/302)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/302)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/302)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/302)
