### PR TITLE
Add first unittests

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -38,7 +38,7 @@ jobs:
             build-essential ccache cmake pkgconf \
             libevent-dev libboost-dev libsqlite3-dev libgl-dev libqrencode-dev \
             qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools \
-            qt6-declarative-dev qml6-module-qtquick qml6-module-qtqml
+            qt6-declarative-dev qml6-module-qt-labs-settings qml6-module-qtquick qml6-module-qtquick-controls qml6-module-qtquick-dialogs qml6-module-qtquick-layouts qml6-module-qtquick-templates qml6-module-qtqml
           echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
 
       - name: Restore Ccache cache
@@ -66,4 +66,3 @@ jobs:
         with:
           name: unsecure_${{ matrix.os }}_gui
           path: build/bin/bitcoin-core-app
-

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -28,7 +28,7 @@ jobs:
       - name: MacOS Install Deps
         if: contains(matrix.os, 'macos')
         run: |
-          brew install cmake ccache boost pkgconf libevent qt@6 qrencode coreutils
+          brew install ccache boost pkgconf libevent qt@6 qrencode coreutils
           echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
 
       - name: Ubuntu Install Deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,15 @@ jobs:
             zlib1g-dev \
             libboost-all-dev \
             qt6-base-dev \
+            qt6-base-dev-tools \
+            qt6-tools-dev \
+            qt6-l10n-tools \
+            qt6-tools-dev-tools \
             qt6-declarative-dev \
-            libqt6quickcontrols2-dev
+            qml6-module-qtquick \
+            qml6-module-qtqml \
+            libgl-dev \
+            libqrencode-dev
 
       - name: Configure (CMake)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            cmake \
+            ninja-build \
+            pkg-config \
+            libevent-dev \
+            libsqlite3-dev \
+            zlib1g-dev \
+            libboost-all-dev \
+            qt6-base-dev \
+            qt6-declarative-dev \
+            libqt6quickcontrols2-dev
+
+      - name: Configure (CMake)
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_APP_TESTS=ON
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,15 @@ jobs:
             qt6-l10n-tools \
             qt6-tools-dev-tools \
             qt6-declarative-dev \
+            qml6-module-qt-labs-settings \
             qml6-module-qtquick \
+            qml6-module-qtquick-controls \
+            qml6-module-qtquick-dialogs \
+            qml6-module-qtquick-layouts \
+            qml6-module-qtquick-templates \
+            qml6-module-qtquick-window \
             qml6-module-qtqml \
+            qml6-module-qtqml-workerscript \
             libgl-dev \
             libqrencode-dev
 
@@ -49,4 +56,3 @@ jobs:
 
       - name: Run tests
         run: ctest --test-dir build --output-on-failure
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,3 +127,10 @@ target_link_libraries(bitcoin-core-app
     bitcoinqml
     bitcoinqt
 )
+
+option(BUILD_APP_TESTS "Build unit tests for the app" ON)
+if(BUILD_APP_TESTS)
+  include(CTest)
+  enable_testing()
+  add_subdirectory(test)
+endif()

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ appropriate document for your platform:
 
 - [build-unix.md](https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md)
 
-In addition the following dependencies are required for the GUI:
+In addition the following dependencies are required for the GUI and tests:
 
 #### Debian-based systems:
 
 ```
 sudo apt install \
   qt6-base-dev \
+  qt6-base-dev-tools \
   qt6-tools-dev \
   qt6-l10n-tools \
   qt6-tools-dev-tools \
@@ -91,6 +92,8 @@ sudo apt install qt6-wayland
 
 ```
 brew install qt@6 qrencode
+# Help CMake find Qt6 on macOS (adjust if needed)
+export CMAKE_PREFIX_PATH="$(brew --prefix qt@6)/lib/cmake"
 ```
 
 ### Build
@@ -116,5 +119,20 @@ Binaries are exported to the `build/` directory:
 build/bin/bitcoin-core-app
 ```
 
+### Run Tests
+
+- Enable tests at configure time and run them via CTest.
+
+```
+cmake -B build -DBUILD_APP_TESTS=ON
+cmake --build build -j$(nproc)
+ctest --test-dir build --output-on-failure
+```
+
+- If CMake reports "Target Qt6::Test not found", ensure Qt6 Test is available
+  and discoverable by CMake:
+
+  - Debian/Ubuntu: `qt6-base-dev` provides the Qt Test module (already listed above).
+  - macOS: set `CMAKE_PREFIX_PATH` as shown so CMake can locate Qt 6 modules.
 
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ sudo apt install \
   qt6-l10n-tools \
   qt6-tools-dev-tools \
   qt6-declarative-dev \
