### PR TITLE
Setup AppMode within InitErrorMessage

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -77,6 +77,13 @@ bool InitErrorMessageBox(
     [[maybe_unused]] unsigned int style)
 {
     QQmlApplicationEngine engine;
+#ifdef __ANDROID__
+    AppMode app_mode(AppMode::MOBILE);
+#else
+    AppMode app_mode(AppMode::DESKTOP);
+#endif // __ANDROID__
+
+    qmlRegisterSingletonInstance<AppMode>("org.bitcoincore.qt", 1, 0, "AppMode", &app_mode);
     engine.rootContext()->setContextProperty("message", QString::fromStdString(message.translated));
     engine.load(QUrl(QStringLiteral("qrc:///qml/pages/initerrormessage.qml")));
     if (engine.rootObjects().isEmpty()) {


### PR DESCRIPTION
If you run the GUI with an invalid parameter, the `initerrormessage` window should appear. But, https://github.com/bitcoin-core/gui-qml/pull/289 introduced a dependency on `AppMode` being available into the `OutlineButton` which the `initerrormessage` window uses. So, the following appears on master and the `initerrormessage` window does not appear:

```
$ ./src/qt/bitcoin-qt -signsadfsad
Error: Cannot parse command line arguments: Invalid parameter -signsadfsad

QQmlApplicationEngine failed to load component
qrc:/qml/pages/initerrormessage.qml:32:9: Type OutlineButton unavailable
qrc:/qml/controls/OutlineButton.qml:7:1: module "org.bitcoincore.qt" is not installed
```

This encapsulates the setting of AppMode into a function, and runs in within the `InitErrorMessageBox` function:

<img width="612" alt="Screen Shot 2023-06-03 at 12 52 55 AM" src="https://github.com/bitcoin-core/gui-qml/assets/23396902/aa46d32f-855e-46b2-b219-d77319f6d492">

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/344)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/344)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/344)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/344)
[![ARM32 Android](https://img.shields.io/badge/OS-Android%2032bit-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android32/unsecure_android_32bit_apk.zip?branch=pull/344)

