### PR TITLE
Add bitcoin address model and address input formatting

### DIFF
--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Bitcoin Core developers
+// Copyright (c) 2021-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -30,6 +30,7 @@
 #include <qml/imageprovider.h>
 #include <qml/models/activitylistmodel.h>
 #include <qml/models/banlistmodel.h>
+#include <qml/models/bitcoinaddress.h>
 #include <qml/models/chainmodel.h>
 #include <qml/models/networktraffictower.h>
 #include <qml/models/nodemodel.h>
@@ -336,6 +337,7 @@ int QmlGuiMain(int argc, char* argv[])
     qmlRegisterType<LineGraph>("org.bitcoincore.qt", 1, 0, "LineGraph");
     qmlRegisterUncreatableType<PeerDetailsModel>("org.bitcoincore.qt", 1, 0, "PeerDetailsModel", "");
     qmlRegisterType<BitcoinAmount>("org.bitcoincore.qt", 1, 0, "BitcoinAmount");
+    qmlRegisterType<BitcoinAddress>("org.bitcoincore.qt", 1, 0, "BitcoinAddress");
     qmlRegisterUncreatableType<Transaction>("org.bitcoincore.qt", 1, 0, "Transaction", "");
     qmlRegisterUncreatableType<SendRecipient>("org.bitcoincore.qt", 1, 0, "SendRecipient", "");
 

--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -1,6 +1,8 @@
 <!DOCTYPE RCC><RCC version="1.0">
     <qresource prefix="/qml">
         <file>components/AboutOptions.qml</file>
+        <file>components/BitcoinAddressInputField.qml</file>
+        <file>components/BitcoinAmountInputField.qml</file>
         <file>components/BlockClock.qml</file>
         <file>components/BlockClockDisplayMode.qml</file>
         <file>components/BlockCounter.qml</file>

--- a/qml/components/BitcoinAddressInputField.qml
+++ b/qml/components/BitcoinAddressInputField.qml
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
+
+import "../controls"
+
+ColumnLayout {
+    id: root
+
+    property var address
+    property string errorText: ""
+    property string labelText: qsTr("Send to")
+    property bool enabled: true
+
+    signal editingFinished()
+
+    Layout.fillWidth: true
+    spacing: 4
+
+    Item {
+        id: inputRow
+        Layout.fillWidth: true
+        implicitHeight: Math.max(label.implicitHeight + 6, addressInput.height)
+
+        CoreText {
+            id: label
+            width: 110
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.topMargin: 6
+            horizontalAlignment: Text.AlignLeft
+            text: root.labelText
+            font.pixelSize: 18
+        }
+
+        TextArea {
+            id: addressInput
+            anchors.left: label.right
+            anchors.right: parent.right
+            anchors.top: parent.top
+            enabled: root.enabled
+            placeholderText: qsTr("Enter address...")
+            text: root.address ? root.address.formattedAddress : ""
+            wrapMode: Text.WrapAnywhere
+            leftPadding: 0
+            topPadding: 0
+            rightPadding: 0
+            bottomPadding: 0
+            height: Math.max(contentHeight, 32)
+            font.family: "Inter"
+            font.styleName: "Regular"
+            font.pixelSize: 18
+            color: Theme.color.neutral9
+            placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+            background: Item {}
+            selectByMouse: true
+
+            onTextChanged: {
+                if (root.address) {
+                    cursorPosition = root.address.setAddress(text, cursorPosition)
+                }
+            }
+
+            onEditingFinished: {
+                if (root.address) {
+                    root.address.setAddress(text, cursorPosition)
+                    root.editingFinished()
+                }
+            }
+
+            onActiveFocusChanged: {
+                if (!activeFocus && root.address) {
+                    root.address.setAddress(text)
+                }
+            }
+        }
+    }
+
+
+    RowLayout {
+        id: addressIssue
+        Layout.fillWidth: true
+        visible: root.errorText.length > 0
+        spacing: 8
+        Layout.topMargin: 4
+
+        Icon {
+            source: "image://images/alert-filled"
+            size: 22
+            color: Theme.color.red
+        }
+
+        CoreText {
+            text: root.errorText
+            font.pixelSize: 15
+            color: Theme.color.red
+            horizontalAlignment: Text.AlignLeft
+            Layout.fillWidth: true
+        }
+    }
+}

