### PR TITLE
Disable forms when loading

### DIFF
--- a/src/qml/components/Separator.qml
+++ b/src/qml/components/Separator.qml
@@ -8,7 +8,7 @@ import "../controls"
 
 Rectangle {
     height: 1
-    color: Theme.color.neutral5
+    color: enabled ? Theme.color.neutral5 : Theme.color.neutral4
 
     Behavior on color {
         ColorAnimation { duration: 150 }

--- a/src/qml/controls/CoreText.qml
+++ b/src/qml/controls/CoreText.qml
@@ -8,7 +8,7 @@ import QtQuick.Controls 2.15
 Text {
     property bool bold: false
     property bool wrap: true
-    color: Theme.color.neutral9
+    color: enabled ? Theme.color.neutral9 : Theme.color.neutral4
     font.family: "Inter"
     font.styleName: bold ? "Semi Bold" : "Regular"
     font.pixelSize: 13

--- a/src/qml/controls/EllipsisMenuButton.qml
+++ b/src/qml/controls/EllipsisMenuButton.qml
@@ -43,6 +43,10 @@ Button {
         State {
             name: "HOVER"; when: root.hovered
             PropertyChanges { target: ellipsisIcon; color: hoverColor }
+        },
+        State {
+            name: "DISABLED"; when: !root.enabled
+            PropertyChanges { target: ellipsisIcon; color: Theme.color.neutral4 }
         }
     ]
 }

--- a/src/qml/controls/LabeledCoinControlButton.qml
+++ b/src/qml/controls/LabeledCoinControlButton.qml
@@ -21,7 +21,6 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         horizontalAlignment: Text.AlignLeft
         width: 110
-        color: Theme.color.neutral9
         font.pixelSize: 18
         text: qsTr("Inputs")
     }
@@ -30,7 +29,7 @@ Item {
         anchors.left: label.right
         anchors.verticalCenter: parent.verticalCenter
         horizontalAlignment: Text.AlignLeft
-        color: Theme.color.orangeLight1
+        color: enabled ? Theme.color.orangeLight1 : Theme.color.neutral2
         font.pixelSize: 18
         text: {
             if (coinCount === 0) {

--- a/src/qml/controls/LabeledTextInput.qml
+++ b/src/qml/controls/LabeledTextInput.qml
@@ -26,7 +26,6 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         horizontalAlignment: Text.AlignLeft
         width: 110
-        color: Theme.color.neutral9
         font.pixelSize: 18
     }
 
@@ -40,7 +39,7 @@ Item {
         font.styleName: "Regular"
         font.pixelSize: 18
         color: Theme.color.neutral9
-        placeholderTextColor: Theme.color.neutral7
+        placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
         background: Item {}
         selectByMouse: true
         onTextEdited: root.textEdited()
@@ -54,7 +53,7 @@ Item {
         Icon {
             id: icon
             source: ""
-            color: Theme.color.neutral8
+            color: enabled ? Theme.color.neutral8 : Theme.color.neutral4
             size: 30
             enabled: source != ""
             onClicked: root.iconClicked()

--- a/src/qml/controls/NavButton.qml
+++ b/src/qml/controls/NavButton.qml
@@ -15,7 +15,7 @@ AbstractButton {
     property int textSize: 18
     property url iconSource: ""
     property Rectangle iconBackground: null
-    property color iconColor: Theme.color.neutral9
+    property color iconColor: enabled ? Theme.color.neutral9 : Theme.color.neutral2
     hoverEnabled: AppMode.isDesktop
     topPadding: text_background.active ? 7 : 14
     bottomPadding: text_background.active ? 7 : 14
@@ -88,7 +88,6 @@ AbstractButton {
                     anchors.verticalCenter: parent.verticalCenter
                     bold: true
                     font.pixelSize: root.textSize
-                    color: Theme.color.neutral9
                     text: root.text
                 }
             }

--- a/src/qml/pages/wallet/RequestPayment.qml
+++ b/src/qml/pages/wallet/RequestPayment.qml
@@ -35,6 +35,9 @@ Page {
 
         RowLayout {
             id: contentRow
+
+            enabled: walletController.initialized
+
             anchors.top: title.bottom
             anchors.topMargin: 40
             anchors.horizontalCenter: parent.horizontalCenter
@@ -59,7 +62,6 @@ Page {
                         anchors.left: parent.left
                         anchors.verticalCenter: parent.verticalCenter
                         horizontalAlignment: Text.AlignLeft
-                        color: Theme.color.neutral9
                         text: "Amount"
                         font.pixelSize: 18
                     }
@@ -73,7 +75,7 @@ Page {
                         font.styleName: "Regular"
                         font.pixelSize: 18
                         color: Theme.color.neutral9
-                        placeholderTextColor: Theme.color.neutral7
+                        placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
                         background: Item {}
                         placeholderText: "0.00000000"
                         selectByMouse: true
@@ -104,14 +106,14 @@ Page {
                             anchors.verticalCenter: parent.verticalCenter
                             text: bitcoinAmount.unitLabel
                             font.pixelSize: 18
-                            color: Theme.color.neutral7
+                            color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
                         }
                         Icon {
                             id: flipIcon
                             anchors.right: parent.right
                             anchors.verticalCenter: parent.verticalCenter
                             source: "image://images/flip-vertical"
-                            color: Theme.color.neutral8
+                            color: unitLabel.enabled ? Theme.color.neutral8 : Theme.color.neutral4
                             size: 30
                         }
                     }
@@ -156,7 +158,6 @@ Page {
                         width: 110
                         text: qsTr("Address")
                         font.pixelSize: 18
-                        color: Theme.color.neutral9
                     }
                     CoreText {
                         id: copyLabel
@@ -166,7 +167,7 @@ Page {
                         width: 110
                         text: qsTr("copy")
                         font.pixelSize: 18
-                        color: Theme.color.neutral7
+                        color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
                     }
 
                     Rectangle {
@@ -182,7 +183,6 @@ Page {
                             anchors.leftMargin: 5
                             horizontalAlignment: Text.AlignLeft
                             font.pixelSize: 18
-                            color: Theme.color.neutral9
                             wrap: true
                         }
                     }

--- a/src/qml/pages/wallet/Send.qml
+++ b/src/qml/pages/wallet/Send.qml
@@ -48,6 +48,8 @@ PageStack {
 
                 spacing: 10
 
+                enabled: walletController.initialized
+
                 Item {
                     id: titleRow
                     Layout.fillWidth: true
@@ -59,6 +61,7 @@ PageStack {
                         anchors.verticalCenter: parent.verticalCenter
                         text: qsTr("Send bitcoin")
                         font.pixelSize: 21
+                        color: Theme.color.neutral9
                         bold: true
                     }
                     EllipsisMenuButton {
@@ -106,7 +109,6 @@ PageStack {
                         anchors.left: parent.left
                         anchors.verticalCenter: parent.verticalCenter
                         horizontalAlignment: Text.AlignLeft
-                        color: Theme.color.neutral9
                         text: qsTr("Amount")
                         font.pixelSize: 18
                     }
@@ -120,7 +122,7 @@ PageStack {
                         font.styleName: "Regular"
                         font.pixelSize: 18
                         color: Theme.color.neutral9
-                        placeholderTextColor: Theme.color.neutral7
+                        placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
                         background: Item {}
                         placeholderText: "0.00000000"
                         selectByMouse: true
@@ -152,14 +154,14 @@ PageStack {
                             anchors.verticalCenter: parent.verticalCenter
                             text: bitcoinAmount.unitLabel
                             font.pixelSize: 18
-                            color: Theme.color.neutral7
+                            color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
                         }
                         Icon {
                             id: flipIcon
                             anchors.right: parent.right
                             anchors.verticalCenter: parent.verticalCenter
                             source: "image://images/flip-vertical"
-                            color: Theme.color.neutral8
+                            icon.color: unitLabel.enabled ? Theme.color.neutral8 : Theme.color.neutral4
                             size: 30
                         }
                     }
@@ -204,7 +206,6 @@ PageStack {
                         id: feeLabel
                         anchors.left: parent.left
                         anchors.top: parent.top
-                        color: Theme.color.neutral9
                         text: "Fee"
                         font.pixelSize: 15
                     }
@@ -213,7 +214,6 @@ PageStack {
                         id: feeValue
                         anchors.right: parent.right
                         anchors.top: parent.top
-                        color: Theme.color.neutral9
                         text: qsTr("Default (~2,000 sats)")
                         font.pixelSize: 15
                     }

--- a/src/qml/walletqmlcontroller.cpp
+++ b/src/qml/walletqmlcontroller.cpp
@@ -120,4 +120,7 @@ void WalletQmlController::initialize()
         m_selected_wallet = m_wallets.front();
         Q_EMIT selectedWalletChanged();
     }
+
+    m_initialized = true;
+    Q_EMIT initializedChanged();
 }

--- a/src/qml/walletqmlcontroller.h
+++ b/src/qml/walletqmlcontroller.h
@@ -6,19 +6,22 @@
 #define BITCOIN_QML_WALLETQMLCONTROLLER_H
 
 #include <qml/models/walletqmlmodel.h>
+
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 
+#include <memory>
+
 #include <QMutex>
 #include <QObject>
 #include <QThread>
-#include <memory>
 
 class WalletQmlController : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(WalletQmlModel* selectedWallet READ selectedWallet NOTIFY selectedWalletChanged)
+    Q_PROPERTY(bool initialized READ initialized NOTIFY initializedChanged)
 
 public:
     explicit WalletQmlController(interfaces::Node& node, QObject *parent = nullptr);
@@ -29,9 +32,11 @@ public:
 
     WalletQmlModel* selectedWallet() const;
     void unloadWallets();
+    bool initialized() const { return m_initialized; }
 
 Q_SIGNALS:
     void selectedWalletChanged();
+    void initializedChanged();
 
 public Q_SLOTS:
     void initialize();
@@ -39,6 +44,7 @@ public Q_SLOTS:
 private:
     void handleLoadWallet(std::unique_ptr<interfaces::Wallet> wallet);
 
+    bool m_initialized{false};
     interfaces::Node& m_node;
     WalletQmlModel* m_selected_wallet;
     QObject* m_worker;


### PR DESCRIPTION
During loading, the Send and Receive forms are disabled and greyed out.

This includes the initialized property added to WalletQmlController just as in #455 

![Screenshot from 2025-05-23 00-40-10](https://github.com/user-attachments/assets/efd5392e-e064-463a-ae84-2edb1a986ea0)
![Screenshot from 2025-05-23 00-39-56](https://github.com/user-attachments/assets/0b69493a-a2cb-425f-9202-f85e9418dfdc)
