### PR TITLE
Keep screen on for Android

### DIFF
--- a/src/qt/android/src/org/bitcoincore/qt/BitcoinQtActivity.java
+++ b/src/qt/android/src/org/bitcoincore/qt/BitcoinQtActivity.java
@@ -3,6 +3,7 @@ package org.bitcoincore.qt;
 import android.os.Bundle;
 import android.system.ErrnoException;
 import android.system.Os;
+import android.view.WindowManager;
 
 import org.qtproject.qt5.android.bindings.QtActivity;
 
@@ -18,6 +19,7 @@ public class BitcoinQtActivity extends QtActivity
             bitcoinDir.mkdir();
         }
 
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         super.onCreate(savedInstanceState);
     }
 }


### PR DESCRIPTION
This will prevent sleep when the user has our Activity visible in the foreground.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/304)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/304)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/304)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/304)
