### PR TITLE
Uncomment DebugMessageHandler install

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -622,7 +622,7 @@ int GuiMain(int argc, char* argv[])
     qApp->installNativeEventFilter(new WinShutdownMonitor());
 #endif
     // Install qDebug() message handler to route to debug.log
-    //qInstallMessageHandler(DebugMessageHandler);
+    qInstallMessageHandler(DebugMessageHandler);
     // Allow parameter interaction before we create the options model
     app.parameterSetup();
     GUIUtil::LogQtInfo();


### PR DESCRIPTION
DebugMessageHandler is needed to route output to debug.log and should not have been commented out.

Mistakenly commented out in https://github.com/bitcoin-core/gui-qml/pull/403
