### PR TITLE
Use handlers with explicit parameters in main.qml and DesktopWallets.qml

### DIFF
--- a/qml/pages/main.qml
+++ b/qml/pages/main.qml
@@ -47,7 +47,7 @@ ApplicationWindow {
         }
         anchors.fill: parent
         focus: true
-        Keys.onReleased: {
+        Keys.onReleased: (event) => {
             if (event.key == Qt.Key_Back) {
                 nodeModel.requestShutdown()
                 event.accepted = true
@@ -86,7 +86,7 @@ ApplicationWindow {
             onAddWallet: {
                 main.push(createWalletWizard, { "launchContext": CreateWalletWizard.Context.Main })
             }
-            onSendTransaction: {
+            onSendTransaction: (multipleRecipientsEnabled) => {
                 if (multipleRecipientsEnabled) {
                     main.push(multipleSendReviewPage)
                 } else {

--- a/qml/pages/wallet/DesktopWallets.qml
+++ b/qml/pages/wallet/DesktopWallets.qml
@@ -141,7 +141,9 @@ Page {
         Activity {
         }
         Send {
-            onTransactionPrepared: root.sendTransaction(multipleRecipientsEnabled)
+            onTransactionPrepared: (multipleRecipientsEnabled) => {
+                root.sendTransaction(multipleRecipientsEnabled)
+            }
         }
         RequestPayment {
         }


### PR DESCRIPTION
Signals with parameters should have handlers that explicitly define the arguments. Without this, Qt will throw a warning in the log stating that injection or parameters is deprecated.

fixes #481 