### PR TITLE
build: Add missed icon file to resources

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -344,6 +344,7 @@ QML_RES_ICONS = \
   qml/res/icons/gear-outline.png \
   qml/res/icons/hidden.png \
   qml/res/icons/info.png \
+  qml/res/icons/minus.png \
   qml/res/icons/network-dark.png \
   qml/res/icons/network-light.png \
   qml/res/icons/plus.png \


### PR DESCRIPTION
This PR fixes [build](https://github.com/bitcoin-core/gui-qml/actions/runs/11076549194/job/30779860142#step:7:1634) on macOS 13 `x86_64`:
```
RCC: Error in 'qml/bitcoin_qml.qrc': Cannot find file 'res/icons/minus.png'
```