### PR TITLE
Wire RequestPayment page to PaymentRequest model

### DIFF
--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -38,6 +38,7 @@
 #include <qml/models/networktraffictower.h>
 #include <qml/models/nodemodel.h>
 #include <qml/models/options_model.h>
+#include <qml/models/paymentrequest.h>
 #include <qml/models/peerdetailsmodel.h>
 #include <qml/models/peerlistsortproxy.h>
 #include <qml/models/peerlistmodel.h>
@@ -348,6 +349,7 @@ int QmlGuiMain(int argc, char* argv[])
     qmlRegisterUncreatableType<PeerDetailsModel>("org.bitcoincore.qt", 1, 0, "PeerDetailsModel", "");
     qmlRegisterType<BitcoinAmount>("org.bitcoincore.qt", 1, 0, "BitcoinAmount");
     qmlRegisterType<BitcoinAddress>("org.bitcoincore.qt", 1, 0, "BitcoinAddress");
+    qmlRegisterType<PaymentRequest>("org.bitcoincore.qt", 1, 0, "PaymentRequest");
     qmlRegisterUncreatableType<Transaction>("org.bitcoincore.qt", 1, 0, "Transaction", "");
     qmlRegisterUncreatableType<SendRecipient>("org.bitcoincore.qt", 1, 0, "SendRecipient", "");
 

--- a/qml/models/paymentrequest.cpp
+++ b/qml/models/paymentrequest.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/paymentrequest.h>
+
+#include <key_io.h>
+
+#include <QString>
+
+PaymentRequest::PaymentRequest(QObject* parent)
+    : QObject(parent)
+{
+    m_amount = new BitcoinAmount(this);
+}
+
+QString PaymentRequest::address() const
+{
+    return QString::fromStdString(EncodeDestination(m_destination));
+}
+
+QString PaymentRequest::addressFormatted() const
+{
+    return FormatAddress(address());
+}
+
+QString PaymentRequest::label() const
+{
+    return m_label;
+}
+
+void PaymentRequest::setLabel(const QString& label)
+{
+    if (m_label == label) {
+        return;
+    }
+    m_label = label;
+    Q_EMIT labelChanged();
+}
+
+QString PaymentRequest::message() const
+{
+    return m_message;
+}
+
+void PaymentRequest::setMessage(const QString& message)
+{
+    if (m_message == message) {
+        return;
+    }
+    m_message = message;
+    Q_EMIT messageChanged();
+}
+
+BitcoinAmount* PaymentRequest::amount() const
+{
+    return m_amount;
+}
+
+QString PaymentRequest::amountError() const
+{
+    return m_amountError;
+}
+
+void PaymentRequest::setAmountError(const QString& error)
+{
+    if (m_amountError == error) {
+        return;
+    }
+    m_amountError = error;
+    Q_EMIT amountErrorChanged();
+}
+
+QString PaymentRequest::id() const
+{
+    return m_id;
+}
+
+void PaymentRequest::setId(unsigned int id)
+{
+    const QString new_id = QString::number(id);
+    if (m_id == new_id) {
+        return;
+    }
+    m_id = new_id;
+    Q_EMIT idChanged();
+}
+
+void PaymentRequest::setDestination(const CTxDestination& destination)
+{
+    m_destination = destination;
+    Q_EMIT addressChanged();
+}
+
+CTxDestination PaymentRequest::destination() const
+{
+    return m_destination;
+}
+
+void PaymentRequest::clear()
+{
+    m_destination = CNoDestination();
+    m_label.clear();
+    m_message.clear();
+    m_amount->clear();
+    m_amountError.clear();
+    m_id.clear();
+    Q_EMIT addressChanged();
+    Q_EMIT labelChanged();
+    Q_EMIT messageChanged();
+    Q_EMIT amountErrorChanged();
+    Q_EMIT idChanged();
+}
+
+QString PaymentRequest::FormatAddress(const QString& address)
+{
+    QString formatted;
+    formatted.reserve(address.length() + address.length() / 4);
+    for (int i = 0; i < address.length(); ++i) {
+        if (i > 0 && (i % 4) == 0) {
+            formatted += QChar(' ');
+        }
+        formatted += address[i];
+    }
+    return formatted;
+}

