### PR TITLE
Bugfix custom datadir doubleClick - Follow-up #392

### DIFF
--- a/src/qml/components/StorageLocations.qml
+++ b/src/qml/components/StorageLocations.qml
@@ -37,7 +37,28 @@ ColumnLayout {
         description: qsTr("Choose the directory and storage device.")
         customDir: customDirOption.checked ? fileDialog.folder : ""
         checked: optionsModel.dataDir !== optionsModel.getDefaultDataDirString
-        onClicked: fileDialog.open()
+        onClicked: {
+            if (AppMode.isDesktop) {
+                if (!singleClickTimer.running) {
+                    // Start the timer if it's not already running
+                    singleClickTimer.start();
+                } else {
+                    // If the timer is running, it's a double-click
+                    singleClickTimer.stop();
+                }
+            } else {
+                fileDialog.open()
+            }
+        }
+        Timer {
+            id: singleClickTimer
+            interval: 300
+            onTriggered: {
+                // If the timer times out, it's a single-click
+                fileDialog.open()
+            }
+            repeat: false // No need to repeat the timer
+        }
     }
     FileDialog {
         id: fileDialog


### PR DESCRIPTION
This is a desktop-only (not mobile/ android) workaround to disable double-click on custom datadir which is on the `StorageLocations.qml` componennt.

Double-clicking was causing the file dialog to get open but losing focus and moving to the background, bringing upfront the main window which was useless because the file dialog is modal ([issue](https://github.com/bitcoin-core/gui-qml/pull/392#pullrequestreview-1973457090) raised originally by @MarnixCroes on PR #392 but still [persists](https://github.com/bitcoin-core/gui-qml/pull/397#pullrequestreview-1998733695) in ongoing PR #397).