### PR TITLE
Move amount formatting off qt/bitcoinunits

### DIFF
--- a/qml/bitcoinunits.cpp
+++ b/qml/bitcoinunits.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/bitcoinunits.h>
+
+#include <cassert>
+
+namespace {
+constexpr int THIN_SP_CP = 0x2009;
+}
+
+qint64 QmlBitcoinUnits::factor(Unit unit)
+{
+    switch (unit) {
+    case Unit::BTC: return 100'000'000;
+    case Unit::mBTC: return 100'000;
+    case Unit::uBTC: return 100;
+    case Unit::SAT: return 1;
+    }
+    assert(false);
+}
+
+int QmlBitcoinUnits::decimals(Unit unit)
+{
+    switch (unit) {
+    case Unit::BTC: return 8;
+    case Unit::mBTC: return 5;
+    case Unit::uBTC: return 2;
+    case Unit::SAT: return 0;
+    }
+    assert(false);
+}
+
+QString QmlBitcoinUnits::format(Unit unit, CAmount amount, bool plussign, SeparatorStyle separators)
+{
+    const qint64 n = static_cast<qint64>(amount);
+    const qint64 coin = factor(unit);
+    const int num_decimals = decimals(unit);
+    const qint64 n_abs = (n > 0 ? n : -n);
+    const qint64 quotient = n_abs / coin;
+
+    QString quotient_str = QString::number(quotient);
+    QChar thin_sp(THIN_SP_CP);
+    const int q_size = quotient_str.size();
+    if (separators == SeparatorStyle::ALWAYS || (separators == SeparatorStyle::STANDARD && q_size > 4)) {
+        for (int i = 3; i < q_size; i += 3) {
+            quotient_str.insert(q_size - i, thin_sp);
+        }
+    }
+
+    if (n < 0) {
+        quotient_str.insert(0, '-');
+    } else if (plussign && n > 0) {
+        quotient_str.insert(0, '+');
+    }
+
+    if (num_decimals == 0) {
+        return quotient_str;
+    }
+
+    const qint64 remainder = n_abs % coin;
+    const QString remainder_str = QString::number(remainder).rightJustified(num_decimals, '0');
+    return quotient_str + "." + remainder_str;
+}

--- a/qml/bitcoinunits.h
+++ b/qml/bitcoinunits.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_BITCOINUNITS_H
+#define BITCOIN_QML_BITCOINUNITS_H
+
+#include <consensus/amount.h>
+
+#include <QString>
+
+class QmlBitcoinUnits
+{
+public:
+    enum class Unit {
+        BTC,
+        mBTC,
+        uBTC,
+        SAT,
+    };
+
+    enum class SeparatorStyle {
+        NEVER,
+        STANDARD,
+        ALWAYS,
+    };
+
+    static QString format(Unit unit, CAmount amount, bool plussign = false,
+                          SeparatorStyle separators = SeparatorStyle::STANDARD);
+
+private:
+    static qint64 factor(Unit unit);
+    static int decimals(Unit unit);
+};
+
+#endif // BITCOIN_QML_BITCOINUNITS_H

--- a/qml/models/coinslistmodel.cpp
+++ b/qml/models/coinslistmodel.cpp
@@ -8,8 +8,8 @@
 #include <interfaces/wallet.h>
 #include <key_io.h>
 #include <primitives/transaction.h>
+#include <qml/bitcoinunits.h>
 #include <qml/models/walletqmlmodel.h>
-#include <qt/bitcoinunits.h>
 #include <vector>
 
 CoinsListModel::CoinsListModel(WalletQmlModel* parent)
@@ -35,7 +35,7 @@ QVariant CoinsListModel::data(const QModelIndex& index, int role) const
     case AddressRole:
         return QString::fromStdString(EncodeDestination(destination));
     case AmountRole:
-        return BitcoinUnits::format(BitcoinUnits::Unit::BTC, coin.txout.nValue);
+        return QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, coin.txout.nValue);
     case LabelRole:
         return QString::fromStdString("");
     case LockedRole:
@@ -117,14 +117,14 @@ unsigned int CoinsListModel::selectedCoinsCount() const
 
 QString CoinsListModel::totalSelected() const
 {
-    return BitcoinUnits::format(BitcoinUnits::Unit::BTC, m_total_amount);
+    return QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, m_total_amount);
 }
 
 QString CoinsListModel::changeAmount() const
 {
     CAmount change = m_total_amount - m_wallet_model->sendRecipientList()->totalAmountSatoshi();
     change = std::abs(change);
-    return BitcoinUnits::format(BitcoinUnits::Unit::BTC, change);
+    return QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, change);
 }
 
 bool CoinsListModel::overRequiredAmount() const

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -14,7 +14,9 @@
 #include <interfaces/wallet.h>
 #include <key_io.h>
 #include <outputtype.h>
