### PR TITLE
android: patch getDrawable in QtActivityDelegate.java

### DIFF
--- a/depends/patches/qt/fix_android_get_drawable.patch
+++ b/depends/patches/qt/fix_android_get_drawable.patch
@@ -1,0 +1,34 @@
+Android 13: Fix warnings on starting an application
+
+On Android 13, currently in beta, android triggers a warning because it
+is using a deprecated getDrawable function.
+The patch changes it to use the non-deprecated alternative as suggested
+in the warning.
+
+Fixes: QTBUG-103568
+
+Upstream commits:
+ - Qt 5.15.11 backport: unavailable
+ - Qt 6.5: e07fea6fb405c6e9affe6e377ad99a98a740c5be
+
+
+--- old/qtbase/src/android/jar/src/org/qtproject/qt5/android/QtActivityDelegate.java
++++ new/qtbase/src/android/jar/src/org/qtproject/qt5/android/QtActivityDelegate.java
+@@ -787,7 +787,7 @@
+                 m_splashScreenSticky = info.metaData.containsKey("android.app.splash_screen_sticky") && info.metaData.getBoolean("android.app.splash_screen_sticky");
+                 int id = info.metaData.getInt(splashScreenKey);
+                 m_splashScreen = new ImageView(m_activity);
+-                m_splashScreen.setImageDrawable(m_activity.getResources().getDrawable(id));
++                m_splashScreen.setImageDrawable(m_activity.getResources().getDrawable(id, m_activity.getTheme()));
+                 m_splashScreen.setScaleType(ImageView.ScaleType.FIT_XY);
+                 m_splashScreen.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+                 m_layout.addView(m_splashScreen);
+@@ -1209,7 +1209,7 @@
+             if (attr.type >= TypedValue.TYPE_FIRST_COLOR_INT && attr.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+                 m_activity.getWindow().setBackgroundDrawable(new ColorDrawable(attr.data));
+             } else {
+-                m_activity.getWindow().setBackgroundDrawable(m_activity.getResources().getDrawable(attr.resourceId));
++                m_activity.getWindow().setBackgroundDrawable(m_activity.getResources().getDrawable(attr.resourceId, m_activity.getTheme()));
+             }
+             if (m_dummyView != null) {
+                 m_layout.removeView(m_dummyView);

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -521,6 +521,7 @@ bitcoin_qt_apk: FORCE
 	cp $(dir $(lastword $(CC)))../sysroot/usr/lib/$(host_alias)/libc++_shared.so $(APK_LIB_DIR)
 	tar xf $(QT_BASE_PATH) -C qt/android/src/ $(QT_BASE_TLD)src/android/jar/src --strip-components=5
 	tar xf $(QT_BASE_PATH) -C qt/android/src/ $(QT_BASE_TLD)src/android/java/src --strip-components=5
+	patch -i ../depends/patches/qt/fix_android_get_drawable.patch qt/android/src/org/qtproject/qt5/android/QtActivityDelegate.java
 	cp qt/bitcoin-qt $(APK_LIB_DIR)/libbitcoin-qt_$(ANDROID_ARCH).so
 	cd qt/android && gradle wrapper --gradle-version=6.6.1
 	cd qt/android && ./gradlew build


### PR DESCRIPTION
The getDrawable method used in the QtActivityDelegate has been deprecated and causes a runtime exception. The patch updates the method to include the theme as a second parameter so it can fully resolve the resources.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/312)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/312)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/312)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/312)
