### PR TITLE
UI Only Custom Datadir 

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -163,6 +163,12 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       if test -d "$qt_plugin_path/../qml/QtQuick/Controls"; then
         QT_LIBS="$QT_LIBS -L$qt_plugin_path/../qml/QtQuick/Controls"
       fi
+      if test -d "$qt_plugin_path/../qml/QtQuick/Dialogs"; then
+        QT_LIBS="$QT_LIBS -L$qt_plugin_path/../qml/QtQuick/Dialogs -L$qt_plugin_path/../qml/QtQuick/Dialogs/Private"
+      fi
+      if test -d "$qt_plugin_path/../qml/Qt/labs/folderlistmodel"; then
+        QT_LIBS="$QT_LIBS -L$qt_plugin_path/../qml/Qt/labs/folderlistmodel"
+      fi
       if test -d "$qt_plugin_path/../qml/Qt/labs/settings"; then
         QT_LIBS="$QT_LIBS -L$qt_plugin_path/../qml/Qt/labs/settings"
       fi
@@ -214,6 +220,9 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
         _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickLayoutsPlugin], [-lqquicklayoutsplugin])
         dnl qtquickcontrols module plugins
         _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickControls1Plugin], [-lqtquickcontrolsplugin])
+        _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuick2DialogsPlugin], [-ldialogplugin])
+        _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuick2DialogsPrivatePlugin], [-ldialogsprivateplugin])
+        _BITCOIN_QT_CHECK_STATIC_PLUGIN([QmlFolderListModelPlugin], [-lqmlfolderlistmodelplugin])
         _BITCOIN_QT_CHECK_STATIC_PLUGIN([QmlSettingsPlugin], [-lqmlsettingsplugin])
         dnl qtquickcontrols2 module plugins
         _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickControls2Plugin], [-lqtquickcontrols2plugin])
@@ -227,6 +236,9 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
         _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickLayoutsPlugin], [-lqml_QtQuick_Layouts_qquicklayoutsplugin])
         dnl qtquickcontrols module plugins
         _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickControls1Plugin], [-lqml_QtQuick_Controls_qtquickcontrolsplugin])
+        _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuick2DialogsPlugin], [-lqml_QtQuick_Dialogs_dialogplugin])
+        _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuick2DialogsPrivatePlugin], [-lqml_QtQuick_Dialogs_Private_dialogsprivateplugin])
+        _BITCOIN_QT_CHECK_STATIC_PLUGIN([QmlFolderListModelPlugin], [-lqml_Qt_labs_folderlistmodel_qmlfolderlistmodelplugin])
         _BITCOIN_QT_CHECK_STATIC_PLUGIN([QmlSettingsPlugin], [-lqml_Qt_labs_settings_qmlsettingsplugin])
         dnl qtquickcontrols2 module plugins
         _BITCOIN_QT_CHECK_STATIC_PLUGIN([QtQuickControls2Plugin], [-lqml_QtQuick_Controls_2_qtquickcontrols2plugin])

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -24,6 +24,7 @@ $(package)_patches += fast_fixed_dtoa_no_optimize.patch
 $(package)_patches += guix_cross_lib_path.patch
 $(package)_patches += fix_android_plugin_names.patch
 $(package)_patches += fix_riscv_atomic.patch
+$(package)_patches += fix_android_controls_file_location.patch
 
 $(package)_qtdeclarative_file_name = qtdeclarative-$($(package)_suffix)
 $(package)_qtdeclarative_sha256_hash = 5cc169d91efb15a1ee7f484862f872c3eaba592dacf3c0fbcb55c0f3c208254a
