### PR TITLE
Add interactive color states to peers table

### DIFF
--- a/src/qml/pages/node/Peers.qml
+++ b/src/qml/pages/node/Peers.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
 import "../../controls"
 import "../../components"
 
@@ -122,14 +123,53 @@ Page {
         }
 
         delegate: Item {
+            id: delegate
             required property int nodeId;
             required property string address;
             required property string subversion;
             required property string direction;
             required property string connectionType;
             required property string network;
+            property color stateColor;
             implicitHeight: 60
             implicitWidth: listView.width
+            state: "FILLED"
+
+            states: [
+                State {
+                    name: "FILLED"
+                    PropertyChanges { target: delegate; stateColor: Theme.color.neutral9 }
+                },
+                State {
+                    name: "HOVER"
+                    PropertyChanges { target: delegate; stateColor: Theme.color.orangeLight1 }
+                },
+                State {
+                    name: "ACTIVE"
+                    PropertyChanges { target: delegate; stateColor: Theme.color.orange }
+                }
+            ]
+
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: AppMode.isDesktop
+                onEntered: {
+                    delegate.state = "HOVER"
+                }
+                onExited: {
+                    delegate.state = "FILLED"
+                }
+                onPressed: {
+                    delegate.state = "ACTIVE"
+                }
+                onReleased: {
+                    if (mouseArea.containsMouse) {
+                        delegate.state = "HOVER"
+                    } else {
+                        delegate.state = "FILLED"
+                    }
+                }
+            }
 
             Connections {
                 target: peerListModelProxy
@@ -190,7 +230,7 @@ Page {
                     Layout.alignment: Qt.AlignLeft
                     id: primary
                     font.pixelSize: 18
-                    color: Theme.color.neutral9
+                    color: delegate.stateColor
                 }
                 CoreText {
                     Layout.alignment: Qt.AlignLeft
@@ -205,7 +245,7 @@ Page {
                     Layout.alignment: Qt.AlignRight
                     id: secondary
                     font.pixelSize: 18
-                    color: Theme.color.neutral9
+                    color: delegate.stateColor
                 }
                 CoreText {
                     Layout.alignment: Qt.AlignRight


### PR DESCRIPTION
Introduces color states for hover and and pressed to the peers in the peers table.


### Light
| Filled | Hover | Pressed |
|--------|-------|---------|
| <img width="486" alt="Screenshot 2023-11-09 at 7 10 37 PM" src="https://github.com/bitcoin-core/gui-qml/assets/23396902/377122f2-b366-4fb6-b9f2-000aaab8d91b"> | <img width="486" alt="Screenshot 2023-11-09 at 7 10 11 PM" src="https://github.com/bitcoin-core/gui-qml/assets/23396902/4fb66b56-e30d-487f-8f7e-b1937d6002d1"> | <img width="486" alt="Screenshot 2023-11-09 at 7 10 20 PM" src="https://github.com/bitcoin-core/gui-qml/assets/23396902/638d3bfe-d52b-4841-89d3-01229783459c"> |

### Dark
| Filled | Hover | Pressed |
|--------|-------|---------|
| <img width="486" alt="Screenshot 2023-11-09 at 7 03 23 PM" src="https://github.com/bitcoin-core/gui-qml/assets/23396902/948c034e-d2c8-42b0-938d-8eda329e03c2"> | <img width="486" alt="Screenshot 2023-11-09 at 7 03 18 PM" src="https://github.com/bitcoin-core/gui-qml/assets/23396902/942bb1a7-05f5-416c-90e8-1701a25ef254"> | <img width="486" alt="Screenshot 2023-11-09 at 7 03 40 PM" src="https://github.com/bitcoin-core/gui-qml/assets/23396902/9f27e928-513c-4c3e-a29e-8325d002db8c"> |

[![Build Artifacts](https://img.shields.io/badge/Build%20Artifacts-green
)](https://github.com/bitcoin-core/gui-qml/actions/runs/6819492294)
