### PR TITLE
Add missing topMargin to Navigation Bar middle detail

### DIFF
--- a/src/qml/controls/NavigationBar.qml
+++ b/src/qml/controls/NavigationBar.qml
@@ -32,6 +32,7 @@ RowLayout {
         Loader {
             Layout.alignment: Qt.AlignHCenter
             id: middle_detail
+            Layout.topMargin: 4
             active: true
             visible: active
             sourceComponent: root.middleDetail


### PR DESCRIPTION
This was missed in https://github.com/bitcoin-core/gui-qml/pull/264

| master | pr |
| ------ | -- |
| <img width="642" alt="Screen Shot 2023-05-26 at 4 03 33 PM" src="https://github.com/bitcoin-core/gui-qml/assets/23396902/fc1523fd-0742-4beb-abb4-850f72a80fe3"> | <img width="642" alt="Screen Shot 2023-05-26 at 3 57 54 PM" src="https://github.com/bitcoin-core/gui-qml/assets/23396902/d643d02e-4410-4267-9521-5405039b0f53"> |


[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/334)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/334)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/334)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/334)
[![ARM32 Android](https://img.shields.io/badge/OS-Android%2032bit-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android32/unsecure_android_32bit_apk.zip?branch=pull/334)
