### PR TITLE
Get new address from selected wallet in receive tab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(Qt 6.2 MODULE REQUIRED
     COMPONENTS ${qt_components}
 )
 find_package(Libevent 2.1.8 MODULE REQUIRED)
+find_package(QRencode MODULE REQUIRED)
 
 # Do not build any executable targets from bitcoin submodule
 set(BUILD_BENCH OFF)
@@ -47,6 +48,7 @@ set(BUILD_TX OFF)
 set(BUILD_UTIL OFF)
 set(BUILD_UTIL_CHAINSTATE OFF)
 set(BUILD_WALLET_TOOL OFF)
+set(USE_QRCODE TRUE)
 # We need this libraries, can ignore the executable bitcoin-qt
 set(BUILD_GUI ON)
 set(ENABLE_WALLET ON)
@@ -100,6 +102,7 @@ target_link_libraries(bitcoinqml
     bitcoin_node
     univalue
     Boost::headers
+    $<TARGET_NAME_IF_EXISTS:QRencode::QRencode>
     Qt6::Qml
     Qt6::Quick
     Qt6::QuickControls2

--- a/cmake/module/FindQRencode.cmake
+++ b/cmake/module/FindQRencode.cmake
@@ -1,0 +1,71 @@
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+#[=======================================================================[
+FindQRencode
+------------
+
+Finds the QRencode header and library.
+
+This is a wrapper around find_package()/pkg_check_modules() commands that:
+ - facilitates searching in various build environments
+ - prints a standard log message
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_QRencode QUIET libqrencode)
+endif()
+
+find_path(QRencode_INCLUDE_DIR
+  NAMES qrencode.h
+  HINTS ${PC_QRencode_INCLUDE_DIRS}
+)
+
+find_library(QRencode_LIBRARY_RELEASE
+  NAMES qrencode
+  HINTS ${PC_QRencode_LIBRARY_DIRS}
+)
+find_library(QRencode_LIBRARY_DEBUG
+  NAMES qrencoded qrencode
+  HINTS ${PC_QRencode_LIBRARY_DIRS}
+)
+include(SelectLibraryConfigurations)
+select_library_configurations(QRencode)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(QRencode
+  REQUIRED_VARS QRencode_LIBRARY QRencode_INCLUDE_DIR
+  VERSION_VAR PC_QRencode_VERSION
+)
+
+if(QRencode_FOUND)
+  if(NOT TARGET QRencode::QRencode)
+    add_library(QRencode::QRencode UNKNOWN IMPORTED)
+  endif()
+  if(QRencode_LIBRARY_RELEASE)
+    set_property(TARGET QRencode::QRencode APPEND PROPERTY
+      IMPORTED_CONFIGURATIONS RELEASE
+    )
+    set_target_properties(QRencode::QRencode PROPERTIES
+      IMPORTED_LOCATION_RELEASE "${QRencode_LIBRARY_RELEASE}"
+    )
+  endif()
+  if(QRencode_LIBRARY_DEBUG)
+    set_property(TARGET QRencode::QRencode APPEND PROPERTY
+      IMPORTED_CONFIGURATIONS DEBUG
+    )
+    set_target_properties(QRencode::QRencode PROPERTIES
+      IMPORTED_LOCATION_DEBUG "${QRencode_LIBRARY_DEBUG}"
+    )
+  endif()
+  set_target_properties(QRencode::QRencode PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${QRencode_INCLUDE_DIR}"
+  )
+endif()
+
+mark_as_advanced(
+  QRencode_INCLUDE_DIR
+)

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -63,6 +63,16 @@ QString WalletQmlModel::name() const
     return QString::fromStdString(m_wallet->getWalletName());
 }
 
+QString WalletQmlModel::newAddress(QString label)
+{
+    if (!m_wallet) {
+        return QString();
+    }
+    OutputType output_type = m_wallet->getDefaultAddressType();
+    util::Result<CTxDestination> dest{m_wallet->getNewDestination(output_type, label.toStdString())};
+    return QString::fromStdString(EncodeDestination(dest.value()));
+}
+
 std::set<interfaces::WalletTx> WalletQmlModel::getWalletTxs() const
 {
     if (!m_wallet) {

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -45,6 +45,7 @@ public:
     WalletQmlModelTransaction* currentTransaction() const { return m_current_transaction; }
     Q_INVOKABLE bool prepareTransaction();
     Q_INVOKABLE void sendTransaction();
+    Q_INVOKABLE QString newAddress(QString label);
 
     std::set<interfaces::WalletTx> getWalletTxs() const;
     interfaces::WalletTx getWalletTx(const uint256& hash) const;

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -208,6 +208,14 @@ Page {
                     }
                 }
 
+                function clear() {
+                    clearRequest.visible = false
+                    title.text = qsTr("Request a payment")
+                    address.text = ""
+                    qrImage.code = ""
+                    continueButton.text = qsTr("Create bitcoin address")
+                }
+
                 ContinueButton {
                     id: clearRequest
                     Layout.fillWidth: true
@@ -221,11 +229,14 @@ Page {
                     backgroundPressedColor: "transparent"
                     text: qsTr("Clear")
                     onClicked: {
-                        clearRequest.visible = false
-                        title.text = qsTr("Request a payment")
-                        address.text = ""
-                        qrImage.code = ""
-                        continueButton.text = qsTr("Create bitcoin address")
+                        columnLayout.clear()
+                    }
+                }
+
+                Connections {
+                    target: walletController
+                    function onSelectedWalletChanged() {
+                        columnLayout.clear()
                     }
                 }
             }

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -16,6 +16,7 @@ Page {
     background: null
 
     property int requestCounter: 0
+    property WalletQmlModel wallet: walletController.selectedWallet
 
     ScrollView {
         clip: true
@@ -198,8 +199,10 @@ Page {
                             requestCounter = requestCounter + 1
                             clearRequest.visible = true
                             title.text = qsTr("Payment request #" + requestCounter)
-                            address.text = "bc1q f5xe y2tf 89k9 zy6k gnru wszy 5fsa truy 9te1 bu"
-                            qrImage.code = "bc1qf5xey2tf89k9zy6kgnruwszy5fsatruy9te1bu"
+                            var newAddress = root.wallet.newAddress(label.text)
+                            var groupedAddress = newAddress.replace(/(.{4})/g, "$1 ").trim()
+                            address.text = groupedAddress
+                            qrImage.code = newAddress
                             continueButton.text = qsTr("Copy payment request")
                         }
                     }

--- a/qml/qrimageprovider.cpp
+++ b/qml/qrimageprovider.cpp
@@ -4,9 +4,7 @@
 
 #include <qml/qrimageprovider.h>
 
-#if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h> /* for USE_QRCODE */
-#endif
+#include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #ifdef USE_QRCODE
 #include <qrencode.h>


### PR DESCRIPTION
Closes https://github.com/bitcoin-core/gui-qml/issues/491

"Create bitcoin address" button now connects to the wallet interface and gets a new address. It generates a QR code and everything clears when switching wallets. It should also save the label if used.

![newaddr](https://github.com/user-attachments/assets/5d51b068-c4aa-41ff-bf13-e3febf6cd847)