--- a/qml/models/paymentrequest.h
+++ b/qml/models/paymentrequest.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_PAYMENTREQUEST_H
+#define BITCOIN_QML_MODELS_PAYMENTREQUEST_H
+
+#include <qml/bitcoinamount.h>
+
+#include <addresstype.h>
+
+#include <QObject>
+#include <QString>
+
+class PaymentRequest : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString address READ address NOTIFY addressChanged)
+    Q_PROPERTY(QString addressFormatted READ addressFormatted NOTIFY addressChanged)
+    Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
+    Q_PROPERTY(QString message READ message WRITE setMessage NOTIFY messageChanged)
+    Q_PROPERTY(BitcoinAmount* amount READ amount CONSTANT)
+    Q_PROPERTY(QString amountError READ amountError NOTIFY amountErrorChanged)
+    Q_PROPERTY(QString id READ id NOTIFY idChanged)
+
+public:
+    explicit PaymentRequest(QObject* parent = nullptr);
+
+    QString address() const;
+    QString addressFormatted() const;
+
+    QString label() const;
+    void setLabel(const QString& label);
+
+    QString message() const;
+    void setMessage(const QString& message);
+
+    BitcoinAmount* amount() const;
+    QString amountError() const;
+    void setAmountError(const QString& error);
+
+    QString id() const;
+    void setId(unsigned int id);
+
+    void setDestination(const CTxDestination& destination);
+    CTxDestination destination() const;
+
+    Q_INVOKABLE void clear();
+
+Q_SIGNALS:
+    void addressChanged();
+    void labelChanged();
+    void messageChanged();
+    void amountErrorChanged();
+    void idChanged();
+
+private:
+    static QString FormatAddress(const QString& address);
+
+    CTxDestination m_destination;
+    QString m_label;
+    QString m_message;
+    QString m_amountError;
+    BitcoinAmount* m_amount;
+    QString m_id;
+};
+
+#endif // BITCOIN_QML_MODELS_PAYMENTREQUEST_H

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -6,6 +6,7 @@
 #include <qml/models/walletqmlmodel.h>
 
 #include <qml/models/activitylistmodel.h>
+#include <qml/models/paymentrequest.h>
 #include <qml/models/sendrecipient.h>
 #include <qml/models/sendrecipientslistmodel.h>
 #include <qml/models/walletqmlmodeltransaction.h>
@@ -21,7 +22,43 @@
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 
-#include <QTimer>
+#include <QDateTime>
+
+namespace {
+struct QmlReceiveRequestRecipient
+{
+    static constexpr int CURRENT_VERSION{1};
+    int nVersion{CURRENT_VERSION};
+    std::string address;
+    std::string label;
+    CAmount amount{0};
+    std::string message;
+    std::string sPaymentRequest;
+    std::string authenticatedMerchant;
+
+    SERIALIZE_METHODS(QmlReceiveRequestRecipient, obj)
+    {
+        READWRITE(obj.nVersion, obj.address, obj.label, obj.amount, obj.message, obj.sPaymentRequest, obj.authenticatedMerchant);
+    }
+};
+
+struct QmlRecentRequestEntry
+{
+    static constexpr int CURRENT_VERSION{1};
+    int nVersion{CURRENT_VERSION};
+    int64_t id{0};
+    QDateTime date;
+    QmlReceiveRequestRecipient recipient;
+
+    SERIALIZE_METHODS(QmlRecentRequestEntry, obj)
+    {
+        unsigned int date_timet;
+        SER_WRITE(obj, date_timet = obj.date.toSecsSinceEpoch());
+        READWRITE(obj.nVersion, obj.id, date_timet, obj.recipient);
+        SER_READ(obj, obj.date = QDateTime::fromSecsSinceEpoch(date_timet));
+    }
+};
+} // namespace
 
 WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObject *parent)
     : QObject(parent)
