### PR TITLE
Various fixes to Send, WalletController, and general QML

### DIFF
--- a/qml/controls/EllipsisMenuToggleItem.qml
+++ b/qml/controls/EllipsisMenuToggleItem.qml
@@ -39,6 +39,7 @@ Button {
         anchors.centerIn: parent
         anchors.margins: 10
         CoreText {
+            id: buttonText
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignVCenter
             horizontalAlignment: Text.AlignLeft

--- a/qml/models/sendrecipientslistmodel.cpp
+++ b/qml/models/sendrecipientslistmodel.cpp
@@ -152,6 +152,12 @@ void SendRecipientsListModel::clear()
 
 void SendRecipientsListModel::clearToFront()
 {
+    if (m_current != 0) {
+        m_current = 0;
+        Q_EMIT currentRecipientChanged();
+        Q_EMIT currentIndexChanged();
+    }
+
     bool count_changed = false;
     while (m_recipients.size() > 1) {
         delete m_recipients.at(1);
@@ -166,11 +172,5 @@ void SendRecipientsListModel::clearToFront()
     if (m_totalAmount != m_recipients[0]->amount()->satoshi()) {
         m_totalAmount = m_recipients[0]->amount()->satoshi();
         Q_EMIT totalAmountChanged();
-    }
-
-    if (m_current != 0) {
-        m_current = 0;
-        Q_EMIT currentRecipientChanged();
-        Q_EMIT currentIndexChanged();
     }
 }

--- a/qml/models/sendrecipientslistmodel.cpp
+++ b/qml/models/sendrecipientslistmodel.cpp
@@ -93,15 +93,17 @@ void SendRecipientsListModel::remove()
         return;
     }
     beginRemoveRows(QModelIndex(), m_current, m_current);
-    delete m_recipients.takeAt(m_current);
+    if (m_current > 0) {
+        int index_to_remove = m_current;
+        setCurrentIndex(m_current - 1);
+        delete m_recipients.takeAt(index_to_remove);
+    } else {
+        auto removed_recipient = m_recipients.takeAt(m_current);
+        Q_EMIT currentRecipientChanged();
+        delete removed_recipient;
+    }
     endRemoveRows();
     Q_EMIT countChanged();
-
-    if (m_current > 0) {
-        setCurrentIndex(m_current - 1);
-    } else {
-        Q_EMIT currentRecipientChanged();
-    }
 }
 
 SendRecipient* SendRecipientsListModel::currentRecipient() const

--- a/qml/walletqmlcontroller.cpp
+++ b/qml/walletqmlcontroller.cpp
@@ -16,7 +16,8 @@
 WalletQmlController::WalletQmlController(interfaces::Node& node, QObject *parent)
     : QObject(parent)
     , m_node(node)
-    , m_selected_wallet(new WalletQmlModel(parent))
+    , m_empty_wallet(new WalletQmlModel(this))
+    , m_selected_wallet(m_empty_wallet)
     , m_worker(new QObject)
     , m_worker_thread(new QThread(this))
 {
@@ -35,6 +36,7 @@ WalletQmlController::~WalletQmlController()
     m_worker_thread->quit();
     m_worker_thread->wait();
     delete m_worker;
+    delete m_empty_wallet;
 }
 
 void WalletQmlController::setSelectedWallet(QString path)
@@ -63,6 +65,8 @@ WalletQmlModel* WalletQmlController::selectedWallet() const
 void WalletQmlController::unloadWallets()
 {
     m_handler_load_wallet->disconnect();
+    m_selected_wallet = m_empty_wallet;
+    Q_EMIT selectedWalletChanged();
     QMutexLocker locker(&m_wallets_mutex);
     for (WalletQmlModel* wallet : m_wallets) {
         delete wallet;

--- a/qml/walletqmlcontroller.h
+++ b/qml/walletqmlcontroller.h
@@ -54,6 +54,7 @@ private:
 
     bool m_initialized{false};
     interfaces::Node& m_node;
+    WalletQmlModel* m_empty_wallet;
     WalletQmlModel* m_selected_wallet;
     QObject* m_worker;
     QThread* m_worker_thread;


### PR DESCRIPTION
The following errors are resolved with these commits.

Missing id for buttonText in EllipsesMenuToggleItem
```
2025-07-27T01:40:01Z GUI: qrc:/qml/controls/EllipsisMenuToggleItem.qml:71: ReferenceError: buttonText is not defined
2025-07-27T01:40:01Z GUI: qrc:/qml/controls/EllipsisMenuToggleItem.qml:71:13: QML PropertyChanges: Cannot assign to non-existent property "color"
```

Null Property after toggling off Multiple Recipients toggle and removing Recipients with the "-" icon
```
2025-07-27T01:40:03Z GUI: qrc:/qml/pages/wallet/Send.qml:258: TypeError: Cannot read property 'label' of null
2025-07-27T01:40:03Z GUI: qrc:/qml/pages/wallet/Send.qml:234: TypeError: Cannot read property 'amount' of null
2025-07-27T01:40:03Z GUI: qrc:/qml/pages/wallet/Send.qml:212: TypeError: Cannot read property 'amount' of null
2025-07-27T01:40:03Z GUI: qrc:/qml/pages/wallet/Send.qml:178: TypeError: Cannot read property 'address' of null
```

Null properties after all wallets are unloaded
```
2025-07-27T01:40:44Z GUI: qrc:/qml/pages/wallet/Send.qml:258: TypeError: Cannot read property 'label' of null
2025-07-27T01:40:44Z GUI: qrc:/qml/pages/wallet/Send.qml:234: TypeError: Cannot read property 'amount' of null
2025-07-27T01:40:44Z GUI: qrc:/qml/pages/wallet/Send.qml:212: TypeError: Cannot read property 'amount' of null
2025-07-27T01:40:44Z GUI: qrc:/qml/pages/wallet/Send.qml:178: TypeError: Cannot read property 'address' of null
2025-07-27T01:40:44Z GUI: qrc:/qml/pages/wallet/Send.qml:31: TypeError: Cannot read property 'recipients' of null
```

