### PR TITLE
Standardize post-onboarding settings window titles to navbar

### DIFF
--- a/src/qml/controls/Header.qml
+++ b/src/qml/controls/Header.qml
@@ -10,6 +10,7 @@ ColumnLayout {
     id: root
     property bool center: true
     required property string header
+    property bool showHeader: true
     property int headerMargin
     property int headerSize: 28
     property bool headerBold: false
@@ -26,19 +27,24 @@ ColumnLayout {
     property bool wrap: true
 
     spacing: 0
-    Label {
+    Loader {
         Layout.fillWidth: true
-        topPadding: root.headerMargin
-        font.family: "Inter"
-        font.styleName: root.headerBold ? "Semi Bold" : "Regular"
-        font.pixelSize: root.headerSize
-        color: root.headerColor
-        text: root.header
-        horizontalAlignment: center ? Text.AlignHCenter : Text.AlignLeft
-        wrapMode: wrap ? Text.WordWrap : Text.NoWrap
+        active: root.showHeader && root.header.length > 0
+        visible: active
+        sourceComponent: Label {
+            Layout.fillWidth: true
+            topPadding: root.headerMargin
+            font.family: "Inter"
+            font.styleName: root.headerBold ? "Semi Bold" : "Regular"
+            font.pixelSize: root.headerSize
+            color: root.headerColor
+            text: root.header
+            horizontalAlignment: center ? Text.AlignHCenter : Text.AlignLeft
+            wrapMode: wrap ? Text.WordWrap : Text.NoWrap
 
-        Behavior on color {
-            ColorAnimation { duration: 150 }
+            Behavior on color {
+                ColorAnimation { duration: 150 }
+            }
         }
     }
     Loader {
@@ -46,7 +52,7 @@ ColumnLayout {
         active: root.description.length > 0
         visible: active
         sourceComponent: Label {
-            topPadding: root.descriptionMargin
+            topPadding: showHeader ? root.descriptionMargin : root.headerMargin
             font.family: "Inter"
             font.styleName: root.descriptionBold ? "Semi Bold" : "Regular"
             font.pixelSize: root.descriptionSize

--- a/src/qml/controls/InformationPage.qml
+++ b/src/qml/controls/InformationPage.qml
@@ -25,6 +25,7 @@ Page {
     property bool center: true
     property int bannerMargin: 20
     required property string headerText
+    property bool showHeader: true
     property int headerMargin: 30
     property int headerSize: 28
     property string description: ""
@@ -70,6 +71,7 @@ Page {
                 headerBold: root.bold
                 center: root.center
                 header: root.headerText
+                showHeader: root.showHeader
                 headerMargin: root.headerMargin
                 headerSize: root.headerSize
                 description: root.description

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -121,12 +121,23 @@ Item {
     Component {
         id: about_page
         SettingsAbout {
+            showHeader: false
             navLeftDetail: NavButton {
                 iconSource: "image://images/caret-left"
                 text: qsTr("Back")
                 onClicked: {
                     nodeSettingsView.pop()
                 }
+            }
+            navMiddleDetail: Header {
+                headerBold: true
+                headerSize: 18
+                header: qsTr("About")
+            }
+            devMiddleDetail: Header {
+                headerBold: true
+                headerSize: 18
+                header: qsTr("Developer settings")
             }
         }
     }
@@ -143,13 +154,14 @@ Item {
             navMiddleDetail: Header {
                 headerBold: true
                 headerSize: 18
-                header: qsTr("Settings")
+                header: qsTr("Display settings")
             }
         }
     }
     Component {
         id: storage_page
         SettingsStorage {
+            showHeader: false
             navLeftDetail: NavButton {
                 iconSource: "image://images/caret-left"
                 text: qsTr("Back")
@@ -157,17 +169,28 @@ Item {
                     nodeSettingsView.pop()
                 }
             }
+            navMiddleDetail: Header {
+                headerBold: true
+                headerSize: 18
+                header: qsTr("Storage settings")
+            }
         }
     }
     Component {
         id: connection_page
         SettingsConnection {
+            showHeader: false
             navLeftDetail: NavButton {
                 iconSource: "image://images/caret-left"
                 text: qsTr("Back")
                 onClicked: {
                     nodeSettingsView.pop()
                 }
+            }
+            navMiddleDetail: Header {
+                headerBold: true
+                headerSize: 18
+                header: qsTr("Connection settings")
             }
         }
     }
@@ -192,12 +215,18 @@ Item {
     Component {
         id: networktraffic_page
         NetworkTraffic {
+            showHeader: false
             navLeftDetail: NavButton {
                 iconSource: "image://images/caret-left"
                 text: qsTr("Back")
                 onClicked: {
                     nodeSettingsView.pop()
                 }
+            }
+            navMiddleDetail: Header {
+                headerBold: true
+                headerSize: 18
+                header: qsTr("Network traffic")
             }
         }
     }

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -182,6 +182,11 @@ Item {
                     peerTableModel.stopAutoRefresh();
                 }
             }
+            navMiddleDetail: Header {
+                headerBold: true
+                headerSize: 18
+                header: qsTr("Peers")
+            }
         }
     }
     Component {

--- a/src/qml/pages/node/Peers.qml
+++ b/src/qml/pages/node/Peers.qml
@@ -11,6 +11,7 @@ import "../../components"
 Page {
     background: null
     property alias navLeftDetail: navbar.leftDetail
+    property alias navMiddleDetail: navbar.middleDetail
 
     header: NavigationBar {
         id: navbar
@@ -32,8 +33,7 @@ Page {
                 id: description
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignHCenter
-                text: qsTr("Peers are nodes you are connected to. You want to ensure that you are connected" +
-                    " to x, y and z, but not a, b, and c. Learn more.")
+                text: qsTr("Peers are nodes you exchange data with.")
                 font.pixelSize: 13
                 color: Theme.color.neutral7
             }

--- a/src/qml/pages/node/Peers.qml
+++ b/src/qml/pages/node/Peers.qml
@@ -16,86 +16,86 @@ Page {
         id: navbar
     }
 
-    CoreText {
-        anchors.top: parent.top
-        anchors.horizontalCenter: parent.horizontalCenter
-        id: description
-        width: Math.min(parent.width - 40, 450)
-        text: qsTr("Peers are nodes you are connected to. You want to ensure that you are connected" +
-            " to x, y and z, but not a, b, and c. Learn more.")
-        font.pixelSize: 13
-        color: Theme.color.neutral7
-    }
-
-    Flickable {
-        id: sortSelection
-        anchors.top: description.bottom
-        anchors.topMargin: 20
-        anchors.horizontalCenter: parent.horizontalCenter
-        width: Math.min(parent.width - 40, toggleButtons.width)
-        height: toggleButtons.height
-        contentWidth: toggleButtons.width
-        boundsMovement: width == toggleButtons.width ?
-            Flickable.StopAtBounds : Flickable.FollowBoundsBehavior
-        RowLayout {
-            id: toggleButtons
-            spacing: 10
-            ToggleButton {
-                text: qsTr("ID")
-                autoExclusive: true
-                checked: true
-                onClicked: {
-                    peerListModelProxy.sortBy = "nodeId"
-                }
-            }
-            ToggleButton {
-                text: qsTr("Direction")
-                autoExclusive: true
-                onClicked: {
-                    peerListModelProxy.sortBy = "direction"
-                }
-            }
-            ToggleButton {
-                text: qsTr("User Agent")
-                autoExclusive: true
-                onClicked: {
-                    peerListModelProxy.sortBy = "subversion"
-                }
-            }
-            ToggleButton {
-                text: qsTr("Type")
-                autoExclusive: true
-                onClicked: {
-                    peerListModelProxy.sortBy = "connectionType"
-                }
-            }
-            ToggleButton {
-                text: qsTr("Ip")
-                autoExclusive: true
-                onClicked: {
-                    peerListModelProxy.sortBy = "address"
-                }
-            }
-            ToggleButton {
-                text: qsTr("Network")
-                autoExclusive: true
-                onClicked: {
-                    peerListModelProxy.sortBy = "network"
-                }
-            }
-        }
-    }
-
     ListView {
         id: listView
         clip: true
         width: Math.min(parent.width - 40, 450)
-        anchors.top: sortSelection.bottom
-        anchors.topMargin: 30
-        anchors.bottom: parent.bottom
+        height: parent.height
         anchors.horizontalCenter: parent.horizontalCenter
         model: peerListModelProxy
         spacing: 15
+
+        header: ColumnLayout {
+            spacing: 20
+            width: parent.width
+            CoreText {
+                id: description
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+                text: qsTr("Peers are nodes you are connected to. You want to ensure that you are connected" +
+                    " to x, y and z, but not a, b, and c. Learn more.")
+                font.pixelSize: 13
+                color: Theme.color.neutral7
+            }
+
+            Flickable {
+                id: sortSelection
+                Layout.fillWidth: true
+                Layout.bottomMargin: 30
+                Layout.alignment: Qt.AlignHCenter
+                height: toggleButtons.height
+                contentWidth: toggleButtons.width
+                boundsMovement: width == toggleButtons.width ?
+                    Flickable.StopAtBound : Flickable.FollowBoundsBehavior
+                RowLayout {
+                    id: toggleButtons
+                    spacing: 10
+                    ToggleButton {
+                        text: qsTr("ID")
+                        autoExclusive: true
+                        checked: true
+                        onClicked: {
+                            peerListModelProxy.sortBy = "nodeId"
+                        }
+                    }
+                    ToggleButton {
+                        text: qsTr("Direction")
+                        autoExclusive: true
+                        onClicked: {
+                            peerListModelProxy.sortBy = "direction"
+                        }
+                    }
+                    ToggleButton {
+                        text: qsTr("User Agent")
+                        autoExclusive: true
+                        onClicked: {
+                            peerListModelProxy.sortBy = "subversion"
+                        }
+                    }
+                    ToggleButton {
+                        text: qsTr("Type")
+                        autoExclusive: true
+                        onClicked: {
+                            peerListModelProxy.sortBy = "connectionType"
+                        }
+                    }
+                    ToggleButton {
+                        text: qsTr("Ip")
+                        autoExclusive: true
+                        onClicked: {
+                            peerListModelProxy.sortBy = "address"
+                        }
+                    }
+                    ToggleButton {
+                        text: qsTr("Network")
+                        autoExclusive: true
+                        onClicked: {
+                            peerListModelProxy.sortBy = "network"
+                        }
+                    }
+                }
+            }
+        }
 
         footer: Loader {
             height: 75

--- a/src/qml/pages/settings/SettingsAbout.qml
+++ b/src/qml/pages/settings/SettingsAbout.qml
@@ -10,9 +10,15 @@ import "../../components"
 
 Item {
     property alias navLeftDetail: aboutSwipe.navLeftDetail
+    property alias navMiddleDetail: aboutSwipe.navMiddleDetail
+    property alias devMiddleDetail: aboutSwipe.devMiddleDetail
+    property alias showHeader: aboutSwipe.showHeader
     SwipeView {
         id: aboutSwipe
         property alias navLeftDetail: about_settings.navLeftDetail
+        property alias navMiddleDetail: about_settings.navMiddleDetail
+        property alias devMiddleDetail: about_developer.navMiddleDetail
+        property alias showHeader: about_settings.showHeader
         anchors.fill: parent
         interactive: false
         orientation: Qt.Horizontal
@@ -29,6 +35,8 @@ Item {
             detailItem: AboutOptions {}
         }
         SettingsDeveloper {
+            id: about_developer
+            showHeader: about_settings.showHeader
             navLeftDetail: NavButton {
                 iconSource: "image://images/caret-left"
                 text: qsTr("Back")

--- a/src/qml/pages/settings/SettingsConnection.qml
+++ b/src/qml/pages/settings/SettingsConnection.qml
@@ -10,11 +10,15 @@ import "../../components"
 
 Item {
     property alias navRightDetail: connectionSwipe.navRightDetail
+    property alias navMiddleDetail: connectionSwipe.navMiddleDetail
     property alias navLeftDetail: connectionSwipe.navLeftDetail
+    property alias showHeader: connectionSwipe.showHeader
     SwipeView {
         id: connectionSwipe
         property alias navRightDetail: connection_settings.navRightDetail
+        property alias navMiddleDetail: connection_settings.navMiddleDetail
         property alias navLeftDetail: connection_settings.navLeftDetail
+        property alias showHeader: connection_settings.showHeader
         anchors.fill: parent
         interactive: false
         orientation: Qt.Horizontal


### PR DESCRIPTION
This moves all settings pages titles post-onboarding into the navbar, standardizing where the title is for all pages. Whereas, currently, we have some within the page content and some in the page navbar. See this issue: https://github.com/BitcoinDesign/Bitcoin-Core-App/issues/55

[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/unsecure_win_gui.zip?branch=pull/346)
[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/unsecure_mac_gui.zip?branch=pull/346)
[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/unsecure_mac_arm64_gui.zip?branch=pull/346)
[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/unsecure_android_apk.zip?branch=pull/346)
[![ARM32 Android](https://img.shields.io/badge/OS-Android%2032bit-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android32/unsecure_android_32bit_apk.zip?branch=pull/346)