@@ -30,6 +67,7 @@ WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObje
     m_activity_list_model = new ActivityListModel(this);
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
+    m_current_payment_request = new PaymentRequest(this);
 }
 
 WalletQmlModel::WalletQmlModel(QObject* parent)
@@ -38,6 +76,7 @@ WalletQmlModel::WalletQmlModel(QObject* parent)
     m_activity_list_model = new ActivityListModel(this);
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
+    m_current_payment_request = new PaymentRequest(this);
 }
 
 WalletQmlModel::~WalletQmlModel()
@@ -45,6 +84,7 @@ WalletQmlModel::~WalletQmlModel()
     delete m_activity_list_model;
     delete m_coins_list_model;
     delete m_send_recipients;
+    delete m_current_payment_request;
     if (m_current_transaction) {
         delete m_current_transaction;
     }
@@ -82,6 +122,76 @@ QString WalletQmlModel::newAddress(QString label)
     OutputType output_type = m_wallet->getDefaultAddressType();
     util::Result<CTxDestination> dest{m_wallet->getNewDestination(output_type, label.toStdString())};
     return QString::fromStdString(EncodeDestination(dest.value()));
+}
+
+void WalletQmlModel::commitPaymentRequest()
+{
+    if (!m_wallet || !m_current_payment_request) {
+        return;
+    }
+
+    if (m_current_payment_request->id().isEmpty()) {
+        m_current_payment_request->setId(nextPaymentRequestId());
+    }
+
+    if (m_current_payment_request->address().isEmpty()) {
+        const OutputType output_type = m_wallet->getDefaultAddressType();
+        const auto destination{m_wallet->getNewDestination(output_type, m_current_payment_request->label().toStdString())};
+        if (!destination) {
+            return;
+        }
+        m_current_payment_request->setDestination(destination.value());
+    }
+
+    bool parse_ok{false};
+    const int64_t request_id{m_current_payment_request->id().toLongLong(&parse_ok)};
+    if (!parse_ok || request_id <= 0) {
+        return;
+    }
+
+    QmlRecentRequestEntry request_entry;
+    request_entry.id = request_id;
+    request_entry.date = QDateTime::currentDateTime();
+    request_entry.recipient.address = m_current_payment_request->address().toStdString();
+    request_entry.recipient.label = m_current_payment_request->label().toStdString();
+    request_entry.recipient.amount = m_current_payment_request->amount()->satoshi();
+    request_entry.recipient.message = m_current_payment_request->message().toStdString();
+
+    DataStream ss{};
+    ss << request_entry;
+
+    m_wallet->setAddressReceiveRequest(
+        m_current_payment_request->destination(),
+        m_current_payment_request->id().toStdString(),
+        ss.str());
+}
+
+unsigned int WalletQmlModel::nextPaymentRequestId() const
+{
+    if (!m_wallet) {
+        return 1;
+    }
+
+    int64_t max_id{0};
+    for (const std::string& request : m_wallet->getAddressReceiveRequests()) {
+        std::vector<uint8_t> data(request.begin(), request.end());
+        DataStream ss{data};
+        QmlRecentRequestEntry entry;
+        try {
+            ss >> entry;
+        } catch (const std::ios_base::failure&) {
+            continue;
+        }
+        if (entry.id > max_id) {
+            max_id = entry.id;
+        }
+    }
+
+    if (max_id <= 0 || max_id >= std::numeric_limits<unsigned int>::max() - 1) {
+        return 1;
+    }
+
+    return static_cast<unsigned int>(max_id + 1);
 }
 
 std::set<interfaces::WalletTx> WalletQmlModel::getWalletTxs() const

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -7,6 +7,7 @@
 
 #include <qml/models/activitylistmodel.h>
 #include <qml/models/coinslistmodel.h>
