### PR TITLE
Correct Default Proxy header description on ProxySettings - Follow-up #391

### DIFF
--- a/src/qml/components/ProxySettings.qml
+++ b/src/qml/components/ProxySettings.qml
@@ -14,7 +14,7 @@ ColumnLayout {
         center: false
         header: qsTr("Default Proxy")
         headerSize: 24
-        description: qsTr("Run peer connections through a proxy (SOCKS5) for improved privacy. The default proxy supports connections via IPv4, IPv6 and Tor. Tor connections can also be run through a separate Tor proxy.")
+        description: qsTr("Run peer connections through a proxy (SOCKS5) for improved privacy. The default proxy supports connections via IPv4, IPv6 and Tor.")
         descriptionSize: 15
         Layout.bottomMargin: 10
     }
@@ -61,7 +61,7 @@ ColumnLayout {
         center: false
         header: qsTr("Tor Proxy")
         headerSize: 24
-        description: qsTr("Enable to run Tor connections through a dedicated proxy.")
+        description: qsTr("Run Tor connections through a dedicated proxy.")
         descriptionSize: 15
         Layout.topMargin: 35
         Layout.bottomMargin: 10


### PR DESCRIPTION
This is a follow-up from https://github.com/bitcoin-core/gui-qml/pull/391#issuecomment-2030046949.

<details>
<summary>Currently/ <code>main</code> branch screenshot.</summary>

![Screenshot from 2024-04-07 23-00-31](https://github.com/bitcoin-core/gui-qml/assets/110166421/ffb86641-9f98-46d0-98d4-3c7ffd826d4e)

</details>
<details>
<summary> This PR branch screenshot.</summary>

![image](https://github.com/bitcoin-core/gui-qml/assets/110166421/279abc03-8417-4345-bb21-06a7ff53eae6)

</details>