### PR TITLE
Introduce Qml Test Bridge

### DIFF
--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+name: GUI Functional Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "**"
+  workflow_dispatch:
+
+jobs:
+  qml-functional-tests:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake pkgconf python3 \
+            libevent-dev libboost-dev libsqlite3-dev libgl-dev libqrencode-dev \
+            qt6-qpa-plugins \
+            qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools \
+            qt6-declarative-dev \
+            qml6-module-qtqml qml6-module-qtqml-models qml6-module-qtqml-workerscript qml6-module-qt-labs-settings \
+            qml6-module-qtquick qml6-module-qtquick-window \
+            qml6-module-qtquick-layouts qml6-module-qtquick-controls \
+            qml6-module-qtquick-dialogs qml6-module-qtquick-templates
+
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DENABLE_TEST_AUTOMATION=ON
+
+      - name: Build
+        run: |
+          cmake --build build -j"$(nproc)"
+
+      - name: Run QML test automation suite
+        env:
+          QT_QUICK_BACKEND: software
+          LIBGL_ALWAYS_SOFTWARE: "1"
+        run: |
+          python3 test/functional/qml_test_bridge_sanity.py
+          python3 test/functional/qml_test_onboarding.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ find_package(Qt 6.2 MODULE REQUIRED
 )
 find_package(Libevent 2.1.8 MODULE REQUIRED)
 
+option(ENABLE_TEST_AUTOMATION "Enable test automation bridge for QML UI testing" OFF)
+
 # Do not build any executable targets from bitcoin submodule
 set(BUILD_BENCH OFF)
 set(BUILD_BITCOIN_BIN OFF)
