### PR TITLE
UI Only Custom Datadir Display

### DIFF
--- a/src/qml/components/StorageLocations.qml
+++ b/src/qml/components/StorageLocations.qml
@@ -17,33 +17,52 @@ ColumnLayout {
     }
     spacing: 15
     OptionButton {
+        id: defaultDirOption
         Layout.fillWidth: true
         ButtonGroup.group: group
         text: qsTr("Default")
         description: qsTr("Your application directory.")
-        recommended: true
-        checked: true
+        customDir: optionsModel.getDefaultDataDirString
+        checked: optionsModel.dataDir === optionsModel.getDefaultDataDirString
+        onClicked: {
+            defaultDirOption.checked = true
+            optionsModel.dataDir = optionsModel.getDefaultDataDirString
+        }
     }
     OptionButton {
+        id: customDirOption
         Layout.fillWidth: true
         ButtonGroup.group: group
         text: qsTr("Custom")
         description: qsTr("Choose the directory and storage device.")
+        customDir: customDirOption.checked ? fileDialog.folder : ""
+        checked: optionsModel.dataDir !== optionsModel.getDefaultDataDirString
         onClicked: fileDialog.open()
     }
     FileDialog {
         id: fileDialog
         selectFolder: true
-        folder: optionsModel.getDefaultDataDirectory
+        folder: shortcuts.home
         onAccepted: {
             optionsModel.setCustomDataDirString(fileDialog.fileUrls[0].toString())
             var customDataDir = fileDialog.fileUrl.toString();
             if (customDataDir !== "") {
-                optionsModel.setCustomDataDirArgs(customDataDir);
+                optionsModel.setCustomDataDirArgs(customDataDir)
+                customDirOption.customDir = optionsModel.getCustomDataDirString()
+                if (optionsModel.dataDir !== optionsModel.getDefaultDataDirString) {
+                    customDirOption.checked = true
+                    defaultDirOption.checked = false
+                }
             }
         }
         onRejected: {
             console.log("Custom datadir selection canceled")
+            if (optionsModel.dataDir !== optionsModel.getDefaultDataDirString) {
+                customDirOption.checked = true
+                defaultDirOption.checked = false
+            } else {
+                defaultDirOption.checked = true
+            }
         }
     }
 }

--- a/src/qml/components/StorageSettings.qml
+++ b/src/qml/components/StorageSettings.qml
@@ -58,4 +58,17 @@ ColumnLayout {
             loadedItem.forceActiveFocus()
         }
     }
+    Separator { Layout.fillWidth: true }
+    Setting {
+        id: customDataDirSetting
+        Layout.fillWidth: true
+        header: qsTr("Data Directory")
+    }
+    CoreText {
+        Layout.fillWidth: true
+        text: optionsModel.dataDir
+        color: Theme.color.neutral7
+        font.pixelSize: 15
+        horizontalAlignment: Text.AlignLeft
+    }
 }

--- a/src/qml/controls/OptionButton.qml
+++ b/src/qml/controls/OptionButton.qml
@@ -11,6 +11,7 @@ Button {
     property string description
     property bool recommended: false
     property string image: ""
+    property string customDir: ""
     padding: 15
     checkable: true
     implicitWidth: 450
@@ -24,6 +25,12 @@ Button {
             borderRadius: 14
         }
     }
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: button.clicked()
+    }
+
     contentItem: RowLayout {
         spacing: 3
         Loader {
@@ -77,6 +84,28 @@ Button {
 
                     Behavior on color {
                         ColorAnimation { duration: 150 }
+                    }
+                }
+            }
+            Loader {
+                Layout.topMargin: 12
+                Layout.fillWidth: true
+                active: button.customDir.length > 0
+                visible: active
+                sourceComponent: Button {
+                    id: container
+                    background: Rectangle {
+                        color: Theme.color.neutral2
+                        radius: 5
+                    }
+                    font.family: "Inter"
+                    font.styleName: "Semi Bold"
+                    font.pixelSize: 13
+                    contentItem: Text {
+                        font: container.font
+                        color: Theme.color.neutral9
+                        text: button.customDir
+                        wrapMode: Text.WordWrap
                     }
                 }
             }

--- a/src/qml/models/options_model.h
+++ b/src/qml/models/options_model.h
@@ -34,6 +34,7 @@ class OptionsQmlModel : public QObject
     Q_PROPERTY(int scriptThreads READ scriptThreads WRITE setScriptThreads NOTIFY scriptThreadsChanged)
     Q_PROPERTY(bool server READ server WRITE setServer NOTIFY serverChanged)
     Q_PROPERTY(bool upnp READ upnp WRITE setUpnp NOTIFY upnpChanged)
+    Q_PROPERTY(QString dataDir READ dataDir WRITE setDataDir NOTIFY dataDirChanged)
     Q_PROPERTY(QString getDefaultDataDirString READ getDefaultDataDirString CONSTANT)
     Q_PROPERTY(QUrl getDefaultDataDirectory READ getDefaultDataDirectory CONSTANT)
 
@@ -60,14 +61,16 @@ public:
     void setServer(bool new_server);
     bool upnp() const { return m_upnp; }
     void setUpnp(bool new_upnp);
+    QString dataDir() const { return m_dataDir; }
+    void setDataDir(QString new_data_dir);
     QString getDefaultDataDirString();
     QUrl getDefaultDataDirectory();
-    Q_INVOKABLE void setCustomDataDirArgs(QString path);
+    Q_INVOKABLE bool setCustomDataDirArgs(QString path);
+    Q_INVOKABLE QString getCustomDataDirString();
 
 public Q_SLOTS:
     void setCustomDataDirString(const QString &new_custom_datadir_string) {
         m_custom_datadir_string = new_custom_datadir_string;
-        m_signalReceived = true;
     }
     Q_INVOKABLE void onboard();
 
@@ -81,6 +84,7 @@ Q_SIGNALS:
     void serverChanged(bool new_server);
     void upnpChanged(bool new_upnp);
     void customDataDirStringChanged(QString new_custom_datadir_string);
+    void dataDirChanged(QString new_data_dir);
 
 private:
     interfaces::Node& m_node;
@@ -100,7 +104,7 @@ private:
     bool m_server;
     bool m_upnp;
     QString m_custom_datadir_string;
-    bool m_signalReceived = false;
+    QString m_dataDir;
 
     common::SettingsValue pruneSetting() const;
 };


### PR DESCRIPTION
This pull request builds upon #392 and introduces enhancements to display the data directory information within the UI. This functionality encompasses both default and custom data directory paths, fulfilling the UI requirements for user-defined data directory selection initiated in #273. 

Also the custom datadir is not persistent at the moment it will be once the back end wiring is added.

<details>
<summary>Ubuntu 22.04 Screenshots</summary>

![datadir_desktop](https://github.com/bitcoin-core/gui-qml/assets/111142327/639873a5-fd5d-44ac-b0be-66e0762a08db)


</details>

<details>
<summary>Android Screenshots</summary>

![datadir_mobile_720](https://github.com/bitcoin-core/gui-qml/assets/111142327/e6fcd12b-f6e6-4efc-adba-071d2caaddef)


</details>

As a potential follow-up enhancement, consider incorporating mechanisms for saving the data directory path. This could be achieved through:

- Double-click functionality: Allow users to save the displayed path by simply double-clicking on it. This provides a convenient and intuitive method for desktop environments.

- Dedicated button: For mobile use cases or scenarios where double-clicking might not be feasible, introduce a dedicated "Save Path" button. This ensures a clear and accessible action for users on various devices.

