### PR TITLE
CaretRightIcon control

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -343,7 +343,7 @@ QML_RES_QML = \
   qml/components/BlockClock.qml \
   qml/components/BlockClockDisplayMode.qml \
   qml/components/BlockCounter.qml \
-  qml/components/CaretRightButton.qml \
+  qml/controls/CaretRightIcon.qml \
   qml/components/ConnectionOptions.qml \
   qml/components/ConnectionSettings.qml \
   qml/components/DeveloperOptions.qml \

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -4,7 +4,7 @@
         <file>components/BlockClock.qml</file>
         <file>components/BlockClockDisplayMode.qml</file>
         <file>components/BlockCounter.qml</file>
-        <file>components/CaretRightButton.qml</file>
+        <file>controls/CaretRightIcon.qml</file>
         <file>components/ConnectionOptions.qml</file>
         <file>components/ConnectionSettings.qml</file>
         <file>components/PeersIndicator.qml</file>

--- a/src/qml/components/AboutOptions.qml
+++ b/src/qml/components/AboutOptions.qml
@@ -65,12 +65,11 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Developer options")
         description: qsTr("Only use these if you have development experience")
-        actionItem: CaretRightButton{
-            stateColor: gotoDeveloper.stateColor
-            onClicked: {
-                aboutSwipe.incrementCurrentIndex()
-            }
+        actionItem: CaretRightButton {
+            color: gotoDeveloper.stateColor
         }
-        onClicked: loadedItem.clicked()
+        onClicked: {
+            aboutSwipe.incrementCurrentIndex()
+        }
     }
 }

--- a/src/qml/components/AboutOptions.qml
+++ b/src/qml/components/AboutOptions.qml
@@ -65,7 +65,7 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Developer options")
         description: qsTr("Only use these if you have development experience")
