### PR TITLE
Stop the peers indicator animation when paused

### DIFF
--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -99,6 +99,7 @@ Item {
         anchors.horizontalCenter: root.horizontalCenter
         numOutboundPeers: nodeModel.numOutboundPeers
         maxNumOutboundPeers: nodeModel.maxNumOutboundPeers
+        paused: root.paused
     }
 
     MouseArea {

--- a/src/qml/components/PeersIndicator.qml
+++ b/src/qml/components/PeersIndicator.qml
@@ -10,6 +10,7 @@ RowLayout {
     id: root
     required property int numOutboundPeers
     required property int maxNumOutboundPeers
+    required property bool paused
     property int size: 5
 
     spacing: 5
@@ -21,12 +22,17 @@ RowLayout {
             radius: width / 2
             color: Theme.color.neutral9
             opacity: (index === 0 && root.numOutboundPeers > 0) || (index + 1 <= root.size * root.numOutboundPeers / root.maxNumOutboundPeers) ? 0.95 : 0.45
-            Behavior on opacity { OpacityAnimator { duration: 100 } }
+            Behavior on opacity { OpacityAnimator { duration: 150 } }
             SequentialAnimation on opacity {
                 loops: Animation.Infinite
-                running: numOutboundPeers === 0 && index === 0
+                running: numOutboundPeers === 0 && index === 0 && !root.paused
                 SmoothedAnimation { to: 0; velocity: 2.2 }
                 SmoothedAnimation { to: 1; velocity: 2.2 }
+            }
+            PropertyAnimation on opacity {
+                running: root.paused
+                to: .45;
+                duration: 150
             }
 
             Behavior on color {


### PR DESCRIPTION
[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/305)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/305)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/305)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/305)
