### PR TITLE
doc: Add `qml-module-qt-labs-settings` to runtime dependencies

### DIFF
--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -74,7 +74,7 @@ The following runtime dependencies are also required for dynamic builds;
 they are not needed for static builds:
 
 ```
-sudo apt install qml-module-qtquick2 qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qtquick-window2
+sudo apt install qml-module-qtquick2 qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qtquick-window2 qml-module-qt-labs-settings
 ```
 
 #### Fedora:


### PR DESCRIPTION
Otherwise, on Ubuntu 23.04:
```
$ ./src/qt/bitcoin-qt
...
QQmlApplicationEngine failed to load component
qrc:/qml/pages/main.qml:8:1: module "Qt.labs.settings" is not installed
~InitExecutor : Stopping thread
~InitExecutor : Stopped thread
```