### PR TITLE
Fix too many arguments warning in BlockClock

### DIFF
--- a/qml/components/BlockClock.qml
+++ b/qml/components/BlockClock.qml
@@ -117,7 +117,7 @@ Item {
                 }
             });
 
-            subText.estimatingChanged(subText.estimating);
+            subText.estimatingChanged();
         }
 
         ColorAnimation on color{


### PR DESCRIPTION
Fixes the following warning

```
expression for onCompleted@qrc:/qml/components/BlockClock.qml:120
Too many arguments, ignoring 1
```