### PR TITLE
Add missing <cstdint> declarations

### DIFF
--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -7,6 +7,7 @@
 
 #include <util/chaintype.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -6,9 +6,10 @@
 #ifndef BITCOIN_NODE_INTERFACE_UI_H
 #define BITCOIN_NODE_INTERFACE_UI_H
 
+#include <cstdint>
 #include <functional>
-#include <memory>
 #include <string>
+#include <vector>
 
 class CBlockIndex;
 enum class SynchronizationState;


### PR DESCRIPTION
I'm not sure what broke here, but I'm unable to build without adding these `cstdint` includes, otherwise both GCC and clang complain for me on Fedora 42:


```
$ ./autogen.sh
$ ./configure --with-qml
$ make
Making all in src
make[1]: Entering directory '/home/kepler/btc/gui-qml/src'
make[2]: Entering directory '/home/kepler/btc/gui-qml/src'
make[3]: Entering directory '/home/kepler/btc/gui-qml'
make[3]: Leaving directory '/home/kepler/btc/gui-qml'
  CXX      bitcoind-bitcoind.o
  CXX      libbitcoin_node_a-banman.o
  CXX      libbitcoin_node_a-httpserver.o
In file included from httpserver.cpp:11:
./chainparamsbase.h:23:5: error: ‘uint16_t’ does not name a type
   23 |     uint16_t RPCPort() const { return m_rpc_port; }
      |     ^~~~~~~~
./chainparamsbase.h:11:1: note: ‘uint16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   10 | #include <memory>
  +++ |+#include <cstdint>
   11 | #include <string>
./chainparamsbase.h:24:5: error: ‘uint16_t’ does not name a type
   24 |     uint16_t OnionServiceTargetPort() const { return m_onion_service_target_port; }
   ```
   
   <details>
   
   <summary>configure output</summary>

