### PR TITLE
Add PeerTableQmlModel

### DIFF
--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -35,6 +35,7 @@
 #include <qml/models/options_model.h>
 #include <qml/models/peerdetailsmodel.h>
 #include <qml/models/peerlistsortproxy.h>
+#include <qml/models/peertableqmlmodel.h>
 #include <qml/models/sendrecipient.h>
 #include <qml/models/walletlistmodel.h>
 #include <qml/models/walletqmlmodel.h>
@@ -289,7 +290,7 @@ int QmlGuiMain(int argc, char* argv[])
         node->startShutdown();
     });
 
-    PeerTableModel peer_model{*node, nullptr};
+    PeerTableQmlModel peer_model{*node, nullptr};
     PeerListSortProxy peer_model_sort_proxy{nullptr};
     peer_model_sort_proxy.setSourceModel(&peer_model);
 

--- a/qml/models/peertableqmlmodel.cpp
+++ b/qml/models/peertableqmlmodel.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/peertableqmlmodel.h>
+
+PeerTableQmlModel::PeerTableQmlModel(interfaces::Node& node, QObject* parent)
+    : PeerTableModel(node, parent)
+{
+}
+
+void PeerTableQmlModel::startAutoRefresh()
+{
+    PeerTableModel::startAutoRefresh();
+}
+
+void PeerTableQmlModel::stopAutoRefresh()
+{
+    PeerTableModel::stopAutoRefresh();
+}

--- a/qml/models/peertableqmlmodel.h
+++ b/qml/models/peertableqmlmodel.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_PEERTABLEQMLMODEL_H
+#define BITCOIN_QML_MODELS_PEERTABLEQMLMODEL_H
+
+#include <bitcoin/src/qt/peertablemodel.h>
+
+#include <QObject>
+
+/**
+ * QML-friendly wrapper for PeerTableModel that exposes methods as invokable
+ * from QML. This allows QML code to call startAutoRefresh() and stopAutoRefresh().
+ */
+class PeerTableQmlModel : public PeerTableModel
+{
+    Q_OBJECT
+
+public:
+    explicit PeerTableQmlModel(interfaces::Node& node, QObject* parent = nullptr);
+
+    Q_INVOKABLE void startAutoRefresh();
+    Q_INVOKABLE void stopAutoRefresh();
+};
+
+#endif // BITCOIN_QML_MODELS_PEERTABLEQMLMODEL_H


### PR DESCRIPTION
The upstream PeerTableModel does not expose its startAutoRefresh and stopAutoRefresh methods as invokable so the PeerTableQmlModel is introduced to make these methods invokable in qml.

fixes #482 