@@ -300,6 +301,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/guix_cross_lib_path.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_android_plugin_names.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_riscv_atomic.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fix_android_controls_file_location.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/fix_android_controls_file_location.patch
+++ b/depends/patches/qt/fix_android_controls_file_location.patch
@@ -1,0 +1,13 @@
+diff --git a/qtquickcontrols/src/controls/plugin.cpp b/src/controls/plugin.cpp
+index 446357aa..a08957cd 100644
+--- a/qtquickcontrols/src/controls/plugin.cpp
++++ b/qtquickcontrols/src/controls/plugin.cpp
+@@ -240,7 +240,7 @@ void QtQuickControls1Plugin::initializeEngine(QQmlEngine *engine, const char *ur
+ QString QtQuickControls1Plugin::fileLocation() const
+ {
+ #ifdef Q_OS_ANDROID
+-    return "qrc:/android_rcc_bundle/qml/QtQuick/Controls";
++    return "qrc:/qt-project.org/imports/QtQuick/Controls";
+ #else
+ #ifndef QT_STATIC
+     if (isLoadedFromResource())

--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -70,7 +70,7 @@ The following runtime dependencies are also required for dynamic builds;
 they are not needed for static builds:
 
 ```
-sudo apt install qml-module-qtquick2 qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qtquick-window2 qml-module-qt-labs-settings
+sudo apt install qml-module-qtquick2 qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-layouts qml-module-qtquick-window2 qml-module-qt-labs-settings
 ```
 ##### Important:
 

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -57,9 +57,12 @@ QT_END_NAMESPACE
 #include <QtPlugin>
 Q_IMPORT_PLUGIN(QtQmlPlugin)
 Q_IMPORT_PLUGIN(QtQmlModelsPlugin)
+Q_IMPORT_PLUGIN(QtQuick2DialogsPlugin)
+Q_IMPORT_PLUGIN(QtQuick2DialogsPrivatePlugin)
 Q_IMPORT_PLUGIN(QtQuick2Plugin)
 Q_IMPORT_PLUGIN(QtQuick2WindowPlugin)
 Q_IMPORT_PLUGIN(QtQuickControls1Plugin)
+Q_IMPORT_PLUGIN(QmlFolderListModelPlugin)
 Q_IMPORT_PLUGIN(QmlSettingsPlugin)
 Q_IMPORT_PLUGIN(QtQuickLayoutsPlugin)
 Q_IMPORT_PLUGIN(QtQuickControls2Plugin)

--- a/src/qml/components/StorageLocations.qml
+++ b/src/qml/components/StorageLocations.qml
@@ -5,6 +5,10 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Dialogs 1.3
+
+import org.bitcoincore.qt 1.0
+
 import "../controls"
 
 ColumnLayout {
@@ -25,5 +29,21 @@ ColumnLayout {
         ButtonGroup.group: group
         text: qsTr("Custom")
         description: qsTr("Choose the directory and storage device.")
+        onClicked: fileDialog.open()
+    }
+    FileDialog {
+        id: fileDialog
+        selectFolder: true
+        folder: optionsModel.getDefaultDataDirectory
+        onAccepted: {
+            optionsModel.setCustomDataDirString(fileDialog.fileUrls[0].toString())
+            var customDataDir = fileDialog.fileUrl.toString();
+            if (customDataDir !== "") {
+                optionsModel.setCustomDataDirArgs(customDataDir);
+            }
+        }
+        onRejected: {
+            console.log("Custom datadir selection canceled")
+        }
     }
 }

--- a/src/qml/models/options_model.cpp
+++ b/src/qml/models/options_model.cpp
@@ -9,12 +9,19 @@
 #include <common/system.h>
 #include <interfaces/node.h>
 #include <qt/guiconstants.h>
+#include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <txdb.h>
 #include <univalue.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <validation.h>
 
 #include <cassert>
+
+#include <QDebug>
+#include <QDir>
+#include <QSettings>
 
 OptionsQmlModel::OptionsQmlModel(interfaces::Node& node)
     : m_node{node}
@@ -104,4 +111,29 @@ common::SettingsValue OptionsQmlModel::pruneSetting() const
 {
     assert(!m_prune || m_prune_size_gb >= 1);
     return m_prune ? PruneGBtoMiB(m_prune_size_gb) : 0;
+}
+
+QString PathToQString(const fs::path &path)
+{
+    return QString::fromStdString(path.u8string());
+}
+
+QString OptionsQmlModel::getDefaultDataDirString()
+{
+    return PathToQString(GetDefaultDataDir());
+}
+
+
+QUrl OptionsQmlModel::getDefaultDataDirectory()
+{
+    QString path = getDefaultDataDirString();
+    return QUrl::fromLocalFile(path);
+}
+
+void OptionsQmlModel::setCustomDataDirArgs(QString path)
+{
+    if (!path.isEmpty()) {
+        // TODO: add actual custom data wiring
+        qDebug() << "PlaceHolder: Created data directory: " << path;
+    }
 }

--- a/src/qml/models/options_model.h
+++ b/src/qml/models/options_model.h
@@ -11,6 +11,8 @@
 #include <validation.h>
 
 #include <QObject>
+#include <QString>
+#include <QUrl>
 
 namespace interfaces {
 class Node;
@@ -32,6 +34,8 @@ class OptionsQmlModel : public QObject
     Q_PROPERTY(int scriptThreads READ scriptThreads WRITE setScriptThreads NOTIFY scriptThreadsChanged)
     Q_PROPERTY(bool server READ server WRITE setServer NOTIFY serverChanged)
     Q_PROPERTY(bool upnp READ upnp WRITE setUpnp NOTIFY upnpChanged)
+    Q_PROPERTY(QString getDefaultDataDirString READ getDefaultDataDirString CONSTANT)
+    Q_PROPERTY(QUrl getDefaultDataDirectory READ getDefaultDataDirectory CONSTANT)
 
 public:
     explicit OptionsQmlModel(interfaces::Node& node);
@@ -56,6 +60,15 @@ public:
     void setServer(bool new_server);
     bool upnp() const { return m_upnp; }
     void setUpnp(bool new_upnp);
+    QString getDefaultDataDirString();
+    QUrl getDefaultDataDirectory();
+    Q_INVOKABLE void setCustomDataDirArgs(QString path);
+
+public Q_SLOTS:
+    void setCustomDataDirString(const QString &new_custom_datadir_string) {
+        m_custom_datadir_string = new_custom_datadir_string;
+        m_signalReceived = true;
+    }
 
 Q_SIGNALS:
     void dbcacheSizeMiBChanged(int new_dbcache_size_mib);
@@ -66,6 +79,7 @@ Q_SIGNALS:
     void scriptThreadsChanged(int new_script_threads);
     void serverChanged(bool new_server);
     void upnpChanged(bool new_upnp);
+    void customDataDirStringChanged(QString new_custom_datadir_string);
 
 private:
     interfaces::Node& m_node;
@@ -83,6 +97,8 @@ private:
     int m_script_threads;
     bool m_server;
     bool m_upnp;
+    QString m_custom_datadir_string;
+    bool m_signalReceived = false;
 
     common::SettingsValue pruneSetting() const;
 };


### PR DESCRIPTION
This pull request is a focused iteration of #390, intended to isolate and test the UI frontend elements. Backend functionality has been intentionally excluded to streamline the testing, review, and merge process.

<details>
<summary>Ubuntu Screenshots</summary>

![Screenshot 2024-03-14 124000](https://github.com/bitcoin-core/gui-qml/assets/111142327/a8d8ebbc-c66c-4626-ba7a-630f19c889ae)
![Screenshot 2024-01-29 074759](https://github.com/bitcoin-core/gui-qml/assets/111142327/fea1b72d-2760-436c-aba5-2094b5826fa4)
![Screenshot 2024-01-29 074734](https://github.com/bitcoin-core/gui-qml/assets/111142327/768f93a0-4f9c-46cc-9b31-7d9fcabaaf1e)


</details>

**Prerequisites**

For testing this pull request, ensure you have the following Qt modules installed:

* On Ubuntu 22.04:

```bash
sudo apt-get install qtdeclarative5-dev
sudo apt-get install qtquickcontrols2-5-dev
sudo apt-get install qml-module-qtquick-controls2
sudo apt install qml-module-qtquick-dialogs
```
* For Android:
  * Make sure you delete the prior depends folder (i.e. `depends/aarch64-linux-android`) and rebuild them.

**Implementation Details**

This introduces `FileDialog` class for a user-friendly selection experience.

* **QML Backend**
    * Updated `options_model` files to account for custom data directory configuration and placeholders for custom `datadir` wiring.
    * Added @johnny9 depends patches to allow static building
* **QML Frontend**
    * Updated `StorageLocations.qml` to allow for custom data directory selection.

Follow up PR will add display of the custom `datadir` in StorageSettings.qml