### PR TITLE
doc: Update PR template, update documentation around CI artifacts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,10 +43,9 @@ patches often sit for a long time.
 -->
 
 <!--
-Links for Windows and macOS build artifacts. Replace <PR> with the assigned pull request number.
+Link to github actions build artifacts.
 
-[![Windows](https://img.shields.io/badge/OS-Windows-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip?branch=pull/<PR>)
-[![Intel macOS](https://img.shields.io/badge/OS-Intel%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip?branch=pull/<PR>)
-[![Apple Silicon macOS](https://img.shields.io/badge/OS-Apple%20Silicon%20macOS-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip?branch=pull/<PR>)
-[![ARM64 Android](https://img.shields.io/badge/OS-Android-green)](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip?branch=pull/<PR>)
+[![Build Artifacts](https://img.shields.io/badge/Build%20Artifacts-green
+)]()
+
 -->

--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -4,17 +4,13 @@
 
 This directory contains the source code for an experimental Bitcoin Core graphical user interface (GUI) built using the [Qt Quick](https://doc.qt.io/qt-5/qtquick-index.html) framework.
 
-Insecure CI artifacts are available for local testing of the master branch, avoiding the need to build:
-- for Windows: [`insecure_win_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/win64/insecure_win_gui.zip)
-- for Intel macOS: [`insecure_mac_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos/insecure_mac_gui.zip)
-- for Apple Silicon macOS: [`insecure_mac_arm64_gui.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/macos_arm64/insecure_mac_arm64_gui.zip)
-- for ARM64 Android: [`insecure_android_apk.zip`](https://api.cirrus-ci.com/v1/artifact/github/bitcoin-core/gui-qml/android/insecure_android_apk.zip)
+Unsecure CI artifacts are available for local testing of the master branch, avoiding the need to build. These can be found under the [Actions](https://github.com/bitcoin-core/gui-qml/actions?query=branch%3Amain) tab. It is required to have and be logged into a github account in order to download these.
 
-Note: For Apple Silicon macOS machines, the binary must be signed before it can
-be ran. To apply a signature, run the following on the unzipped CI artifact:
+Note: For macOS, the CI artifact binary must be made executable and code-signed before it can
+be ran. To make executable and apply a signature, run the following on the unzipped CI artifact:
 
 ```
-codesign -s - ./Downloads/insecure_mac_arm64_gui
+chmod +x ./Downloads/bitcoin-qt && codesign -s - ./Downloads/bitcoin-qt
 ```
 
 ## Goals and Limitations


### PR DESCRIPTION
Update PR template and documentation for the move to github actions, also mentions the new need to make the macOS binary executable.