### PR TITLE
doc: document qttools5-dev-tools qml build requirement

### DIFF
--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -67,7 +67,7 @@ Aside from the dependencies listed in [build-unix.md](../../doc/build-unix.md), 
 #### Debian-based systems:
 
 ```
-sudo apt install qtdeclarative5-dev qtquickcontrols2-5-dev
+sudo apt install qtdeclarative5-dev qtquickcontrols2-5-dev qttools5-dev-tools
 ```
 
 The following runtime dependencies are also required for dynamic builds;


### PR DESCRIPTION
This was needed on a fresh Ubuntu 22.04 installation running on ARM64. The package provides `lrelease`. Not needed on fedora.