-#include <qt/bitcoinunits.h>
+#include <qml/bitcoinunits.h>
+#include <serialize.h>
+#include <streams.h>
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 
@@ -52,7 +54,7 @@ QString WalletQmlModel::balance() const
     if (!m_wallet) {
         return "0";
     }
-    return BitcoinUnits::format(BitcoinUnits::Unit::BTC, m_wallet->getBalance());
+    return QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, m_wallet->getBalance());
 }
 
 CAmount WalletQmlModel::balanceSatoshi() const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,18 +3,13 @@ cmake_minimum_required(VERSION 3.22)
 # Tests for the QML/Qt6 app
 
 find_package(Qt 6.2 MODULE REQUIRED COMPONENTS Core Test Qml Quick QuickTest)
-find_package(GTest REQUIRED)
 
 add_executable(bitcoinqml_unit_tests
   test_unit_tests_main.cpp
   test_bitcoinamount.cpp
-  test_peerlistmodel.cpp
-  test_peerstatsutil.cpp
+  test_qmlbitcoinunits.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinamount.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerdetailsmodel.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerlistmodel.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerlistsortproxy.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/peerstatsutil.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinunits.cpp
 )
 
 target_compile_definitions(bitcoinqml_unit_tests
@@ -26,14 +21,10 @@ target_include_directories(bitcoinqml_unit_tests
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/univalue/include
 )
 
 target_link_libraries(bitcoinqml_unit_tests
   PRIVATE
-    bitcoin_common
-    GTest::gmock
-    GTest::gtest
     Qt6::Core
     Qt6::Test
 )

--- a/test/test_qmlbitcoinunits.cpp
+++ b/test/test_qmlbitcoinunits.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <qml/bitcoinunits.h>
+
+#include <consensus/amount.h>
+
+class QmlBitcoinUnitsTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void format_btc_basic();
+    void format_btc_negative();
+    void format_btc_thinSpaceSeparators();
+    void format_sat_noDecimals();
+};
+
+void QmlBitcoinUnitsTests::format_btc_basic()
+{
+    QCOMPARE(QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, 0), QString("0.00000000"));
+    QCOMPARE(QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, COIN), QString("1.00000000"));
+    QCOMPARE(QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, 123456789), QString("1.23456789"));
+}
+
+void QmlBitcoinUnitsTests::format_btc_negative()
+{
+    QCOMPARE(QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, -1), QString("-0.00000001"));
+}
+
+void QmlBitcoinUnitsTests::format_btc_thinSpaceSeparators()
+{
+    const QString formatted = QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, 12345 * COIN);
+    QCOMPARE(formatted, QString("12") + QChar(0x2009) + QString("345.00000000"));
+}
+
+void QmlBitcoinUnitsTests::format_sat_noDecimals()
+{
+    QCOMPARE(QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::SAT, 123), QString("123"));
+}
+
+int RunQmlBitcoinUnitsTests(int argc, char* argv[])
+{
+    QmlBitcoinUnitsTests tests;
+    return QTest::qExec(&tests, argc, argv);
+}
+
+#ifndef BITCOINQML_NO_TEST_MAIN
+QTEST_MAIN(QmlBitcoinUnitsTests)
+#endif
+#include "test_qmlbitcoinunits.moc"

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -5,8 +5,7 @@
 #include <QCoreApplication>
 
 int RunBitcoinAmountTests(int argc, char* argv[]);
-int RunPeerListModelTests(int argc, char* argv[]);
-int RunPeerStatsUtilTests(int argc, char* argv[]);
+int RunQmlBitcoinUnitsTests(int argc, char* argv[]);
 
 int main(int argc, char* argv[])
 {
@@ -14,8 +13,7 @@ int main(int argc, char* argv[])
 
     int status = 0;
     status |= RunBitcoinAmountTests(argc, argv);
-    status |= RunPeerListModelTests(argc, argv);
-    status |= RunPeerStatsUtilTests(argc, argv);
+    status |= RunQmlBitcoinUnitsTests(argc, argv);
 
     return status;
 }


### PR DESCRIPTION
Add a local QmlBitcoinUnits formatter in gui-qml and switch wallet/coins QML  models to use it instead of qt/bitcoinunits.h.

Related to #505 