### PR TITLE
create wallet: set focus on TextField so it is automatically selected

### DIFF
--- a/src/qml/pages/wallet/CreateName.qml
+++ b/src/qml/pages/wallet/CreateName.qml
@@ -40,6 +40,7 @@ Page {
 
         CoreTextField {
             id: walletNameInput
+            focus: true
             Layout.fillWidth: true
             Layout.leftMargin: 20
             Layout.rightMargin: 20

--- a/src/qml/pages/wallet/CreatePassword.qml
+++ b/src/qml/pages/wallet/CreatePassword.qml
@@ -62,6 +62,7 @@ Page {
             Layout.topMargin: 5
             Layout.leftMargin: 20
             Layout.rightMargin: 20
+            focus: true
             hideText: true
             placeholderText: qsTr("Enter password...")
         }


### PR DESCRIPTION
add `focus: true` to make it automatically selected so user doesn't have to first manually select it before it can type something

addresses https://github.com/bitcoin-core/gui-qml/pull/403#pullrequestreview-2082083987