### PR TITLE
ci, build: Update GHA actions and fix build bugs

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Depends cache
         id: depends_cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             depends/built
@@ -93,7 +93,7 @@ jobs:
           make -j$(nproc) HOST=${{ matrix.host.triplet }} LOG=1
 
       - name: Restore Ccache cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: ccache-cache
         with:
           path: ${{ env.CCACHE_DIR }}
@@ -112,13 +112,13 @@ jobs:
           ccache --version | head -n 1 && ccache --show-stats
 
       - name: Save Ccache cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ matrix.host.triplet }}-ccache-${{ github.run_id }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.host.artifact }}
           path: src/qt/${{ matrix.host.gui_exe }}
@@ -183,7 +183,7 @@ jobs:
         run: |
           make -j$(nproc) -C src/qt apk
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.host.artifact }}
           path: src/qt/android/build/outputs/apk/debug/android-debug.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"
 
       - name: Restore Ccache cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.job }}-ccache-${{ github.run_id }}
@@ -76,7 +76,7 @@ jobs:
         run: ./ci/test_run_all.sh
 
       - name: Save Ccache cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: github.event_name != 'pull_request'
         with:
           path: ${{ env.CCACHE_DIR }}
@@ -151,7 +151,7 @@ jobs:
 
       - name: Restore static Qt cache
         id: static-qt-cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: C:\Qt_static
           key: ${{ github.job }}-static-qt-${{ hashFiles('msbuild_version', 'qt_url', 'qt_conf') }}
@@ -194,14 +194,14 @@ jobs:
 
       - name: Save static Qt cache
         if: steps.static-qt-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: C:\Qt_static
           key: ${{ github.job }}-static-qt-${{ hashFiles('msbuild_version', 'qt_url', 'qt_conf') }}
 
       - name: Ccache installation cache
         id: ccache-installation-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             C:\ProgramData\chocolatey\lib\ccache
@@ -217,7 +217,7 @@ jobs:
           Copy-Item -Path "$env:ChocolateyInstall\lib\ccache\tools\ccache-$env:CI_CCACHE_VERSION-windows-x86_64\ccache.exe" -Destination "C:\ccache\cl.exe"
 
       - name: Restore Ccache cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ~/AppData/Local/ccache
           key: ${{ github.job }}-ccache-${{ github.run_id }}
@@ -232,13 +232,13 @@ jobs:
           Get-Content -Path "$env:GITHUB_WORKSPACE\vcpkg_commit"
 
       - name: vcpkg tools cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: C:/vcpkg/downloads/tools
           key: ${{ github.job }}-vcpkg-tools
 
       - name: vcpkg binary cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/AppData/Local/vcpkg/archives
           key: ${{ github.job }}-vcpkg-binary-${{ hashFiles('vcpkg_commit', 'msbuild_version', 'build_msvc/vcpkg.json') }}
@@ -256,7 +256,7 @@ jobs:
         run: ccache --show-stats
 
       - name: Save Ccache cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: github.event_name != 'pull_request'
         with:
           path: ~/AppData/Local/ccache

--- a/configure.ac
+++ b/configure.ac
@@ -745,7 +745,7 @@ case $host in
          dnl option to system-ify all /usr/local/include paths without adding it to the list
          dnl of search paths in case it's not already there.
          if test "$suppress_external_warnings" != "no"; then
-           AX_CHECK_PREPROC_FLAG([-Xclang -internal-isystem/usr/local/include], [CORE_CPPFLAGS="$CORE_CPPFLAGS -Xclang -internal-isystem/usr/local/include"], [], [$CXXFLAG_WERROR])
+           AX_CHECK_PREPROC_FLAG([-Xclang -internal-isystem -Xclang /usr/local/include/], [CORE_CPPFLAGS="$CORE_CPPFLAGS -Xclang -internal-isystem -Xclang /usr/local/include/"], [], [$CXXFLAG_WERROR])
          fi
 
          if test "$use_bdb" != "no" && $BREW list --versions berkeley-db@4 >/dev/null && test "$BDB_CFLAGS" = "" && test "$BDB_LIBS" = ""; then

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -367,6 +367,7 @@ QML_RES_QML = \
   qml/controls/Header.qml \
   qml/controls/Icon.qml \
   qml/controls/InformationPage.qml \
+  qml/controls/IPAddressValueInput.qml \
   qml/controls/NavButton.qml \
   qml/controls/PageIndicator.qml \
   qml/controls/NavigationBar.qml \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -141,6 +141,7 @@ BITCOIN_QT_H = \
   qt/createwalletdialog.h \
   qt/csvmodelwriter.h \
   qt/editaddressdialog.h \
+  qt/guiconstants.h \
   qt/guiutil.h \
   qt/initexecutor.h \
   qt/intro.h \


### PR DESCRIPTION
The second commit has been cherry-picked from https://github.com/bitcoin/bitcoin/pull/29195.

Link to github actions build artifacts:

[![Build Artifacts](https://img.shields.io/badge/Build%20Artifacts-green
)](https://github.com/bitcoin-core/gui-qml/actions/runs/9242930899)