### PR TITLE
Persist Proxy settings

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -22,6 +22,9 @@
 #include <tuple>
 #include <vector>
 
+static const char DEFAULT_PROXY_HOST[] = "127.0.0.1";
+static constexpr uint16_t DEFAULT_PROXY_PORT = 9050;
+
 class BanMan;
 class CFeeRate;
 class CNodeStats;
@@ -125,6 +128,12 @@ public:
 
     //! Get proxy.
     virtual bool getProxy(Network net, Proxy& proxy_info) = 0;
+
+    //! Get default proxy address.
+    virtual std::string defaultProxyAddress() = 0;
+
+    //! Validate a proxy address.
+    virtual bool validateProxyAddress(const std::string& addr_port) = 0;
 
     //! Get number of connections.
     virtual size_t getNodeCount(ConnectionDirection flags) = 0;

--- a/src/qml/components/ProxySettings.qml
+++ b/src/qml/components/ProxySettings.qml
@@ -7,7 +7,12 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import "../controls"
 
+import org.bitcoincore.qt 1.0
+
 ColumnLayout {
+    property string ipAndPortHeader: qsTr("IP and Port")
+    property string invalidIpError: qsTr("Invalid IP address or port format. Use '255.255.255.255:65535' or '[ffff::]:65535'")
+
     spacing: 4
     Header {
         headerBold: true
@@ -41,14 +46,17 @@ ColumnLayout {
     Setting {
         id: defaultProxy
         Layout.fillWidth: true
-        header: qsTr("IP and Port")
-        errorText: qsTr("Invalid IP address or port format. Please use the format '255.255.255.255:65535'.")
+        header: ipAndPortHeader
+        errorText: invalidIpError
         state: !defaultProxyEnable.loadedItem.checked ? "DISABLED" : "FILLED"
         showErrorText: !defaultProxy.loadedItem.validInput && defaultProxyEnable.loadedItem.checked
         actionItem: IPAddressValueInput {
             parentState: defaultProxy.state
-            description: "127.0.0.1:9050"
+            description: nodeModel.defaultProxyAddress()
             activeFocusOnTab: true
+            onTextChanged: {
+                validInput = nodeModel.validateProxyAddress(text);
+            }
         }
         onClicked: {
             loadedItem.filled = true
@@ -89,14 +97,17 @@ ColumnLayout {
     Setting {
         id: torProxy
         Layout.fillWidth: true
-        header: qsTr("IP and Port")
-        errorText: qsTr("Invalid IP address or port format. Please use the format '255.255.255.255:65535'.")
+        header: ipAndPortHeader
+        errorText: invalidIpError
         state: !torProxyEnable.loadedItem.checked ? "DISABLED" : "FILLED"
         showErrorText: !torProxy.loadedItem.validInput && torProxyEnable.loadedItem.checked
         actionItem: IPAddressValueInput {
             parentState: torProxy.state
-            description: "127.0.0.1:9050"
+            description: nodeModel.defaultProxyAddress()
             activeFocusOnTab: true
+            onTextChanged: {
+                validInput = nodeModel.validateProxyAddress(text);
+            }
         }
         onClicked: {
             loadedItem.filled = true

--- a/src/qml/components/ProxySettings.qml
+++ b/src/qml/components/ProxySettings.qml
@@ -35,7 +35,9 @@ ColumnLayout {
                 } else {
                     defaultProxy.state = "FILLED"
                 }
+                optionsModel.setIsProxySet(checked)
             }
+            checked: optionsModel.isProxySet
         }
         onClicked: {
             loadedItem.toggle()
@@ -52,10 +54,12 @@ ColumnLayout {
         showErrorText: !defaultProxy.loadedItem.validInput && defaultProxyEnable.loadedItem.checked
         actionItem: IPAddressValueInput {
             parentState: defaultProxy.state
-            description: nodeModel.defaultProxyAddress()
+            text: optionsModel.proxyAddress
             activeFocusOnTab: true
             onTextChanged: {
-                validInput = nodeModel.validateProxyAddress(text);
+                if (validInput = nodeModel.validateProxyAddress(text)) {
+                    optionsModel.setProxyAddress(text);
+                }
             }
         }
         onClicked: {
@@ -86,7 +90,9 @@ ColumnLayout {
                 } else {
                     torProxy.state = "FILLED"
                 }
+                optionsModel.setIsTorProxySet(checked)
             }
+            checked: optionsModel.isTorProxySet
         }
         onClicked: {
             loadedItem.toggle()
@@ -103,10 +109,12 @@ ColumnLayout {
         showErrorText: !torProxy.loadedItem.validInput && torProxyEnable.loadedItem.checked
         actionItem: IPAddressValueInput {
             parentState: torProxy.state
-            description: nodeModel.defaultProxyAddress()
+            text: optionsModel.torProxyAddress
             activeFocusOnTab: true
             onTextChanged: {
-                validInput = nodeModel.validateProxyAddress(text);
+                if (validInput = nodeModel.validateProxyAddress(text)) {
+                    optionsModel.setTorProxyAddress(text);
+                }
             }
         }
         onClicked: {

--- a/src/qml/controls/IPAddressValueInput.qml
+++ b/src/qml/controls/IPAddressValueInput.qml
@@ -16,9 +16,9 @@ TextInput {
     property bool validInput: true
     enabled: true
     state: root.parentState
-    validator: RegExpValidator { regExp: /[0-9.:]*/ } // Allow only digits, dots, and colons
+    validator: RegularExpressionValidator { regularExpression: /^[\][0-9a-f.:]+$/i } // Allow only IPv4/ IPv6 chars
 
-    maximumLength: 21
+    maximumLength: 47
 
     states: [
         State {
@@ -52,31 +52,5 @@ TextInput {
 
     Behavior on color {
         ColorAnimation { duration: 150 }
-    }
-
-    function isValidIPPort(input)
-    {
-        var parts = input.split(":");
-        if (parts.length !== 2) return false;
-        if (parts[1].length === 0) return false; // port part is empty
-        var ipAddress = parts[0];
-        var ipAddressParts = ipAddress.split(".");
-        if (ipAddressParts.length !== 4) return false;
-        for (var i = 0; (i < ipAddressParts.length); i++) {
-            if (ipAddressParts[i].length === 0) return false; // ip group number part is empty
-            if (parseInt(ipAddressParts[i]) > 255) return false;
-        }
-        var port = parseInt(parts[1]);
-        if (port < 1 || port > 65535) return false;
-        return true;
-    }
-
-    // Connections element to ensure validation on editing finished
-    Connections {
-        target: root
-        function onTextChanged() {
-            // Validate the input whenever editing is finished
-            validInput = isValidIPPort(root.text);
-        }
     }
 }

--- a/src/qml/models/nodemodel.cpp
+++ b/src/qml/models/nodemodel.cpp
@@ -166,3 +166,13 @@ void NodeModel::ConnectToNumConnectionsChangedSignal()
             setNumOutboundPeers(new_num_peers.outbound_full_relay + new_num_peers.block_relay);
         });
 }
+
+bool NodeModel::validateProxyAddress(QString address_port)
+{
+    return m_node.validateProxyAddress(address_port.toStdString());
+}
+
+QString NodeModel::defaultProxyAddress()
+{
+    return QString::fromStdString(m_node.defaultProxyAddress());
+}

--- a/src/qml/models/nodemodel.h
+++ b/src/qml/models/nodemodel.h
@@ -62,6 +62,9 @@ public:
     void startShutdownPolling();
     void stopShutdownPolling();
 
+    Q_INVOKABLE bool validateProxyAddress(QString addr_port);
+    Q_INVOKABLE QString defaultProxyAddress();
+
 public Q_SLOTS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
 

--- a/src/qml/models/options_model.h
+++ b/src/qml/models/options_model.h
@@ -37,6 +37,14 @@ class OptionsQmlModel : public QObject
     Q_PROPERTY(QString dataDir READ dataDir WRITE setDataDir NOTIFY dataDirChanged)
     Q_PROPERTY(QString getDefaultDataDirString READ getDefaultDataDirString CONSTANT)
     Q_PROPERTY(QUrl getDefaultDataDirectory READ getDefaultDataDirectory CONSTANT)
+    Q_PROPERTY(QString proxyAddress READ proxyAddress WRITE setProxyAddress NOTIFY proxyAddressChanged)
+    Q_PROPERTY(bool isProxySet READ isProxySet WRITE setIsProxySet NOTIFY isProxySetChanged)
+    Q_PROPERTY(QString torProxyAddress READ torProxyAddress WRITE setTorProxyAddress NOTIFY proxyAddressChanged)
+    Q_PROPERTY(bool isTorProxySet READ isTorProxySet WRITE setIsTorProxySet NOTIFY isTorProxySetChanged)
+
+protected:
+    bool evaluateIfProxyIsSet();
+    bool evaluateIfTorProxyIsSet();
 
 public:
     explicit OptionsQmlModel(interfaces::Node& node, bool is_onboarded);
@@ -67,6 +75,14 @@ public:
     QUrl getDefaultDataDirectory();
     Q_INVOKABLE bool setCustomDataDirArgs(QString path);
     Q_INVOKABLE QString getCustomDataDirString();
+    QString proxyAddress() const { return m_proxy_address; }
+    Q_INVOKABLE void setProxyAddress(QString new_proxy_address);
+    bool isProxySet() const { return m_is_proxy_set; }
+    Q_INVOKABLE void setIsProxySet(bool is_set);
+    QString torProxyAddress() const { return m_tor_proxy_address; }
+    Q_INVOKABLE void setTorProxyAddress(QString new_proxy_address);
+    bool isTorProxySet() const { return m_is_tor_proxy_set; }
+    Q_INVOKABLE void setIsTorProxySet(bool is_set);
 
 public Q_SLOTS:
     void setCustomDataDirString(const QString &new_custom_datadir_string) {
@@ -85,6 +101,10 @@ Q_SIGNALS:
     void upnpChanged(bool new_upnp);
     void customDataDirStringChanged(QString new_custom_datadir_string);
     void dataDirChanged(QString new_data_dir);
+    void proxyAddressChanged(QString new_proxy_address);
+    void isProxySetChanged(bool is_set);
+    void torProxyAddressChanged(QString new_proxy_address);
+    void isTorProxySetChanged(bool is_set);
 
 private:
     interfaces::Node& m_node;
@@ -105,6 +125,10 @@ private:
     bool m_upnp;
     QString m_custom_datadir_string;
     QString m_dataDir;
+    QString m_proxy_address;
+    bool m_is_proxy_set;
+    QString m_tor_proxy_address;
+    bool m_is_tor_proxy_set;
 
     common::SettingsValue pruneSetting() const;
 };


### PR DESCRIPTION
_(This is based on top of #430)._

Adding the required logic to persist the configuration of both default Proxy and Tor proxy values to `settings.json`([location](https://github.com/bitcoin-core/gui-qml/blob/main/doc/files.md)).

Disabling a proxy thru its switch will remove the setting from the config file.

---

<ins>_What to test on this PR_</ins>:

Simply verify that the proxy value entered in the UI gets persisted into the file mentioned above, and if you manually touch the file or restart the application, the UI reflects the values read from the file.

<ins>_How to test that the Proxy feature it's actually working_</ins>:

<details>
<summary>1. Start <code>bitcoin-qt</code> with rpc enabled (with `-proxy` option OR leave it without it to verify that the value is getting read from the `settings.json` file).</summary>

`./src/qt/bitcoin-qt -regtest -proxy=127.0.0.1 -server=1`

</details>
<details>
<summary>2. Run rpc <code>getnetworkinfo</code> from <code>bitcoin-cli</code> to verify the proxy has been set (you might need to update the <code>-rpcport</code> according to the chainnet selected option).</summary>

```
./src/bitcoin-cli -regtest -rpcport=18443 getnetworkinfo
{
  "version": 259900,
  "subversion": "/Satoshi:25.99.0/",
  "protocolversion": 70016,
  "localservices": "0000000000000409",
  "localservicesnames": [
    "NETWORK",
    "WITNESS",
    "NETWORK_LIMITED"
  ],
  "localrelay": true,
  "timeoffset": 0,
  "networkactive": true,
  "connections": 0,
  "connections_in": 0,
  "connections_out": 0,
  "networks": [
    {
      "name": "ipv4",
      "limited": false,
      "reachable": true,
      "proxy": "127.0.0.1:9050",
...

```
</details>

3. If you wish to check also the proper proxy traffic you can setup up a local proxy following the "_Test instructions_" section at the top description of the `gui` PR [#836](https://github.com/bitcoin-core/gui/pull/836#issue-2527108426).
