### PR TITLE
ci, gha: Add "lint" job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,20 @@ env:
   MAKEJOBS: '-j10'
 
 jobs:
+  lint:
+    name: 'lint'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          sudo ./ci/lint/04_install.sh
+          echo "PATH=/python_build/bin:$PATH" >> "$GITHUB_ENV"
+          echo "CIRRUS_PR=${{ github.event.number }}" >> "$GITHUB_ENV"
+      - run: |
+          ./ci/lint/06_script.sh
+
   macos-native-x86_64:
     name: 'macOS 13 native, x86_64, no depends, sqlite only, gui'
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks).

--- a/test/lint/lint-whitespace.py
+++ b/test/lint/lint-whitespace.py
@@ -76,7 +76,7 @@ def get_diff(commit_range, check_only_code):
     exclude_args = [":(exclude)" + dir for dir in EXCLUDED_DIRS]
 
     if check_only_code:
-        what_files = ["*.cpp", "*.h", "*.md", "*.py", "*.sh"]
+        what_files = ["*.cpp", "*.h", "*.md", "*.py", "*.sh", "*.qml"]
     else:
         what_files = ["."]
 


### PR DESCRIPTION
This PR ports the "lint" job to the GitHub Actions CI from now decommissioned Cirrus CI.

Also a linter learned to catch tabs in the `*.qml` files.