### PR TITLE
Wallet creation flow font weight and color tweaks

### DIFF
--- a/src/qml/pages/wallet/AddWallet.qml
+++ b/src/qml/pages/wallet/AddWallet.qml
@@ -46,6 +46,7 @@ StackView {
                 Layout.leftMargin: 20
                 Layout.rightMargin: 20
                 header: qsTr("Add a wallet")
+                headerBold: true
                 description: qsTr("In this early stage of development, only wallet.dat files are supported.")
             }
 

--- a/src/qml/pages/wallet/CreateBackup.qml
+++ b/src/qml/pages/wallet/CreateBackup.qml
@@ -55,6 +55,7 @@ Page {
             Layout.leftMargin: 20
             Layout.rightMargin: 20
             header: qsTr("Back up your wallet")
+            headerBold: true
             description: qsTr("Your wallet is a file stored on your hard disk.\nTo prevent accidental loss, it is recommended you keep a copy of your wallet file in a secure place, like a dedicated USB Drive.")
         }
 

--- a/src/qml/pages/wallet/CreateConfirm.qml
+++ b/src/qml/pages/wallet/CreateConfirm.qml
@@ -55,6 +55,7 @@ Page {
             Layout.leftMargin: 20
             Layout.rightMargin: 20
             header: qsTr("Your wallet has been created")
+            headerBold: true
             description: qsTr("It is good practice to make a small test transaction before you actively use this wallet for larger amounts.")
         }
 

--- a/src/qml/pages/wallet/CreateIntro.qml
+++ b/src/qml/pages/wallet/CreateIntro.qml
@@ -72,7 +72,7 @@ Page {
             Layout.leftMargin: 20
             Layout.rightMargin: 20
             Layout.fillWidth: true
-            color: Theme.color.neutral7
+            color: Theme.color.neutral4
         }
 
         CoreText {
@@ -88,7 +88,7 @@ Page {
             Layout.leftMargin: 20
             Layout.rightMargin: 20
             Layout.fillWidth: true
-            color: Theme.color.neutral7
+            color: Theme.color.neutral4
         }
 
         CoreText {

--- a/src/qml/pages/wallet/CreateName.qml
+++ b/src/qml/pages/wallet/CreateName.qml
@@ -36,6 +36,7 @@ Page {
             Layout.leftMargin: 20
             Layout.rightMargin: 20
             header: qsTr("Choose a wallet name")
+            headerBold: true
         }
 
         CoreTextField {

--- a/src/qml/pages/wallet/CreatePassword.qml
+++ b/src/qml/pages/wallet/CreatePassword.qml
@@ -44,6 +44,7 @@ Page {
             Layout.leftMargin: 20
             Layout.rightMargin: 20
             header: qsTr("Choose a password")
+            headerBold: true
             description: qsTr("It is recommended to set a password to protect your wallet file from unwanted access from others.")
         }
 


### PR DESCRIPTION
There are some very minor implementation discrepancies from the design in the wallet creation flow. The font weights for several titles are regular, but should be semi-bold (see all the other screens in the onboarding flow for examples). Two divider lines are neutral 7, but should be the neutral 4 color.

See the following image with screenshots for the comparison. Top row shows the before, the bottom row shows the after. The second column is where the two divider line colors were adjusted. The other columns is where the font weight of the header was adjusted.

![image](https://github.com/user-attachments/assets/173955a9-438a-43b0-b5f7-9b23955b7286)

This is my first PR for this project, let me know what I am doing wrong.