### PR TITLE
Allow IPv6 in Proxy settings and moving validation out from the UI into the model/ interface

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -22,6 +22,9 @@
 #include <tuple>
 #include <vector>
 
+static const char DEFAULT_PROXY_HOST[] = "127.0.0.1";
+static constexpr uint16_t DEFAULT_PROXY_PORT = 9050;
+
 class BanMan;
 class CFeeRate;
 class CNodeStats;
@@ -125,6 +128,12 @@ public:
 
     //! Get proxy.
     virtual bool getProxy(Network net, Proxy& proxy_info) = 0;
+
+    //! Get default proxy address.
+    virtual std::string defaultProxyAddress() = 0;
+
+    //! Validate a proxy address.
+    virtual bool validateProxyAddress(const std::string& addr_port) = 0;
 
     //! Get number of connections.
     virtual size_t getNodeCount(ConnectionDirection flags) = 0;

--- a/src/qml/components/ProxySettings.qml
+++ b/src/qml/components/ProxySettings.qml
@@ -7,7 +7,12 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import "../controls"
 
+import org.bitcoincore.qt 1.0
+
 ColumnLayout {
+    property string ipAndPortHeader: qsTr("IP and Port")
+    property string invalidIpError: qsTr("Invalid IP address or port format. Use '255.255.255.255:65535' or '[ffff::]:65535'")
+
     spacing: 4
     Header {
         headerBold: true
@@ -41,14 +46,17 @@ ColumnLayout {
     Setting {
         id: defaultProxy
         Layout.fillWidth: true
-        header: qsTr("IP and Port")
-        errorText: qsTr("Invalid IP address or port format. Please use the format '255.255.255.255:65535'.")
+        header: ipAndPortHeader
+        errorText: invalidIpError
         state: !defaultProxyEnable.loadedItem.checked ? "DISABLED" : "FILLED"
         showErrorText: !defaultProxy.loadedItem.validInput && defaultProxyEnable.loadedItem.checked
         actionItem: IPAddressValueInput {
             parentState: defaultProxy.state
-            description: "127.0.0.1:9050"
+            description: nodeModel.defaultProxyAddress()
             activeFocusOnTab: true
+            onTextChanged: {
+                validInput = nodeModel.validateProxyAddress(text);
+            }
         }
         onClicked: {
             loadedItem.filled = true
@@ -89,14 +97,17 @@ ColumnLayout {
     Setting {
         id: torProxy
         Layout.fillWidth: true
-        header: qsTr("IP and Port")
-        errorText: qsTr("Invalid IP address or port format. Please use the format '255.255.255.255:65535'.")
+        header: ipAndPortHeader
+        errorText: invalidIpError
         state: !torProxyEnable.loadedItem.checked ? "DISABLED" : "FILLED"
         showErrorText: !torProxy.loadedItem.validInput && torProxyEnable.loadedItem.checked
         actionItem: IPAddressValueInput {
             parentState: torProxy.state
-            description: "127.0.0.1:9050"
+            description: nodeModel.defaultProxyAddress()
             activeFocusOnTab: true
+            onTextChanged: {
+                validInput = nodeModel.validateProxyAddress(text);
+            }
         }
         onClicked: {
             loadedItem.filled = true

--- a/src/qml/controls/IPAddressValueInput.qml
+++ b/src/qml/controls/IPAddressValueInput.qml
@@ -16,9 +16,9 @@ TextInput {
     property bool validInput: true
     enabled: true
     state: root.parentState
-    validator: RegExpValidator { regExp: /[0-9.:]*/ } // Allow only digits, dots, and colons
+    validator: RegularExpressionValidator { regularExpression: /^[\][0-9a-f.:]+$/i } // Allow only IPv4/ IPv6 chars
 
-    maximumLength: 21
+    maximumLength: 47
 
     states: [
         State {
@@ -52,31 +52,5 @@ TextInput {
 
     Behavior on color {
         ColorAnimation { duration: 150 }
-    }
-
-    function isValidIPPort(input)
-    {
-        var parts = input.split(":");
-        if (parts.length !== 2) return false;
-        if (parts[1].length === 0) return false; // port part is empty
-        var ipAddress = parts[0];
-        var ipAddressParts = ipAddress.split(".");
-        if (ipAddressParts.length !== 4) return false;
-        for (var i = 0; (i < ipAddressParts.length); i++) {
-            if (ipAddressParts[i].length === 0) return false; // ip group number part is empty
-            if (parseInt(ipAddressParts[i]) > 255) return false;
-        }
-        var port = parseInt(parts[1]);
-        if (port < 1 || port > 65535) return false;
-        return true;
-    }
-
-    // Connections element to ensure validation on editing finished
-    Connections {
-        target: root
-        function onTextChanged() {
-            // Validate the input whenever editing is finished
-            validInput = isValidIPPort(root.text);
-        }
     }
 }

--- a/src/qml/models/nodemodel.cpp
+++ b/src/qml/models/nodemodel.cpp
@@ -166,3 +166,13 @@ void NodeModel::ConnectToNumConnectionsChangedSignal()
             setNumOutboundPeers(new_num_peers.outbound_full_relay + new_num_peers.block_relay);
         });
 }
+
+bool NodeModel::validateProxyAddress(QString address_port)
+{
+    return m_node.validateProxyAddress(address_port.toStdString());
+}
+
+QString NodeModel::defaultProxyAddress()
+{
+    return QString::fromStdString(m_node.defaultProxyAddress());
+}

--- a/src/qml/models/nodemodel.h
+++ b/src/qml/models/nodemodel.h
@@ -62,6 +62,9 @@ public:
     void startShutdownPolling();
     void stopShutdownPolling();
 
+    Q_INVOKABLE bool validateProxyAddress(QString addr_port);
+    Q_INVOKABLE QString defaultProxyAddress();
+
 public Q_SLOTS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
 


### PR DESCRIPTION
The main purposes of this PR are:
- Allow configure proxy server with IPv6 (after testing exhaustively in current `bitcoin-qt` [repo](https://github.com/bitcoin-core/gui/) and `bitcoind` - e.g. [IPv6 on Qt](https://github.com/bitcoin-core/gui/pull/836#issue-2527108426); [IP validation in Qt](https://github.com/bitcoin-core/gui/pull/813))
- More importantly: moving the validation logic out from the UI (component/ control/ widget) into the back-end (model/ interfaces). It seemed currently in [Qt](https://github.com/bitcoin-core/gui/) all this logic (validation, network classes) was coupled to the UI since the beginning (more than [12y ago](https://github.com/bitcoin-core/gui/blame/c4443c2be141e5f45bb10376056f3083e97cde50/src/qt/optionsmodel.cpp)) instead of using interfaces (introduced much later) that would be the correct thing to do.

Feedback and suggestions are very welcome and will help establish a foundation for leaving business logic out of the UI going forward.

---
<details>
<summary>In order to test it, if it's the first time you run <code>./src/qt/bitcoin-qt</code> you need to go thru the on-boarding flow (<i>start->next->next->next->next->connection settings->Proxy settings</i>) otherwise you need to go to the settings (top right gear icon) then <i>Connection->Proxy settings</i>.</summary>
 
![image](https://github.com/user-attachments/assets/9f10c4b7-b7e4-4807-b895-1c03d9c00037)

</details>

Before this change, only IPv4 address were allow in the value input, now also IPv6 can be entered.

---
There are some [look and feel kind of issues](https://github.com/bitcoin-core/gui-qml/pull/430#issuecomment-2498871269) that will be handled on follow-ups (issues: #437 and #438).