--- a/qml/components/BitcoinAddressInputField.qml
+++ b/qml/components/BitcoinAddressInputField.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Bitcoin Core developers
+// Copyright (c) 2025-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qml/components/BitcoinAmountInputField.qml
+++ b/qml/components/BitcoinAmountInputField.qml
@@ -1,0 +1,134 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
+
+import "../controls"
+
+ColumnLayout {
+    id: root
+
+    property var amount
+    property string errorText: ""
+    property string labelText: qsTr("Amount")
+    property bool enabled: true
+
+    signal editingFinished(string value)
+
+    Layout.fillWidth: true
+    spacing: 4
+
+    Item {
+        id: inputRow
+        height: amountInput.height
+        Layout.fillWidth: true
+
+        CoreText {
+            id: lbl
+            width: 110
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            horizontalAlignment: Text.AlignLeft
+            text: root.labelText
+            font.pixelSize: 18
+        }
+
+        TextField {
+            id: amountInput
+            anchors.left: lbl.right
+            anchors.verticalCenter: parent.verticalCenter
+            leftPadding: 0
+            enabled: root.enabled
+            font.family: "Inter"
+            font.styleName: "Regular"
+            font.pixelSize: 18
+            color: Theme.color.neutral9
+            placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+            background: Item {}
+            placeholderText: "0.00000000"
+            selectByMouse: true
+
+            text: root.amount ? root.amount.display : ""
+
+            onEditingFinished: {
+                if (root.amount) {
+                    root.amount.display = text
+                }
+                root.editingFinished(text)
+            }
+
+            onActiveFocusChanged: {
+                if (!activeFocus && root.amount) {
+                    root.amount.display = text
+                    root.editingFinished(text)
+                }
+            }
+
+            validator: RegExpValidator {
+                regExp: /^(0|[1-9]\d*)(\.\d{0,8})?$/
+            }
+            maximumLength: 17
+        }
+
+        Item {
+            width: unitLabel.width + flipIcon.width
+            height: Math.max(unitLabel.height, flipIcon.height)
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            opacity: root.enabled ? 1.0 : 0.5
+
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                enabled: root.enabled && root.amount
+                onClicked: {
+                    root.amount.display = amountInput.text
+                    root.amount.flipUnit()
+                }
+            }
+
+            CoreText {
+                id: unitLabel
+                anchors.right: flipIcon.left
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.amount ? root.amount.unitLabel : ""
+                font.pixelSize: 18
+                color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+            }
+
+            Icon {
+                id: flipIcon
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                source: "image://images/flip-vertical"
+                icon.color: enabled ? Theme.color.neutral8 : Theme.color.neutral4
+                size: 30
+            }
+        }
+    }
+
+    RowLayout {
+        id: errorRow
+        Layout.fillWidth: true
+        visible: root.errorText.length > 0
+
+        Icon {
+            source: "image://images/alert-filled"
+            size: 22
+            color: Theme.color.red
+        }
+
+        CoreText {
+            text: root.errorText
+            font.pixelSize: 15
+            color: Theme.color.red
+            horizontalAlignment: Text.AlignLeft
+            Layout.fillWidth: true
+        }
+    }
+}

--- a/qml/components/BitcoinAmountInputField.qml
+++ b/qml/components/BitcoinAmountInputField.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Bitcoin Core developers
+// Copyright (c) 2025-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qml/controls/LabeledTextInput.qml
+++ b/qml/controls/LabeledTextInput.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Bitcoin Core developers
+// Copyright (c) 2024-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -15,9 +15,13 @@ Item {
     property alias enabled: input.enabled
     property alias validator: input.validator
     property alias maximumLength: input.maximumLength
+    property alias cursorPosition: input.cursorPosition
+    property alias inputActiveFocus: input.activeFocus
 
     signal iconClicked
     signal textEdited
+    signal editingFinished
+    signal inputFocusChanged
 
     id: root
     implicitHeight: input.height
