### PR TITLE
Remove constraint on continueButton width for mobile

### DIFF
--- a/src/qml/controls/InformationPage.qml
+++ b/src/qml/controls/InformationPage.qml
@@ -116,6 +116,9 @@ Page {
                 target: continueButton
                 anchors.top: undefined
                 anchors.bottom: continueButton.parent.bottom
+                anchors.horizontalCenter: undefined
+                anchors.right: continueButton.parent.right
+                anchors.left: continueButton.parent.left
             }
             PropertyChanges {
                 target: scrollView


### PR DESCRIPTION
The design file [specifies](https://www.figma.com/file/ek8w3n3upbluw5UL2lGhRx/Bitcoin-Core-App-Design?type=design&node-id=2643-85540&t=JFQoNposUHCoPQqO-4) that on mobile, the continueButton should take up the width of the display with a padding of 20px on the left and right. This was correctly implemented in https://github.com/bitcoin-core/gui-qml/pull/171, but then removed in https://github.com/bitcoin-core/gui-qml/pull/190.

Opening for designer feedback.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/336)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/336)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/336)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/336)
[![ARM32 Android](https://img.shields.io/badge/OS-Android%2032bit-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android32/unsecure_android_32bit_apk.zip?branch=pull/336)

