### PR TITLE
Change PageStack easing type to InOutCubic

### DIFF
--- a/src/qml/controls/PageStack.qml
+++ b/src/qml/controls/PageStack.qml
@@ -13,9 +13,8 @@ StackView {
             property: vertical ? "y" : "x"
             from: vertical ? parent.height : parent.width
             to: 0
-            duration: 400
-            easing.type: Easing.Bezier
-            easing.bezierCurve: [0.5, 0.0, 0.2, 1.0]
+            duration: 500
+            easing.type: Easing.InOutCubic
         }
     }
     pushExit: Transition {
@@ -23,9 +22,8 @@ StackView {
             property: vertical ? "y" : "x"
             from: 0
             to: vertical ? -parent.height : -parent.width
-            duration: 400
-            easing.type: Easing.Bezier
-            easing.bezierCurve: [0.5, 0.0, 0.2, 1.0]
+            duration: 500
+            easing.type: Easing.InOutCubic
         }
     }
     popEnter: Transition {
@@ -33,9 +31,8 @@ StackView {
             property: vertical ? "y" : "x"
             from: vertical ? -parent.height : -parent.width
             to: 0
-            duration: 400
-            easing.type: Easing.Bezier
-            easing.bezierCurve: [0.5, 0.0, 0.2, 1.0]
+            duration: 500
+            easing.type: Easing.InOutCubic
         }
     }
     popExit: Transition {
@@ -43,9 +40,8 @@ StackView {
             property: vertical ? "y" : "x"
             from: 0
             to: vertical ? parent.height : parent.width
-            duration: 400
-            easing.type: Easing.Bezier
-            easing.bezierCurve: [0.5, 0.0, 0.2, 1.0]
+            duration: 500
+            easing.type: Easing.InOutCubic
         }
     }
 }


### PR DESCRIPTION
See #452 for the problem description, and the [first comment](https://github.com/bitcoin-core/gui-qml/issues/452#issuecomment-2889176783) in that thread with the rationale for this change. The current easing type is not supported by QtQuick 2.15. This PR changes the easing type to a supported one that is close to the desired custom bezier curve.

I am relying on Github Copilot for the analysis of the problem. Seems correct, but maybe you know something neither me or AI knows.

Addresses #452