### PR TITLE
Activity page fixes

### DIFF
--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -16,7 +16,7 @@ PageStack {
     Connections {
         target: walletController
         function onSelectedWalletChanged() {
-            root.StackView.view.pop()
+            stackView.pop()
         }
     }
 

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -87,6 +87,7 @@ PageStack {
 
                 ListView {
                     id: listView
+                    anchors.fill: parent
                     clip: true
                     model: walletController.selectedWallet.activityListModel
                     delegate: ItemDelegate {


### PR DESCRIPTION
There were two errors that prevented the Activity page from working correctly

The first was a missing anchor for the listView, The patch correctly has the listView fill its parent so it appears now.

Before:
<img width="869" height="716" alt="Screenshot from 2025-07-21 22-57-11" src="https://github.com/user-attachments/assets/21c4801f-831d-4efa-b5d8-28cf49f6eca5" />
After:
<img width="869" height="716" alt="Screenshot from 2025-07-21 22-57-18" src="https://github.com/user-attachments/assets/d32b827c-6093-4dae-a0cf-6107c5cff77b" />

The second fix fixes a bad reference to the stackView and gets rid of the following error in debug.log
`2025-07-22T02:47:12Z GUI: qrc:/qml/pages/wallet/Activity.qml:19: TypeError: Cannot call method 'pop' of null`
