### PR TITLE
Fix For BlockClock Min Size

### DIFF
--- a/src/qml/components/BlockClock.qml
+++ b/src/qml/components/BlockClock.qml
@@ -42,7 +42,8 @@ Item {
         id: dial
         anchors.horizontalCenter: root.horizontalCenter
         scale: Theme.blockclocksize
-        width: Math.min((root.parentWidth * dial.scale), (root.parentHeight * dial.scale))
+        width: {Math.max(Math.min(200, Math.min(root.parentWidth - 30, root.parentHeight - 30)), 
+                Math.min((root.parentWidth * dial.scale), (root.parentHeight * dial.scale)))}
         height: dial.width
         penWidth: dial.width / 50
         timeRatioList: chainModel.timeRatioList


### PR DESCRIPTION
Issue and Fix:

This fixes https://github.com/bitcoin-core/gui-qml/issues/382

[GBKS](https://github.com/GBKS) reported an issue where the blockclock on their Galaxy A32 5G phone displayed incorrectly under the min size of 200 pixels.
They provided a fix implemented in this pull request:

`Math.max(Math.min(200, root.parentWidth - 30), Math.min((root.parentWidth * dial.scale), (root.parentHeight * dial.scale)))`

Verification:

I tested the fix on both a virtual device Galaxy A32 5G in Android Studio and a physical Galaxy A13 5G (armv7) device. The fix successfully resolves the pixel-related display issue on both devices.
