### PR TITLE
doc: Add missing fedora dependency

### DIFF
--- a/src/qml/README.md
+++ b/src/qml/README.md
@@ -79,7 +79,7 @@ If you're unable to install the dependencies through your system's package manag
 #### Fedora:
 
 ```
-sudo dnf install qt5-qtdeclarative-devel qt5-qtquickcontrols2-devel
+sudo dnf install qt5-qtdeclarative-devel qt5-qtquickcontrols qt5-qtquickcontrols2-devel
 ```
 
 ### Build


### PR DESCRIPTION
Without the `qt5-quickcontrols` package, this builds on fedora 40 but fails to run:


```console
$ ./configure --with-qml
# [...]
Options used to compile and link:
  with gui / qt   = yes
    with qml      = yes
    with qr       = yes
$ ./src/qt/bitcoin-qt
QSocketNotifier: Can only be used with threads started with QThread
QQmlApplicationEngine failed to load component
qrc:/qml/pages/main.qml:68:9: Type OnboardingWizard unavailable
qrc:/qml/pages/onboarding/OnboardingWizard.qml:38:9: Type OnboardingStorageLocation unavailable
qrc:/qml/pages/onboarding/OnboardingStorageLocation.qml:26:17: Type StorageLocations unavailable
qrc:/qml/components/StorageLocations.qml:8:1: module "QtQuick.Dialogs" is not installed
```