@@ -45,6 +49,8 @@ Item {
         background: Item {}
         selectByMouse: true
         onTextEdited: root.textEdited()
+        onEditingFinished: root.editingFinished()
+        onActiveFocusChanged: root.inputFocusChanged()
     }
 
     Item {

--- a/qml/models/bitcoinaddress.cpp
+++ b/qml/models/bitcoinaddress.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/bitcoinaddress.h>
+
+namespace {
+constexpr int MAX_BITCOIN_ADDRESS_LENGTH = 90;
+
+bool IsBitcoinAddressChar(const QChar c)
+{
+    const ushort ch = c.unicode();
+    return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z');
+}
+} // namespace
+
+BitcoinAddress::BitcoinAddress(QObject* parent)
+    : QObject(parent)
+{
+    // Initialize with empty address
+    setAddress("", 0);
+}
+
+BitcoinAddress::BitcoinAddress(const QString& address, QObject* parent)
+    : QObject(parent)
+{
+    setAddress(address, 0);
+}
+
+QString BitcoinAddress::address() const
+{
+    return m_address;
+}
+
+bool BitcoinAddress::isEmpty() const
+{
+    return m_address.isEmpty();
+}
+
+QString BitcoinAddress::formattedAddress() const
+{
+    return m_formattedAddress;
+}
+
+QString BitcoinAddress::ellipsesAddress() const
+{
+    return ellipsesAddress(m_address);
+}
+
+int BitcoinAddress::setAddress(const QString& input, int cursorPosition)
+{
+    // 1) Count how many valid chars were before the old cursor.
+    int posInClean = 0;
+    const int lenIn = qMin(qMax(cursorPosition, 0), input.length());
+    for (int i = 0; i < lenIn; ++i) {
+        if (IsBitcoinAddressChar(input[i])) {
+            ++posInClean;
+        }
+    }
+
+    // 2) Build the raw (no-space) address, filtering and capping at 90 chars.
+    QString raw;
+    raw.reserve(qMin(input.length(), MAX_BITCOIN_ADDRESS_LENGTH));
+    for (QChar c : input) {
+        if (IsBitcoinAddressChar(c)) {
+            raw += c;
+            if (raw.length() >= MAX_BITCOIN_ADDRESS_LENGTH) {
+                break;
+            }
+        }
+    }
+
+    // 3) Format into groups of 4 chars separated by spaces.
+    QString fmt = BitcoinAddress::formattedAddress(raw);
+
+    // 4) Map back to a cursor position in the new formatted string.
+    int newCursor = 0, seen = 0;
+    while (newCursor < fmt.length() && seen < posInClean) {
+        if (fmt[newCursor] != QChar(' ')) {
+            ++seen;
+        }
+        ++newCursor;
+    }
+
+    if (raw == m_address && fmt == m_formattedAddress) {
+        return newCursor;
+    }
+
+    m_address = raw;
+    m_formattedAddress = fmt;
+    Q_EMIT addressChanged();
+    Q_EMIT formattedAddressChanged();
+    Q_EMIT ellipsesAddressChanged();
+
+    return newCursor;
+}
+
+QString BitcoinAddress::formattedAddress(const QString& address)
+{
+    QString fmt;
+    fmt.reserve(address.length() + address.length() / 4);
+    for (int i = 0; i < address.length(); ++i) {
+        if (i > 0 && (i % 4) == 0) {
+            fmt += QChar(' ');
+        }
+        fmt += address[i];
+    }
+    return fmt;
+}
+
+QString BitcoinAddress::ellipsesAddress(const QString& address)
+{
+    if (address.length() > 8) {
+        QString left = address.left(4) + ' ' + address.mid(4, 4);
+
+        QString right = address.mid(address.length() - 8, 4) + ' ' + address.right(4);
+
+        return left + " ... " + right;
+    } else {
+        return address;
+    }
+}

--- a/qml/models/bitcoinaddress.cpp
+++ b/qml/models/bitcoinaddress.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Bitcoin Core developers
+// Copyright (c) 2025-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qml/models/bitcoinaddress.h
+++ b/qml/models/bitcoinaddress.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_BITCOINADDRESS_H
+#define BITCOIN_QML_MODELS_BITCOINADDRESS_H
+
+#include <QObject>
+#include <QString>
+
+class BitcoinAddress : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString address READ address NOTIFY addressChanged)
+    Q_PROPERTY(QString formattedAddress READ formattedAddress NOTIFY formattedAddressChanged)
+    Q_PROPERTY(QString ellipsesAddress READ ellipsesAddress NOTIFY ellipsesAddressChanged)
+
+public:
+    explicit BitcoinAddress(QObject* parent = nullptr);
+    BitcoinAddress(const QString& address, QObject* parent = nullptr);
+
+    static QString ellipsesAddress(const QString& address);
+    static QString formattedAddress(const QString& address);
+
+    QString address() const;
+    bool isEmpty() const;
+    QString formattedAddress() const;
+    QString ellipsesAddress() const;
+    Q_INVOKABLE int setAddress(const QString& address, int cursorPosition = 0);
+
+Q_SIGNALS:
+    void addressChanged();
+    void formattedAddressChanged();
+    void ellipsesAddressChanged();
+
+private:
+    QString m_address;
+    QString m_formattedAddress;
+};
+
+#endif // BITCOIN_QML_MODELS_BITCOINADDRESS_H

