### PR TITLE
Update build-unix.md to ensure clang is installed when changing configure flag for compilation

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -33,7 +33,9 @@ Alternatively, or in addition, debugging information can be skipped for compilat
     ./configure CXXFLAGS="-O2"
 
 Finally, clang (often less resource hungry) can be used instead of gcc, which is used by default:
+Make sure clang is installed
 
+    sudo apt install clang
     ./configure CXX=clang++ CC=clang
 
 ## Linux Distribution Specific Instructions


### PR DESCRIPTION
make sure clang is installed otherwise ./configure command will fail

Added a step to make sure clang is installed on the linux machine before using the ./configure command to use clang instead of gcc, clang is not listed as the dependencies needed for linux.

suggestion for improvement only as I spent some time troubleshooting and didn't realise this was the error, was trying to follow instructions to build android and the make apk would fail due to not having a clang.


