### PR TITLE
android: go back to the app when clicking the notification

### DIFF
--- a/src/qt/android/src/org/bitcoincore/qt/BitcoinQtService.java
+++ b/src/qt/android/src/org/bitcoincore/qt/BitcoinQtService.java
@@ -7,6 +7,7 @@ package org.bitcoincore.qt;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Intent;
 import android.util.Log;
 import org.qtproject.qt5.android.bindings.QtService;
@@ -27,10 +28,14 @@ public class BitcoinQtService extends QtService
         NotificationManager notificationManager = getSystemService(NotificationManager.class);
         notificationManager.createNotificationChannel(channel);
 
+        Intent intent = new Intent(this, BitcoinQtActivity.class);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
+
         Notification notification = new Notification.Builder(this, "bitcoin_channel_id")
             .setSmallIcon(R.drawable.bitcoin)
             .setContentTitle("Running bitcoin")
             .setOngoing(true)
+            .setContentIntent(pendingIntent)
             .build();
 
         startForeground(1, notification);


### PR DESCRIPTION
This commit sets up the intent that will reopen the BitcoinQtActivity when a user clicks the notification when its in their notification bar.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/314)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/314)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/314)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/314)
