### PR TITLE
Wiring for Custom Datadir

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -433,9 +433,12 @@ QML_RES_QML = \
   qml/pages/wallet/WalletSelect.qml
 
 if TARGET_ANDROID
-BITCOIN_QT_H += qml/androidnotifier.h
-BITCOIN_QML_BASE_CPP += qml/androidnotifier.cpp
-QT_MOC_CPP += qml/moc_androidnotifier.cpp
+BITCOIN_QT_H += qml/androidnotifier.h \
+                qml/androidcustomdatadir.h
+BITCOIN_QML_BASE_CPP += qml/androidnotifier.cpp \
+                        qml/androidcustomdatadir.cpp
+QT_MOC_CPP += qml/moc_androidnotifier.cpp \
+              qml/moc_androidcustomdatadir.cpp
 endif
 
 BITCOIN_QT_CPP = $(BITCOIN_QT_BASE_CPP)

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <map>
 #include <string>
+#include <univalue.h>
 #include <vector>
 
 class UniValue;

--- a/src/qml/androidcustomdatadir.cpp
+++ b/src/qml/androidcustomdatadir.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 The Bitcoin Core developers
+// Copyright (c) 2023-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qml/androidcustomdatadir.cpp
+++ b/src/qml/androidcustomdatadir.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/androidcustomdatadir.h>
+
+#include <common/args.h>
+#include <qml/util.h>
+#include <qml/guiconstants.h>
+#include <qt/guiutil.h>
+
+#include <QDebug>
+#include <QFile>
+#include <QStandardPaths>
+#include <QDir>
+
+AndroidCustomDataDir::AndroidCustomDataDir(QObject * parent)
+    : QObject(parent)
+{
+    m_default_data_dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+}
+
+void AndroidCustomDataDir::setDataDir(const QString & new_data_dir)
+{
+    if (m_data_dir == new_data_dir) {
+        return;
+    }
+
+    m_data_dir = new_data_dir;
+    gArgs.SoftSetArg("-datadir", fs::PathToString(GUIUtil::QStringToPath(m_data_dir)));
+    gArgs.ClearPathCache();
+    Q_EMIT dataDirChanged();
+}
+
+QString AndroidCustomDataDir::readCustomDataDir()
+{
+    QFile file(m_default_data_dir + "/filepath.txt");
+    QString storedPath;
+
+    if (file.open(QIODevice::ReadOnly)) {
+        QTextStream in(&file);
+        storedPath = in.readAll().trimmed();
+        file.close();
+        // Process the retrieved path
+        qDebug() << "Retrieved path: " << storedPath;
+    }
+    return storedPath;
+}

--- a/src/qml/androidcustomdatadir.h
+++ b/src/qml/androidcustomdatadir.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_ANDROIDCUSTOMDATADIR_H
+#define BITCOIN_QML_ANDROIDCUSTOMDATADIR_H
+
+#include <QFile>
+#include <QStandardPaths>
+#include <QDir>
+
+class AndroidCustomDataDir : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString dataDir READ dataDir WRITE setDataDir NOTIFY dataDirChanged)
+
+public:
+    explicit AndroidCustomDataDir(QObject * parent = nullptr);
+
+    QString dataDir() const { return m_data_dir; }
+    void setDataDir(const QString & new_data_dir);
+    QString readCustomDataDir();
+
+Q_SIGNALS:
+    void dataDirChanged();
+
+private:
+    QString m_data_dir;
+    QString m_default_data_dir;
+};
+
+#endif // BITCOIN_QML_ANDROIDCUSTOMDATADIR_H