--- a/qml/models/bitcoinaddress.h
+++ b/qml/models/bitcoinaddress.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Bitcoin Core developers
+// Copyright (c) 2025-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qml/models/sendrecipient.cpp
+++ b/qml/models/sendrecipient.cpp
@@ -1,29 +1,31 @@
-// Copyright (c) 2025 The Bitcoin Core developers
+// Copyright (c) 2025-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <qml/models/sendrecipient.h>
 
 #include <qml/bitcoinamount.h>
+#include <qml/models/bitcoinaddress.h>
 #include <qml/models/walletqmlmodel.h>
 
 #include <key_io.h>
 
 SendRecipient::SendRecipient(WalletQmlModel* wallet, QObject* parent)
-    : QObject(parent), m_wallet(wallet), m_amount(new BitcoinAmount(this))
+    : QObject(parent), m_wallet(wallet), m_address(new BitcoinAddress(this)), m_amount(new BitcoinAmount(this))
 {
     connect(m_amount, &BitcoinAmount::amountChanged, this, &SendRecipient::validateAmount);
+    connect(m_address, &BitcoinAddress::formattedAddressChanged, this, &SendRecipient::validateAddress);
 }
 
-QString SendRecipient::address() const
+BitcoinAddress* SendRecipient::address() const
 {
     return m_address;
 }
 
 void SendRecipient::setAddress(const QString& address)
 {
-    if (m_address != address) {
-        m_address = address;
+    if (m_address->address() != address) {
+        m_address->setAddress(address, 0);
         Q_EMIT addressChanged();
         validateAddress();
     }
@@ -101,18 +103,19 @@ void SendRecipient::clear()
     m_label = "";
     m_message = "";
     m_subtractFeeFromAmount = false;
-    setAddress("");
+    m_address->setAddress("", 0);
     m_amount->clear();
+    Q_EMIT addressChanged();
     Q_EMIT labelChanged();
     Q_EMIT messageChanged();
 }
 
 void SendRecipient::validateAddress()
 {
-    if (!m_address.isEmpty() && !IsValidDestinationString(m_address.toStdString())) {
-        if (IsValidDestinationString(m_address.toStdString(), *CChainParams::Main())) {
+    if (!m_address->isEmpty() && !IsValidDestinationString(m_address->address().toStdString())) {
+        if (IsValidDestinationString(m_address->address().toStdString(), *CChainParams::Main())) {
             setAddressError(tr("Address is valid for mainnet, not the current network"));
-        } else if (IsValidDestinationString(m_address.toStdString(), *CChainParams::TestNet())) {
+        } else if (IsValidDestinationString(m_address->address().toStdString(), *CChainParams::TestNet())) {
             setAddressError(tr("Address is valid for testnet, not the current network"));
         } else {
             setAddressError(tr("Invalid address format"));
@@ -145,5 +148,5 @@ void SendRecipient::validateAmount()
 
 bool SendRecipient::isValid() const
 {
-    return m_addressError.isEmpty() && m_amountError.isEmpty() && m_amount->satoshi() > 0 && !m_address.isEmpty();
+    return m_addressError.isEmpty() && m_amountError.isEmpty() && m_amount->satoshi() > 0 && !m_address->isEmpty();
 }

--- a/qml/models/sendrecipient.h
+++ b/qml/models/sendrecipient.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Bitcoin Core developers
+// Copyright (c) 2025-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,6 +6,7 @@
 #define BITCOIN_QML_MODELS_SENDRECIPIENT_H
 
 #include <qml/bitcoinamount.h>
+#include <qml/models/bitcoinaddress.h>
 
 #include <QObject>
 #include <QString>
@@ -15,7 +16,7 @@ class WalletQmlModel;
 class SendRecipient : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QString address READ address WRITE setAddress NOTIFY addressChanged)
+    Q_PROPERTY(BitcoinAddress* address READ address CONSTANT)
     Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
     Q_PROPERTY(QString message READ message WRITE setMessage NOTIFY messageChanged)
     Q_PROPERTY(BitcoinAmount* amount READ amount CONSTANT)
@@ -27,7 +28,7 @@ class SendRecipient : public QObject
 public:
     explicit SendRecipient(WalletQmlModel* wallet, QObject* parent = nullptr);
 
-    QString address() const;
+    BitcoinAddress* address() const;
     void setAddress(const QString& address);
     QString addressError() const;
     void setAddressError(const QString& error);
@@ -64,7 +65,7 @@ private:
     void validateAmount();
 
     const WalletQmlModel* m_wallet;
-    QString m_address{""};
+    BitcoinAddress* m_address;
     QString m_addressError{""};
     QString m_label{""};
     QString m_message{""};

--- a/qml/models/sendrecipientslistmodel.cpp
+++ b/qml/models/sendrecipientslistmodel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Bitcoin Core developers
+// Copyright (c) 2025-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -29,7 +29,7 @@ QVariant SendRecipientsListModel::data(const QModelIndex& index, int role) const
 
     const auto& r = m_recipients[index.row()];
     switch (role) {
-    case AddressRole: return r->address();
+    case AddressRole: return r->address()->ellipsesAddress();
     case LabelRole: return r->label();
     case AmountRole: return r->amount()->toDisplay();
     case MessageRole: return r->message();

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2024 The Bitcoin Core developers
+// Copyright (c) 2024-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -125,7 +125,7 @@ bool WalletQmlModel::prepareTransaction()
     std::vector<wallet::CRecipient> vecSend;
     CAmount total = 0;
     for (auto* recipient : m_send_recipients->recipients()) {
-        CTxDestination destination = DecodeDestination(recipient->address().toStdString());
+        CTxDestination destination = DecodeDestination(recipient->address()->address().toStdString());
         wallet::CRecipient c_recipient = {destination, recipient->cAmount(), recipient->subtractFeeFromAmount()};
         m_coin_control.m_feerate = CFeeRate(1000);
         vecSend.push_back(c_recipient);

--- a/qml/models/walletqmlmodeltransaction.cpp
+++ b/qml/models/walletqmlmodeltransaction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2025 The Bitcoin Core developers
+// Copyright (c) 2011-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,7 +10,7 @@
 #include <policy/policy.h>
 
 WalletQmlModelTransaction::WalletQmlModelTransaction(const SendRecipientsListModel* recipient, QObject* parent)
-    : QObject(parent), m_address(recipient->recipients().at(0)->address()), m_amount(recipient->totalAmountSatoshi()), m_fee(0), m_label(recipient->recipients().at(0)->label()), m_wtx(nullptr)
+    : QObject(parent), m_address(recipient->recipients().at(0)->address()->address()), m_amount(recipient->totalAmountSatoshi()), m_fee(0), m_label(recipient->recipients().at(0)->label()), m_wtx(nullptr)
 {
 }
 

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Bitcoin Core developers
+// Copyright (c) 2024-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -169,42 +169,11 @@ PageStack {
                     Layout.fillWidth: true
                 }
 
-                ColumnLayout {
+                BitcoinAddressInputField {
                     Layout.fillWidth: true
-
-                    LabeledTextInput {
-                        id: address
-                        Layout.fillWidth: true
-                        labelText: qsTr("Send to")
-                        placeholderText: qsTr("Enter address...")
-                        text: root.recipient.address
-                        onTextEdited: root.recipient.address = address.text
-                        validator: RegularExpressionValidator {
-                            regularExpression: /^[0-9A-HJ-NP-Za-z]+$/
-                        }
-                        maximumLength: 62
-                    }
-
-                    RowLayout {
-                        id: addressIssue
-                        Layout.fillWidth: true
-                        visible: root.recipient.addressError.length > 0
-
-                        Icon {
-                            source: "image://images/alert-filled"
-                            size: 22
-                            color: Theme.color.red
-                        }
-
-                        CoreText {
-                            id: warningText
-                            text: root.recipient.addressError
-                            font.pixelSize: 15
-                            color: Theme.color.red
-                            horizontalAlignment: Text.AlignLeft
-                            Layout.fillWidth: true
-                        }
-                    }
+                    enabled: walletController.initialized
+                    address: root.recipient.address
+                    errorText: root.recipient.addressError
                 }
 
                 Separator {


### PR DESCRIPTION
Introduces BitcoinAddress model and new BitcoinAddressInputField qml component backed by the model. This formats the address input to have a space between every 4 characters so that the address is easier to read.

https://github.com/user-attachments/assets/a8b86e40-c056-41c6-a3cd-b4fa33732d4d


