### PR TITLE
Remove setting link to developer documentation

### DIFF
--- a/src/qml/components/DeveloperOptions.qml
+++ b/src/qml/components/DeveloperOptions.qml
@@ -10,20 +10,6 @@ import "../controls"
 ColumnLayout {
     spacing: 4
     Setting {
-        id: devDocsLink
-        Layout.fillWidth: true
-        header: qsTr("Developer documentation")
-        actionItem: ExternalLink {
-            parentState: devDocsLink.state
-            iconSource: "qrc:/icons/export"
-            iconWidth: 30
-            iconHeight: 30
-            link: "https://bitcoin.org/en/bitcoin-core/contribute/documentation"
-        }
-        onClicked: loadedItem.clicked()
-    }
-    Separator { Layout.fillWidth: true }
-    Setting {
         id: dbcacheSetting
         Layout.fillWidth: true
         header: qsTr("Database cache size (MiB)")


### PR DESCRIPTION
We already point to the source code to the official bitcoincore website and the source code in the `About` page. Additionally, this points to bitcoin.org, which we probably don't want to point to.

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/337)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/337)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/337)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/337)
[![ARM32 Android](https://img.shields.io/badge/OS-Android%2032bit-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android32/unsecure_android_32bit_apk.zip?branch=pull/337)