@@ -67,6 +69,9 @@ set_target_properties(bitcoin_wallet PROPERTIES AUTOUIC OFF)
 set(CMAKE_AUTOMOC_MOC_OPTIONS "-I${CMAKE_CURRENT_SOURCE_DIR}/qml")
 file(GLOB_RECURSE QML_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/qml/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/qml/*.h")
 list(FILTER QML_SOURCES EXCLUDE REGEX "androidnotifier\\.(cpp|h)$")
+if(NOT ENABLE_TEST_AUTOMATION)
+  list(FILTER QML_SOURCES EXCLUDE REGEX "qml/test/")
+endif()
 set(QML_QRC "${CMAKE_CURRENT_SOURCE_DIR}/qml/bitcoin_qml.qrc")
 qt6_add_resources(QML_QRC_CPP ${QML_QRC})
 list(APPEND QML_SOURCES ${QML_QRC_CPP})
@@ -80,6 +85,11 @@ target_compile_definitions(bitcoinqml
     QT_NO_KEYWORDS
     QT_USE_QSTRINGBUILDER
 )
+if(ENABLE_TEST_AUTOMATION)
+  find_package(Qt6 REQUIRED COMPONENTS Network)
+  target_compile_definitions(bitcoinqml PUBLIC ENABLE_TEST_AUTOMATION)
+  target_link_libraries(bitcoinqml PUBLIC Qt6::Network)
+endif()
 target_include_directories(bitcoinqml
   PRIVATE
     # to keep the convention of #include <qml/*.h>

--- a/doc/test-bridge.md
+++ b/doc/test-bridge.md
@@ -1,0 +1,313 @@
+# QML Test Automation Bridge
+
+The test bridge is a lightweight IPC server embedded in `bitcoin-core-app` that
+allows external test scripts to observe and drive the QML user interface. It is
+designed for use with the Bitcoin Core functional test framework
+(`BitcoinTestFramework`) and communicates over a Unix domain socket using
+newline-delimited JSON messages.
+
+The bridge is **test-only infrastructure** — it is compiled in only when
+`ENABLE_TEST_AUTOMATION` is set at build time and activated only when the
+`-test-automation` flag is passed at runtime.
+
+## Building with the test bridge
+
+```bash
+cmake -B build -DENABLE_TEST_AUTOMATION=ON
+cmake --build build
+```
+
+When `ENABLE_TEST_AUTOMATION=ON`:
+
+- The `qml/test/` directory is included in the build.
+- The `ENABLE_TEST_AUTOMATION` preprocessor macro is defined.
+- `Qt6::Network` is linked (provides `QLocalServer` / `QLocalSocket`).
+
+When `ENABLE_TEST_AUTOMATION=OFF` (the default), none of the test bridge code
+is compiled into the binary.
+
+## Running with the test bridge
+
+```bash
+# Specify a socket path explicitly
+./build/bin/bitcoin-core-app -test-automation=/tmp/test_bridge.sock
+
+# Or use the default path (<datadir>/test_bridge.sock)
+./build/bin/bitcoin-core-app -test-automation
+```
+
+For headless CI environments, combine with the Qt offscreen platform:
+
+```bash
+QT_QPA_PLATFORM=offscreen ./build/bin/bitcoin-core-app -test-automation=/tmp/test_bridge.sock
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│  Python functional test             │
+│  (BitcoinTestFramework subclass)    │
+│                                     │
+│  ┌──────────┐    ┌───────────────┐  │
+│  │ JSON-RPC │    │ QmlDriver     │  │
+│  │ (backend │    │ (UI actions   │  │
+│  │  state)  │    │  via socket)  │  │
+│  └────┬─────┘    └──────┬────────┘  │
+└───────┼─────────────────┼───────────┘
+        │                 │
+        ▼                 ▼
+┌─────────────────────────────────────┐
+│  bitcoin-core-app                   │
+│                                     │
+│  ┌──────────┐    ┌───────────────┐  │
+│  │ RPC      │    │ TestBridge    │  │
+│  │ server   │    │ (QLocalServer │  │
+│  │          │    │  JSON IPC)    │  │
+│  └──────────┘    └───────────────┘  │
+└─────────────────────────────────────┘
+```
+
+Two channels work together in functional tests:
+
+- **JSON-RPC** (already exists) — set up backend state: create wallets, fund
+  addresses, generate blocks.
+- **Test bridge socket** (new) — observe and drive the QML UI.
+
+## Protocol
+
+The test bridge accepts **newline-delimited JSON** commands over a Unix domain
+socket and returns a single JSON response line for each command.
+
+### Commands
+
+#### `get_current_page`
+
+Returns the `objectName` (or QML class name) of the current page shown in the
+main `StackView`.
+
+```json
+→ {"cmd": "get_current_page"}
+← {"page": "CreateWalletWizard"}
+```
+
+#### `get_property`
+
+Reads an arbitrary property from a named QML object.
+
+```json
+→ {"cmd": "get_property", "objectName": "importButton", "prop": "visible"}
+← {"value": true}
+```
+
+#### `click`
+
+Simulates a click on a named QML object. The bridge tries three strategies in
+order:
+
+1. Invoke the `clicked()` signal directly.
+2. Invoke `toggle()` if available.
+3. Synthesize mouse press/release events at the item center.
+
+```json
+→ {"cmd": "click", "objectName": "importButton"}
+← {"ok": true}
+```
+
+#### `set_text`
+
+Sets the `text` property on a named QML object (e.g., `TextField`).
+
+```json
+→ {"cmd": "set_text", "objectName": "walletNameField", "text": "my_wallet"}
+← {"ok": true}
+```
+
+#### `get_text`
+
+Reads the `text` property from a named QML object.
+
+```json
+→ {"cmd": "get_text", "objectName": "errorLabel"}
+← {"text": "File not found"}
+```
+
+#### `wait_for_page`
+
+Blocks until the named QML object exists and is visible, or the timeout
+expires. The bridge processes Qt events while waiting so the UI can update.
+
+```json
+→ {"cmd": "wait_for_page", "page": "ImportReview", "timeout": 5000}
+← {"ok": true}
+```
+
+If the timeout is reached:
+
+```json
+← {"error": "Timed out waiting for page: ImportReview"}
+```
+
+#### `list_objects`
+
+Returns all QML objects in the tree that have a non-empty `objectName`.
+Useful for debugging and discovering available targets.
+
+```json
+→ {"cmd": "list_objects"}
+← {"objects": [
+     {"objectName": "main", "className": "PageStack"},
+     {"objectName": "importButton", "className": "ContinueButton_QMLTYPE_42"},
+     ...
+   ]}
+```
+
+### Error responses
+
+All commands may return an error response instead of their normal result:
+
+```json
+← {"error": "Object not found: someButton"}
+```
+
+## Python client — `QmlDriver`
+
+A ready-to-use Python client is provided at `test/functional/qml_driver.py`.
+
+```python
+from qml_driver import QmlDriver
+
+gui = QmlDriver("/tmp/test_bridge.sock")
+
+gui.click("importWalletButton")
+gui.wait_for_page("ImportWallet")
+gui.set_text("walletNameField", "my_wallet")
+
+page = gui.get_current_page()
+text = gui.get_text("errorLabel")
+visible = gui.get_property("importButton", "visible")
+objects = gui.list_objects()
+
+gui.close()
+```
+
+The driver retries the initial connection for up to 30 seconds (configurable
+via the `timeout` constructor parameter), which allows it to connect even if
+the GUI process hasn't finished starting yet.
+
+All commands raise `QmlDriverError` on failure.
+
+## Running tests
+
+Test scripts live in `test/functional/`. They can either launch a fresh
+headless GUI instance automatically, or attach to an already-running app.
+
+### Launch a new instance (default)
+
+```bash
+python3 test/functional/qml_test_bridge_sanity.py
+python3 test/functional/qml_test_onboarding.py
+```
+
+The harness starts `bitcoin-core-app` with `QT_QPA_PLATFORM=offscreen`,
+`-resetguisettings`, and a temporary datadir. The process is shut down
+automatically when the test finishes.
+
+### Attach to a running instance
+
+Start the app with the test bridge enabled:
+
+```bash
+./build/bin/bitcoin-core-app -test-automation=/tmp/test_bridge.sock
+```
+
+Then run tests against it:
+
+```bash
+python3 test/functional/qml_test_bridge_sanity.py --socket-path /tmp/test_bridge.sock
+python3 test/functional/qml_test_onboarding.py --socket-path /tmp/test_bridge.sock
+```
+
+When `--socket-path` is provided the harness connects to the existing socket
+and does **not** launch or terminate the application.
+
+### Available tests
+
+| Script | Description |
+|---|---|
+| `qml_test_bridge_sanity.py` | Bridge protocol smoke test: list_objects, get_current_page, get_property, error handling, wait_for_page timeout |
+| `qml_test_onboarding.py` | Walks through the full onboarding flow (Cover → Strengthen → Blockclock → StorageLocation → StorageAmount → Connection) |
+
+## Prerequisite: `objectName` annotations
+
+The test bridge locates QML elements by their `objectName` property. Every
+interactive element that tests need to access **must** have an `objectName`
+set:
+
+```qml
+ContinueButton {
+    objectName: "importWalletButton"
+    text: qsTr("Import wallet")
+    onClicked: root.push(importWallet)
+}
+
+TextField {
+    objectName: "walletNameField"
+}
+
+CoreText {
+    objectName: "importErrorLabel"
+}
+```
+
+When adding new QML pages or controls, include `objectName` for any element
+that a test might need to interact with or inspect.
+
+### `InformationPage` button naming
+
+`InformationPage` exposes a `buttonObjectName` property (default:
+`"continueButton"`) that controls the `objectName` of its built-in
+`ContinueButton`. Each page should override it with a unique name so tests
+can click the correct button unambiguously:
+
+```qml
+InformationPage {
+    objectName: "onboardingStrengthen"
+    buttonObjectName: "onboardingStrengthenButton"
+    ...
+}
+```
+
+### Onboarding pages
+
+The following `objectName` values are set on the onboarding flow pages and
+their buttons:
+
+| Page | `objectName` | Button `objectName` |
+|---|---|---|
+| OnboardingCover | `onboardingCover` | `onboardingCoverButton` |
+| OnboardingStrengthen | `onboardingStrengthen` | `onboardingStrengthenButton` |
+| OnboardingBlockclock | `onboardingBlockclock` | `onboardingBlockclockButton` |
+| OnboardingStorageLocation | `onboardingStorageLocation` | `onboardingStorageLocationButton` |
+| OnboardingStorageAmount | `onboardingStorageAmount` | `onboardingStorageAmountButton` |
+| OnboardingConnection | `onboardingConnection` | `onboardingConnectionButton` |
+
+## Source files
+
+| File | Description |
+|---|---|
+| `qml/test/testbridge.h` | `TestBridge` class declaration |
+| `qml/test/testbridge.cpp` | `TestBridge` implementation |
+| `qml/bitcoin.cpp` | Integration point (`-test-automation` arg, bridge init) |
+| `CMakeLists.txt` | `ENABLE_TEST_AUTOMATION` option and conditional compilation |
+| `test/functional/qml_driver.py` | Python `QmlDriver` client |
+| `test/functional/qml_test_harness.py` | Shared test harness (launch / attach, cleanup, tree dump) |
+| `test/functional/qml_test_bridge_sanity.py` | Bridge protocol sanity test |
+| `test/functional/qml_test_onboarding.py` | Onboarding flow walk-through test |
+
+## Security considerations
+
+- The test bridge is **never compiled** in default builds (`ENABLE_TEST_AUTOMATION` defaults to `OFF`).
+- Even when compiled in, it is **never activated** unless `-test-automation` is explicitly passed.
+- The Unix domain socket is local-only and subject to filesystem permissions.
+- Release builds and CI artifact builds should **not** enable `ENABLE_TEST_AUTOMATION`.

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -43,6 +43,9 @@
 #include <qml/qrimageprovider.h>
 #include <qml/util.h>
 #include <qml/walletqmlcontroller.h>
+#ifdef ENABLE_TEST_AUTOMATION
+#include <qml/test/testbridge.h>
+#endif
 #include <qt/guiutil.h>
 #include <qt/initexecutor.h>
 #include <qt/networkstyle.h>
@@ -90,6 +93,9 @@ void SetupUIArgs(ArgsManager& argsman)
     argsman.AddArg("-lang=<lang>", "Set language, for example \"de_DE\" (default: system locale)", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-min", "Start minimized", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-resetguisettings", "Reset all settings changed in the GUI", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
+#ifdef ENABLE_TEST_AUTOMATION
+    argsman.AddArg("-test-automation=<path>", "Enable test automation bridge on the given Unix socket path", ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
+#endif
 }
 
 AppMode SetupAppMode()
@@ -347,6 +353,19 @@ int QmlGuiMain(int argc, char* argv[])
     if (!window) {
         return EXIT_FAILURE;
     }
+
+#ifdef ENABLE_TEST_AUTOMATION
+    std::unique_ptr<TestBridge> test_bridge;
+    if (gArgs.IsArgSet("-test-automation")) {
+        QString socket_path = QString::fromStdString(gArgs.GetArg("-test-automation", ""));
+        if (socket_path.isEmpty()) {
+            // Default to a socket in the data directory.
+            socket_path = QString::fromStdString(
+                (gArgs.GetDataDirNet() / "test_bridge.sock").utf8string());
+        }
+        test_bridge = std::make_unique<TestBridge>(&engine, socket_path);
+    }
+#endif
 
     // Install qDebug() message handler to route to debug.log
     qInstallMessageHandler(DebugMessageHandler);

--- a/qml/controls/InformationPage.qml
+++ b/qml/controls/InformationPage.qml
@@ -37,6 +37,7 @@ Page {
     property string subtext: ""
     property int subtextMargin: 30
     property int subtextSize: 15
+    property string buttonObjectName: "continueButton"
     property real maximumWidth: 600
     property real detailMaximumWidth: 450
 
@@ -99,6 +100,7 @@ Page {
         }
         ContinueButton {
             id: continueButton
+            objectName: root.buttonObjectName
             visible: root.buttonText.length > 0
             enabled: visible
             width: Math.min(300, parent.width - 2 * anchors.leftMargin)

--- a/qml/controls/PageStack.qml
+++ b/qml/controls/PageStack.qml
@@ -7,6 +7,28 @@ import QtQuick.Controls 2.15
 
 StackView {
     property bool vertical: false
+    // Expose the deepest active page in nested PageStack hierarchies.
+    readonly property var currentLeafItem: resolveCurrentLeafItem(currentItem)
+    readonly property string currentLeafObjectName: {
+        const leaf = currentLeafItem
+        return leaf && leaf.objectName ? leaf.objectName : ""
+    }
+
+    function resolveCurrentLeafItem(item) {
+        let current = item
+        let guard = 0
+        while (current && guard < 64) {
+            guard += 1
+            if (current.currentItem !== undefined &&
+                current.depth !== undefined &&
+                current.currentItem) {
+                current = current.currentItem
+                continue
+            }
+            return current
+        }
+        return current
+    }
 
     pushEnter: Transition {
         NumberAnimation {

--- a/qml/controls/PageStack.qml
+++ b/qml/controls/PageStack.qml
@@ -7,28 +7,6 @@ import QtQuick.Controls 2.15
 
 StackView {
     property bool vertical: false
-    // Expose the deepest active page in nested PageStack hierarchies.
-    readonly property var currentLeafItem: resolveCurrentLeafItem(currentItem)
-    readonly property string currentLeafObjectName: {
-        const leaf = currentLeafItem
-        return leaf && leaf.objectName ? leaf.objectName : ""
-    }
-
-    function resolveCurrentLeafItem(item) {
-        let current = item
-        let guard = 0
-        while (current && guard < 64) {
-            guard += 1
-            if (current.currentItem !== undefined &&
-                current.depth !== undefined &&
-                current.currentItem) {
-                current = current.currentItem
-                continue
-            }
-            return current
-        }
-        return current
-    }
 
     pushEnter: Transition {
         NumberAnimation {

--- a/qml/pages/main.qml
+++ b/qml/pages/main.qml
@@ -20,6 +20,9 @@ ApplicationWindow {
     minimumHeight: 665
     color: Theme.color.background
     visible: true
+    // Exposed for test automation bridge lookups.
+    property var testCurrentPageItem: main.currentLeafItem
+    property string testCurrentPageName: main.currentLeafObjectName
 
     Settings {
         property alias x: appWindow.x

--- a/qml/pages/main.qml
+++ b/qml/pages/main.qml
@@ -20,9 +20,6 @@ ApplicationWindow {
     minimumHeight: 665
     color: Theme.color.background
     visible: true
-    // Exposed for test automation bridge lookups.
-    property var testCurrentPageItem: main.currentLeafItem
-    property string testCurrentPageName: main.currentLeafObjectName
 
     Settings {
         property alias x: appWindow.x
@@ -37,6 +34,7 @@ ApplicationWindow {
 
     PageStack {
         id: main
+        objectName: "mainPageStack"
         initialItem: {
             if (needOnboarding) {
                 onboardingWizard

--- a/qml/pages/onboarding/OnboardingBlockclock.qml
+++ b/qml/pages/onboarding/OnboardingBlockclock.qml
@@ -9,6 +9,8 @@ import "../../controls"
 
 InformationPage {
     id: root
+    objectName: "onboardingBlockclock"
+    buttonObjectName: "onboardingBlockclockButton"
     navLeftDetail: NavButton {
         iconSource: "image://images/caret-left"
         text: qsTr("Back")

--- a/qml/pages/onboarding/OnboardingConnection.qml
+++ b/qml/pages/onboarding/OnboardingConnection.qml
@@ -11,6 +11,7 @@ import "../settings"
 
 Page {
     id: root
+    objectName: "onboardingConnection"
     signal back
     signal next
     background: null
@@ -23,6 +24,7 @@ Page {
         Component {
             id: onboardingConnection
             InformationPage {
+                buttonObjectName: "onboardingConnectionButton"
                 navLeftDetail: NavButton {
                     iconSource: "image://images/caret-left"
                     text: qsTr("Back")

--- a/qml/pages/onboarding/OnboardingCover.qml
+++ b/qml/pages/onboarding/OnboardingCover.qml
@@ -11,6 +11,7 @@ import "../settings"
 
 Page {
     id: root
+    objectName: "onboardingCover"
     signal next
     background: null
     clip: true
@@ -21,6 +22,7 @@ Page {
         Component {
             id: onboardingCover
             InformationPage {
+                buttonObjectName: "onboardingCoverButton"
                 navRightDetail: NavButton {
                     iconSource: "image://images/info"
                     iconHeight: 24

--- a/qml/pages/onboarding/OnboardingStorageAmount.qml
+++ b/qml/pages/onboarding/OnboardingStorageAmount.qml
@@ -11,6 +11,7 @@ import "../settings"
 
 Page {
     id: root
+    objectName: "onboardingStorageAmount"
     signal back
     signal next
     property bool customStorage: false
@@ -25,6 +26,7 @@ Page {
         Component {
             id: onboardingStorageAmount
             InformationPage {
+                buttonObjectName: "onboardingStorageAmountButton"
                 navLeftDetail: NavButton {
                     iconSource: "image://images/caret-left"
                     text: qsTr("Back")

--- a/qml/pages/onboarding/OnboardingStorageLocation.qml
+++ b/qml/pages/onboarding/OnboardingStorageLocation.qml
@@ -11,6 +11,8 @@ import "../../components"
 
 InformationPage {
     id: root
+    objectName: "onboardingStorageLocation"
+    buttonObjectName: "onboardingStorageLocationButton"
     navLeftDetail: NavButton {
         iconSource: "image://images/caret-left"
         text: qsTr("Back")

--- a/qml/pages/onboarding/OnboardingStrengthen.qml
+++ b/qml/pages/onboarding/OnboardingStrengthen.qml
@@ -9,6 +9,8 @@ import "../../controls"
 
 InformationPage {
     id: root
+    objectName: "onboardingStrengthen"
+    buttonObjectName: "onboardingStrengthenButton"
     navLeftDetail: NavButton {
         iconSource: "image://images/caret-left"
         text: qsTr("Back")

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -189,72 +189,45 @@ QByteArray TestBridge::processCommand(const QByteArray& json_cmd)
 
 QByteArray TestBridge::cmdGetCurrentPage()
 {
-    // Walk the visual tree looking for StackView instances (which have both
-    // "currentItem" and "depth" properties).  Drill into nested StackViews
-    // (e.g. OnboardingWizard is a PageStack inside the main PageStack) to
-    // return the deepest page.  We check for "depth" to distinguish StackView
-    // from StackLayout, which also has "currentItem" but is not a page stack.
+    auto pageResponse = [](QObject* page_obj) {
+        QString name = page_obj->objectName();
+        if (name.isEmpty()) {
+            name = QString::fromLatin1(page_obj->metaObject()->className());
+        }
+        QJsonObject resp;
+        resp[QStringLiteral("page")] = name;
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+    };
+
+    // Preferred path: read precomputed page information exposed by main.qml.
     for (QObject* root : m_engine->rootObjects()) {
-        auto* window = qobject_cast<QQuickWindow*>(root);
-        if (!window) continue;
-
-        // Breadth-first search through the visual item tree.
-        std::vector<QQuickItem*> queue;
-        queue.push_back(window->contentItem());
-
-        QObject* deepest_page = nullptr;
-        QObject* deepest_named_page = nullptr;
-
-        while (!queue.empty()) {
-            QQuickItem* item = queue.back();
-            queue.pop_back();
-            if (!item) continue;
-
-            // Only consider items that look like a StackView: they must
-            // have both "currentItem" and "depth" properties.
-            QVariant depth = item->property("depth");
-            QVariant current = item->property("currentItem");
-            if (depth.isValid() && current.isValid()) {
-                QObject* current_obj = current.value<QObject*>();
-                if (current_obj) {
-                    deepest_page = current_obj;
-                    if (!current_obj->objectName().isEmpty()) {
-                        deepest_named_page = current_obj;
-                    }
-                    // Push the current item itself back into the queue
-                    // so that if it is a nested StackView (e.g.
-                    // OnboardingWizard) it gets checked for its own
-                    // currentItem on the next iteration.  Its children
-                    // will be explored when it is popped and either
-                    // matched (StackView) or falls through to the
-                    // childItems loop below.
-                    auto* current_item = qobject_cast<QQuickItem*>(current_obj);
-                    if (current_item) {
-                        queue.push_back(current_item);
-                    }
-                    continue;
-                }
-            }
-
-            for (QQuickItem* child : item->childItems()) {
-                queue.push_back(child);
-            }
+        QVariant page_item = root->property("testCurrentPageItem");
+        QObject* page_obj = page_item.value<QObject*>();
+        if (page_obj) {
+            return pageResponse(page_obj);
         }
 
-        // Prefer the deepest page that has an objectName.  Fall back
-        // to the class name of the absolute deepest page otherwise.
-        QObject* result_page = deepest_named_page ? deepest_named_page : deepest_page;
-        if (result_page) {
-            QString name = result_page->objectName();
-            if (name.isEmpty()) {
-                name = QString::fromLatin1(result_page->metaObject()->className());
-            }
+        const QString page_name = root->property("testCurrentPageName").toString();
+        if (!page_name.isEmpty()) {
             QJsonObject resp;
-            resp[QStringLiteral("page")] = name;
+            resp[QStringLiteral("page")] = page_name;
             return QJsonDocument(resp).toJson(QJsonDocument::Compact);
         }
     }
-    return errorResponse(QStringLiteral("Could not determine current page"));
+
+    // Compatibility fallback for roots that directly expose currentItem.
+    for (QObject* root : m_engine->rootObjects()) {
+        QVariant depth = root->property("depth");
+        QVariant current = root->property("currentItem");
+        if (!depth.isValid() || !current.isValid()) continue;
+
+        QObject* current_obj = current.value<QObject*>();
+        if (current_obj) {
+            return pageResponse(current_obj);
+        }
+    }
+
+    return errorResponse(QStringLiteral("Could not determine current page; missing testCurrentPageItem/testCurrentPageName"));
 }
 
 QByteArray TestBridge::cmdGetProperty(const QString& object_name, const QString& prop)

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -11,7 +11,6 @@
 #include <QMetaObject>
 #include <QMetaProperty>
 #include <QImage>
-#include <QQmlContext>
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QThread>

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -68,6 +68,9 @@ void TestBridge::handleClientData()
         return;
     }
 
+   // Keep this guard on while handling commands. wait_for_page and
+   // wait_for_property run a nested event loop, which, if not guarded,
+   // could allow a second command to begin.
     QScopedValueRollback<bool> processing_guard(m_processing_client_data, true);
 
     do {

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -10,6 +10,7 @@
 #include <QMetaMethod>
 #include <QMetaObject>
 #include <QMetaProperty>
+#include <QImage>
 #include <QQmlContext>
 #include <QQuickItem>
 #include <QQuickWindow>
@@ -49,6 +50,7 @@ void TestBridge::handleNewConnection()
 {
     while (QLocalSocket* client = m_server->nextPendingConnection()) {
         m_clients.push_back(client);
+        m_read_buffers.insert(client, QByteArray{});
         connect(client, &QLocalSocket::readyRead, this, &TestBridge::handleClientData);
         connect(client, &QLocalSocket::disconnected, this, &TestBridge::handleClientDisconnected);
         qInfo("TestBridge: client connected");
@@ -60,13 +62,14 @@ void TestBridge::handleClientData()
     auto* client = qobject_cast<QLocalSocket*>(sender());
     if (!client) return;
 
-    m_read_buffer.append(client->readAll());
+    QByteArray& read_buffer = m_read_buffers[client];
+    read_buffer.append(client->readAll());
 
     // Process newline-delimited JSON commands.
     int newline_pos;
-    while ((newline_pos = m_read_buffer.indexOf('\n')) != -1) {
-        QByteArray line = m_read_buffer.left(newline_pos);
-        m_read_buffer.remove(0, newline_pos + 1);
+    while ((newline_pos = read_buffer.indexOf('\n')) != -1) {
+        QByteArray line = read_buffer.left(newline_pos);
+        read_buffer.remove(0, newline_pos + 1);
 
         if (line.trimmed().isEmpty()) continue;
 
@@ -86,6 +89,7 @@ void TestBridge::handleClientDisconnected()
     if (it != m_clients.end()) {
         m_clients.erase(it);
     }
+    m_read_buffers.remove(client);
     client->deleteLater();
     qInfo("TestBridge: client disconnected");
 }
@@ -112,24 +116,27 @@ QObject* TestBridge::findObjectByName(const QString& name) const
     return nullptr;
 }
 
-void TestBridge::collectNamedObjects(QObject* root, std::vector<std::pair<QString, QString>>& results) const
+void TestBridge::collectNamedObjects(QObject* root, std::vector<NamedObjectEntry>& results, QSet<const QObject*>& visited, int depth) const
 {
     if (!root) return;
+    if (visited.contains(root)) return;
+    visited.insert(root);
+
     if (!root->objectName().isEmpty()) {
-        results.emplace_back(root->objectName(),
-                             QString::fromLatin1(root->metaObject()->className()));
+        NamedObjectEntry named_entry;
+        named_entry.object_name = root->objectName();
+        named_entry.class_name = QString::fromLatin1(root->metaObject()->className());
+        named_entry.depth = depth;
+        results.push_back(named_entry);
     }
     for (QObject* child : root->children()) {
-        collectNamedObjects(child, results);
+        collectNamedObjects(child, results, visited, depth + 1);
     }
     // Also traverse visual children for QQuickItem-based trees.
     auto* item = qobject_cast<QQuickItem*>(root);
     if (item) {
         for (QQuickItem* visual_child : item->childItems()) {
-            // Avoid duplicates — only traverse if not already a QObject child.
-            if (visual_child->parent() != root) {
-                collectNamedObjects(visual_child, results);
-            }
+            collectNamedObjects(visual_child, results, visited, depth + 1);
         }
     }
 }
@@ -161,8 +168,19 @@ QByteArray TestBridge::processCommand(const QByteArray& json_cmd)
         return cmdWaitForPage(
             obj.value(QStringLiteral("page")).toString(),
             obj.value(QStringLiteral("timeout")).toInt(5000));
+    } else if (cmd == QLatin1String("wait_for_property")) {
+        return cmdWaitForProperty(
+            obj.value(QStringLiteral("objectName")).toString(),
+            obj.value(QStringLiteral("prop")).toString(),
+            obj.value(QStringLiteral("timeout")).toInt(5000),
+            obj.value(QStringLiteral("value")),
+            obj.contains(QStringLiteral("value")),
+            obj.value(QStringLiteral("contains")).toString(),
+            obj.value(QStringLiteral("nonEmpty")).toBool(false));
     } else if (cmd == QLatin1String("get_text")) {
         return cmdGetText(obj.value(QStringLiteral("objectName")).toString());
+    } else if (cmd == QLatin1String("save_screenshot")) {
+        return cmdSaveScreenshot(obj.value(QStringLiteral("path")).toString());
     } else if (cmd == QLatin1String("list_objects")) {
         return cmdListObjects();
     }
@@ -276,21 +294,38 @@ QByteArray TestBridge::cmdClick(const QString& object_name)
     // For QQuickItem-based controls, we can also simulate a mouse click.
     auto* item = qobject_cast<QQuickItem*>(obj);
 
-    // First, try to find and invoke a "clicked" signal.
     const QMetaObject* meta = obj->metaObject();
-    int clicked_index = meta->indexOfSignal("clicked()");
-    if (clicked_index >= 0) {
-        meta->method(clicked_index).invoke(obj, Qt::DirectConnection);
+
+    // Prefer real click()/trigger()/toggle() methods so buttons update state
+    // (e.g. checked tabs in a ButtonGroup) rather than only emitting signals.
+    int click_method_index = meta->indexOfMethod("click()");
+    if (click_method_index >= 0) {
+        meta->method(click_method_index).invoke(obj, Qt::DirectConnection);
         QJsonObject resp;
         resp[QStringLiteral("ok")] = true;
         return QJsonDocument(resp).toJson(QJsonDocument::Compact);
     }
 
-    // Fallback: for QQuickItems, try the "toggle" or "trigger" method
-    // or directly invoke via AbstractButton's clicked().
+    int trigger_index = meta->indexOfMethod("trigger()");
+    if (trigger_index >= 0) {
+        meta->method(trigger_index).invoke(obj, Qt::DirectConnection);
+        QJsonObject resp;
+        resp[QStringLiteral("ok")] = true;
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+    }
+
     int toggle_index = meta->indexOfMethod("toggle()");
     if (toggle_index >= 0) {
         meta->method(toggle_index).invoke(obj, Qt::DirectConnection);
+        QJsonObject resp;
+        resp[QStringLiteral("ok")] = true;
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+    }
+
+    // Then try to find and invoke a "clicked" signal.
+    int clicked_index = meta->indexOfSignal("clicked()");
+    if (clicked_index >= 0) {
+        meta->method(clicked_index).invoke(obj, Qt::DirectConnection);
         QJsonObject resp;
         resp[QStringLiteral("ok")] = true;
         return QJsonDocument(resp).toJson(QJsonDocument::Compact);
@@ -335,6 +370,19 @@ QByteArray TestBridge::cmdSetText(const QString& object_name, const QString& tex
     // Try "text" property first (covers TextField, TextInput, TextArea, etc.)
     if (obj->property("text").isValid()) {
         obj->setProperty("text", text);
+
+        // Trigger edit hooks so model-backed fields that update on textEdited
+        // or editingFinished are deterministic under test automation.
+        const QMetaObject* meta = obj->metaObject();
+        if (int idx = meta->indexOfSignal("textEdited(QString)"); idx >= 0) {
+            meta->method(idx).invoke(obj, Qt::DirectConnection, Q_ARG(QString, text));
+        }
+        if (int idx = meta->indexOfSignal("editingFinished()"); idx >= 0) {
+            meta->method(idx).invoke(obj, Qt::DirectConnection);
+        } else if (int idx = meta->indexOfMethod("editingFinished()"); idx >= 0) {
+            meta->method(idx).invoke(obj, Qt::DirectConnection);
+        }
+
         QJsonObject resp;
         resp[QStringLiteral("ok")] = true;
         return QJsonDocument(resp).toJson(QJsonDocument::Compact);
@@ -358,7 +406,9 @@ QByteArray TestBridge::cmdWaitForPage(const QString& page_name, int timeout_ms)
         QObject* obj = findObjectByName(page_name);
         if (obj) {
             auto* item = qobject_cast<QQuickItem*>(obj);
-            if (!item || item->isVisible()) {
+            const QVariant visible = obj->property("visible");
+            const bool is_visible = item ? item->isVisible() : (!visible.isValid() || visible.toBool());
+            if (is_visible) {
                 QJsonObject resp;
                 resp[QStringLiteral("ok")] = true;
                 return QJsonDocument(resp).toJson(QJsonDocument::Compact);
@@ -372,6 +422,47 @@ QByteArray TestBridge::cmdWaitForPage(const QString& page_name, int timeout_ms)
     }
 
     return errorResponse(QStringLiteral("Timed out waiting for page: %1").arg(page_name));
+}
+
+QByteArray TestBridge::cmdWaitForProperty(const QString& object_name, const QString& prop, int timeout_ms, const QJsonValue& expected, bool has_expected, const QString& contains, bool non_empty)
+{
+    if (object_name.isEmpty() || prop.isEmpty()) {
+        return errorResponse(QStringLiteral("objectName and prop are required"));
+    }
+
+    const int poll_interval_ms = 50;
+    int elapsed = 0;
+
+    while (elapsed < timeout_ms) {
+        QObject* obj = findObjectByName(object_name);
+        if (obj) {
+            QVariant value = obj->property(prop.toLatin1().constData());
+            if (value.isValid()) {
+                bool matched = true;
+
+                if (!contains.isEmpty()) {
+                    matched = value.toString().contains(contains);
+                } else if (non_empty) {
+                    matched = !value.toString().trimmed().isEmpty();
+                } else if (has_expected) {
+                    matched = (QJsonValue::fromVariant(value) == expected);
+                }
+
+                if (matched) {
+                    QJsonObject resp;
+                    resp[QStringLiteral("ok")] = true;
+                    resp[QStringLiteral("value")] = QJsonValue::fromVariant(value);
+                    return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+                }
+            }
+        }
+
+        QCoreApplication::processEvents(QEventLoop::AllEvents, poll_interval_ms);
+        QThread::msleep(poll_interval_ms);
+        elapsed += poll_interval_ms;
+    }
+
+    return errorResponse(QStringLiteral("Timed out waiting for property: %1.%2").arg(object_name, prop));
 }
 
 QByteArray TestBridge::cmdGetText(const QString& object_name)
@@ -395,19 +486,58 @@ QByteArray TestBridge::cmdGetText(const QString& object_name)
     return QJsonDocument(resp).toJson(QJsonDocument::Compact);
 }
 
+QByteArray TestBridge::cmdSaveScreenshot(const QString& path)
+{
+    if (path.isEmpty()) {
+        return errorResponse(QStringLiteral("path is required"));
+    }
+
+    QQuickWindow* window = nullptr;
+    for (QObject* root : m_engine->rootObjects()) {
+        window = qobject_cast<QQuickWindow*>(root);
+        if (window) break;
+    }
+    if (!window) {
+        return errorResponse(QStringLiteral("No QQuickWindow root object found"));
+    }
+
+    // Let pending UI updates settle before capturing.
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+    QThread::msleep(50);
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+
+    const QImage image = window->grabWindow();
+    if (image.isNull()) {
+        return errorResponse(QStringLiteral("Failed to capture screenshot"));
+    }
+
+    if (!image.save(path, "PNG")) {
+        return errorResponse(QStringLiteral("Failed to save screenshot: %1").arg(path));
+    }
+
+    QJsonObject resp;
+    resp[QStringLiteral("ok")] = true;
+    resp[QStringLiteral("path")] = path;
+    resp[QStringLiteral("width")] = image.width();
+    resp[QStringLiteral("height")] = image.height();
+    return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+}
+
 QByteArray TestBridge::cmdListObjects()
 {
-    std::vector<std::pair<QString, QString>> objects;
+    std::vector<NamedObjectEntry> objects;
+    QSet<const QObject*> visited;
     for (QObject* root : m_engine->rootObjects()) {
-        collectNamedObjects(root, objects);
+        collectNamedObjects(root, objects, visited, 0);
     }
 
     QJsonArray arr;
-    for (const auto& [name, class_name] : objects) {
-        QJsonObject entry;
-        entry[QStringLiteral("objectName")] = name;
-        entry[QStringLiteral("className")] = class_name;
-        arr.append(entry);
+    for (const auto& obj_entry : objects) {
+        QJsonObject json_entry;
+        json_entry[QStringLiteral("objectName")] = obj_entry.object_name;
+        json_entry[QStringLiteral("className")] = obj_entry.class_name;
+        json_entry[QStringLiteral("depth")] = obj_entry.depth;
+        arr.append(json_entry);
     }
 
     QJsonObject resp;

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -1,0 +1,423 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/test/testbridge.h>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMetaMethod>
+#include <QMetaObject>
+#include <QMetaProperty>
+#include <QQmlContext>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QThread>
+#include <QTimer>
+#include <QVariant>
+
+#include <algorithm>
+
+TestBridge::TestBridge(QQmlApplicationEngine* engine, const QString& socket_path, QObject* parent)
+    : QObject(parent), m_engine(engine), m_server(new QLocalServer(this))
+{
+    // Remove any stale socket file from a previous run.
+    QLocalServer::removeServer(socket_path);
+
+    if (!m_server->listen(socket_path)) {
+        qWarning("TestBridge: failed to listen on %s: %s",
+                 qPrintable(socket_path),
+                 qPrintable(m_server->errorString()));
+        return;
+    }
+
+    connect(m_server, &QLocalServer::newConnection, this, &TestBridge::handleNewConnection);
+    qInfo("TestBridge: listening on %s", qPrintable(socket_path));
+}
+
+TestBridge::~TestBridge()
+{
+    for (auto* client : m_clients) {
+        client->disconnectFromServer();
+        client->deleteLater();
+    }
+    m_server->close();
+}
+
+void TestBridge::handleNewConnection()
+{
+    while (QLocalSocket* client = m_server->nextPendingConnection()) {
+        m_clients.push_back(client);
+        connect(client, &QLocalSocket::readyRead, this, &TestBridge::handleClientData);
+        connect(client, &QLocalSocket::disconnected, this, &TestBridge::handleClientDisconnected);
+        qInfo("TestBridge: client connected");
+    }
+}
+
+void TestBridge::handleClientData()
+{
+    auto* client = qobject_cast<QLocalSocket*>(sender());
+    if (!client) return;
+
+    m_read_buffer.append(client->readAll());
+
+    // Process newline-delimited JSON commands.
+    int newline_pos;
+    while ((newline_pos = m_read_buffer.indexOf('\n')) != -1) {
+        QByteArray line = m_read_buffer.left(newline_pos);
+        m_read_buffer.remove(0, newline_pos + 1);
+
+        if (line.trimmed().isEmpty()) continue;
+
+        QByteArray response = processCommand(line);
+        response.append('\n');
+        client->write(response);
+        client->flush();
+    }
+}
+
+void TestBridge::handleClientDisconnected()
+{
+    auto* client = qobject_cast<QLocalSocket*>(sender());
+    if (!client) return;
+
+    auto it = std::find(m_clients.begin(), m_clients.end(), client);
+    if (it != m_clients.end()) {
+        m_clients.erase(it);
+    }
+    client->deleteLater();
+    qInfo("TestBridge: client disconnected");
+}
+
+QObject* TestBridge::findObjectByName(const QString& name) const
+{
+    for (QObject* root : m_engine->rootObjects()) {
+        if (root->objectName() == name) return root;
+
+        // Collect all children with this name.
+        QList<QObject*> matches = root->findChildren<QObject*>(name);
+        if (matches.isEmpty()) continue;
+
+        // Prefer a visible QQuickItem (important when StackView keeps
+        // hidden pages in the tree with duplicate objectNames).
+        for (QObject* obj : matches) {
+            auto* item = qobject_cast<QQuickItem*>(obj);
+            if (item && item->isVisible()) return obj;
+        }
+
+        // Fall back to the first match.
+        return matches.first();
+    }
+    return nullptr;
+}
+
+void TestBridge::collectNamedObjects(QObject* root, std::vector<std::pair<QString, QString>>& results) const
+{
+    if (!root) return;
+    if (!root->objectName().isEmpty()) {
+        results.emplace_back(root->objectName(),
+                             QString::fromLatin1(root->metaObject()->className()));
+    }
+    for (QObject* child : root->children()) {
+        collectNamedObjects(child, results);
+    }
+    // Also traverse visual children for QQuickItem-based trees.
+    auto* item = qobject_cast<QQuickItem*>(root);
+    if (item) {
+        for (QQuickItem* visual_child : item->childItems()) {
+            // Avoid duplicates — only traverse if not already a QObject child.
+            if (visual_child->parent() != root) {
+                collectNamedObjects(visual_child, results);
+            }
+        }
+    }
+}
+
+QByteArray TestBridge::processCommand(const QByteArray& json_cmd)
+{
+    QJsonParseError parse_error;
+    QJsonDocument doc = QJsonDocument::fromJson(json_cmd, &parse_error);
+    if (doc.isNull()) {
+        return errorResponse(QStringLiteral("JSON parse error: %1").arg(parse_error.errorString()));
+    }
+
+    QJsonObject obj = doc.object();
+    QString cmd = obj.value(QStringLiteral("cmd")).toString();
+
+    if (cmd == QLatin1String("get_current_page")) {
+        return cmdGetCurrentPage();
+    } else if (cmd == QLatin1String("get_property")) {
+        return cmdGetProperty(
+            obj.value(QStringLiteral("objectName")).toString(),
+            obj.value(QStringLiteral("prop")).toString());
+    } else if (cmd == QLatin1String("click")) {
+        return cmdClick(obj.value(QStringLiteral("objectName")).toString());
+    } else if (cmd == QLatin1String("set_text")) {
+        return cmdSetText(
+            obj.value(QStringLiteral("objectName")).toString(),
+            obj.value(QStringLiteral("text")).toString());
+    } else if (cmd == QLatin1String("wait_for_page")) {
+        return cmdWaitForPage(
+            obj.value(QStringLiteral("page")).toString(),
+            obj.value(QStringLiteral("timeout")).toInt(5000));
+    } else if (cmd == QLatin1String("get_text")) {
+        return cmdGetText(obj.value(QStringLiteral("objectName")).toString());
+    } else if (cmd == QLatin1String("list_objects")) {
+        return cmdListObjects();
+    }
+
+    return errorResponse(QStringLiteral("Unknown command: %1").arg(cmd));
+}
+
+QByteArray TestBridge::cmdGetCurrentPage()
+{
+    // Walk the visual tree looking for StackView instances (which have both
+    // "currentItem" and "depth" properties).  Drill into nested StackViews
+    // (e.g. OnboardingWizard is a PageStack inside the main PageStack) to
+    // return the deepest page.  We check for "depth" to distinguish StackView
+    // from StackLayout, which also has "currentItem" but is not a page stack.
+    for (QObject* root : m_engine->rootObjects()) {
+        auto* window = qobject_cast<QQuickWindow*>(root);
+        if (!window) continue;
+
+        // Breadth-first search through the visual item tree.
+        std::vector<QQuickItem*> queue;
+        queue.push_back(window->contentItem());
+
+        QObject* deepest_page = nullptr;
+        QObject* deepest_named_page = nullptr;
+
+        while (!queue.empty()) {
+            QQuickItem* item = queue.back();
+            queue.pop_back();
+            if (!item) continue;
+
+            // Only consider items that look like a StackView: they must
+            // have both "currentItem" and "depth" properties.
+            QVariant depth = item->property("depth");
+            QVariant current = item->property("currentItem");
+            if (depth.isValid() && current.isValid()) {
+                QObject* current_obj = current.value<QObject*>();
+                if (current_obj) {
+                    deepest_page = current_obj;
+                    if (!current_obj->objectName().isEmpty()) {
+                        deepest_named_page = current_obj;
+                    }
+                    // Push the current item itself back into the queue
+                    // so that if it is a nested StackView (e.g.
+                    // OnboardingWizard) it gets checked for its own
+                    // currentItem on the next iteration.  Its children
+                    // will be explored when it is popped and either
+                    // matched (StackView) or falls through to the
+                    // childItems loop below.
+                    auto* current_item = qobject_cast<QQuickItem*>(current_obj);
+                    if (current_item) {
+                        queue.push_back(current_item);
+                    }
+                    continue;
+                }
+            }
+
+            for (QQuickItem* child : item->childItems()) {
+                queue.push_back(child);
+            }
+        }
+
+        // Prefer the deepest page that has an objectName.  Fall back
+        // to the class name of the absolute deepest page otherwise.
+        QObject* result_page = deepest_named_page ? deepest_named_page : deepest_page;
+        if (result_page) {
+            QString name = result_page->objectName();
+            if (name.isEmpty()) {
+                name = QString::fromLatin1(result_page->metaObject()->className());
+            }
+            QJsonObject resp;
+            resp[QStringLiteral("page")] = name;
+            return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+        }
+    }
+    return errorResponse(QStringLiteral("Could not determine current page"));
+}
+
+QByteArray TestBridge::cmdGetProperty(const QString& object_name, const QString& prop)
+{
+    if (object_name.isEmpty() || prop.isEmpty()) {
+        return errorResponse(QStringLiteral("objectName and prop are required"));
+    }
+
+    QObject* obj = findObjectByName(object_name);
+    if (!obj) {
+        return errorResponse(QStringLiteral("Object not found: %1").arg(object_name));
+    }
+
+    QVariant value = obj->property(prop.toLatin1().constData());
+    if (!value.isValid()) {
+        return errorResponse(QStringLiteral("Property not found: %1.%2").arg(object_name, prop));
+    }
+
+    QJsonObject resp;
+    resp[QStringLiteral("value")] = QJsonValue::fromVariant(value);
+    return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+}
+
+QByteArray TestBridge::cmdClick(const QString& object_name)
+{
+    if (object_name.isEmpty()) {
+        return errorResponse(QStringLiteral("objectName is required"));
+    }
+
+    QObject* obj = findObjectByName(object_name);
+    if (!obj) {
+        return errorResponse(QStringLiteral("Object not found: %1").arg(object_name));
+    }
+
+    // Try invoking the clicked() signal or onClicked handler.
+    // For QQuickItem-based controls, we can also simulate a mouse click.
+    auto* item = qobject_cast<QQuickItem*>(obj);
+
+    // First, try to find and invoke a "clicked" signal.
+    const QMetaObject* meta = obj->metaObject();
+    int clicked_index = meta->indexOfSignal("clicked()");
+    if (clicked_index >= 0) {
+        meta->method(clicked_index).invoke(obj, Qt::DirectConnection);
+        QJsonObject resp;
+        resp[QStringLiteral("ok")] = true;
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+    }
+
+    // Fallback: for QQuickItems, try the "toggle" or "trigger" method
+    // or directly invoke via AbstractButton's clicked().
+    int toggle_index = meta->indexOfMethod("toggle()");
+    if (toggle_index >= 0) {
+        meta->method(toggle_index).invoke(obj, Qt::DirectConnection);
+        QJsonObject resp;
+        resp[QStringLiteral("ok")] = true;
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+    }
+
+    // Last resort: if it's a QQuickItem, synthesize pointer events.
+    if (item) {
+        QQuickWindow* window = item->window();
+        if (window) {
+            QPointF center = item->mapToScene(
+                QPointF(item->width() / 2.0, item->height() / 2.0));
+            QPoint pos = center.toPoint();
+
+            QMouseEvent press(QEvent::MouseButtonPress, pos, window->mapToGlobal(pos),
+                              Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+            QMouseEvent release(QEvent::MouseButtonRelease, pos, window->mapToGlobal(pos),
+                                Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+
+            QCoreApplication::sendEvent(window, &press);
+            QCoreApplication::sendEvent(window, &release);
+
+            QJsonObject resp;
+            resp[QStringLiteral("ok")] = true;
+            return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+        }
+    }
+
+    return errorResponse(QStringLiteral("Cannot click object: %1").arg(object_name));
+}
+
+QByteArray TestBridge::cmdSetText(const QString& object_name, const QString& text)
+{
+    if (object_name.isEmpty()) {
+        return errorResponse(QStringLiteral("objectName is required"));
+    }
+
+    QObject* obj = findObjectByName(object_name);
+    if (!obj) {
+        return errorResponse(QStringLiteral("Object not found: %1").arg(object_name));
+    }
+
+    // Try "text" property first (covers TextField, TextInput, TextArea, etc.)
+    if (obj->property("text").isValid()) {
+        obj->setProperty("text", text);
+        QJsonObject resp;
+        resp[QStringLiteral("ok")] = true;
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+    }
+
+    return errorResponse(QStringLiteral("Object %1 has no 'text' property").arg(object_name));
+}
+
+QByteArray TestBridge::cmdWaitForPage(const QString& page_name, int timeout_ms)
+{
+    if (page_name.isEmpty()) {
+        return errorResponse(QStringLiteral("page is required"));
+    }
+
+    // Poll for the page to appear. We process events between checks.
+    const int poll_interval_ms = 50;
+    int elapsed = 0;
+
+    while (elapsed < timeout_ms) {
+        // Check if the requested page/object exists and is visible.
+        QObject* obj = findObjectByName(page_name);
+        if (obj) {
+            auto* item = qobject_cast<QQuickItem*>(obj);
+            if (!item || item->isVisible()) {
+                QJsonObject resp;
+                resp[QStringLiteral("ok")] = true;
+                return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+            }
+        }
+
+        // Process pending events to let the UI update.
+        QCoreApplication::processEvents(QEventLoop::AllEvents, poll_interval_ms);
+        QThread::msleep(poll_interval_ms);
+        elapsed += poll_interval_ms;
+    }
+
+    return errorResponse(QStringLiteral("Timed out waiting for page: %1").arg(page_name));
+}
+
+QByteArray TestBridge::cmdGetText(const QString& object_name)
+{
+    if (object_name.isEmpty()) {
+        return errorResponse(QStringLiteral("objectName is required"));
+    }
+
+    QObject* obj = findObjectByName(object_name);
+    if (!obj) {
+        return errorResponse(QStringLiteral("Object not found: %1").arg(object_name));
+    }
+
+    QVariant text_val = obj->property("text");
+    if (!text_val.isValid()) {
+        return errorResponse(QStringLiteral("Object %1 has no 'text' property").arg(object_name));
+    }
+
+    QJsonObject resp;
+    resp[QStringLiteral("text")] = text_val.toString();
+    return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+}
+
+QByteArray TestBridge::cmdListObjects()
+{
+    std::vector<std::pair<QString, QString>> objects;
+    for (QObject* root : m_engine->rootObjects()) {
+        collectNamedObjects(root, objects);
+    }
+
+    QJsonArray arr;
+    for (const auto& [name, class_name] : objects) {
+        QJsonObject entry;
+        entry[QStringLiteral("objectName")] = name;
+        entry[QStringLiteral("className")] = class_name;
+        arr.append(entry);
+    }
+
+    QJsonObject resp;
+    resp[QStringLiteral("objects")] = arr;
+    return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+}
+
+QByteArray TestBridge::errorResponse(const QString& message)
+{
+    QJsonObject resp;
+    resp[QStringLiteral("error")] = message;
+    return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+}

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -324,39 +324,51 @@ QByteArray TestBridge::cmdClick(const QString& object_name)
 
     const QMetaObject* meta = obj->metaObject();
 
-    // Prefer real click()/trigger()/toggle() methods so buttons update state
-    // (e.g. checked tabs in a ButtonGroup) rather than only emitting signals.
+    // Prefer real click() when available.
+    // If click() is missing, use a conservative fallback order that preserves
+    // existing onClicked handlers and checkable-button state updates.
+    auto okResponse = []() {
+        QJsonObject resp;
+        resp[QStringLiteral("ok")] = true;
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+    };
+
+    bool invoked = false;
     int click_method_index = meta->indexOfMethod("click()");
     if (click_method_index >= 0) {
-        meta->method(click_method_index).invoke(obj, Qt::DirectConnection);
-        QJsonObject resp;
-        resp[QStringLiteral("ok")] = true;
-        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+        invoked = meta->method(click_method_index).invoke(obj, Qt::DirectConnection);
+        if (invoked) {
+            return okResponse();
+        }
     }
 
-    int trigger_index = meta->indexOfMethod("trigger()");
-    if (trigger_index >= 0) {
-        meta->method(trigger_index).invoke(obj, Qt::DirectConnection);
-        QJsonObject resp;
-        resp[QStringLiteral("ok")] = true;
-        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
-    }
-
+    // If the control is checkable and click() is unavailable, try toggling
+    // first so selection state (e.g. ButtonGroup) changes under automation.
+    const bool checkable = obj->property("checkable").toBool();
     int toggle_index = meta->indexOfMethod("toggle()");
-    if (toggle_index >= 0) {
-        meta->method(toggle_index).invoke(obj, Qt::DirectConnection);
-        QJsonObject resp;
-        resp[QStringLiteral("ok")] = true;
-        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+    if (checkable && toggle_index >= 0) {
+        invoked = meta->method(toggle_index).invoke(obj, Qt::DirectConnection);
     }
 
-    // Then try to find and invoke a "clicked" signal.
+    // Invoke clicked() so QML onClicked handlers run for controls without
+    // click() support.
     int clicked_index = meta->indexOfSignal("clicked()");
     if (clicked_index >= 0) {
-        meta->method(clicked_index).invoke(obj, Qt::DirectConnection);
-        QJsonObject resp;
-        resp[QStringLiteral("ok")] = true;
-        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+        if (meta->method(clicked_index).invoke(obj, Qt::DirectConnection)) {
+            return okResponse();
+        }
+    }
+
+    // Last meta-object fallback for action-like objects.
+    int trigger_index = meta->indexOfMethod("trigger()");
+    if (trigger_index >= 0) {
+        if (meta->method(trigger_index).invoke(obj, Qt::DirectConnection)) {
+            return okResponse();
+        }
+    }
+
+    if (invoked) {
+        return okResponse();
     }
 
     // Last resort: if it's a QQuickItem, synthesize pointer events.

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -10,9 +10,12 @@
 #include <QMetaMethod>
 #include <QMetaObject>
 #include <QMetaProperty>
+#include <QEventLoop>
 #include <QImage>
+#include <QPointer>
 #include <QQuickItem>
 #include <QQuickWindow>
+#include <QScopedValueRollback>
 #include <QThread>
 #include <QTimer>
 #include <QVariant>
@@ -58,11 +61,37 @@ void TestBridge::handleNewConnection()
 
 void TestBridge::handleClientData()
 {
-    auto* client = qobject_cast<QLocalSocket*>(sender());
+    if (m_processing_client_data) {
+        // A nested event loop is active while executing a command. Defer any
+        // re-entrant readyRead delivery until the active command completes.
+        m_pending_client_data = true;
+        return;
+    }
+
+    QScopedValueRollback<bool> processing_guard(m_processing_client_data, true);
+
+    do {
+        m_pending_client_data = false;
+        std::vector<QPointer<QLocalSocket>> clients_snapshot;
+        clients_snapshot.reserve(m_clients.size());
+        for (QLocalSocket* client : m_clients) {
+            clients_snapshot.emplace_back(client);
+        }
+        for (const QPointer<QLocalSocket>& client : clients_snapshot) {
+            if (!client) continue;
+            processClientCommands(client.data());
+        }
+    } while (m_pending_client_data);
+}
+
+void TestBridge::processClientCommands(QLocalSocket* client)
+{
     if (!client) return;
 
     QByteArray& read_buffer = m_read_buffers[client];
-    read_buffer.append(client->readAll());
+    if (client->bytesAvailable() > 0) {
+        read_buffer.append(client->readAll());
+    }
 
     // Process newline-delimited JSON commands.
     int newline_pos;
@@ -73,6 +102,9 @@ void TestBridge::handleClientData()
         if (line.trimmed().isEmpty()) continue;
 
         QByteArray response = processCommand(line);
+        if (client->state() != QLocalSocket::ConnectedState) {
+            return;
+        }
         response.append('\n');
         client->write(response);
         client->flush();
@@ -369,28 +401,44 @@ QByteArray TestBridge::cmdWaitForPage(const QString& page_name, int timeout_ms)
         return errorResponse(QStringLiteral("page is required"));
     }
 
-    // Poll for the page to appear. We process events between checks.
-    const int poll_interval_ms = 50;
-    int elapsed = 0;
-
-    while (elapsed < timeout_ms) {
-        // Check if the requested page/object exists and is visible.
+    auto conditionMatched = [&]() {
         QObject* obj = findObjectByName(page_name);
-        if (obj) {
-            auto* item = qobject_cast<QQuickItem*>(obj);
-            const QVariant visible = obj->property("visible");
-            const bool is_visible = item ? item->isVisible() : (!visible.isValid() || visible.toBool());
-            if (is_visible) {
-                QJsonObject resp;
-                resp[QStringLiteral("ok")] = true;
-                return QJsonDocument(resp).toJson(QJsonDocument::Compact);
-            }
-        }
+        if (!obj) return false;
 
-        // Process pending events to let the UI update.
-        QCoreApplication::processEvents(QEventLoop::AllEvents, poll_interval_ms);
-        QThread::msleep(poll_interval_ms);
-        elapsed += poll_interval_ms;
+        auto* item = qobject_cast<QQuickItem*>(obj);
+        const QVariant visible = obj->property("visible");
+        return item ? item->isVisible() : (!visible.isValid() || visible.toBool());
+    };
+
+    if (conditionMatched()) {
+        QJsonObject resp;
+        resp[QStringLiteral("ok")] = true;
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+    }
+
+    QEventLoop wait_loop;
+    QTimer timeout_timer;
+    timeout_timer.setSingleShot(true);
+    timeout_timer.setInterval(std::max(0, timeout_ms));
+
+    QTimer poll_timer;
+    poll_timer.setInterval(50);
+
+    QObject::connect(&timeout_timer, &QTimer::timeout, &wait_loop, &QEventLoop::quit);
+    QObject::connect(&poll_timer, &QTimer::timeout, &wait_loop, [&]() {
+        if (conditionMatched()) {
+            wait_loop.quit();
+        }
+    });
+
+    timeout_timer.start();
+    poll_timer.start();
+    wait_loop.exec();
+
+    if (conditionMatched()) {
+        QJsonObject resp;
+        resp[QStringLiteral("ok")] = true;
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
     }
 
     return errorResponse(QStringLiteral("Timed out waiting for page: %1").arg(page_name));
@@ -402,36 +450,62 @@ QByteArray TestBridge::cmdWaitForProperty(const QString& object_name, const QStr
         return errorResponse(QStringLiteral("objectName and prop are required"));
     }
 
-    const int poll_interval_ms = 50;
-    int elapsed = 0;
-
-    while (elapsed < timeout_ms) {
+    auto conditionMatched = [&](QVariant* out_value) {
         QObject* obj = findObjectByName(object_name);
-        if (obj) {
-            QVariant value = obj->property(prop.toLatin1().constData());
-            if (value.isValid()) {
-                bool matched = true;
+        if (!obj) return false;
 
-                if (!contains.isEmpty()) {
-                    matched = value.toString().contains(contains);
-                } else if (non_empty) {
-                    matched = !value.toString().trimmed().isEmpty();
-                } else if (has_expected) {
-                    matched = (QJsonValue::fromVariant(value) == expected);
-                }
+        QVariant value = obj->property(prop.toLatin1().constData());
+        if (!value.isValid()) return false;
 
-                if (matched) {
-                    QJsonObject resp;
-                    resp[QStringLiteral("ok")] = true;
-                    resp[QStringLiteral("value")] = QJsonValue::fromVariant(value);
-                    return QJsonDocument(resp).toJson(QJsonDocument::Compact);
-                }
-            }
+        bool matched = true;
+        if (!contains.isEmpty()) {
+            matched = value.toString().contains(contains);
+        } else if (non_empty) {
+            matched = !value.toString().trimmed().isEmpty();
+        } else if (has_expected) {
+            matched = (QJsonValue::fromVariant(value) == expected);
         }
 
-        QCoreApplication::processEvents(QEventLoop::AllEvents, poll_interval_ms);
-        QThread::msleep(poll_interval_ms);
-        elapsed += poll_interval_ms;
+        if (!matched) return false;
+
+        if (out_value) {
+            *out_value = value;
+        }
+        return true;
+    };
+
+    QVariant matched_value;
+    if (conditionMatched(&matched_value)) {
+        QJsonObject resp;
+        resp[QStringLiteral("ok")] = true;
+        resp[QStringLiteral("value")] = QJsonValue::fromVariant(matched_value);
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+    }
+
+    QEventLoop wait_loop;
+    QTimer timeout_timer;
+    timeout_timer.setSingleShot(true);
+    timeout_timer.setInterval(std::max(0, timeout_ms));
+
+    QTimer poll_timer;
+    poll_timer.setInterval(50);
+
+    QObject::connect(&timeout_timer, &QTimer::timeout, &wait_loop, &QEventLoop::quit);
+    QObject::connect(&poll_timer, &QTimer::timeout, &wait_loop, [&]() {
+        if (conditionMatched(nullptr)) {
+            wait_loop.quit();
+        }
+    });
+
+    timeout_timer.start();
+    poll_timer.start();
+    wait_loop.exec();
+
+    if (conditionMatched(&matched_value)) {
+        QJsonObject resp;
+        resp[QStringLiteral("ok")] = true;
+        resp[QStringLiteral("value")] = QJsonValue::fromVariant(matched_value);
+        return QJsonDocument(resp).toJson(QJsonDocument::Compact);
     }
 
     return errorResponse(QStringLiteral("Timed out waiting for property: %1.%2").arg(object_name, prop));

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -147,6 +147,32 @@ QObject* TestBridge::findObjectByName(const QString& name) const
     return nullptr;
 }
 
+QObject* TestBridge::resolveCurrentLeafItem(QObject* item) const
+{
+    QObject* current = item;
+    QSet<const QObject*> seen;
+    int guard = 0;
+
+    while (current && guard < 64 && !seen.contains(current)) {
+        seen.insert(current);
+        ++guard;
+
+        const QVariant depth = current->property("depth");
+        const QVariant current_item = current->property("currentItem");
+        if (!depth.isValid() || !current_item.isValid()) {
+            return current;
+        }
+
+        QObject* next = current_item.value<QObject*>();
+        if (!next) {
+            return current;
+        }
+        current = next;
+    }
+
+    return current;
+}
+
 void TestBridge::collectNamedObjects(QObject* root, std::vector<NamedObjectEntry>& results, QSet<const QObject*>& visited, int depth) const
 {
     if (!root) return;
@@ -231,19 +257,14 @@ QByteArray TestBridge::cmdGetCurrentPage()
         return QJsonDocument(resp).toJson(QJsonDocument::Compact);
     };
 
-    // Preferred path: read precomputed page information exposed by main.qml.
+    // Preferred path: resolve from the named main PageStack in main.qml.
     for (QObject* root : m_engine->rootObjects()) {
-        QVariant page_item = root->property("testCurrentPageItem");
-        QObject* page_obj = page_item.value<QObject*>();
+        QObject* main_stack = root->findChild<QObject*>(QStringLiteral("mainPageStack"));
+        if (!main_stack) continue;
+
+        QObject* page_obj = resolveCurrentLeafItem(main_stack->property("currentItem").value<QObject*>());
         if (page_obj) {
             return pageResponse(page_obj);
-        }
-
-        const QString page_name = root->property("testCurrentPageName").toString();
-        if (!page_name.isEmpty()) {
-            QJsonObject resp;
-            resp[QStringLiteral("page")] = page_name;
-            return QJsonDocument(resp).toJson(QJsonDocument::Compact);
         }
     }
 
@@ -253,13 +274,13 @@ QByteArray TestBridge::cmdGetCurrentPage()
         QVariant current = root->property("currentItem");
         if (!depth.isValid() || !current.isValid()) continue;
 
-        QObject* current_obj = current.value<QObject*>();
+        QObject* current_obj = resolveCurrentLeafItem(current.value<QObject*>());
         if (current_obj) {
             return pageResponse(current_obj);
         }
     }
 
-    return errorResponse(QStringLiteral("Could not determine current page; missing testCurrentPageItem/testCurrentPageName"));
+    return errorResponse(QStringLiteral("Could not determine current page; missing mainPageStack/current page item"));
 }
 
 QByteArray TestBridge::cmdGetProperty(const QString& object_name, const QString& prop)

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -9,7 +9,6 @@
 #include <QJsonObject>
 #include <QMetaMethod>
 #include <QMetaObject>
-#include <QMetaProperty>
 #include <QEventLoop>
 #include <QImage>
 #include <QPointer>

--- a/qml/test/testbridge.h
+++ b/qml/test/testbridge.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_TEST_TESTBRIDGE_H
+#define BITCOIN_QML_TEST_TESTBRIDGE_H
+
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QObject>
+#include <QQmlApplicationEngine>
+#include <QString>
+
+#include <vector>
+
+/// Exposes QML object tree to external test scripts over a Unix domain socket.
+/// Enabled only when compiled with ENABLE_TEST_AUTOMATION and launched with
+/// --test-automation=<socket_path>.
+///
+/// Supported commands (JSON over newline-delimited stream):
+///   {"cmd": "get_current_page"}
+///   {"cmd": "get_property", "objectName": "<name>", "prop": "<property>"}
+///   {"cmd": "click", "objectName": "<name>"}
+///   {"cmd": "set_text", "objectName": "<name>", "text": "<value>"}
+///   {"cmd": "wait_for_page", "page": "<objectName>", "timeout": <ms>}
+///   {"cmd": "get_text", "objectName": "<name>"}
+///   {"cmd": "list_objects"}
+class TestBridge : public QObject
+{
+    Q_OBJECT
+
+public:
+    /// Construct a TestBridge listening on @p socket_path.
+    /// @p engine must remain valid for the lifetime of this object.
+    explicit TestBridge(QQmlApplicationEngine* engine, const QString& socket_path, QObject* parent = nullptr);
+    ~TestBridge() override;
+
+private Q_SLOTS:
+    void handleNewConnection();
+    void handleClientData();
+    void handleClientDisconnected();
+
+private:
+    /// Find a QObject by objectName, searching the entire QML tree.
+    QObject* findObjectByName(const QString& name) const;
+
+    /// Recursively collect all named objects from the QML tree.
+    void collectNamedObjects(QObject* root, std::vector<std::pair<QString, QString>>& results) const;
+
+    /// Process a single JSON command and return the JSON response.
+    QByteArray processCommand(const QByteArray& json_cmd);
+
+    /// Dispatch individual command handlers.
+    QByteArray cmdGetCurrentPage();
+    QByteArray cmdGetProperty(const QString& object_name, const QString& prop);
+    QByteArray cmdClick(const QString& object_name);
+    QByteArray cmdSetText(const QString& object_name, const QString& text);
+    QByteArray cmdWaitForPage(const QString& page_name, int timeout_ms);
+    QByteArray cmdGetText(const QString& object_name);
+    QByteArray cmdListObjects();
+
+    /// Build a JSON error response.
+    static QByteArray errorResponse(const QString& message);
+
+    QQmlApplicationEngine* m_engine;
+    QLocalServer* m_server;
+    std::vector<QLocalSocket*> m_clients;
+    QByteArray m_read_buffer;
+};
+
+#endif // BITCOIN_QML_TEST_TESTBRIDGE_H

--- a/qml/test/testbridge.h
+++ b/qml/test/testbridge.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Bitcoin Core developers
+// Copyright (c) 2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,6 +10,9 @@
 #include <QObject>
 #include <QQmlApplicationEngine>
 #include <QString>
+#include <QHash>
+#include <QJsonValue>
+#include <QSet>
 
 #include <vector>
 
@@ -23,7 +26,9 @@
 ///   {"cmd": "click", "objectName": "<name>"}
 ///   {"cmd": "set_text", "objectName": "<name>", "text": "<value>"}
 ///   {"cmd": "wait_for_page", "page": "<objectName>", "timeout": <ms>}
+///   {"cmd": "wait_for_property", "objectName": "<name>", "prop": "<property>", ...}
 ///   {"cmd": "get_text", "objectName": "<name>"}
+///   {"cmd": "save_screenshot", "path": "<png_path>"}
 ///   {"cmd": "list_objects"}
 class TestBridge : public QObject
 {
@@ -41,11 +46,17 @@ private Q_SLOTS:
     void handleClientDisconnected();
 
 private:
+    struct NamedObjectEntry {
+        QString object_name;
+        QString class_name;
+        int depth;
+    };
+
     /// Find a QObject by objectName, searching the entire QML tree.
     QObject* findObjectByName(const QString& name) const;
 
     /// Recursively collect all named objects from the QML tree.
-    void collectNamedObjects(QObject* root, std::vector<std::pair<QString, QString>>& results) const;
+    void collectNamedObjects(QObject* root, std::vector<NamedObjectEntry>& results, QSet<const QObject*>& visited, int depth) const;
 
     /// Process a single JSON command and return the JSON response.
     QByteArray processCommand(const QByteArray& json_cmd);
@@ -56,7 +67,9 @@ private:
     QByteArray cmdClick(const QString& object_name);
     QByteArray cmdSetText(const QString& object_name, const QString& text);
     QByteArray cmdWaitForPage(const QString& page_name, int timeout_ms);
+    QByteArray cmdWaitForProperty(const QString& object_name, const QString& prop, int timeout_ms, const QJsonValue& expected, bool has_expected, const QString& contains, bool non_empty);
     QByteArray cmdGetText(const QString& object_name);
+    QByteArray cmdSaveScreenshot(const QString& path);
     QByteArray cmdListObjects();
 
     /// Build a JSON error response.
@@ -65,7 +78,7 @@ private:
     QQmlApplicationEngine* m_engine;
     QLocalServer* m_server;
     std::vector<QLocalSocket*> m_clients;
-    QByteArray m_read_buffer;
+    QHash<QLocalSocket*, QByteArray> m_read_buffers;
 };
 
 #endif // BITCOIN_QML_TEST_TESTBRIDGE_H

--- a/qml/test/testbridge.h
+++ b/qml/test/testbridge.h
@@ -60,6 +60,7 @@ private:
 
     /// Process a single JSON command and return the JSON response.
     QByteArray processCommand(const QByteArray& json_cmd);
+    void processClientCommands(QLocalSocket* client);
 
     /// Dispatch individual command handlers.
     QByteArray cmdGetCurrentPage();
@@ -79,6 +80,8 @@ private:
     QLocalServer* m_server;
     std::vector<QLocalSocket*> m_clients;
     QHash<QLocalSocket*, QByteArray> m_read_buffers;
+    bool m_processing_client_data{false};
+    bool m_pending_client_data{false};
 };
 
 #endif // BITCOIN_QML_TEST_TESTBRIDGE_H

--- a/qml/test/testbridge.h
+++ b/qml/test/testbridge.h
@@ -54,6 +54,7 @@ private:
 
     /// Find a QObject by objectName, searching the entire QML tree.
     QObject* findObjectByName(const QString& name) const;
+    QObject* resolveCurrentLeafItem(QObject* item) const;
 
     /// Recursively collect all named objects from the QML tree.
     void collectNamedObjects(QObject* root, std::vector<NamedObjectEntry>& results, QSet<const QObject*>& visited, int depth) const;

--- a/qml/test/testbridge.h
+++ b/qml/test/testbridge.h
@@ -5,14 +5,15 @@
 #ifndef BITCOIN_QML_TEST_TESTBRIDGE_H
 #define BITCOIN_QML_TEST_TESTBRIDGE_H
 
+#include <QByteArray>
+#include <QHash>
+#include <QJsonValue>
 #include <QLocalServer>
 #include <QLocalSocket>
 #include <QObject>
 #include <QQmlApplicationEngine>
-#include <QString>
-#include <QHash>
-#include <QJsonValue>
 #include <QSet>
+#include <QString>
 
 #include <vector>
 

--- a/test/functional/qml_driver.py
+++ b/test/functional/qml_driver.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024 The Bitcoin Core developers
+# Copyright (c) 2026 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Driver for the QML test automation bridge.

--- a/test/functional/qml_driver.py
+++ b/test/functional/qml_driver.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Driver for the QML test automation bridge.
+
+Connects to the TestBridge Unix domain socket exposed by bitcoin-core-app
+when launched with --test-automation=<socket_path>.  Provides a Pythonic
+interface for functional tests to observe and drive the QML UI.
+"""
+
+import json
+import socket
+import time
+
+
+class QmlDriverError(Exception):
+    """Raised when the test bridge returns an error response."""
+
+
+class QmlDriver:
+    """Drives the QML GUI via the TestBridge Unix domain socket."""
+
+    def __init__(self, socket_path, timeout=30):
+        """Connect to the test bridge.
+
+        Args:
+            socket_path: Path to the Unix domain socket.
+            timeout: Socket timeout in seconds for individual operations.
+        """
+        self.socket_path = socket_path
+        self.timeout = timeout
+        self.sock = None
+        self._connect()
+
+    def _connect(self):
+        """Establish connection to the test bridge, retrying briefly."""
+        deadline = time.time() + self.timeout
+        last_err = None
+        while time.time() < deadline:
+            try:
+                self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                self.sock.settimeout(self.timeout)
+                self.sock.connect(self.socket_path)
+                return
+            except (ConnectionRefusedError, FileNotFoundError) as e:
+                last_err = e
+                if self.sock:
+                    self.sock.close()
+                    self.sock = None
+                time.sleep(0.25)
+        raise QmlDriverError(
+            f"Could not connect to test bridge at {self.socket_path}: {last_err}"
+        )
+
+    def close(self):
+        """Close the connection."""
+        if self.sock:
+            self.sock.close()
+            self.sock = None
+
+    # ── High-level commands ──────────────────────────────────────────
+
+    def get_current_page(self):
+        """Return the objectName (or class name) of the current page."""
+        resp = self._send({"cmd": "get_current_page"})
+        if "error" in resp:
+            raise QmlDriverError(
+                f"get_current_page() failed: {resp['error']}"
+            )
+        return resp["page"]
+
+    def click(self, object_name):
+        """Simulate a click on the named QML object."""
+        resp = self._send({"cmd": "click", "objectName": object_name})
+        if "error" in resp:
+            raise QmlDriverError(f"click({object_name!r}) failed: {resp['error']}")
+
+    def set_text(self, object_name, text):
+        """Set the text property of the named QML object."""
+        resp = self._send({"cmd": "set_text", "objectName": object_name, "text": text})
+        if "error" in resp:
+            raise QmlDriverError(
+                f"set_text({object_name!r}) failed: {resp['error']}"
+            )
+
+    def get_text(self, object_name):
+        """Return the text property of the named QML object."""
+        resp = self._send({"cmd": "get_text", "objectName": object_name})
+        if "error" in resp:
+            raise QmlDriverError(
+                f"get_text({object_name!r}) failed: {resp['error']}"
+            )
+        return resp["text"]
+
+    def get_property(self, object_name, prop):
+        """Return an arbitrary property value from a named QML object."""
+        resp = self._send(
+            {"cmd": "get_property", "objectName": object_name, "prop": prop}
+        )
+        if "error" in resp:
+            raise QmlDriverError(
+                f"get_property({object_name!r}, {prop!r}) failed: {resp['error']}"
+            )
+        return resp["value"]
+
+    def wait_for_page(self, page_name, timeout_ms=5000):
+        """Block until the named page/object is visible.
+
+        Args:
+            page_name: objectName of the page to wait for.
+            timeout_ms: Maximum wait time in milliseconds.
+        """
+        resp = self._send(
+            {"cmd": "wait_for_page", "page": page_name, "timeout": timeout_ms}
+        )
+        if "error" in resp:
+            raise QmlDriverError(
+                f"wait_for_page({page_name!r}) failed: {resp['error']}"
+            )
+
+    def list_objects(self):
+        """Return a list of dicts with objectName and className for all
+        named objects in the QML tree.  Useful for debugging."""
+        resp = self._send({"cmd": "list_objects"})
+        if "error" in resp:
+            raise QmlDriverError(f"list_objects failed: {resp['error']}")
+        return resp["objects"]
+
+    # ── Transport layer ──────────────────────────────────────────────
+
+    def _send(self, cmd):
+        """Send a JSON command and return the parsed JSON response."""
+        payload = json.dumps(cmd) + "\n"
+        self.sock.sendall(payload.encode("utf-8"))
+        return self._recv()
+
+    def _recv(self):
+        """Read a newline-delimited JSON response."""
+        buf = b""
+        while True:
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                raise QmlDriverError("Connection closed by test bridge")
+            buf += chunk
+            if b"\n" in buf:
+                line, _ = buf.split(b"\n", 1)
+                return json.loads(line)

--- a/test/functional/qml_test_bridge_sanity.py
+++ b/test/functional/qml_test_bridge_sanity.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024 The Bitcoin Core developers
+# Copyright (c) 2026 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Sanity test for the QML test automation bridge.

--- a/test/functional/qml_test_bridge_sanity.py
+++ b/test/functional/qml_test_bridge_sanity.py
@@ -26,12 +26,16 @@ def run_tests():
         print("\nTest 1: list_objects")
         objects = gui.list_objects()
         assert isinstance(objects, list), "list_objects should return a list"
+        object_names = {obj["objectName"] for obj in objects}
+        assert "mainPageStack" in object_names, \
+            "Expected mainPageStack in list_objects output"
         print(f"  Found {len(objects)} named object(s) in QML tree.")
         if objects:
             for obj in objects[:10]:
                 print(f"    - {obj['objectName']} ({obj['className']})")
             if len(objects) > 10:
                 print(f"    ... and {len(objects) - 10} more")
+        print("  Found mainPageStack")
         print("  PASSED")
 
         # ── Test 2: get_current_page ─────────────────────────────

--- a/test/functional/qml_test_bridge_sanity.py
+++ b/test/functional/qml_test_bridge_sanity.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Sanity test for the QML test automation bridge.
+
+Verifies that the test bridge protocol works: listing objects, reading
+properties, error handling, and page detection.
+
+This test requires the binary to be built with -DENABLE_TEST_AUTOMATION=ON.
+"""
+
+import sys
+
+from qml_test_harness import QmlTestHarness, QmlDriverError, dump_qml_tree, parse_args
+
+
+def run_tests():
+    args = parse_args()
+    harness = QmlTestHarness(socket_path=args.socket_path)
+    try:
+        harness.start()
+        gui = harness.driver
+
+        # ── Test 1: list_objects ─────────────────────────────────
+        print("\nTest 1: list_objects")
+        objects = gui.list_objects()
+        assert isinstance(objects, list), "list_objects should return a list"
+        print(f"  Found {len(objects)} named object(s) in QML tree.")
+        if objects:
+            for obj in objects[:10]:
+                print(f"    - {obj['objectName']} ({obj['className']})")
+            if len(objects) > 10:
+                print(f"    ... and {len(objects) - 10} more")
+        print("  PASSED")
+
+        # ── Test 2: get_current_page ─────────────────────────────
+        print("\nTest 2: get_current_page")
+        page = gui.get_current_page()
+        assert isinstance(page, str) and len(page) > 0, \
+            f"Expected non-empty page name, got: {page!r}"
+        print(f"  Current page: {page}")
+        print("  PASSED")
+
+        # ── Test 3: get_property on a known object ───────────────
+        print("\nTest 3: get_property")
+        if objects:
+            first_obj = objects[0]["objectName"]
+            try:
+                val = gui.get_property(first_obj, "objectName")
+                assert val == first_obj, \
+                    f"Expected objectName={first_obj!r}, got {val!r}"
+                print(f"  get_property({first_obj!r}, 'objectName') = {val!r}")
+                print("  PASSED")
+            except QmlDriverError as e:
+                print(f"  Skipped (property read failed): {e}")
+        else:
+            print("  Skipped (no named objects found)")
+
+        # ── Test 4: error handling — object not found ────────────
+        print("\nTest 4: error handling for missing object")
+        try:
+            gui.click("nonExistentObject12345")
+            assert False, "Expected QmlDriverError for missing object"
+        except QmlDriverError as e:
+            assert "not found" in str(e).lower() or "Object not found" in str(e), \
+                f"Unexpected error message: {e}"
+            print(f"  Correctly raised error: {e}")
+            print("  PASSED")
+
+        # ── Test 5: error handling — missing property ────────────
+        print("\nTest 5: error handling for missing property")
+        if objects:
+            first_obj = objects[0]["objectName"]
+            try:
+                gui.get_property(first_obj, "completelyFakeProperty999")
+                assert False, "Expected QmlDriverError for missing property"
+            except QmlDriverError as e:
+                assert "not found" in str(e).lower() or "error" in str(e).lower(), \
+                    f"Unexpected error message: {e}"
+                print(f"  Correctly raised error: {e}")
+                print("  PASSED")
+        else:
+            print("  Skipped (no named objects found)")
+
+        # ── Test 6: wait_for_page with short timeout ─────────────
+        print("\nTest 6: wait_for_page timeout for non-existent page")
+        try:
+            gui.wait_for_page("pageDoesNotExist999", timeout_ms=500)
+            assert False, "Expected QmlDriverError for timeout"
+        except QmlDriverError as e:
+            assert "timed out" in str(e).lower() or "Timed out" in str(e), \
+                f"Unexpected error message: {e}"
+            print(f"  Correctly timed out: {e}")
+            print("  PASSED")
+
+        print("\n" + "=" * 50)
+        print("All tests PASSED")
+        print("=" * 50)
+
+    except Exception as e:
+        print(f"\nFAILED: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        dump_qml_tree(gui)
+        sys.exit(1)
+    finally:
+        harness.stop()
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/functional/qml_test_bridge_sanity.py
+++ b/test/functional/qml_test_bridge_sanity.py
@@ -18,6 +18,7 @@ from qml_test_harness import QmlTestHarness, QmlDriverError, dump_qml_tree, pars
 def run_tests():
     args = parse_args()
     harness = QmlTestHarness(socket_path=args.socket_path)
+    gui = None
     try:
         harness.start()
         gui = harness.driver
@@ -106,7 +107,8 @@ def run_tests():
         print(f"\nFAILED: {e}", file=sys.stderr)
         import traceback
         traceback.print_exc()
-        dump_qml_tree(gui)
+        if gui is not None:
+            dump_qml_tree(gui)
         sys.exit(1)
     finally:
         harness.stop()

--- a/test/functional/qml_test_harness.py
+++ b/test/functional/qml_test_harness.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Shared test harness for QML test automation.
+
+Provides QmlTestHarness which launches bitcoin-core-app with the test
+bridge enabled and connects a QmlDriver instance.
+"""
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+
+from qml_driver import QmlDriver, QmlDriverError
+
+
+# How long to wait for the GUI process to start (seconds).
+GUI_STARTUP_TIMEOUT = 30
+
+
+def find_gui_binary():
+    """Locate the bitcoin-core-app binary.
+
+    Search order:
+      1. BITCOIN_CORE_APP environment variable
+      2. <repo_root>/build/bin/bitcoin-core-app
+    """
+    env_path = os.getenv("BITCOIN_CORE_APP")
+    if env_path and os.path.isfile(env_path):
+        return env_path
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+    build_path = os.path.join(repo_root, 'build', 'bin', 'bitcoin-core-app')
+    if os.path.isfile(build_path):
+        return build_path
+
+    raise FileNotFoundError(
+        "Cannot find bitcoin-core-app binary. "
+        "Set BITCOIN_CORE_APP env var or build with -DENABLE_TEST_AUTOMATION=ON."
+    )
+
+
+def setup_datadir(tmpdir):
+    """Create a minimal regtest data directory with bitcoin.conf."""
+    datadir = os.path.join(tmpdir, "node0")
+    os.makedirs(datadir, exist_ok=True)
+    conf_path = os.path.join(datadir, "bitcoin.conf")
+    with open(conf_path, "w", encoding="utf8") as f:
+        f.write("regtest=1\n")
+        f.write("[regtest]\n")
+        f.write("server=1\n")
+        f.write("discover=0\n")
+        f.write("dnsseed=0\n")
+        f.write("fixedseeds=0\n")
+        f.write("listenonion=0\n")
+        f.write("printtoconsole=0\n")
+        f.write("connect=0\n")
+        f.write("shrinkdebugfile=0\n")
+    return datadir
+
+
+def parse_args():
+    """Parse common CLI arguments for QML test scripts."""
+    parser = argparse.ArgumentParser(
+        description="QML test automation",
+        add_help=True,
+    )
+    parser.add_argument(
+        "--socket-path",
+        help="Connect to an already-running bitcoin-core-app instance at "
+             "this Unix socket path instead of launching a new one.  "
+             "Start the app with: bitcoin-core-app -test-automation=<path>",
+    )
+    return parser.parse_args()
+
+
+class QmlTestHarness:
+    """Test harness that launches the GUI and connects the test bridge.
+
+    If socket_path is provided, attaches to an already-running instance
+    instead of launching a new one.
+    """
+
+    def __init__(self, socket_path=None):
+        self.external = socket_path is not None
+        self.process = None
+        self.driver = None
+
+        if self.external:
+            self.socket_path = socket_path
+            self.tmpdir = None
+            self.datadir = None
+        else:
+            self.gui_binary = find_gui_binary()
+            self.tmpdir = tempfile.mkdtemp(prefix="qml_test_bridge_")
+            self.datadir = setup_datadir(self.tmpdir)
+            self.socket_path = os.path.join(self.tmpdir, "test_bridge.sock")
+
+    def start(self):
+        """Launch bitcoin-core-app or attach to an existing instance."""
+        if self.external:
+            print(f"Connecting to existing GUI at {self.socket_path} ...")
+            self.driver = QmlDriver(self.socket_path, timeout=GUI_STARTUP_TIMEOUT)
+            print("QmlDriver connected to test bridge.")
+            return
+
+        env = dict(os.environ)
+        env["QT_QPA_PLATFORM"] = "offscreen"
+
+        args = [
+            self.gui_binary,
+            f"-datadir={self.datadir}",
+            f"-test-automation={self.socket_path}",
+            "-resetguisettings",
+            "-logtimemicros",
+            "-debug",
+            "-debugexclude=libevent",
+            "-debugexclude=leveldb",
+            "-nolisten",
+        ]
+
+        print(f"Starting GUI: {' '.join(args)}")
+        self.process = subprocess.Popen(
+            args,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        # Connect the QmlDriver (retries internally until the socket appears).
+        self.driver = QmlDriver(self.socket_path, timeout=GUI_STARTUP_TIMEOUT)
+        print("QmlDriver connected to test bridge.")
+
+    def stop(self):
+        """Shut down the GUI process (only if we launched it)."""
+        if self.process and self.process.poll() is None:
+            self.process.send_signal(signal.SIGTERM)
+            try:
+                self.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait()
+        if self.driver:
+            self.driver.close()
+
+
+def dump_qml_tree(driver):
+    """Print the full QML object tree for debugging."""
+    try:
+        print("\n--- QML object tree at failure ---")
+        all_objects = driver.list_objects()
+        for obj in all_objects:
+            print(f"  {obj['objectName']} ({obj['className']})")
+        print(f"--- {len(all_objects)} objects total ---")
+    except Exception:
+        print("  (could not retrieve object tree)")

--- a/test/functional/qml_test_harness.py
+++ b/test/functional/qml_test_harness.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024 The Bitcoin Core developers
+# Copyright (c) 2026 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Shared test harness for QML test automation.

--- a/test/functional/qml_test_harness.py
+++ b/test/functional/qml_test_harness.py
@@ -10,6 +10,7 @@ bridge enabled and connects a QmlDriver instance.
 
 import argparse
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -146,6 +147,9 @@ class QmlTestHarness:
                 self.process.wait()
         if self.driver:
             self.driver.close()
+        if self.tmpdir:
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+            self.tmpdir = None
 
 
 def dump_qml_tree(driver):

--- a/test/functional/qml_test_onboarding.py
+++ b/test/functional/qml_test_onboarding.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that walks through the full onboarding flow via the test bridge.
+
+Clicks through every onboarding page and verifies the app exits
+onboarding into the main view.
+
+This test requires the binary to be built with -DENABLE_TEST_AUTOMATION=ON.
+"""
+
+import sys
+import time
+
+from qml_test_harness import QmlTestHarness, QmlDriverError, dump_qml_tree, parse_args
+
+
+def run_tests():
+    args = parse_args()
+    harness = QmlTestHarness(socket_path=args.socket_path)
+    try:
+        harness.start()
+        gui = harness.driver
+
+        # The app starts fresh (-resetguisettings), so we should land on
+        # the onboarding cover page.
+        page = gui.get_current_page()
+        print(f"Initial page: {page}")
+        assert "onboardingCover" in page or "Cover" in page, \
+            f"Expected to start on onboardingCover, got: {page}"
+
+        # Define the expected progression through onboarding.
+        # Each entry is (button_to_click, expected_next_page).
+        onboarding_steps = [
+            ("onboardingCoverButton",           "onboardingStrengthen"),
+            ("onboardingStrengthenButton",      "onboardingBlockclock"),
+            ("onboardingBlockclockButton",      "onboardingStorageLocation"),
+            ("onboardingStorageLocationButton", "onboardingStorageAmount"),
+            ("onboardingStorageAmountButton",   "onboardingConnection"),
+        ]
+
+        for button, expected_page in onboarding_steps:
+            print(f"Click {button} ...")
+            gui.click(button)
+            gui.wait_for_page(expected_page, timeout_ms=5000)
+            current = gui.get_current_page()
+            assert expected_page in current, \
+                f"Expected {expected_page}, got: {current}"
+            print(f"  -> page: {current}")
+
+        # Click Next on the final connection page to finish onboarding.
+        print("Click onboardingConnectionButton (finish onboarding) ...")
+        gui.click("onboardingConnectionButton")
+
+        # After onboarding completes, we should no longer be on an
+        # onboarding page. The app navigates to either the desktop
+        # wallets view or the node runner, depending on configuration.
+        time.sleep(1)  # Allow navigation to settle.
+        final_page = gui.get_current_page()
+        print(f"  -> post-onboarding page: {final_page}")
+        assert "onboarding" not in final_page.lower(), \
+            f"Still on an onboarding page after finishing: {final_page}"
+
+        print("\n" + "=" * 50)
+        print("All tests PASSED")
+        print("=" * 50)
+
+    except Exception as e:
+        print(f"\nFAILED: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        dump_qml_tree(gui)
+        sys.exit(1)
+    finally:
+        harness.stop()
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/functional/qml_test_onboarding.py
+++ b/test/functional/qml_test_onboarding.py
@@ -54,11 +54,14 @@ def run_tests():
         print("Click onboardingConnectionButton (finish onboarding) ...")
         gui.click("onboardingConnectionButton")
 
-        # After onboarding completes, we should no longer be on an
-        # onboarding page. The app navigates to either the desktop
-        # wallets view or the node runner, depending on configuration.
-        time.sleep(1)  # Allow navigation to settle.
+        # Wait until onboarding has actually transitioned out of onboarding
+        # pages; this avoids flaky fixed sleeps on slower machines.
+        deadline = time.time() + 10
         final_page = gui.get_current_page()
+        while "onboarding" in final_page.lower() and time.time() < deadline:
+            time.sleep(0.1)
+            final_page = gui.get_current_page()
+
         print(f"  -> post-onboarding page: {final_page}")
         assert "onboarding" not in final_page.lower(), \
             f"Still on an onboarding page after finishing: {final_page}"

--- a/test/functional/qml_test_onboarding.py
+++ b/test/functional/qml_test_onboarding.py
@@ -19,6 +19,7 @@ from qml_test_harness import QmlTestHarness, QmlDriverError, dump_qml_tree, pars
 def run_tests():
     args = parse_args()
     harness = QmlTestHarness(socket_path=args.socket_path)
+    gui = None
     try:
         harness.start()
         gui = harness.driver
@@ -70,7 +71,8 @@ def run_tests():
         print(f"\nFAILED: {e}", file=sys.stderr)
         import traceback
         traceback.print_exc()
-        dump_qml_tree(gui)
+        if gui is not None:
+            dump_qml_tree(gui)
         sys.exit(1)
     finally:
         harness.stop()


### PR DESCRIPTION
Adds a build config to compile in a json rpc server that can be used to query the QML engine tree and send click events to it. Python driver and harness are added as well as two basic tests.  qml_test_bridge_sanity.py does a basic test against the test-bridge and qml_test_onboard.py does a basic click through of the onboard views.

Related to #506 