-        actionItem: CaretRightButton {
+        actionItem: CaretRightIcon {
             color: gotoDeveloper.stateColor
         }
         onClicked: {

--- a/src/qml/components/CaretRightButton.qml
+++ b/src/qml/components/CaretRightButton.qml
@@ -7,10 +7,6 @@ import QtQuick.Controls 2.15
 import "../controls"
 
 Icon {
-    id: root
-    required property color stateColor
-    enabled: true
     source: "image://images/caret-right"
-    color: root.stateColor
     size: 18
 }

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -67,7 +67,7 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Proxy settings")
         actionItem: CaretRightButton {
-            stateColor: gotoProxy.stateColor
+            color: gotoProxy.stateColor
         }
         onClicked: connectionSwipe.incrementCurrentIndex()
     }

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -66,7 +66,7 @@ ColumnLayout {
         id: gotoProxy
         Layout.fillWidth: true
         header: qsTr("Proxy settings")
-        actionItem: CaretRightButton {
+        actionItem: CaretRightIcon {
             color: gotoProxy.stateColor
         }
         onClicked: connectionSwipe.incrementCurrentIndex()

--- a/src/qml/controls/CaretRightIcon.qml
+++ b/src/qml/controls/CaretRightIcon.qml
@@ -4,7 +4,6 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import "../controls"
 
 Icon {
     source: "image://images/caret-right"

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -42,12 +42,11 @@ Item {
                     Layout.fillWidth: true
                     header: qsTr("About")
                     actionItem: CaretRightButton {
-                        stateColor: gotoAbout.stateColor
-                        onClicked: {
-                            nodeSettingsView.push(about_page)
-                        }
+                        color: gotoAbout.stateColor
                     }
-                    onClicked: loadedItem.clicked()
+                    onClicked: {
+                        nodeSettingsView.push(about_page)
+                    }
                 }
                 Separator { Layout.fillWidth: true }
                 Setting {
@@ -55,12 +54,11 @@ Item {
                     Layout.fillWidth: true
                     header: qsTr("Display")
                     actionItem: CaretRightButton {
-                        stateColor: gotoDisplay.stateColor
-                        onClicked: {
-                            nodeSettingsView.push(display_page)
-                        }
+                        color: gotoDisplay.stateColor
                     }
-                    onClicked: loadedItem.clicked()
+                    onClicked: {
+                        nodeSettingsView.push(display_page)
+                    }
                 }
                 Separator { Layout.fillWidth: true }
                 Setting {
@@ -68,12 +66,11 @@ Item {
                     Layout.fillWidth: true
                     header: qsTr("Storage")
                     actionItem: CaretRightButton {
-                        stateColor: gotoStorage.stateColor
-                        onClicked: {
-                            nodeSettingsView.push(storage_page)
-                        }
+                        color: gotoStorage.stateColor
                     }
-                    onClicked: loadedItem.clicked()
+                    onClicked: {
+                        nodeSettingsView.push(storage_page)
+                    }
                 }
                 Separator { Layout.fillWidth: true }
                 Setting {
@@ -81,12 +78,11 @@ Item {
                     Layout.fillWidth: true
                     header: qsTr("Connection")
                     actionItem: CaretRightButton {
-                        stateColor: gotoConnection.stateColor
-                        onClicked: {
-                            nodeSettingsView.push(connection_page)
-                        }
+                        color: gotoConnection.stateColor
                     }
-                    onClicked: loadedItem.clicked()
+                    onClicked: {
+                        nodeSettingsView.push(connection_page)
+                    }
                 }
                 Separator { Layout.fillWidth: true }
                 Setting {
@@ -94,13 +90,12 @@ Item {
                     Layout.fillWidth: true
                     header: qsTr("Peers")
                     actionItem: CaretRightButton {
-                        stateColor: gotoPeers.stateColor
-                        onClicked: {
-                            peerTableModel.startAutoRefresh();
-                            nodeSettingsView.push(peers_page)
-                        }
+                        color: gotoPeers.stateColor
                     }
-                    onClicked: loadedItem.clicked()
+                    onClicked: {
+                        peerTableModel.startAutoRefresh();
+                        nodeSettingsView.push(peers_page)
+                    }
                 }
                 Separator { Layout.fillWidth: true }
                 Setting {
@@ -108,12 +103,11 @@ Item {
                     Layout.fillWidth: true
                     header: qsTr("Network Traffic")
                     actionItem: CaretRightButton {
-                        stateColor: gotoNetworkTraffic.stateColor
-                        onClicked: {
-                            nodeSettingsView.push(networktraffic_page)
-                        }
+                        color: gotoNetworkTraffic.stateColor
                     }
-                    onClicked: loadedItem.clicked()
+                    onClicked: {
+                        nodeSettingsView.push(networktraffic_page)
+                    }
                 }
             }
         }

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -41,7 +41,7 @@ Item {
                     id: gotoAbout
                     Layout.fillWidth: true
                     header: qsTr("About")
-                    actionItem: CaretRightButton {
+                    actionItem: CaretRightIcon {
                         color: gotoAbout.stateColor
                     }
                     onClicked: {
@@ -53,7 +53,7 @@ Item {
                     id: gotoDisplay
                     Layout.fillWidth: true
                     header: qsTr("Display")
-                    actionItem: CaretRightButton {
+                    actionItem: CaretRightIcon {
                         color: gotoDisplay.stateColor
                     }
                     onClicked: {
@@ -65,7 +65,7 @@ Item {
                     id: gotoStorage
                     Layout.fillWidth: true
                     header: qsTr("Storage")
-                    actionItem: CaretRightButton {
+                    actionItem: CaretRightIcon {
                         color: gotoStorage.stateColor
                     }
                     onClicked: {
@@ -77,7 +77,7 @@ Item {
                     id: gotoConnection
                     Layout.fillWidth: true
                     header: qsTr("Connection")
-                    actionItem: CaretRightButton {
+                    actionItem: CaretRightIcon {
                         color: gotoConnection.stateColor
                     }
                     onClicked: {
@@ -89,7 +89,7 @@ Item {
                     id: gotoPeers
                     Layout.fillWidth: true
                     header: qsTr("Peers")
-                    actionItem: CaretRightButton {
+                    actionItem: CaretRightIcon {
                         color: gotoPeers.stateColor
                     }
                     onClicked: {
@@ -102,7 +102,7 @@ Item {
                     id: gotoNetworkTraffic
                     Layout.fillWidth: true
                     header: qsTr("Network Traffic")
-                    actionItem: CaretRightButton {
+                    actionItem: CaretRightIcon {
                         color: gotoNetworkTraffic.stateColor
                     }
                     onClicked: {

--- a/src/qml/pages/settings/SettingsDisplay.qml
+++ b/src/qml/pages/settings/SettingsDisplay.qml
@@ -40,7 +40,7 @@ Item {
                     id: gotoTheme
                     Layout.fillWidth: true
                     header: qsTr("Theme")
-                    actionItem: CaretRightButton {
+                    actionItem: CaretRightIcon {
                         color: gotoTheme.stateColor
                     }
                     onClicked: {
@@ -52,7 +52,7 @@ Item {
                     id: gotoBlockClockSize
                     Layout.fillWidth: true
                     header: qsTr("Block clock display mode")
-                    actionItem: CaretRightButton {
+                    actionItem: CaretRightIcon {
                         color: gotoBlockClockSize.stateColor
                     }
                     onClicked: {

--- a/src/qml/pages/settings/SettingsDisplay.qml
+++ b/src/qml/pages/settings/SettingsDisplay.qml
@@ -41,12 +41,11 @@ Item {
                     Layout.fillWidth: true
                     header: qsTr("Theme")
                     actionItem: CaretRightButton {
-                        stateColor: gotoTheme.stateColor
-                        onClicked: {
-                            nodeSettingsView.push(theme_page)
-                        }
+                        color: gotoTheme.stateColor
                     }
-                    onClicked: loadedItem.clicked()
+                    onClicked: {
+                        nodeSettingsView.push(theme_page)
+                    }
                 }
                 Separator { Layout.fillWidth: true }
                 Setting {
@@ -54,12 +53,11 @@ Item {
                     Layout.fillWidth: true
                     header: qsTr("Block clock display mode")
                     actionItem: CaretRightButton {
-                        stateColor: gotoBlockClockSize.stateColor
-                        onClicked: {
-                            nodeSettingsView.push(blockclocksize_page)
-                        }
+                        color: gotoBlockClockSize.stateColor
                     }
-                    onClicked: loadedItem.clicked()
+                    onClicked: {
+                        nodeSettingsView.push(blockclocksize_page)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Replace `CaretRightButton` with a more appropriate `CaretRightIcon`, and refactor the `clicked` signed.

This also is a step towards removing the `loadedItem` property from `Setting`.