--- a/src/qml/components/AboutOptions.qml
+++ b/src/qml/components/AboutOptions.qml
@@ -51,7 +51,7 @@ ColumnLayout {
         header: qsTr("Version")
         actionItem: ExternalLink {
             parentState: versionLink.state
-            description: nodeModel.fullClientVersion
+            description: optionsModel.fullClientVersion
             link: "https://bitcoin.org/en/download"
             iconSource: "image://images/caret-right"
             iconWidth: 18

--- a/src/qml/components/StorageLocations.qml
+++ b/src/qml/components/StorageLocations.qml
@@ -22,11 +22,22 @@ ColumnLayout {
         ButtonGroup.group: group
         text: qsTr("Default")
         description: qsTr("Your application directory.")
-        customDir: optionsModel.getDefaultDataDirString
-        checked: optionsModel.dataDir === optionsModel.getDefaultDataDirString
+        checked: true
+        customDir: updateCustomDir()
+        function updateCustomDir() {
+            if (checked) {
+                optionsModel.dataDir = optionsModel.getDefaultDataDirString;
+                optionsModel.defaultReset();
+                return optionsModel.dataDir;
+            } else {
+                return "";
+            }
+        }
         onClicked: {
             defaultDirOption.checked = true
+            customDirOption.checked = false
             optionsModel.dataDir = optionsModel.getDefaultDataDirString
+            optionsModel.defaultReset()
         }
     }
     OptionButton {
@@ -35,9 +46,12 @@ ColumnLayout {
         ButtonGroup.group: group
         text: qsTr("Custom")
         description: qsTr("Choose the directory and storage device.")
-        customDir: customDirOption.checked ? fileDialog.folder : ""
+        customDir: customDirOption.checked ? optionsModel.getCustomDataDirString() : ""
         checked: optionsModel.dataDir !== optionsModel.getDefaultDataDirString
-        onClicked: fileDialog.open()
+        onClicked: {
+            defaultDirOption.checked = false
+            fileDialog.open();
+        }
     }
     FileDialog {
         id: fileDialog
@@ -49,10 +63,8 @@ ColumnLayout {
             if (customDataDir !== "") {
                 optionsModel.setCustomDataDirArgs(customDataDir)
                 customDirOption.customDir = optionsModel.getCustomDataDirString()
-                if (optionsModel.dataDir !== optionsModel.getDefaultDataDirString) {
-                    customDirOption.checked = true
-                    defaultDirOption.checked = false
-                }
+                customDirOption.checked = true
+                defaultDirOption.checked = false
             }
         }
         onRejected: {

--- a/src/qml/components/StorageOptions.qml
+++ b/src/qml/components/StorageOptions.qml
@@ -22,7 +22,7 @@ ColumnLayout {
         Layout.fillWidth: true
         ButtonGroup.group: group
         text: qsTr("Reduce storage")
-        description: qsTr("Uses about %1GB. For simple wallet use.").arg(chainModel.assumedChainstateSize + 2)
+        description: qsTr("Uses about %1GB. For simple wallet use.").arg(optionsModel.assumedChainstateSize + 2)
         recommended: true
         checked: !root.customStorage && optionsModel.prune
         onClicked: {
@@ -40,7 +40,7 @@ ColumnLayout {
         text: qsTr("Store all data")
         checked: !optionsModel.prune
         description: qsTr("Uses about %1GB. Support the network.").arg(
-            chainModel.assumedBlockchainSize + chainModel.assumedChainstateSize)
+            optionsModel.assumedBlockchainSize + optionsModel.assumedChainstateSize)
         onClicked: {
             optionsModel.prune = false
         }

--- a/src/qml/models/nodemodel.h
+++ b/src/qml/models/nodemodel.h
@@ -7,7 +7,6 @@
 
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
-#include <clientversion.h>
 
 #include <memory>
 
@@ -27,7 +26,6 @@ class NodeModel : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int blockTipHeight READ blockTipHeight NOTIFY blockTipHeightChanged)
-    Q_PROPERTY(QString fullClientVersion READ fullClientVersion CONSTANT)
     Q_PROPERTY(int numOutboundPeers READ numOutboundPeers NOTIFY numOutboundPeersChanged)
     Q_PROPERTY(int maxNumOutboundPeers READ maxNumOutboundPeers CONSTANT)
     Q_PROPERTY(int remainingSyncTime READ remainingSyncTime NOTIFY remainingSyncTimeChanged)
@@ -40,7 +38,6 @@ public:
 
     int blockTipHeight() const { return m_block_tip_height; }
     void setBlockTipHeight(int new_height);
-    QString fullClientVersion() const { return QString::fromStdString(FormatFullVersion()); }
     int numOutboundPeers() const { return m_num_outbound_peers; }
     void setNumOutboundPeers(int new_num);
     int maxNumOutboundPeers() const { return m_max_num_outbound_peers; }

--- a/src/qml/models/options_model.cpp
+++ b/src/qml/models/options_model.cpp
@@ -9,6 +9,9 @@
 #include <common/system.h>
 #include <interfaces/node.h>
 #include <mapport.h>
+#ifdef __ANDROID__
+#include <qml/androidcustomdatadir.h>
+#endif
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
@@ -23,28 +26,95 @@
 #include <QDebug>
 #include <QDir>
 #include <QSettings>
+#include <QFile>
+#include <QTextStream>
+#include <QStandardPaths>
 
-OptionsQmlModel::OptionsQmlModel(interfaces::Node& node, bool is_onboarded)
+OptionsQmlModel::OptionsQmlModel(interfaces::Node* node, bool is_onboarded)
     : m_node{node}
     , m_onboarded{is_onboarded}
 {
-    m_dbcache_size_mib = SettingToInt(m_node.getPersistentSetting("dbcache"), nDefaultDbCache);
+    gArgs.LockSettings([&](common::Settings& cs) {
+        // Clear existing settings to ensure we're only storing new command line arguments
+        m_cli_settings.command_line_options.clear();
 
-    m_listen = SettingToBool(m_node.getPersistentSetting("listen"), DEFAULT_LISTEN);
+        // Copy only the command line arguments from the provided settings
+        m_cli_settings.command_line_options = cs.command_line_options;
+    });
 
-    m_natpmp = SettingToBool(m_node.getPersistentSetting("natpmp"), DEFAULT_NATPMP);
+    if (!is_onboarded) {
+        // added this to lock settings to default values
+        if (!gArgs.IsArgSet("-resetguisettings")) {
+            gArgs.LockSettings([&](common::Settings& s) { m_previous_settings = s; });
+        }
+        m_dbcache_size_mib = nDefaultDbCache;
+        m_listen = DEFAULT_LISTEN;
+        m_natpmp = DEFAULT_NATPMP;
+        int64_t prune_value = 0;
+        m_prune = (prune_value > 1);
+        m_prune_size_gb = m_prune ? PruneMiBtoGB(prune_value) : DEFAULT_PRUNE_TARGET_GB;
+        m_script_threads = DEFAULT_SCRIPTCHECK_THREADS;
+        m_server = false;
+        m_upnp = DEFAULT_UPNP;
+    }
 
-    int64_t prune_value{SettingToInt(m_node.getPersistentSetting("prune"), 0)};
-    m_prune = (prune_value > 1);
-    m_prune_size_gb = m_prune ? PruneMiBtoGB(prune_value) : DEFAULT_PRUNE_TARGET_GB;
+#ifdef __ANDROID__
+    if (!getCustomDataDirString().isEmpty() && (m_dataDir != getDefaultDataDirString())) {
+            m_dataDir = getCustomDataDirString();
+        } else {
+            m_dataDir = getDefaultDataDirString();
+        }
+#else
+    QSettings settings;
+    m_dataDir = settings.value("strDataDir", m_dataDir).toString();
+#endif // __ANDROID__
+}
 
-    m_script_threads = SettingToInt(m_node.getPersistentSetting("par"), DEFAULT_SCRIPTCHECK_THREADS);
+void OptionsQmlModel::requestShutdown()
+{
+    Q_EMIT requestedShutdown();
+}
 
-    m_server = SettingToBool(m_node.getPersistentSetting("server"), false);
+void OptionsQmlModel::setNode(interfaces::Node* node, bool is_onboarded) {
+    if (node != nullptr) {
+        m_node = node;
+        if (is_onboarded) {
+            m_dbcache_size_mib = SettingToInt(m_node->getPersistentSetting("dbcache"), nDefaultDbCache);
 
-    m_upnp = SettingToBool(m_node.getPersistentSetting("upnp"), DEFAULT_UPNP);
+            m_listen = SettingToBool(m_node->getPersistentSetting("listen"), DEFAULT_LISTEN);
 
-    m_dataDir = getDefaultDataDirString();
+            m_natpmp = SettingToBool(m_node->getPersistentSetting("natpmp"), DEFAULT_NATPMP);
+
+            int64_t prune_value{SettingToInt(m_node->getPersistentSetting("prune"), 0)};
+            m_prune = (prune_value > 1);
+            m_prune_size_gb = m_prune ? PruneMiBtoGB(prune_value) : DEFAULT_PRUNE_TARGET_GB;
+
+            m_script_threads = SettingToInt(m_node->getPersistentSetting("par"), DEFAULT_SCRIPTCHECK_THREADS);
+
+            m_server = SettingToBool(m_node->getPersistentSetting("server"), false);
+
+            m_upnp = SettingToBool(m_node->getPersistentSetting("upnp"), DEFAULT_UPNP);
+#ifdef __ANDROID__
+            m_dataDir = AndroidCustomDataDir().readCustomDataDir().isEmpty() ? getDefaultDataDirString()
+                        : AndroidCustomDataDir().readCustomDataDir();
+#else
+            if ((gArgs.IsArgSet("-datadir") && !gArgs.GetPathArg("-datadir").empty())) {
+                m_dataDir = QString::fromStdString(gArgs.GetPathArg("-datadir").generic_string());
+            }
+            else {
+                m_custom_datadir_string = m_settings.value("strDataDir", m_custom_datadir_string).toString();
+
+                m_dataDir = fs::exists(GUIUtil::QStringToPath(m_custom_datadir_string)) ? m_custom_datadir_string
+                            : QString::fromStdString(SettingToString(m_node->getPersistentSetting("datadir"), ""));
+
+                if (m_dataDir.isEmpty()) {
+                    m_dataDir = getDefaultDataDirString();
+                }
+            }
+#endif // __ANDROID__
+        }
+        return;
+    }
 }
 
 void OptionsQmlModel::setDbcacheSizeMiB(int new_dbcache_size_mib)
@@ -52,7 +122,7 @@ void OptionsQmlModel::setDbcacheSizeMiB(int new_dbcache_size_mib)
     if (new_dbcache_size_mib != m_dbcache_size_mib) {
         m_dbcache_size_mib = new_dbcache_size_mib;
         if (m_onboarded) {
-            m_node.updateRwSetting("dbcache", new_dbcache_size_mib);
+            m_node->updateRwSetting("dbcache", new_dbcache_size_mib);
         }
         Q_EMIT dbcacheSizeMiBChanged(new_dbcache_size_mib);
     }
@@ -63,7 +133,7 @@ void OptionsQmlModel::setListen(bool new_listen)
     if (new_listen != m_listen) {
         m_listen = new_listen;
         if (m_onboarded) {
-            m_node.updateRwSetting("listen", new_listen);
+            m_node->updateRwSetting("listen", new_listen);
         }
         Q_EMIT listenChanged(new_listen);
     }
@@ -74,7 +144,7 @@ void OptionsQmlModel::setNatpmp(bool new_natpmp)
     if (new_natpmp != m_natpmp) {
         m_natpmp = new_natpmp;
         if (m_onboarded) {
-            m_node.updateRwSetting("natpmp", new_natpmp);
+            m_node->updateRwSetting("natpmp", new_natpmp);
         }
         Q_EMIT natpmpChanged(new_natpmp);
     }
@@ -85,7 +155,7 @@ void OptionsQmlModel::setPrune(bool new_prune)
     if (new_prune != m_prune) {
         m_prune = new_prune;
         if (m_onboarded) {
-            m_node.updateRwSetting("prune", pruneSetting());
+            m_node->updateRwSetting("prune", pruneSetting());
         }
         Q_EMIT pruneChanged(new_prune);
     }
@@ -96,7 +166,7 @@ void OptionsQmlModel::setPruneSizeGB(int new_prune_size_gb)
     if (new_prune_size_gb != m_prune_size_gb) {
         m_prune_size_gb = new_prune_size_gb;
         if (m_onboarded) {
-            m_node.updateRwSetting("prune", pruneSetting());
+            m_node->updateRwSetting("prune", pruneSetting());
         }
         Q_EMIT pruneSizeGBChanged(new_prune_size_gb);
     }
@@ -107,7 +177,7 @@ void OptionsQmlModel::setScriptThreads(int new_script_threads)
     if (new_script_threads != m_script_threads) {
         m_script_threads = new_script_threads;
         if (m_onboarded) {
-            m_node.updateRwSetting("par", new_script_threads);
+            m_node->updateRwSetting("par", new_script_threads);
         }
         Q_EMIT scriptThreadsChanged(new_script_threads);
     }
@@ -118,7 +188,7 @@ void OptionsQmlModel::setServer(bool new_server)
     if (new_server != m_server) {
         m_server = new_server;
         if (m_onboarded) {
-            m_node.updateRwSetting("server", new_server);
+            m_node->updateRwSetting("server", new_server);
         }
         Q_EMIT serverChanged(new_server);
     }
@@ -129,7 +199,7 @@ void OptionsQmlModel::setUpnp(bool new_upnp)
     if (new_upnp != m_upnp) {
         m_upnp = new_upnp;
         if (m_onboarded) {
-            m_node.updateRwSetting("upnp", new_upnp);
+            m_node->updateRwSetting("upnp", new_upnp);
         }
         Q_EMIT upnpChanged(new_upnp);
     }
@@ -158,6 +228,33 @@ QUrl OptionsQmlModel::getDefaultDataDirectory()
     return QUrl::fromLocalFile(path);
 }
 
+void OptionsQmlModel::defaultReset()
+{
+    QSettings settings;
+    // Save the strDataDir setting
+    QString path = GUIUtil::getDefaultDataDirectory();
+
+    setDataDir(path);
+
+    // Remove all entries from our QSettings object
+    settings.clear();
+
+    // Set strDataDir
+    settings.setValue("strDataDir", path);
+
+    // Set that this was reset
+    settings.setValue("fReset", true);
+
+    // Clear the settings
+    gArgs.LockSettings([&](common::Settings& s) { s = m_previous_settings; });
+
+    // reinstate command line arguments
+    gArgs.LockSettings([&](common::Settings& cs) { cs = m_cli_settings; });
+    gArgs.SoftSetBoolArg("-printtoconsole", false);
+
+    gArgs.ClearPathCache();
+}
+
 bool OptionsQmlModel::setCustomDataDirArgs(QString path)
 {
     if (!path.isEmpty()) {
@@ -167,13 +264,35 @@ bool OptionsQmlModel::setCustomDataDirArgs(QString path)
     QString originalPrefix = "content://com.android.externalstorage.documents/tree/primary%3A";
     QString newPrefix = "/storage/self/primary/";
     QString path = uri.replace(originalPrefix, newPrefix);
+    QString dataDir = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+    QFile file(dataDir + "/filepath.txt");
+    if (file.open(QIODevice::WriteOnly)) {
+        QTextStream out(&file);
+        out << path; // Store the QString path into filepath.txt
+        file.close();
+    }
 #else
+    QSettings settings;
     path = QUrl(path).toLocalFile();
 #endif // __ANDROID__
-        qDebug() << "PlaceHolder: Created data directory: " << path;
+        try{
+            if (TryCreateDirectories(GUIUtil::QStringToPath(path))) {
+                // qDebug() << "Created data directory: " << path;
+                TryCreateDirectories(GUIUtil::QStringToPath(path) / "wallets");
+            }
+        } catch (const std::exception& e) {
+            qDebug() << "Error creating data directory: " << e.what();
+        }
+#ifndef __ANDROID__
+        settings.setValue("strDataDir", path);
+#endif // __ANDROID__
+        if(path != GUIUtil::getDefaultDataDirectory()) {
+        gArgs.SoftSetArg("-datadir", fs::PathToString(GUIUtil::QStringToPath(path)));
+        }
+        gArgs.ClearPathCache();
+        Q_EMIT customDataDirStringChanged(m_custom_datadir_string);
 
         m_custom_datadir_string = path;
-        Q_EMIT customDataDirStringChanged(path);
         setDataDir(path);
         return true;
     }
@@ -203,27 +322,31 @@ void OptionsQmlModel::setDataDir(QString new_data_dir)
 
 void OptionsQmlModel::onboard()
 {
-    m_node.resetSettings();
+    m_node->resetSettings();
     if (m_dbcache_size_mib != nDefaultDbCache) {
-        m_node.updateRwSetting("dbcache", m_dbcache_size_mib);
+        m_node->updateRwSetting("dbcache", m_dbcache_size_mib);
     }
     if (m_listen) {
-        m_node.updateRwSetting("listen", m_listen);
+        m_node->updateRwSetting("listen", m_listen);
     }
     if (m_natpmp) {
-        m_node.updateRwSetting("natpmp", m_natpmp);
+        m_node->updateRwSetting("natpmp", m_natpmp);
     }
     if (m_prune) {
-        m_node.updateRwSetting("prune", pruneSetting());
+        m_node->updateRwSetting("prune", pruneSetting());
     }
     if (m_script_threads != DEFAULT_SCRIPTCHECK_THREADS) {
-        m_node.updateRwSetting("par", m_script_threads);
+        m_node->updateRwSetting("par", m_script_threads);
     }
     if (m_server) {
-        m_node.updateRwSetting("server", m_server);
+        m_node->updateRwSetting("server", m_server);
     }
     if (m_upnp) {
-        m_node.updateRwSetting("upnp", m_upnp);
+        m_node->updateRwSetting("upnp", m_upnp);
+    }
+    if (m_dataDir != getDefaultDataDirString()) {
+        std::string dataDirStd = m_dataDir.toStdString();
+        m_node->updateRwSetting("datadir", UniValue(dataDirStd));
     }
     m_onboarded = true;
 }

--- a/src/qml/pages/main.qml
+++ b/src/qml/pages/main.qml
@@ -49,14 +49,14 @@ ApplicationWindow {
         focus: true
         Keys.onReleased: {
             if (event.key == Qt.Key_Back) {
-                nodeModel.requestShutdown()
+                optionsModel.requestShutdown()
                 event.accepted = true
             }
         }
     }
 
     Connections {
-        target: nodeModel
+        target: optionsModel
         function onRequestedShutdown() {
             main.clear()
             main.push(shutdown)
@@ -78,6 +78,7 @@ ApplicationWindow {
             OnboardingConnection {}
 
             onFinishedChanged: {
+                optionsModel.onboardingFinished()
                 optionsModel.onboard()
                 if (AppMode.walletEnabled && AppMode.isDesktop) {
                     main.push(desktopWallets)

--- a/src/qml/pages/onboarding/OnboardingStorageLocation.qml
+++ b/src/qml/pages/onboarding/OnboardingStorageLocation.qml
@@ -19,7 +19,7 @@ InformationPage {
     bold: true
     headerText: qsTr("Storage location")
     headerMargin: 0
-    description: qsTr("Where do you want to store the downloaded block data?\nYou need a minimum of %1GB of storage.").arg(chainModel.assumedChainstateSize + 1)
+    description: qsTr("Where do you want to store the downloaded block data?\nYou need a minimum of %1GB of storage.").arg(optionsModel.assumedChainstateSize + 1)
     descriptionMargin: 20
     detailActive: true
     detailItem: StorageLocations {}

--- a/src/qt/android/AndroidManifest.xml
+++ b/src/qt/android/AndroidManifest.xml
@@ -3,7 +3,9 @@
     <uses-sdk android:targetSdkVersion="24"/>
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/src/qt/android/src/org/bitcoincore/qt/BitcoinQtActivity.java
+++ b/src/qt/android/src/org/bitcoincore/qt/BitcoinQtActivity.java
@@ -8,6 +8,8 @@ import android.system.ErrnoException;
 import android.system.Os;
 import android.view.WindowManager;
 import android.view.View;
+import android.Manifest;
+import android.content.pm.PackageManager;
 
 import org.qtproject.qt5.android.bindings.QtActivity;
 
@@ -15,6 +17,8 @@ import java.io.File;
 
 public class BitcoinQtActivity extends QtActivity
 {
+    private static final int PERMISSIONS_REQUEST_CODE = 123;
+
     @Override
     public void onCreate(Bundle savedInstanceState)
     {
@@ -36,5 +40,22 @@ public class BitcoinQtActivity extends QtActivity
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
             WindowManager.LayoutParams.FLAG_FULLSCREEN);
         super.onCreate(savedInstanceState);
+
+        if (checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(new String[] {
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            }, PERMISSIONS_REQUEST_CODE);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        if (requestCode == PERMISSIONS_REQUEST_CODE) {
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                System.out.println("Permission was granted");
+            } else {
+                System.out.println("Permission was denied");
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request builds upon previous issues (#390, #392, and #397) by re-introducing the functionality for users to specify a custom data directory (`datadir`) during the onboarding process.

The majority of changes in `qml/bitcoin.cpp` are mainly splitting the onboarding and node creation so that the user can set their preferred `datatdir` it's inspired by the `qt/bitcoin.cpp` however it uses the anonymous namespace instead of using a class. The intention came from feedback on https://github.com/bitcoin-core/gui-qml/pull/390

In the QML pages, the `node_model` context property is no longer been initialized during onboarding. We're now using `options_model` instead. This means the code has been updated to use the `options_model` for settings that were previously set with the `node_model` context property.

Support for the Android version is being added to this PR.