### PR TITLE
Introduce Signal Based Navigation Model to have Self-Contained Pages

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -428,12 +428,12 @@ QML_RES_QML = \
   qml/pages/settings/SettingsProxy.qml \
   qml/pages/settings/SettingsStorage.qml \
   qml/pages/settings/SettingsTheme.qml \
-  qml/pages/wallet/AddWallet.qml \
   qml/pages/wallet/CreateBackup.qml \
   qml/pages/wallet/CreateConfirm.qml \
   qml/pages/wallet/CreateIntro.qml \
   qml/pages/wallet/CreateName.qml \
   qml/pages/wallet/CreatePassword.qml \
+  qml/pages/wallet/CreateWalletWizard.qml \
   qml/pages/wallet/DesktopWallets.qml \
   qml/pages/wallet/WalletBadge.qml \
   qml/pages/wallet/WalletSelect.qml

--- a/src/qml/bitcoin_qml.qrc
+++ b/src/qml/bitcoin_qml.qrc
@@ -68,12 +68,12 @@
         <file>pages/settings/SettingsProxy.qml</file>
         <file>pages/settings/SettingsStorage.qml</file>
         <file>pages/settings/SettingsTheme.qml</file>
-        <file>pages/wallet/AddWallet.qml</file>
         <file>pages/wallet/CreateBackup.qml</file>
         <file>pages/wallet/CreateConfirm.qml</file>
         <file>pages/wallet/CreateIntro.qml</file>
         <file>pages/wallet/CreateName.qml</file>
         <file>pages/wallet/CreatePassword.qml</file>
+        <file>pages/wallet/CreateWalletWizard.qml</file>
         <file>pages/wallet/DesktopWallets.qml</file>
         <file>pages/wallet/WalletBadge.qml</file>
         <file>pages/wallet/WalletSelect.qml</file>

