### PR TITLE
cmake: Add missed `Boost::headers`

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -52,10 +52,6 @@ jobs:
       - name: Build
         run: |
           git submodule update --init
-          if [[ "${{ matrix.os }}" == macos* ]]; then
-            export CPLUS_INCLUDE_PATH="$(brew --prefix boost)/include"
-            export LIBRARY_PATH="$(brew --prefix boost)/lib"
-          fi
           cmake -B build
           cmake --build build -j$(nproc)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ target_link_libraries(bitcoinqml
     core_interface
     bitcoin_node
     univalue
+    Boost::headers
     Qt6::Qml
     Qt6::Quick
     Qt6::QuickControls2


### PR DESCRIPTION
This PR fixes building on macOS with Boost installed via Homebrew.