+  qml6-module-qt-labs-settings \
   qml6-module-qtquick \
+  qml6-module-qtquick-controls \
+  qml6-module-qtquick-dialogs \
+  qml6-module-qtquick-layouts \
+  qml6-module-qtquick-templates \
+  qml6-module-qtquick-window \
   qml6-module-qtqml \
   libgl-dev \
   libqrencode-dev
@@ -134,5 +140,3 @@ ctest --test-dir build --output-on-failure
 
   - Debian/Ubuntu: `qt6-base-dev` provides the Qt Test module (already listed above).
   - macOS: set `CMAKE_PREFIX_PATH` as shown so CMake can locate Qt 6 modules.
-
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,24 +2,49 @@ cmake_minimum_required(VERSION 3.22)
 
 # Tests for the QML/Qt6 app
 
-find_package(Qt 6.2 MODULE REQUIRED COMPONENTS Test Core)
+find_package(Qt 6.2 MODULE REQUIRED COMPONENTS Core Test Qml Quick QuickTest)
 
-add_executable(bitcoinqml_tests
+add_executable(bitcoinqml_unit_tests
+  test_unit_tests_main.cpp
   test_bitcoinamount.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinamount.cpp
 )
 
-target_include_directories(bitcoinqml_tests
+target_compile_definitions(bitcoinqml_unit_tests
+  PRIVATE
+    BITCOINQML_NO_TEST_MAIN
+)
+
+target_include_directories(bitcoinqml_unit_tests
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src
 )
 
-target_link_libraries(bitcoinqml_tests
+target_link_libraries(bitcoinqml_unit_tests
   PRIVATE
     Qt6::Core
     Qt6::Test
 )
 
-add_test(NAME bitcoinqml_tests COMMAND bitcoinqml_tests)
+add_test(NAME bitcoinqml_unit_tests COMMAND bitcoinqml_unit_tests)
 
+add_executable(bitcoinqml_qmltests
+  qml/qml_tests_main.cpp
+)
+
+target_compile_definitions(bitcoinqml_qmltests
+  PRIVATE
+    BITCOINQML_QML_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../qml"
+    QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/qml"
+)
+
+target_link_libraries(bitcoinqml_qmltests
+  PRIVATE
+    Qt6::Core
+    Qt6::Qml
+    Qt6::Quick
+    Qt6::QuickTest
+)
+
+add_test(NAME bitcoinqml_qmltests COMMAND bitcoinqml_qmltests -platform offscreen)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+
+# Tests for the QML/Qt6 app
+
+find_package(Qt 6.2 MODULE REQUIRED COMPONENTS Test Core)
+
+add_executable(bitcoinqml_tests
+  test_bitcoinamount.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinamount.cpp
+)
+
+target_include_directories(bitcoinqml_tests
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src
+)
+
+target_link_libraries(bitcoinqml_tests
+  PRIVATE
+    Qt6::Core
+    Qt6::Test
+)
+
+add_test(NAME bitcoinqml_tests COMMAND bitcoinqml_tests)
+

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtQuickTest/quicktest.h>
+
+#include <QQmlEngine>
+
+class QmlTestsSetup : public QObject
+{
+    Q_OBJECT
+
+public Q_SLOTS:
+    void qmlEngineAvailable(QQmlEngine* engine)
+    {
+        engine->addImportPath(QStringLiteral(BITCOINQML_QML_SOURCE_DIR));
+    }
+};
+
+QUICK_TEST_MAIN_WITH_SETUP(bitcoinqml_qmltests, QmlTestsSetup)
+
+#include "qml_tests_main.moc"

--- a/test/qml/tst_valueinput.qml
+++ b/test/qml/tst_valueinput.qml
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/controls"
+
+TestCase {
+    name: "ValueInput"
+    when: windowShown
+    width: 900
+    height: 700
+
+    Component {
+        id: valueInputComponent
+
+        ValueInput {
+            objectName: "valueInputControl"
+            parentState: "ACTIVE"
+            description: "250"
+            filled: true
+        }
+    }
+
+    function test_valueInput_has_stable_selector_and_initial_state() {
+        const input = createTemporaryObject(valueInputComponent, this)
+        verify(input !== null)
+
+        compare(input.objectName, "valueInputControl")
+        compare(input.maximumLength, 5)
+        compare(input.text, "250")
+        compare(input.enabled, true)
+    }
+
+    function test_valueInput_checkValidity_bounds() {
+        const input = createTemporaryObject(valueInputComponent, this)
+        verify(input !== null)
+
+        verify(input.checkValidity(5, 10, 5))
+        verify(input.checkValidity(5, 10, 10))
+        verify(!input.checkValidity(5, 10, 4))
+        verify(!input.checkValidity(5, 10, 11))
+    }
+
+    function test_valueInput_disabled_state_disables_input() {
+        const input = createTemporaryObject(valueInputComponent, this)
+        verify(input !== null)
+
+        input.parentState = "DISABLED"
+        compare(input.enabled, false)
+    }
+}

--- a/test/test_bitcoinamount.cpp
+++ b/test/test_bitcoinamount.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <qml/bitcoinamount.h>
+
+class BitcoinAmountTests : public QObject {
+    Q_OBJECT
+
+private Q_SLOTS:
+    void satsToBtcString_basic();
+    void satsToBtcString_negative();
+    void btcToSats_roundtrip();
+    void sanitize_clampsAndFilters();
+    void display_flow_btc();
+    void display_flow_sat();
+    void flipUnit_changesLabelAndDisplaySignal();
+};
+
+void BitcoinAmountTests::satsToBtcString_basic()
+{
+    QCOMPARE(BitcoinAmount::satsToBtcString(0), QString("0.00000000"));
+    QCOMPARE(BitcoinAmount::satsToBtcString(1), QString("0.00000001"));
+    QCOMPARE(BitcoinAmount::satsToBtcString(COIN), QString("1.00000000"));
+    QCOMPARE(BitcoinAmount::satsToBtcString(21 * COIN), QString("21.00000000"));
+    QCOMPARE(BitcoinAmount::satsToBtcString(100000123), QString("1.00000123"));
+}
+
+void BitcoinAmountTests::satsToBtcString_negative()
+{
+    QCOMPARE(BitcoinAmount::satsToBtcString(-1), QString("-0.00000001"));
+}
+
+void BitcoinAmountTests::btcToSats_roundtrip()
+{
+    BitcoinAmount amt;
+    amt.setUnit(BitcoinAmount::Unit::BTC);
+    amt.fromDisplay("1.23456789");
+    QCOMPARE(amt.toDisplay(), QString("1.23456789"));
+}
+
+void BitcoinAmountTests::sanitize_clampsAndFilters()
+{
+    BitcoinAmount amt;
+    amt.setUnit(BitcoinAmount::Unit::BTC);
+    amt.fromDisplay("abc1.2.3xyz");
+    QCOMPARE(amt.toDisplay(), QString("1.20000000"));
+}
+
+void BitcoinAmountTests::display_flow_btc()
+{
+    BitcoinAmount amt;
+    amt.setUnit(BitcoinAmount::Unit::BTC);
+    amt.setSatoshi(2 * COIN);
+    QCOMPARE(amt.toDisplay(), QString("2.00000000"));
+}
+
+void BitcoinAmountTests::display_flow_sat()
+{
+    BitcoinAmount amt;
+    amt.setUnit(BitcoinAmount::Unit::SAT);
+    amt.setSatoshi(123);
+    QCOMPARE(amt.toDisplay(), QString("123"));
+}
+
+void BitcoinAmountTests::flipUnit_changesLabelAndDisplaySignal()
+{
+    BitcoinAmount amt;
+    amt.setSatoshi(100);
+    QSignalSpy spy(&amt, &BitcoinAmount::displayChanged);
+    amt.flipUnit();
+    QVERIFY(spy.count() >= 1);
+}
+
+QTEST_MAIN(BitcoinAmountTests)
+#include "test_bitcoinamount.moc"

--- a/test/test_bitcoinamount.cpp
+++ b/test/test_bitcoinamount.cpp
@@ -74,5 +74,13 @@ void BitcoinAmountTests::flipUnit_changesLabelAndDisplaySignal()
     QVERIFY(spy.count() >= 1);
 }
 
+int RunBitcoinAmountTests(int argc, char* argv[])
+{
+    BitcoinAmountTests tests;
+    return QTest::qExec(&tests, argc, argv);
+}
+
+#ifndef BITCOINQML_NO_TEST_MAIN
 QTEST_MAIN(BitcoinAmountTests)
+#endif
 #include "test_bitcoinamount.moc"

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QCoreApplication>
+
+int RunBitcoinAmountTests(int argc, char* argv[]);
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    int status = 0;
+    status |= RunBitcoinAmountTests(argc, argv);
+
+    return status;
+}


### PR DESCRIPTION
This adds an initial unittest against the bitcoinamount module. This is the simplest c++ module to test so its an easy first target. I think the Qt test framework is the best fit for the project and eventually I imagine GMock will be needed to mock out portions of bitcoin interfaces as well as more complex modules get tested. These changes update the CMake definitions and add a BUILD_APP_TESTS option to toggle building of the unittests. 

A new ci workflow is added as well to run the unittests (and eventually other testing that we have).