--- a/src/qml/components/AboutOptions.qml
+++ b/src/qml/components/AboutOptions.qml
@@ -8,6 +8,8 @@ import QtQuick.Layouts 1.15
 import "../controls"
 
 ColumnLayout {
+    id: root
+    signal next
     spacing: 4
     Setting {
         id: websiteLink
@@ -69,7 +71,7 @@ ColumnLayout {
             color: gotoDeveloper.stateColor
         }
         onClicked: {
-            aboutSwipe.incrementCurrentIndex()
+            root.next()
         }
     }
     ExternalPopup {

--- a/src/qml/components/ConnectionSettings.qml
+++ b/src/qml/components/ConnectionSettings.qml
@@ -8,6 +8,8 @@ import QtQuick.Layouts 1.15
 import "../controls"
 
 ColumnLayout {
+    id: root
+    signal next
     spacing: 4
     Setting {
         Layout.fillWidth: true
@@ -69,6 +71,6 @@ ColumnLayout {
         actionItem: CaretRightIcon {
             color: gotoProxy.stateColor
         }
-        onClicked: connectionSwipe.incrementCurrentIndex()
+        onClicked: root.next()
     }
 }

--- a/src/qml/controls/InformationPage.qml
+++ b/src/qml/controls/InformationPage.qml
@@ -9,6 +9,8 @@ import org.bitcoincore.qt 1.0
 
 Page {
     id: root
+    signal back
+    signal next
     implicitHeight: information.height + continueButton.height + buttonMargin
     property alias bannerItem: banner_loader.sourceComponent
     property alias detailItem: detail_loader.sourceComponent
@@ -106,7 +108,7 @@ Page {
             anchors.rightMargin: 20
             anchors.horizontalCenter: parent.horizontalCenter
             text: root.buttonText
-            onClicked: root.lastPage ? swipeView.finished = true : swipeView.incrementCurrentIndex()
+            onClicked: root.next()
         }
     }
 

--- a/src/qml/pages/main.qml
+++ b/src/qml/pages/main.qml
@@ -70,12 +70,29 @@ ApplicationWindow {
             property bool finished: false
             interactive: false
 
-            OnboardingCover {}
-            OnboardingStrengthen {}
-            OnboardingBlockclock {}
-            OnboardingStorageLocation {}
-            OnboardingStorageAmount {}
-            OnboardingConnection {}
+            OnboardingCover {
+                onNext: swipeView.incrementCurrentIndex()
+            }
+            OnboardingStrengthen {
+                onBack: swipeView.decrementCurrentIndex()
+                onNext: swipeView.incrementCurrentIndex()
+            }
+            OnboardingBlockclock {
+                onBack: swipeView.decrementCurrentIndex()
+                onNext: swipeView.incrementCurrentIndex()
+            }
+            OnboardingStorageLocation {
+                onBack: swipeView.decrementCurrentIndex()
+                onNext: swipeView.incrementCurrentIndex()
+            }
+            OnboardingStorageAmount {
+                onBack: swipeView.decrementCurrentIndex()
+                onNext: swipeView.incrementCurrentIndex()
+            }
+            OnboardingConnection {
+                onBack: swipeView.decrementCurrentIndex()
+                onNext: swipeView.finished = true
+            }
 
             onFinishedChanged: {
                 optionsModel.onboard()

--- a/src/qml/pages/main.qml
+++ b/src/qml/pages/main.qml
@@ -98,7 +98,7 @@ ApplicationWindow {
                 optionsModel.onboard()
                 if (AppMode.walletEnabled && AppMode.isDesktop) {
                     main.push(desktopWallets)
-                    main.push(addWallet)
+                    main.push(createWalletWizard)
                 } else {
                     main.push(node)
                 }
@@ -112,8 +112,8 @@ ApplicationWindow {
     }
 
     Component {
-        id: addWallet
-        AddWallet {
+        id: createWalletWizard
+        CreateWalletWizard {
             onFinished: {
                 main.pop()
             }

--- a/src/qml/pages/node/NetworkTraffic.qml
+++ b/src/qml/pages/node/NetworkTraffic.qml
@@ -19,7 +19,16 @@ InformationPage {
         id: settings
         property alias trafficGraphScale: root.trafficGraphScale
     }
-
+    navLeftDetail: NavButton {
+        iconSource: "image://images/caret-left"
+        text: qsTr("Back")
+        onClicked: root.back()
+    }
+    navMiddleDetail: Header {
+        headerBold: true
+        headerSize: 18
+        header: qsTr("Network traffic")
+    }
     bannerActive: false
     bold: true
     headerText: qsTr("Network Traffic")

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -122,24 +122,7 @@ Item {
     Component {
         id: about_page
         SettingsAbout {
-            showHeader: false
-            navLeftDetail: NavButton {
-                iconSource: "image://images/caret-left"
-                text: qsTr("Back")
-                onClicked: {
-                    nodeSettingsView.pop()
-                }
-            }
-            navMiddleDetail: Header {
-                headerBold: true
-                headerSize: 18
-                header: qsTr("About")
-            }
-            devMiddleDetail: Header {
-                headerBold: true
-                headerSize: 18
-                header: qsTr("Developer settings")
-            }
+            onBack: nodeSettingsView.pop()
         }
     }
     Component {
@@ -153,37 +136,13 @@ Item {
     Component {
         id: storage_page
         SettingsStorage {
-            showHeader: false
-            navLeftDetail: NavButton {
-                iconSource: "image://images/caret-left"
-                text: qsTr("Back")
-                onClicked: {
-                    nodeSettingsView.pop()
-                }
-            }
-            navMiddleDetail: Header {
-                headerBold: true
-                headerSize: 18
-                header: qsTr("Storage settings")
-            }
+            onBack: nodeSettingsView.pop()
         }
     }
     Component {
         id: connection_page
         SettingsConnection {
-            showHeader: false
-            navLeftDetail: NavButton {
-                iconSource: "image://images/caret-left"
-                text: qsTr("Back")
-                onClicked: {
-                    nodeSettingsView.pop()
-                }
-            }
-            navMiddleDetail: Header {
-                headerBold: true
-                headerSize: 18
-                header: qsTr("Connection settings")
-            }
+            onBack: nodeSettingsView.pop()
         }
     }
     Component {
@@ -210,18 +169,7 @@ Item {
         id: networktraffic_page
         NetworkTraffic {
             showHeader: false
-            navLeftDetail: NavButton {
-                iconSource: "image://images/caret-left"
-                text: qsTr("Back")
-                onClicked: {
-                    nodeSettingsView.pop()
-                }
-            }
-            navMiddleDetail: Header {
-                headerBold: true
-                headerSize: 18
-                header: qsTr("Network traffic")
-            }
+            onBack: nodeSettingsView.pop()
         }
     }
 }

--- a/src/qml/pages/node/NodeSettings.qml
+++ b/src/qml/pages/node/NodeSettings.qml
@@ -128,7 +128,7 @@ Item {
     Component {
         id: display_page
         SettingsDisplay {
-            onBackClicked: {
+            onBack: {
                 nodeSettingsView.pop()
             }
         }
@@ -148,7 +148,7 @@ Item {
     Component {
         id: peers_page
         Peers {
-            onBackClicked: {
+            onBack: {
                 nodeSettingsView.pop()
                 peerTableModel.stopAutoRefresh();
             }
@@ -160,7 +160,7 @@ Item {
     Component {
         id: peer_details
         PeerDetails {
-            onBackClicked: {
+            onBack: {
                 nodeSettingsView.pop()
             }
         }

--- a/src/qml/pages/node/PeerDetails.qml
+++ b/src/qml/pages/node/PeerDetails.qml
@@ -11,14 +11,14 @@ import "../../components"
 
 Page {
     id: root
-    signal backClicked()
+    signal back()
 
     property PeerDetailsModel details
 
     Connections {
         target: details
         function onDisconnected() {
-            root.backClicked()
+            root.back()
         }
     }
 
@@ -27,7 +27,7 @@ Page {
         leftItem: NavButton {
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
-            onClicked: root.backClicked()
+            onClicked: root.back()
         }
         centerItem: Header {
             headerBold: true

--- a/src/qml/pages/node/Peers.qml
+++ b/src/qml/pages/node/Peers.qml
@@ -11,7 +11,7 @@ import "../../controls"
 import "../../components"
 
 Page {
-    signal backClicked
+    signal back
     signal peerSelected(PeerDetailsModel peerDetails)
 
     id: root
@@ -21,7 +21,7 @@ Page {
         leftItem: NavButton {
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
-            onClicked: root.backClicked()
+            onClicked: root.back()
         }
         centerItem: Header {
             headerBold: true

--- a/src/qml/pages/onboarding/OnboardingBlockclock.qml
+++ b/src/qml/pages/onboarding/OnboardingBlockclock.qml
@@ -8,10 +8,11 @@ import QtQuick.Layouts 1.15
 import "../../controls"
 
 InformationPage {
+    id: root
     navLeftDetail: NavButton {
         iconSource: "image://images/caret-left"
         text: qsTr("Back")
-        onClicked: swipeView.decrementCurrentIndex()
+        onClicked: root.back()
     }
     bannerItem: Image {
         source: Theme.image.blocktime

--- a/src/qml/pages/onboarding/OnboardingConnection.qml
+++ b/src/qml/pages/onboarding/OnboardingConnection.qml
@@ -10,6 +10,9 @@ import "../../components"
 import "../settings"
 
 Page {
+    id: root
+    signal back
+    signal next
     background: null
     clip: true
     SwipeView {
@@ -21,7 +24,7 @@ Page {
             navLeftDetail: NavButton {
                 iconSource: "image://images/caret-left"
                 text: qsTr("Back")
-                onClicked: swipeView.decrementCurrentIndex()
+                onClicked: root.back()
             }
             bannerItem: Image {
                 Layout.topMargin: 20
@@ -47,6 +50,7 @@ Page {
             lastPage: true
             buttonText: qsTr("Next")
             buttonMargin: 20
+            onNext: root.next()
         }
         SettingsConnection {
             navRightDetail: NavButton {

--- a/src/qml/pages/onboarding/OnboardingConnection.qml
+++ b/src/qml/pages/onboarding/OnboardingConnection.qml
@@ -53,12 +53,8 @@ Page {
             onNext: root.next()
         }
         SettingsConnection {
-            navRightDetail: NavButton {
-                text: qsTr("Done")
-                onClicked: {
-                    connections.decrementCurrentIndex()
-                }
-            }
+            onboarding: true
+            onBack: connections.decrementCurrentIndex()
         }
     }
 }

--- a/src/qml/pages/onboarding/OnboardingCover.qml
+++ b/src/qml/pages/onboarding/OnboardingCover.qml
@@ -10,6 +10,8 @@ import "../../components"
 import "../settings"
 
 Page {
+    id: root
+    signal next
     background: null
     clip: true
     SwipeView {
@@ -48,6 +50,7 @@ Page {
             descriptionSize: 24
             subtext: qsTr("100% open-source & open-design")
             buttonText: qsTr("Start")
+            onNext: root.next()
         }
         SettingsAbout {
             navLeftDetail: NavButton {

--- a/src/qml/pages/onboarding/OnboardingCover.qml
+++ b/src/qml/pages/onboarding/OnboardingCover.qml
@@ -53,13 +53,8 @@ Page {
             onNext: root.next()
         }
         SettingsAbout {
-            navLeftDetail: NavButton {
-                iconSource: "image://images/caret-left"
-                text: qsTr("Back")
-                onClicked: {
-                    introductions.decrementCurrentIndex()
-                }
-            }
+            onboarding: true
+            onBack: introductions.decrementCurrentIndex()
         }
     }
 }

--- a/src/qml/pages/onboarding/OnboardingStorageAmount.qml
+++ b/src/qml/pages/onboarding/OnboardingStorageAmount.qml
@@ -10,6 +10,9 @@ import "../../components"
 import "../settings"
 
 Page {
+    id: root
+    signal back
+    signal next
     background: null
     clip: true
     SwipeView {
@@ -21,7 +24,7 @@ Page {
             navLeftDetail: NavButton {
                 iconSource: "image://images/caret-left"
                 text: qsTr("Back")
-                onClicked: swipeView.decrementCurrentIndex()
+                onClicked: root.back()
             }
             bannerActive: false
             bold: true
@@ -47,6 +50,7 @@ Page {
             }
             buttonText: qsTr("Next")
             buttonMargin: 20
+            onNext: root.next()
         }
         SettingsStorage {
             id: advancedStorage

--- a/src/qml/pages/onboarding/OnboardingStorageAmount.qml
+++ b/src/qml/pages/onboarding/OnboardingStorageAmount.qml
@@ -54,12 +54,8 @@ Page {
         }
         SettingsStorage {
             id: advancedStorage
-            navRightDetail: NavButton {
-                text: qsTr("Done")
-                onClicked: {
-                    storages.decrementCurrentIndex()
-                }
-            }
+            onboarding: true
+            onBack: storages.decrementCurrentIndex()
         }
     }
 }

--- a/src/qml/pages/onboarding/OnboardingStorageLocation.qml
+++ b/src/qml/pages/onboarding/OnboardingStorageLocation.qml
@@ -10,10 +10,11 @@ import "../../controls"
 import "../../components"
 
 InformationPage {
+    id: root
     navLeftDetail: NavButton {
         iconSource: "image://images/caret-left"
         text: qsTr("Back")
-        onClicked: swipeView.decrementCurrentIndex()
+        onClicked: root.back()
     }
     bannerActive: false
     bold: true

--- a/src/qml/pages/onboarding/OnboardingStrengthen.qml
+++ b/src/qml/pages/onboarding/OnboardingStrengthen.qml
@@ -8,10 +8,11 @@ import QtQuick.Layouts 1.15
 import "../../controls"
 
 InformationPage {
+    id: root
     navLeftDetail: NavButton {
         iconSource: "image://images/caret-left"
         text: qsTr("Back")
-        onClicked: swipeView.decrementCurrentIndex()
+        onClicked: root.back()
     }
     bannerItem: Image {
         source: Theme.image.network

--- a/src/qml/pages/settings/SettingsAbout.qml
+++ b/src/qml/pages/settings/SettingsAbout.qml
@@ -32,7 +32,9 @@ Item {
             description: qsTr("Bitcoin Core is an open source project.\nIf you find it useful, please contribute.\n\n This is experimental software.")
             descriptionMargin: 20
             detailActive: true
-            detailItem: AboutOptions {}
+            detailItem: AboutOptions {
+                onNext: aboutSwipe.incrementCurrentIndex()
+            }
         }
         SettingsDeveloper {
             id: about_developer

--- a/src/qml/pages/settings/SettingsAbout.qml
+++ b/src/qml/pages/settings/SettingsAbout.qml
@@ -9,16 +9,11 @@ import "../../controls"
 import "../../components"
 
 Item {
-    property alias navLeftDetail: aboutSwipe.navLeftDetail
-    property alias navMiddleDetail: aboutSwipe.navMiddleDetail
-    property alias devMiddleDetail: aboutSwipe.devMiddleDetail
-    property alias showHeader: aboutSwipe.showHeader
+    id: root
+    signal back
+    property bool onboarding: false
     SwipeView {
         id: aboutSwipe
-        property alias navLeftDetail: about_settings.navLeftDetail
-        property alias navMiddleDetail: about_settings.navMiddleDetail
-        property alias devMiddleDetail: about_developer.navMiddleDetail
-        property alias showHeader: about_settings.showHeader
         anchors.fill: parent
         interactive: false
         orientation: Qt.Horizontal
@@ -27,6 +22,7 @@ Item {
             bannerActive: false
             bannerMargin: 0
             bold: true
+            showHeader: root.onboarding
             headerText: qsTr("About")
             headerMargin: 0
             description: qsTr("Bitcoin Core is an open source project.\nIf you find it useful, please contribute.\n\n This is experimental software.")
@@ -35,17 +31,49 @@ Item {
             detailItem: AboutOptions {
                 onNext: aboutSwipe.incrementCurrentIndex()
             }
-        }
-        SettingsDeveloper {
-            id: about_developer
-            showHeader: about_settings.showHeader
-            navLeftDetail: NavButton {
-                iconSource: "image://images/caret-left"
-                text: qsTr("Back")
-                onClicked: {
-                    aboutSwipe.decrementCurrentIndex()
+
+            states: [
+                State {
+                    when: root.onboarding
+                    PropertyChanges {
+                        target: about_settings
+                        navLeftDetail: backButton
+                        navMiddleDetail: null
+                    }
+                },
+                State {
+                    when: !root.onboarding
+                    PropertyChanges {
+                        target: about_settings
+                        navLeftDetail: backButton
+                        navMiddleDetail: header
+                    }
+                }
+            ]
+
+            Component {
+                id: backButton
+                NavButton {
+                    iconSource: "image://images/caret-left"
+                    text: qsTr("Back")
+                    onClicked: root.back()
+                }
+            }
+            Component {
+                id: header
+                Header {
+                    headerBold: true
+                    headerSize: 18
+                    header: qsTr("About")
                 }
             }
         }
+        SettingsDeveloper {
+            id: about_developer
+            onboarding: root.onboarding
+            onBack: aboutSwipe.decrementCurrentIndex()
+        }
     }
 }
+
+

--- a/src/qml/pages/settings/SettingsBlockClockDisplayMode.qml
+++ b/src/qml/pages/settings/SettingsBlockClockDisplayMode.qml
@@ -9,7 +9,7 @@ import "../../controls"
 import "../../components"
 
 Page {
-    signal backClicked
+    signal back
 
     id: root
     background: null
@@ -22,7 +22,7 @@ Page {
         leftItem: NavButton {
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
-            onClicked: root.backClicked()
+            onClicked: root.back()
         }
         centerItem: Header {
             headerBold: true

--- a/src/qml/pages/settings/SettingsConnection.qml
+++ b/src/qml/pages/settings/SettingsConnection.qml
@@ -31,7 +31,9 @@ Item {
             headerText: qsTr("Connection settings")
             headerMargin: 0
             detailActive: true
-            detailItem: ConnectionSettings {}
+            detailItem: ConnectionSettings {
+                onNext: connectionSwipe.incrementCurrentIndex()
+            }
         }
         SettingsProxy {
             onBackClicked: {

--- a/src/qml/pages/settings/SettingsConnection.qml
+++ b/src/qml/pages/settings/SettingsConnection.qml
@@ -9,16 +9,12 @@ import "../../controls"
 import "../../components"
 
 Item {
-    property alias navRightDetail: connectionSwipe.navRightDetail
-    property alias navMiddleDetail: connectionSwipe.navMiddleDetail
-    property alias navLeftDetail: connectionSwipe.navLeftDetail
-    property alias showHeader: connectionSwipe.showHeader
+    id: root
+    signal back
+    property bool onboarding: false
     SwipeView {
         id: connectionSwipe
-        property alias navRightDetail: connection_settings.navRightDetail
-        property alias navMiddleDetail: connection_settings.navMiddleDetail
-        property alias navLeftDetail: connection_settings.navLeftDetail
-        property alias showHeader: connection_settings.showHeader
+        property bool onboarding: false
         anchors.fill: parent
         interactive: false
         orientation: Qt.Horizontal
@@ -28,11 +24,58 @@ Item {
             clip: true
             bannerActive: false
             bold: true
+            showHeader: root.onboarding
             headerText: qsTr("Connection settings")
             headerMargin: 0
             detailActive: true
             detailItem: ConnectionSettings {
                 onNext: connectionSwipe.incrementCurrentIndex()
+            }
+
+            states: [
+                State {
+                    when: root.onboarding
+                    PropertyChanges {
+                        target: connection_settings
+                        navLeftDetail: null
+                        navMiddleDetail: null
+                        navRightDetail: doneButton
+                    }
+                },
+                State {
+                    when: !root.onboarding
+                    PropertyChanges {
+                        target: connection_settings
+                        navLeftDetail: backButton
+                        navMiddleDetail: header
+                        navRightDetail: null
+                    }
+                }
+            ]
+
+            Component {
+                id: backButton
+                NavButton {
+                    iconSource: "image://images/caret-left"
+                    text: qsTr("Back")
+                    onClicked: root.back()
+                }
+            }
+            Component {
+                id: header
+                Header {
+                    headerBold: true
+                    headerSize: 18
+                    header: qsTr("Connection settings")
+                }
+            }
+
+            Component {
+                id: doneButton
+                NavButton {
+                    text: qsTr("Done")
+                    onClicked: root.back()
+                }
             }
         }
         SettingsProxy {

--- a/src/qml/pages/settings/SettingsConnection.qml
+++ b/src/qml/pages/settings/SettingsConnection.qml
@@ -79,7 +79,7 @@ Item {
             }
         }
         SettingsProxy {
-            onBackClicked: {
+            onBack: {
                 connectionSwipe.decrementCurrentIndex()
             }
         }

--- a/src/qml/pages/settings/SettingsDeveloper.qml
+++ b/src/qml/pages/settings/SettingsDeveloper.qml
@@ -9,10 +9,46 @@ import "../../controls"
 import "../../components"
 
 InformationPage {
+    id: root
+    property bool onboarding: false
+    navLeftDetail: NavButton {
+        iconSource: "image://images/caret-left"
+        text: qsTr("Back")
+        onClicked: {
+            root.back()
+        }
+    }
     bannerActive: false
     bold: true
+    showHeader: root.onboarding
     headerText: qsTr("Developer options")
     headerMargin: 0
     detailActive: true
     detailItem: DeveloperOptions {}
+
+    states: [
+        State {
+            when: root.onboarding
+            PropertyChanges {
+                target: root
+                navMiddleDetail: null
+            }
+        },
+        State {
+            when: !root.onboarding
+            PropertyChanges {
+                target: root
+                navMiddleDetail: header
+            }
+        }
+    ]
+
+    Component {
+        id: header
+        Header {
+            headerBold: true
+            headerSize: 18
+            header: qsTr("Developer settings")
+        }
+    }
 }

--- a/src/qml/pages/settings/SettingsDisplay.qml
+++ b/src/qml/pages/settings/SettingsDisplay.qml
@@ -9,7 +9,7 @@ import "../../controls"
 import "../../components"
 
 Item {
-    signal backClicked
+    signal back
 
     id: root
 
@@ -29,7 +29,7 @@ Item {
                 leftItem: NavButton {
                     iconSource: "image://images/caret-left"
                     text: qsTr("Back")
-                    onClicked: root.backClicked()
+                    onClicked: root.back()
                 }
                 centerItem: Header {
                     headerBold: true
@@ -70,7 +70,7 @@ Item {
     Component {
         id: theme_page
         SettingsTheme {
-            onBackClicked: {
+            onBack: {
                 nodeSettingsView.pop()
             }
         }
@@ -78,7 +78,7 @@ Item {
     Component {
         id: blockclocksize_page
         SettingsBlockClockDisplayMode {
-            onBackClicked: {
+            onBack: {
                 nodeSettingsView.pop()
             }
         }

--- a/src/qml/pages/settings/SettingsProxy.qml
+++ b/src/qml/pages/settings/SettingsProxy.qml
@@ -9,7 +9,7 @@ import "../../controls"
 import "../../components"
 
 Page {
-    signal backClicked
+    signal back
 
     id: root
 
@@ -23,7 +23,7 @@ Page {
         leftItem: NavButton {
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
-            onClicked: root.backClicked()
+            onClicked: root.back()
         }
         centerItem: Header {
             headerBold: true

--- a/src/qml/pages/settings/SettingsStorage.qml
+++ b/src/qml/pages/settings/SettingsStorage.qml
@@ -9,10 +9,57 @@ import "../../controls"
 import "../../components"
 
 InformationPage {
+    id: root
+    property bool onboarding: false
     bannerActive: false
     bold: true
+    showHeader: root.onboarding
     headerText: qsTr("Storage settings")
     headerMargin: 0
     detailActive: true
     detailItem: StorageSettings {}
+    states: [
+        State {
+            when: root.onboarding
+            PropertyChanges {
+                target: root
+                navLeftDetail: null
+                navMiddleDetail: null
+                navRightDetail: doneButton
+            }
+        },
+        State {
+            when: !root.onboarding
+            PropertyChanges {
+                target: root
+                navLeftDetail: backButton
+                navMiddleDetail: header
+                navRightDetail: null
+            }
+        }
+    ]
+
+    Component {
+        id: backButton
+        NavButton {
+            iconSource: "image://images/caret-left"
+            text: qsTr("Back")
+            onClicked: root.back()
+        }
+    }
+    Component {
+        id: header
+        Header {
+            headerBold: true
+            headerSize: 18
+            header: qsTr("Storage Settings")
+        }
+    }
+    Component {
+        id: doneButton
+        NavButton {
+            text: qsTr("Done")
+            onClicked: root.back()
+        }
+    }
 }

--- a/src/qml/pages/settings/SettingsTheme.qml
+++ b/src/qml/pages/settings/SettingsTheme.qml
@@ -9,7 +9,7 @@ import "../../controls"
 import "../../components"
 
 Page {
-    signal backClicked
+    signal back
 
     id: root
     background: null
@@ -22,7 +22,7 @@ Page {
         leftItem: NavButton {
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
-            onClicked: root.backClicked()
+            onClicked: root.back()
         }
         centerItem: Header {
             headerBold: true

--- a/src/qml/pages/wallet/CreateBackup.qml
+++ b/src/qml/pages/wallet/CreateBackup.qml
@@ -12,6 +12,8 @@ import "../settings"
 
 Page {
     id: root
+    signal back
+    signal next
     background: null
 
     header: NavigationBar2 {
@@ -20,7 +22,7 @@ Page {
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
             onClicked: {
-                root.StackView.view.pop()
+                root.back()
             }
         }
     }
@@ -83,7 +85,7 @@ Page {
             Layout.alignment: Qt.AlignCenter
             text: qsTr("Done")
             onClicked: {
-                root.StackView.view.finished()
+                root.next()
             }
         }
     }

--- a/src/qml/pages/wallet/CreateConfirm.qml
+++ b/src/qml/pages/wallet/CreateConfirm.qml
@@ -12,6 +12,8 @@ import "../settings"
 
 Page {
     id: root
+    signal back
+    signal next
     background: null
 
     header: NavigationBar2 {
@@ -20,7 +22,7 @@ Page {
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
             onClicked: {
-                root.StackView.view.pop()
+                root.back()
             }
         }
     }
@@ -67,7 +69,7 @@ Page {
             Layout.alignment: Qt.AlignCenter
             text: qsTr("Next")
             onClicked: {
-                root.StackView.view.push("qrc:/qml/pages/wallet/CreateBackup.qml")
+                root.next()
             }
         }
     }

--- a/src/qml/pages/wallet/CreateIntro.qml
+++ b/src/qml/pages/wallet/CreateIntro.qml
@@ -12,6 +12,8 @@ import "../settings"
 
 Page {
     id: root
+    signal back
+    signal next
     background: null
 
     header: NavigationBar2 {
@@ -20,7 +22,7 @@ Page {
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
             onClicked: {
-                root.StackView.view.pop()
+                root.back()
             }
         }
     }
@@ -107,7 +109,7 @@ Page {
             Layout.alignment: Qt.AlignCenter
             text: qsTr("Start")
             onClicked: {
-                root.StackView.view.push("qrc:/qml/pages/wallet/CreateName.qml")
+                root.next()
             }
         }
     }

--- a/src/qml/pages/wallet/CreateName.qml
+++ b/src/qml/pages/wallet/CreateName.qml
@@ -12,6 +12,9 @@ import "../settings"
 
 Page {
     id: root
+    signal back
+    signal next
+    property string walletName: ""
     background: null
 
     header: NavigationBar2 {
@@ -20,7 +23,7 @@ Page {
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
             onClicked: {
-                root.StackView.view.pop()
+                root.back()
             }
         }
     }
@@ -62,14 +65,8 @@ Page {
             text: qsTr("Continue")
             onClicked: {
                 console.log("Creating wallet with name: " + walletNameInput.text)
-                root.StackView.view.push(createPassword)
-            }
-        }
-
-        Component {
-            id: createPassword
-            CreatePassword {
-                walletName: walletNameInput.text
+                root.walletName = walletNameInput.text
+                root.next()
             }
         }
     }

--- a/src/qml/pages/wallet/CreatePassword.qml
+++ b/src/qml/pages/wallet/CreatePassword.qml
@@ -12,6 +12,8 @@ import "../settings"
 
 Page {
     id: root
+    signal back
+    signal next
     background: null
 
     required property string walletName;
@@ -22,14 +24,14 @@ Page {
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
             onClicked: {
-                root.StackView.view.pop()
+                root.back()
             }
         }
         rightItem: NavButton {
             text: qsTr("Skip")
             onClicked: {
                 walletController.createSingleSigWallet(walletName, "")
-                root.StackView.view.push("qrc:/qml/pages/wallet/CreateConfirm.qml")
+                root.next()
             }
         }
     }
@@ -108,7 +110,7 @@ Page {
             enabled: password.text != "" && passwordRepeat.text != "" && password.text == passwordRepeat.text && confirmToggle.loadedItem.checked
             onClicked: {
                 walletController.createSingleSigWallet(walletName, password.text)
-                root.StackView.view.push("qrc:/qml/pages/wallet/CreateConfirm.qml")
+                root.next()
             }
         }
     }

--- a/src/qml/pages/wallet/CreateWalletWizard.qml
+++ b/src/qml/pages/wallet/CreateWalletWizard.qml
@@ -11,9 +11,10 @@ import "../settings"
 import "../wallet"
 
 StackView {
-    id: addWalletStack
+    id: root
 
     signal finished()
+    property string walletName: ""
 
     initialItem: Page {
         background: null
@@ -23,7 +24,7 @@ StackView {
             rightItem: NavButton {
                 text: qsTr("Skip")
                 onClicked: {
-                    addWalletStack.finished()
+                    root.finished()
                 }
             }
         }
@@ -59,7 +60,7 @@ StackView {
                 Layout.alignment: Qt.AlignCenter
                 text: qsTr("Create wallet")
                 onClicked: {
-                    addWalletStack.push("qrc:/qml/pages/wallet/CreateIntro.qml");
+                    root.push(intro)
                 }
             }
 
@@ -79,5 +80,44 @@ StackView {
             }
         }
     }
+    Component {
+        id: intro
+        CreateIntro {
+            onBack: root.pop()
+            onNext: root.push(name)
+        }
+    }
+    Component {
+        id: name
+        CreateName {
+            id: createName
+            onBack: root.pop()
+            onNext: {
+                root.walletName = createName.walletName
+                root.push(password)
+            }
+        }
+    }
+    Component {
+        id: password
+        CreatePassword {
+            walletName: root.walletName
+            onBack: root.pop()
+            onNext: root.push(confirm)
+        }
+    }
+    Component {
+        id: confirm
+        CreateConfirm {
+            onBack: root.pop()
+            onNext: root.push(backup)
+        }
+    }
+    Component {
+        id: backup
+        CreateBackup {
+            onBack: root.pop()
+            onNext: root.finished()
+        }
+    }
 }
-


### PR DESCRIPTION
Here we introduce a Signal Based navigation model, so that we can have self-contained pages. Self-contained pages include everything they need where they are declared, and do not have more than one definition. This makes pages modular, easier to reason about, but also easier to maintain by eliminating dependencies on hard-coded IDs, direct calls to parent views, and interlinked properties between pages.

When we want to reason about `PageA.qml`, we only have to look in there and the child components it uses, and not have to use a search function to ensure we have the entire scope of `PageA.qml`.

To Achieve this, this PR implements the following main ideas:

1. Ensure that pages are not hardcoding and reaching into an outside view.
2. Ensure we don't alias down any components into pages, and instead have pages define all their components, but react to state events
3. Ensure we don't have interlinked properties between pages
4. Move navigation and page linking logic from the pages themselves and into the declaration of the view itself.

Additionally, while here we structure the CreateWallet flow into a Wizard.

**Follow-Ups:**

Consider moving onboarding and walletName into more appropriate backend objects.

[![Build Artifacts](https://img.shields.io/badge/Build%20Artifacts-green
)]()