### PR TITLE
upnp: add compatibility for miniupnpc 2.2.8

### DIFF
--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -163,8 +163,11 @@ static bool ProcessUpnp()
     struct UPNPUrls urls;
     struct IGDdatas data;
     int r;
-
+#if MINIUPNPC_API_VERSION <= 17
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
+#else
+    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), nullptr, 0);
+#endif
     if (r == 1)
     {
         if (fDiscover) {


### PR DESCRIPTION
This PR backports https://github.com/bitcoin/bitcoin/pull/30283 to resolve the current CI issues with Homebrew's `miniupnpc` package version 2.2.8.