### PR TITLE
Using a different configuration file name from QT

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -123,6 +123,7 @@ BITCOIN_QT_H = \
   qml/models/peerlistsortproxy.h \
   qml/appmode.h \
   qml/bitcoin.h \
+  qml/guiconstants.h \
   qml/imageprovider.h \
   qml/util.h \
   qt/addressbookpage.h \
@@ -140,7 +141,6 @@ BITCOIN_QT_H = \
   qt/createwalletdialog.h \
   qt/csvmodelwriter.h \
   qt/editaddressdialog.h \
-  qt/guiconstants.h \
   qt/guiutil.h \
   qt/initexecutor.h \
   qt/intro.h \

--- a/src/qml/bitcoin.cpp
+++ b/src/qml/bitcoin.cpp
@@ -27,7 +27,7 @@
 #include <qml/models/peerlistsortproxy.h>
 #include <qml/imageprovider.h>
 #include <qml/util.h>
-#include <qt/guiconstants.h>
+#include <qml/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/initexecutor.h>
 #include <qt/networkstyle.h>
@@ -72,7 +72,6 @@ void SetupUIArgs(ArgsManager& argsman)
     argsman.AddArg("-lang=<lang>", "Set language, for example \"de_DE\" (default: system locale)", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-min", "Start minimized", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-resetguisettings", "Reset all settings changed in the GUI", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
-    argsman.AddArg("-splash", strprintf("Show splash screen on startup (default: %u)", DEFAULT_SPLASHSCREEN), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
 }
 
 bool InitErrorMessageBox(

--- a/src/qml/guiconstants.h
+++ b/src/qml/guiconstants.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2011-2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_GUICONSTANTS_H
+#define BITCOIN_QML_GUICONSTANTS_H
+
+#define QAPP_ORG_NAME "BitcoinCore"
+#define QAPP_ORG_DOMAIN "bitcoincore.org"
+#define QAPP_APP_NAME_DEFAULT "BitcoinCore-App"
+#define QAPP_APP_NAME_TESTNET "BitcoinCore-App-testnet"
+#define QAPP_APP_NAME_SIGNET "BitcoinCore-App-signet"
+#define QAPP_APP_NAME_REGTEST "BitcoinCore-App-regtest"
+
+#endif // BITCOIN_QML_GUICONSTANTS_H


### PR DESCRIPTION
At the moment both QT and QML gui apps are using the same naming convention for configuration files (`Bitcoin*.conf`), so separating `guiconstants.h` file from QT, copying it from `src/qt` to `src/qml` and updating `QAPP_APP_NAME_*` constants values will avoid them clashing with each other trying to persist/ read same or different settings (e.g. configuration file for QT on signet will be still named as `Bitcoin-Qt-signet.conf`, as of today, while QML will start using a separate file named `Bitcoin-Qml-signet.conf` - before this fix, currently sometimes a user can get a warning on reading incorrect settings or values: `QVariant::load: unknown user type with name BitcoinUnits::Unit.`).

This could be a temporary fix (? - gui constants file contents has been cleaned up as [suggested](https://github.com/bitcoin-core/gui-qml/pull/398#issuecomment-2054563863)) so instances from both QT and QML gui apps don't interfere between them during QML development. This change will be transparent for both QT gui app and users.

<details>
<summary>Sample of a separate QT config file on <code>signet</code> (<code>Bitcoin-Qt-signet.conf</code>).</summary>

```
[General]
DisplayBitcoinUnit=@Variant(\0\0\0\x7f\0\0\0\x13\x42itcoinUnits::Unit\0\0)
MainWindowGeometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\x2\xa3\0\0\x1v\0\0\x5\xb0\0\0\x3^\0\0\x2\xa3\0\0\x1v\0\0\x5\xb0\0\0\x3^\0\0\0\0\0\0\0\0\a\x80\0\0\x2\xa3\0\0\x1v\0\0\x5\xb0\0\0\x3^)
PeersTabBanlistHeaderState=@ByteArray()
PeersTabPeerHeaderState=@ByteArray()
RPCConsoleWindowGeometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\x2q\0\0\x1\x8f\0\0\x5T\0\0\x3<\0\0\x2q\0\0\x1\x8f\0\0\x5T\0\0\x3<\0\0\0\0\0\0\0\0\a\x80\0\0\x2q\0\0\x1\x8f\0\0\x5T\0\0\x3<)
RPCConsoleWindowPeersTabSplitterSizes=@ByteArray(\0\0\0\xff\0\0\0\x1\0\0\0\x2\xff\xff\xff\xff\xff\xff\xff\xff\0\xff\xff\xff\xff\x1\0\0\0\x1\0)
SubFeeFromAmount=false
enable_psbt_controls=false
fCoinControlFeatures=false
fHideTrayIcon=false
fMinimizeOnClose=false
fMinimizeToTray=false
fRestartRequired=false
nSettingsVersion=279900
strDataDir=/home/pablo/.bitcoin
strThirdPartyTxUrls=
```

</details>
<details>
<summary>Sample of a separate QML config file on <code>signet</code> (<code>Bitcoin-Qml-signet.conf</code>).</summary>

```
[General]
blockclocksize=0.4166666666666667
dark=true
height=665
width=640
x=755
y=339
```

</details>