### PR TITLE
Fix QSettings initialization failure on startup when parsing invalid arguments

### DIFF
--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -164,6 +164,13 @@ int QmlGuiMain(int argc, char* argv[])
     SetupEnvironment();
     util::ThreadSetInternalName("main");
 
+    // must be set before parsing command-line options; otherwise,
+    // if invalid parameters were passed, QSetting initialization would fail
+    // and the error will be displayed on terminal
+    app.setOrganizationName(QAPP_ORG_NAME);
+    app.setOrganizationDomain(QAPP_ORG_DOMAIN);
+    app.setApplicationName(QAPP_APP_NAME_DEFAULT);
+
     /// Parse command-line options. We do this after qt in order to show an error if there are problems parsing these.
     SetupServerArgs(gArgs);
     SetupUIArgs(gArgs);
@@ -172,12 +179,6 @@ int QmlGuiMain(int argc, char* argv[])
         InitError(strprintf(Untranslated("Cannot parse command line arguments: %s\n"), error));
         return EXIT_FAILURE;
     }
-
-    // must be set before OptionsModel is initialized or translations are loaded,
-    // as it is used to locate QSettings
-    app.setOrganizationName(QAPP_ORG_NAME);
-    app.setOrganizationDomain(QAPP_ORG_DOMAIN);
-    app.setApplicationName(QAPP_APP_NAME_DEFAULT);
 
     /// Determine availability of data directory.
     if (!CheckDataDirOption(gArgs)) {


### PR DESCRIPTION
This fixes #361.

After applying the fix, no QML source code errors should be displayed on the terminal:

![image](https://github.com/bitcoin-core/gui-qml/assets/110166421/c6acc58d-a08d-48cd-836d-591c074e6001)
