### PR TITLE
android: PowerManager and WifiManager resource locks

### DIFF
--- a/src/qt/android/AndroidManifest.xml
+++ b/src/qt/android/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <uses-feature android:glEsVersion="0x00020000" android:required="true" />
 

--- a/src/qt/android/src/org/bitcoincore/qt/BitcoinQtService.java
+++ b/src/qt/android/src/org/bitcoincore/qt/BitcoinQtService.java
@@ -9,6 +9,7 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Intent;
+import android.net.wifi.WifiManager;
 import android.util.Log;
 import org.qtproject.qt5.android.bindings.QtService;
 import android.content.Context;
@@ -17,6 +18,7 @@ import android.os.PowerManager;
 public class BitcoinQtService extends QtService
 {
     private PowerManager.WakeLock wakeLock;
+    private WifiManager.WifiLock wifiLock;
 
     @Override
     public void onCreate() {
@@ -44,12 +46,16 @@ public class BitcoinQtService extends QtService
         startForeground(1, notification);
         PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
         wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "BitcoinCore::IBD");
+
+        WifiManager wifiManager = (WifiManager) getSystemService(Context.WIFI_SERVICE);
+        wifiLock = wifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "BitcoinCore::WIFI_LOCK");
     }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         super.onStartCommand(intent, flags, startId);
         wakeLock.acquire();
+        wifiLock.acquire();
         return START_NOT_STICKY;
     }
 
@@ -58,6 +64,10 @@ public class BitcoinQtService extends QtService
         super.onDestroy();
         if (wakeLock.isHeld()) {
             wakeLock.release(); // Release the wake lock
+        }
+
+        if (wifiLock.isHeld()) {
+            wifiLock.release(); // Release the WiFi lock
         }
     }
 }

--- a/src/qt/android/src/org/bitcoincore/qt/BitcoinQtService.java
+++ b/src/qt/android/src/org/bitcoincore/qt/BitcoinQtService.java
@@ -11,9 +11,12 @@ import android.app.PendingIntent;
 import android.content.Intent;
 import android.util.Log;
 import org.qtproject.qt5.android.bindings.QtService;
+import android.content.Context;
+import android.os.PowerManager;
 
 public class BitcoinQtService extends QtService
 {
+    private PowerManager.WakeLock wakeLock;
 
     @Override
     public void onCreate() {
@@ -39,11 +42,22 @@ public class BitcoinQtService extends QtService
             .build();
 
         startForeground(1, notification);
+        PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
+        wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "BitcoinCore::IBD");
     }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         super.onStartCommand(intent, flags, startId);
+        wakeLock.acquire();
         return START_NOT_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (wakeLock.isHeld()) {
+            wakeLock.release(); // Release the wake lock
+        }
     }
 }


### PR DESCRIPTION
This obtains a [PARTIAL_WAKE_LOCK](https://developer.android.com/reference/android/os/PowerManager#PARTIAL_WAKE_LOCK) from Android's [PowerManager](https://developer.android.com/reference/android/os/PowerManager#summary) and a [WIFI_MODE_FULL_HIGH_PERF](https://developer.android.com/reference/android/net/wifi/WifiManager#WIFI_MODE_FULL_HIGH_PERF) from the [WifiManager](https://developer.android.com/reference/android/net/wifi/WifiManager#summary). This ensures that the CPU will run our tasks when the screen is off and that Wi-Fi download/upload speeds are not dropped. This makes background IBD performance the same as when the app is in the foreground. 

Eventually, we can make this customizable by the user, according to their power/network preferences.

For more information see:
- https://developer.android.com/training/scheduling/wakelock#cpu
- https://developer.android.com/training/connectivity

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/319)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/319)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/319)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/319)
