### PR TITLE
Remember network traffic graph scale

### DIFF
--- a/src/qml/pages/node/NetworkTraffic.qml
+++ b/src/qml/pages/node/NetworkTraffic.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import Qt.labs.settings 1.0
 import "../../controls"
 import "../../components"
 
@@ -12,7 +13,13 @@ import org.bitcoincore.qt 1.0
 
 InformationPage {
     id: root
-    property int maxSamples: 300
+    property int trafficGraphScale: 300
+
+    Settings {
+        id: settings
+        property alias trafficGraphScale: root.trafficGraphScale
+    }
+
     bannerActive: false
     bold: true
     headerText: qsTr("Network Traffic")
@@ -41,10 +48,11 @@ InformationPage {
                 anchors.centerIn: parent
                 anchors.margins: 3
                 spacing: 5
+
                 ToggleButton {
                     text: qsTr("5 min")
                     autoExclusive: true
-                    checked: true
+                    checked: root.trafficGraphScale === 300
                     bgRadius: 3
                     textColor: Theme.color.neutral9
                     textActiveColor: Theme.color.neutral0
@@ -52,14 +60,15 @@ InformationPage {
                     bgDefaultColor: Theme.color.neutral3
 
                     onClicked: {
-                        root.maxSamples = 300
-                        networkTrafficTower.updateFilterWindowSize(root.maxSamples / 10)
+                        root.trafficGraphScale = 300
+                        networkTrafficTower.updateFilterWindowSize(root.trafficGraphScale / 10)
                     }
                 }
 
                 ToggleButton {
                     text: qsTr("1 hour")
                     autoExclusive: true
+                    checked: root.trafficGraphScale === 3600
                     bgRadius: 3
                     textColor: Theme.color.neutral9
                     textActiveColor: Theme.color.neutral0
@@ -67,14 +76,15 @@ InformationPage {
                     bgDefaultColor: Theme.color.neutral3
 
                     onClicked: {
-                        root.maxSamples = 3600
-                        networkTrafficTower.updateFilterWindowSize(root.maxSamples / 10)
+                        root.trafficGraphScale = 3600
+                        networkTrafficTower.updateFilterWindowSize(root.trafficGraphScale / 10)
                     }
                 }
 
                 ToggleButton {
                     text: qsTr("12 hours")
                     autoExclusive: true
+                    checked: root.trafficGraphScale === 3600 * 12
                     bgRadius: 3
                     textColor: Theme.color.neutral9
                     textActiveColor: Theme.color.neutral0
@@ -82,14 +92,15 @@ InformationPage {
                     bgDefaultColor: Theme.color.neutral3
 
                     onClicked: {
-                        root.maxSamples = 3600 * 12
-                        networkTrafficTower.updateFilterWindowSize(root.maxSamples / 10)
+                        root.trafficGraphScale = 3600 * 12
+                        networkTrafficTower.updateFilterWindowSize(root.trafficGraphScale / 10)
                     }
                 }
 
                 ToggleButton {
                     text: qsTr("1 day")
                     autoExclusive: true
+                    checked: root.trafficGraphScale === 3600 * 24
                     bgRadius: 3
                     textColor: Theme.color.neutral9
                     textActiveColor: Theme.color.neutral0
@@ -97,8 +108,8 @@ InformationPage {
                     bgDefaultColor: Theme.color.neutral3
 
                     onClicked: {
-                        root.maxSamples = 3600 * 24
-                        networkTrafficTower.updateFilterWindowSize(root.maxSamples / 10)
+                        root.trafficGraphScale = 3600 * 24
+                        networkTrafficTower.updateFilterWindowSize(root.trafficGraphScale / 10)
                     }
                 }
             }
@@ -118,7 +129,7 @@ InformationPage {
             fillColor: Theme.color.green
             lineColor: Theme.color.green
             markerLineColor: Theme.color.neutral2
-            maxSamples: root.maxSamples
+            maxSamples: root.trafficGraphScale
             maxValue: networkTrafficTower.maxReceivedRateBps
             valueList: networkTrafficTower.receivedRateList
             maxRateBps: networkTrafficTower.maxReceivedRateBps
@@ -137,7 +148,7 @@ InformationPage {
             fillColor: Theme.color.blue
             lineColor: Theme.color.blue
             markerLineColor: Theme.color.neutral2
-            maxSamples: root.maxSamples
+            maxSamples: root.trafficGraphScale
             maxValue: networkTrafficTower.maxSentRateBps
             valueList: networkTrafficTower.sentRateList
             maxRateBps: networkTrafficTower.maxSentRateBps


### PR DESCRIPTION
This is nice to have but also fixes an issue in the UI when selecting a time scale, moving away from the graph, then coming back to the graph:

## master 

| select 1hr | leave, then come back | select 5 min again|
| ---------- | --------------------- | ----------------- |
| <img width="642" alt="Screen Shot 2023-04-21 at 1 10 15 AM" src="https://user-images.githubusercontent.com/23396902/233546043-3b9240d2-94b8-4a19-866d-25d59982959d.png"> | <img width="641" alt="Screen Shot 2023-04-21 at 1 10 28 AM" src="https://user-images.githubusercontent.com/23396902/233546097-0c06393f-d1c0-41f6-a002-637bf40c05fb.png"> |  <img width="643" alt="Screen Shot 2023-04-21 at 1 10 39 AM" src="https://user-images.githubusercontent.com/23396902/233546112-5878a7ea-c001-4b09-864a-aeee3da6b290.png"> |

## PR

| select 1hr | leave, then come back | select 5 min again|
| ---------- | --------------------- | ----------------- |
| <img width="752" alt="Screen Shot 2023-04-21 at 1 14 13 AM" src="https://user-images.githubusercontent.com/23396902/233546333-0999aaab-1924-420c-9105-604a758d30d6.png"> | <img width="752" alt="Screen Shot 2023-04-21 at 1 14 19 AM" src="https://user-images.githubusercontent.com/23396902/233546353-502a676c-c567-46d1-b64a-62bac2a5e53d.png"> |  <img width="752" alt="Screen Shot 2023-04-21 at 1 14 21 AM" src="https://user-images.githubusercontent.com/23396902/233546369-bbdd405b-19cd-4b92-b1fb-d4f2a27f2b65.png"> |

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/328)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/328)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/328)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/328)