```
checking for pkg-config... /bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking for a BSD-compatible install... /bin/install -c
checking whether sleep supports fractional seconds... yes
checking filesystem timestamp resolution... 0.01
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking xargs -n works... yes
checking whether to enable maintainer-specific portions of Makefiles... yes
checking for g++... g++
checking whether the C++ compiler works... yes
checking for C++ compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C++... yes
checking whether g++ accepts -g... yes
checking for g++ option to enable C++11 features... none needed
checking whether make supports the include directive... yes (GNU style)
checking dependency style of g++... gcc3
checking whether g++ supports C++17 features with -std=c++17... yes
checking whether the compiler supports GNU Objective C++... no
checking whether g++ -std=c++17 accepts -g... no
checking dependency style of g++ -std=c++17... gcc3
checking how to print strings... printf
checking for gcc... gcc
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking for a sed that does not truncate output... /bin/sed
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for fgrep... /bin/grep -F
checking for ld used by gcc... /bin/ld
checking if the linker (/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /bin/nm -B
checking the name lister (/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /bin/ld option to reload object files... -r
checking for file... file
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ranlib... ranlib
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking command to parse /bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for a working dd... /bin/dd
checking how to truncate binary pipes... /bin/dd bs=4096 count=1
checking for mt... no
checking if : is a manifest tool... no
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... no
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... yes
checking how to run the C++ preprocessor... g++ -std=c++17 -E
checking for ld used by g++ -std=c++17... /bin/ld -m elf_x86_64
checking if the linker (/bin/ld -m elf_x86_64) is GNU ld... yes
checking whether the g++ -std=c++17 linker (/bin/ld -m elf_x86_64) supports shared libraries... yes
checking for g++ -std=c++17 option to produce PIC... -fPIC -DPIC
checking if g++ -std=c++17 PIC flag -fPIC -DPIC works... yes
checking if g++ -std=c++17 static flag -static works... no
checking if g++ -std=c++17 supports -c -o file.o... yes
checking if g++ -std=c++17 supports -c -o file.o... (cached) yes
checking whether the g++ -std=c++17 linker (/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking for ar... /bin/ar
checking for gcov... /bin/gcov
checking for llvm-cov... /bin/llvm-cov
checking for lcov... no
checking for python3.8... no
checking for python3.9... no
checking for python3.10... no
checking for python3.11... no
checking for python3.12... no
checking for python3... /bin/python3
checking for genhtml... no
checking for git... /bin/git
checking for ccache... /bin/ccache
checking for xgettext... /bin/xgettext
checking for hexdump... /bin/hexdump
checking for objcopy... /bin/objcopy
checking for doxygen... /bin/doxygen
checking whether C++ compiler accepts -Werror... yes
checking whether the linker accepts -Wl,--fatal-warnings... yes
checking whether C++ compiler accepts -Wall... yes
checking whether C++ compiler accepts -Wextra... yes
checking whether C++ compiler accepts -Wgnu... no
checking whether C++ compiler accepts -Wformat -Wformat-security... yes
checking whether C++ compiler accepts -Wvla... yes
checking whether C++ compiler accepts -Wshadow-field... no
checking whether C++ compiler accepts -Wthread-safety... no
checking whether C++ compiler accepts -Wloop-analysis... no
checking whether C++ compiler accepts -Wredundant-decls... yes
checking whether C++ compiler accepts -Wunused-member-function... no
checking whether C++ compiler accepts -Wdate-time... yes
checking whether C++ compiler accepts -Wconditional-uninitialized... no
checking whether C++ compiler accepts -Wduplicated-branches... yes
checking whether C++ compiler accepts -Wduplicated-cond... yes
checking whether C++ compiler accepts -Wlogical-op... yes
checking whether C++ compiler accepts -Woverloaded-virtual... yes
checking whether C++ compiler accepts -Wsuggest-override... yes
checking whether C++ compiler accepts -Wunreachable-code-loop-increment... no
checking whether C++ compiler accepts -Wimplicit-fallthrough... yes
checking whether C++ compiler accepts -Wdocumentation... no
checking whether C++ compiler accepts -Wunused-parameter... yes
checking whether C++ compiler accepts -Wself-assign... no
checking whether C++ compiler accepts -fno-extended-identifiers... yes
checking whether C++ compiler accepts -msse4.2... yes
checking whether C++ compiler accepts -msse4.1... yes
checking whether C++ compiler accepts -mavx -mavx2... yes
checking whether C++ compiler accepts -msse4 -msha... yes
checking whether C++ compiler accepts -mpclmul... yes
checking for SSE4.2 intrinsics... yes
checking for SSE4.1 intrinsics... yes
checking for AVX2 intrinsics... yes
checking for x86 SHA-NI intrinsics... yes
checking whether C++ compiler accepts -march=armv8-a+crc... no
checking whether C++ compiler accepts -march=armv8-a+crypto... no
checking for ARMv8 CRC32 intrinsics... no
checking for ARMv8 SHA-NI intrinsics... no
checking whether byte ordering is bigendian... no
checking how to run the C preprocessor... gcc -E
checking for egrep -e... (cached) /bin/grep -E
checking whether gcc is Clang... no
checking whether pthreads work with "-pthread" and "-lpthread"... yes
checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
checking whether more special flags are required for pthreads... no
checking for PTHREAD_PRIO_INHERIT... yes
checking whether std::atomic can be used without link library... yes
checking for gcc option to enable large file support... none needed
checking for g++ -std=c++17 options needed to detect all undeclared functions... none needed
checking whether strerror_r is declared... yes
checking whether strerror_r returns char *... yes
checking whether C++ compiler accepts -fPIC... yes
checking whether C++ compiler accepts -fstack-reuse=none... yes
checking whether C++ compiler accepts -Wstack-protector... yes
checking whether C++ compiler accepts -fstack-protector-all... yes
checking whether C++ compiler accepts -fcf-protection=full... yes
checking whether C++ compiler accepts -fstack-clash-protection... yes
checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
checking whether C++ preprocessor accepts -U_FORTIFY_SOURCE... yes
checking whether the linker accepts -Wl,--enable-reloc-section... no
checking whether the linker accepts -Wl,--dynamicbase... no
checking whether the linker accepts -Wl,--nxcompat... no
checking whether the linker accepts -Wl,--high-entropy-va... no
checking whether the linker accepts -Wl,-z,relro... yes
checking whether the linker accepts -Wl,-z,now... yes
checking whether the linker accepts -Wl,-z,separate-code... yes
checking whether the linker accepts -fPIE -pie... yes
checking for endian.h... yes
checking for sys/endian.h... no
checking for byteswap.h... yes
checking for sys/select.h... yes
checking for sys/prctl.h... yes
checking for sys/sysctl.h... no
checking for vm/vm_param.h... no
checking for sys/vmmeter.h... no
checking for sys/resources.h... no
checking whether getifaddrs is declared... yes
checking whether ifaddrs funcs can be used without link library... yes
checking whether freeifaddrs is declared... yes
checking whether ifaddrs funcs can be used without link library... yes
checking whether fork is declared... yes
checking whether setsid is declared... yes
checking whether pipe2 is declared... yes
checking for timingsafe_bcmp... no
checking whether le16toh is declared... yes
checking whether le32toh is declared... yes
checking whether le64toh is declared... yes
checking whether htole16 is declared... yes
checking whether htole32 is declared... yes
checking whether htole64 is declared... yes
checking whether be16toh is declared... yes
checking whether be32toh is declared... yes
checking whether be64toh is declared... yes
checking whether htobe16 is declared... yes
checking whether htobe32 is declared... yes
checking whether htobe64 is declared... yes
checking whether bswap_16 is declared... yes
checking whether bswap_32 is declared... yes
checking whether bswap_64 is declared... yes
checking for __builtin_clzl... yes
checking for __builtin_clzll... yes
checking for getmemoryinfo... yes
checking for mallopt M_ARENA_MAX... yes
checking for posix_fallocate... yes
checking for default visibility attribute... yes
checking for dllexport attribute... no
checking for thread_local support... yes
checking for gmtime_r... yes
checking for Linux getrandom function... yes
checking for getentropy via sys/random.h... yes
checking for sysctl... no
checking for sysctl KERN_ARND... no
checking for if type char equals int8_t... no
checking for fdatasync... yes
checking for F_FULLFSYNC... no
checking for O_CLOEXEC... yes
checking for __builtin_prefetch... yes
checking for _mm_prefetch... yes
checking for strong getauxval support in the system headers... yes
checking for std::system... yes
checking for ::_wsystem... no
checking for Qt5Core >= 5.11.3... yes
checking for Qt5Gui >= 5.11.3... yes
checking for Qt5Widgets >= 5.11.3... yes
checking for Qt5Network >= 5.11.3... yes
checking for Qt5Test >= 5.11.3... yes
checking for Qt5DBus >= 5.11.3... yes
checking for Qt5Qml >= 5.11.3... yes
checking for Qt5QmlModels >= 5.11.3... yes
checking for Qt5Quick >= 5.11.3... yes
checking for Qt5QuickControls2 >= 5.11.3... yes
checking for static Qt... no
checking whether -fPIE can be used with this Qt config... yes
checking for moc-qt5... /usr/lib64/qt5/bin/moc-qt5
checking for uic-qt5... /usr/lib64/qt5/bin/uic-qt5
checking for rcc-qt5... /usr/lib64/qt5/bin/rcc-qt5
checking for lrelease-qt5... /usr/lib64/qt5/bin/lrelease-qt5
checking for lupdate-qt5... /usr/lib64/qt5/bin/lupdate-qt5
checking for lconvert-qt5... /usr/lib64/qt5/bin/lconvert-qt5
checking whether to build Bitcoin Core GUI... yes (Qt5)
checking whether main function is needed for fuzz binary... checking whether the linker accepts ... no
yes
checking for __builtin_mul_overflow... yes
checking for Berkeley DB C++ headers... /usr/include/libdb/
checking for sqlite3 >= 3.7.17... yes
checking whether to build wallet with support for sqlite... yes
checking whether Userspace, Statically Defined Tracing tracepoints are supported... yes
checking for miniupnpc/miniupnpc.h... no
checking for miniupnpc/upnpcommands.h... no
checking for miniupnpc/upnperrors.h... no
checking for natpmp.h... no
checking for Boost headers >= 1.64.0 (106400)... yes
checking whether C++ preprocessor accepts -DBOOST_NO_CXX98_FUNCTION_BASE... yes
checking whether Boost.Process can be used... yes
checking for libevent >= 2.1.8... yes
checking for libevent_pthreads >= 2.1.8... yes
checking if evhttp_connection_get_peer expects const char**... no
checking for libqrencode... yes
checking for libzmq >= 4... yes
checking for libmultiprocess... no
checking whether to build bitcoind... yes
checking whether to build bitcoin-cli... yes
checking whether to build bitcoin-tx... yes
checking whether to build bitcoin-wallet... yes
checking whether to build bitcoin-util... yes
checking whether to build experimental bitcoin-chainstate... no
checking whether to build libraries... yes
checking if ccache should be used... yes
checking whether C compiler accepts -fdebug-prefix-map=A=B... yes
checking whether C preprocessor accepts -fmacro-prefix-map=A=B... yes
checking if wallet should be enabled... yes
checking whether to build with support for UPnP... no
checking whether to build with support for NAT-PMP... no
checking whether to build GUI with support for D-Bus... yes
checking whether to build GUI with support for QR codes... yes
checking whether to build test_bitcoin-qt... no
checking whether to build test_bitcoin... yes
checking whether to reduce exports... no
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating libbitcoinconsensus.pc
config.status: creating Makefile
config.status: creating src/Makefile
config.status: creating doc/man/Makefile
config.status: creating share/setup.nsi
config.status: creating share/qt/Info.plist
config.status: creating test/config.ini
config.status: creating contrib/devtools/split-debug.sh
config.status: creating doc/Doxyfile
config.status: creating src/config/bitcoin-config.h
config.status: src/config/bitcoin-config.h is unchanged
config.status: executing depfiles commands
config.status: executing libtool commands
=== configuring in src/secp256k1 (/home/kepler/btc/gui-qml/src/secp256k1)
configure: running /bin/sh ./configure --disable-option-checking '--prefix=/usr/local'  '--with-qml' '--disable-shared' '--with-pic' '--enable-benchmark=no' '--enable-module-recovery' '--disable-module-ecdh' --cache-file=/dev/null --srcdir=.
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking for a BSD-compatible install... /bin/install -c
checking whether sleep supports fractional seconds... yes
checking filesystem timestamp resolution... 0.01
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking xargs -n works... yes
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking whether gcc understands -c and -o together... yes
checking whether make supports the include directive... yes (GNU style)
checking dependency style of gcc... gcc3
checking dependency style of gcc... gcc3
checking for ar... ar
checking the archiver (ar) interface... ar
checking how to print strings... printf
checking for a sed that does not truncate output... /bin/sed
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for fgrep... /bin/grep -F
checking for ld used by gcc... /bin/ld
checking if the linker (/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /bin/nm -B
checking the name lister (/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /bin/ld option to reload object files... -r
checking for file... file
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ranlib... ranlib
checking for archiver @FILE support... @
checking for strip... strip
checking command to parse /bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for a working dd... /bin/dd
checking how to truncate binary pipes... /bin/dd bs=4096 count=1
checking for mt... no
checking if : is a manifest tool... no
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... no
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... no
checking whether to build static libraries... yes
checking if gcc supports -Werror... yes
checking if gcc supports -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef... yes
checking if gcc supports -Wno-overlength-strings... yes
checking if gcc supports -Wall... yes
checking if gcc supports -Wno-unused-function... yes
checking if gcc supports -Wextra... yes
checking if gcc supports -Wcast-align... yes
checking if gcc supports -Wcast-align=strict... yes
checking if gcc supports -Wconditional-uninitialized... no
checking if gcc supports -Wreserved-identifier... no
checking if gcc supports -fvisibility=hidden... yes
checking for valgrind support... yes
checking for x86_64 assembly availability... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating libsecp256k1.pc
config.status: executing depfiles commands
config.status: executing libtool commands

Build Options:
  with external callbacks = no
  with benchmarks         = no
  with tests              = yes
  with ctime tests        = yes
  with coverage           = no
  with examples           = no
  module ecdh             = no
  module recovery         = yes
  module extrakeys        = yes
  module schnorrsig       = yes
  module ellswift         = yes

  asm                     = x86_64
  ecmult window size      = 15
  ecmult gen prec. bits   = 4

  valgrind                = yes
  CC                      = gcc
  CPPFLAGS                = 
  SECP_CFLAGS             = -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden 
  CFLAGS                  = -g -O2
  LDFLAGS                 = 

Options used to compile and link:
  external signer = yes
  multiprocess    = no
  with libs       = yes
  with wallet     = yes
    with sqlite   = yes
    with bdb      = no
  with gui / qt   = yes
    with qml      = yes
    with qr       = yes
  with zmq        = yes
  with test       = yes
  with fuzz binary = yes
  with bench      = yes
  with upnp       = no
  with natpmp     = no
  use asm         = yes
  USDT tracing    = yes
  sanitizers      = 
  debug enabled   = no
  gprof enabled   = no
  werror          = no
  LTO             = no

  target os       = linux-gnu
  build os        = linux-gnu

  CC              = /bin/ccache gcc
  CFLAGS          = -pthread -g -O2
  CPPFLAGS        =  -fmacro-prefix-map=$(abs_top_srcdir)=.  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3  -DHAVE_BUILD_INFO -DPROVIDE_FUZZ_MAIN_FUNCTION 
  CXX             = /bin/ccache g++ -std=c++17
  CXXFLAGS        =   -fdebug-prefix-map=$(abs_top_srcdir)=.  -fstack-reuse=none -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection  -Wall -Wextra -Wformat -Wformat-security -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough  -Wno-unused-parameter    -fno-extended-identifiers -g -O2
  LDFLAGS         =  -lpthread  -Wl,-z,relro -Wl,-z,now -Wl,-z,separate-code -pie   
  AR              = /bin/ar
  ARFLAGS         = cr

```