+#include <qml/models/paymentrequest.h>
 #include <qml/models/sendrecipient.h>
 #include <qml/models/sendrecipientslistmodel.h>
 #include <qml/models/walletqmlmodeltransaction.h>
@@ -29,6 +30,7 @@ class WalletQmlModel : public QObject
     Q_PROPERTY(ActivityListModel* activityListModel READ activityListModel CONSTANT)
     Q_PROPERTY(CoinsListModel* coinsListModel READ coinsListModel CONSTANT)
     Q_PROPERTY(SendRecipientsListModel* recipients READ sendRecipientList CONSTANT)
+    Q_PROPERTY(PaymentRequest* currentPaymentRequest READ currentPaymentRequest CONSTANT)
     Q_PROPERTY(WalletQmlModelTransaction* currentTransaction READ currentTransaction NOTIFY currentTransactionChanged)
     Q_PROPERTY(unsigned int targetBlocks READ feeTargetBlocks WRITE setFeeTargetBlocks NOTIFY feeTargetBlocksChanged)
     Q_PROPERTY(bool isWalletLoaded READ isWalletLoaded NOTIFY walletIsLoadedChanged)
@@ -41,10 +43,12 @@ public:
     QString name() const;
     QString balance() const;
     CAmount balanceSatoshi() const;
+    Q_INVOKABLE void commitPaymentRequest();
 
     ActivityListModel* activityListModel() const { return m_activity_list_model; }
     CoinsListModel* coinsListModel() const { return m_coins_list_model; }
     SendRecipientsListModel* sendRecipientList() const { return m_send_recipients; }
+    PaymentRequest* currentPaymentRequest() const { return m_current_payment_request; }
     WalletQmlModelTransaction* currentTransaction() const { return m_current_transaction; }
     Q_INVOKABLE bool prepareTransaction();
     Q_INVOKABLE void sendTransaction();
@@ -84,10 +88,13 @@ Q_SIGNALS:
     void walletIsLoadedChanged();
 
 private:
+    unsigned int nextPaymentRequestId() const;
+
     std::unique_ptr<interfaces::Wallet> m_wallet;
     ActivityListModel* m_activity_list_model{nullptr};
     CoinsListModel* m_coins_list_model{nullptr};
     SendRecipientsListModel* m_send_recipients{nullptr};
+    PaymentRequest* m_current_payment_request{nullptr};
     WalletQmlModelTransaction* m_current_transaction{nullptr};
     wallet::CCoinControl m_coin_control;
     bool m_is_wallet_loaded{false};

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -15,8 +15,8 @@ Page {
     id: root
     background: null
 
-    property int requestCounter: 0
     property WalletQmlModel wallet: walletController.selectedWallet
+    property PaymentRequest request: wallet ? wallet.currentPaymentRequest : null
 
     ScrollView {
         clip: true
@@ -29,7 +29,9 @@ Page {
             anchors.left: contentRow.left
             anchors.top: parent.top
             anchors.topMargin: 20
-            text: qsTr("Request a payment")
+            text: root.request !== null && root.request.id !== ""
+                ? qsTr("Payment request #") + root.request.id
+                : qsTr("Request a payment")
             font.pixelSize: 21
             bold: true
         }
@@ -37,7 +39,7 @@ Page {
         RowLayout {
             id: contentRow
 
-            enabled: walletController.initialized
+            enabled: walletController.initialized && root.request !== null
 
             anchors.top: title.bottom
             anchors.topMargin: 40
@@ -51,10 +53,6 @@ Page {
                 spacing: 5
 
                 Item {
-                    BitcoinAmount {
-                        id: bitcoinAmount
-                    }
-
                     height: amountInput.height
                     Layout.fillWidth: true
                     CoreText {
@@ -63,7 +61,7 @@ Page {
                         anchors.left: parent.left
                         anchors.verticalCenter: parent.verticalCenter
                         horizontalAlignment: Text.AlignLeft
-                        text: "Amount"
+                        text: qsTr("Amount")
                         font.pixelSize: 18
                     }
 
@@ -80,9 +78,28 @@ Page {
                         background: Item {}
                         placeholderText: "0.00000000"
                         selectByMouse: true
+                        text: root.request ? root.request.amount.display : ""
                         onTextEdited: {
-                            amountInput.text = bitcoinAmount.sanitize(amountInput.text)
+                            if (root.request) {
+                                root.request.amount.display = text
+                            }
                         }
+                        onEditingFinished: {
+                            if (root.request) {
+                                root.request.amount.format()
+                            }
+                        }
+                        onActiveFocusChanged: {
+                            if (!activeFocus && root.request) {
+                                root.request.amount.format()
+                            }
+                        }
+                        validator: RegularExpressionValidator {
+                            regularExpression: !root.request || root.request.amount.unit === BitcoinAmount.BTC
+                                ? /^(0|[1-9]\d{0,7})(\.\d{0,8})?$/
+                                : /^(0|[1-9]\d{0,15})$/
+                        }
+                        maximumLength: !root.request || root.request.amount.unit === BitcoinAmount.BTC ? 17 : 16
                     }
                     Item {
                         width: unitLabel.width + flipIcon.width
@@ -92,12 +109,8 @@ Page {
                         MouseArea {
                             anchors.fill: parent
                             onClicked: {
-                                if (bitcoinAmount.unit == BitcoinAmount.BTC) {
-                                    amountInput.text = bitcoinAmount.convert(amountInput.text, BitcoinAmount.BTC)
-                                    bitcoinAmount.unit = BitcoinAmount.SAT
-                                } else {
-                                    amountInput.text = bitcoinAmount.convert(amountInput.text, BitcoinAmount.SAT)
-                                    bitcoinAmount.unit = BitcoinAmount.BTC
+                                if (root.request) {
+                                    root.request.amount.flipUnit()
                                 }
                             }
                         }
@@ -105,7 +118,7 @@ Page {
                             id: unitLabel
                             anchors.right: flipIcon.left
                             anchors.verticalCenter: parent.verticalCenter
-                            text: bitcoinAmount.unitLabel
+                            text: root.request ? root.request.amount.unitLabel : ""
                             font.pixelSize: 18
                             color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
                         }
@@ -120,6 +133,25 @@ Page {
                     }
                 }
 
+                RowLayout {
+                    Layout.fillWidth: true
+                    visible: root.request !== null && root.request.amountError.length > 0
+
+                    Icon {
+                        source: "image://images/alert-filled"
+                        size: 22
+                        color: Theme.color.red
+                    }
+
+                    CoreText {
+                        text: root.request ? root.request.amountError : ""
+                        font.pixelSize: 15
+                        color: Theme.color.red
+                        horizontalAlignment: Text.AlignLeft
+                        Layout.fillWidth: true
+                    }
+                }
+
                 Separator {
                     Layout.fillWidth: true
                 }
@@ -129,6 +161,12 @@ Page {
                     Layout.fillWidth: true
                     labelText: qsTr("Label")
                     placeholderText: qsTr("Enter label...")
+                    text: root.request ? root.request.label : ""
+                    onTextEdited: {
+                        if (root.request) {
+                            root.request.label = label.text
+                        }
+                    }
                 }
 
                 Separator {
@@ -140,6 +178,12 @@ Page {
                     Layout.fillWidth: true
                     labelText: qsTr("Message")
                     placeholderText: qsTr("Enter message...")
+                    text: root.request ? root.request.message : ""
+                    onTextEdited: {
+                        if (root.request) {
+                            root.request.message = message.text
+                        }
+                    }
                 }
 
                 Separator {
@@ -168,7 +212,7 @@ Page {
                         width: 110
                         text: qsTr("copy")
                         font.pixelSize: 18
-                        color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                        color: copyArea.enabled ? Theme.color.orange : Theme.color.neutral4
                     }
 
                     Rectangle {
@@ -184,8 +228,33 @@ Page {
                             anchors.leftMargin: 5
                             horizontalAlignment: Text.AlignLeft
                             font.pixelSize: 18
-                            wrap: true
+                            wrapMode: Text.WordWrap
+                            text: root.request ? root.request.addressFormatted : ""
                         }
+                    }
+
+                    MouseArea {
+                        id: copyArea
+                        anchors.left: parent.left
+                        anchors.top: addressLabel.bottom
+                        anchors.right: addressLabel.right
+                        anchors.bottom: parent.bottom
+                        hoverEnabled: true
+                        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                        enabled: root.request !== null && root.request.address !== ""
+                        onClicked: Clipboard.setText(root.request.address)
+                    }
+
+                    MouseArea {
+                        id: addressArea
+                        anchors.left: addressLabel.right
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        anchors.bottom: parent.bottom
+                        hoverEnabled: true
+                        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                        enabled: root.request !== null && root.request.address !== ""
+                        onClicked: Clipboard.setText(root.request.address)
                     }
                 }
 
@@ -193,34 +262,26 @@ Page {
                     id: continueButton
                     Layout.fillWidth: true
                     Layout.topMargin: 30
-                    text: qsTr("Create bitcoin address")
+                    text: root.request !== null && root.request.id !== ""
+                        ? qsTr("Copy payment request")
+                        : qsTr("Create bitcoin address")
                     onClicked: {
-                        if (!clearRequest.visible) {
-                            requestCounter = requestCounter + 1
-                            clearRequest.visible = true
-                            title.text = qsTr("Payment request #" + requestCounter)
-                            var newAddress = root.wallet.newAddress(label.text)
-                            var groupedAddress = newAddress.replace(/(.{4})/g, "$1 ").trim()
-                            address.text = groupedAddress
-                            qrImage.code = newAddress
-                            continueButton.text = qsTr("Copy payment request")
+                        if (!root.request) {
+                            return
+                        }
+                        if (root.request.address === "") {
+                            root.wallet.commitPaymentRequest()
+                        } else {
+                            Clipboard.setText(root.request.address)
                         }
                     }
-                }
-
-                function clear() {
-                    clearRequest.visible = false
-                    title.text = qsTr("Request a payment")
-                    address.text = ""
-                    qrImage.code = ""
-                    continueButton.text = qsTr("Create bitcoin address")
                 }
 
                 ContinueButton {
                     id: clearRequest
                     Layout.fillWidth: true
                     Layout.topMargin: 10
-                    visible: false
+                    visible: root.request !== null && root.request.id !== ""
                     borderColor: Theme.color.neutral6
                     borderHoverColor: Theme.color.orangeLight1
                     borderPressedColor: Theme.color.orangeLight2
@@ -229,14 +290,18 @@ Page {
                     backgroundPressedColor: "transparent"
                     text: qsTr("Clear")
                     onClicked: {
-                        columnLayout.clear()
+                        if (root.request) {
+                            root.request.clear()
+                        }
                     }
                 }
 
                 Connections {
                     target: walletController
                     function onSelectedWalletChanged() {
-                        columnLayout.clear()
+                        if (root.request) {
+                            root.request.clear()
+                        }
                     }
                 }
             }
@@ -254,6 +319,7 @@ Page {
                     id: qrImage
                     backgroundColor: "transparent"
                     foregroundColor: Theme.color.neutral9
+                    code: root.request ? root.request.address : ""
                 }
             }
         }


### PR DESCRIPTION
- add qml/models/paymentrequest.{h,cpp}
- expose WalletQmlModel::currentPaymentRequest
- add WalletQmlModel::commitPaymentRequest()
- define recent request entry struct for serialization
- persist receive requests via setAddressReceiveRequest()
- register PaymentRequest in qml/bitcoin.cpp
- update RequestPayment.qml to bind amount/label/message/address to model
- keep create/copy/clear actions model-driven

Easiest way to currently test is to create the payment request and then load up the wallet in the Qt gui

