### PR TITLE
Decouple from src/qt networkstyle and add related test coverage

### DIFF
--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -20,7 +20,6 @@
 #include <noui.h>
 #include <qt/guiutil.h>
 #include <qt/initexecutor.h>
-#include <qt/networkstyle.h>
 #include <qml/appmode.h>
 #include <qml/bitcoinamount.h>
 #include <qml/clipboard.h>
@@ -45,14 +44,12 @@
 #include <qml/models/walletqmlmodel.h>
 #include <qml/models/walletqmlmodeltransaction.h>
 #include <qml/qrimageprovider.h>
+#include <qml/networkstyle.h>
 #include <qml/util.h>
 #include <qml/walletqmlcontroller.h>
 #ifdef ENABLE_TEST_AUTOMATION
 #include <qml/test/testbridge.h>
 #endif
-#include <qt/guiutil.h>
-#include <qt/initexecutor.h>
-#include <qt/networkstyle.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
 
@@ -62,6 +59,7 @@
 #include <tuple>
 
 #include <QDebug>
+#include <QFontDatabase>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
@@ -180,6 +178,13 @@ void setupChainQSettings(QGuiApplication* app, QString chain)
         app->setApplicationName(QAPP_APP_NAME_SIGNET);
     } else if (chain.compare("REGTEST") == 0) {
         app->setApplicationName(QAPP_APP_NAME_REGTEST);
+    }
+}
+
+void LoadFontResource(const QString& path)
+{
+    if (QFontDatabase::addApplicationFont(path) < 0) {
+        qWarning() << "Failed to load font resource:" << path;
     }
 }
 } // namespace
@@ -309,8 +314,8 @@ int QmlGuiMain(int argc, char* argv[])
     QObject::connect(&node_model, &NodeModel::nodeInitialized,
                      &ban_list_model, &BanListModel::refresh);
 
-    GUIUtil::LoadFont(":/fonts/inter/regular");
-    GUIUtil::LoadFont(":/fonts/inter/semibold");
+    LoadFontResource(":/fonts/inter/regular");
+    LoadFontResource(":/fonts/inter/semibold");
 
     QQmlApplicationEngine engine;
 

--- a/qml/guiconstants.h
+++ b/qml/guiconstants.h
@@ -5,11 +5,20 @@
 #ifndef BITCOIN_QML_GUICONSTANTS_H
 #define BITCOIN_QML_GUICONSTANTS_H
 
+#include <cstdint>
+
 #define QAPP_ORG_NAME "BitcoinCore"
 #define QAPP_ORG_DOMAIN "bitcoincore.org"
 #define QAPP_APP_NAME_DEFAULT "BitcoinCore-App"
 #define QAPP_APP_NAME_TESTNET "BitcoinCore-App-testnet"
+#define QAPP_APP_NAME_TESTNET4 "BitcoinCore-App-testnet4"
 #define QAPP_APP_NAME_SIGNET "BitcoinCore-App-signet"
 #define QAPP_APP_NAME_REGTEST "BitcoinCore-App-regtest"
+
+// One gigabyte (GB) in bytes.
+static constexpr uint64_t GB_BYTES{1000000000};
+
+// Default prune target displayed in QML settings (GB).
+static constexpr int DEFAULT_PRUNE_TARGET_GB{2};
 
 #endif // BITCOIN_QML_GUICONSTANTS_H

--- a/qml/imageprovider.cpp
+++ b/qml/imageprovider.cpp
@@ -4,7 +4,7 @@
 
 #include <qml/imageprovider.h>
 
-#include <qt/networkstyle.h>
+#include <qml/networkstyle.h>
 
 #include <QFile>
 #include <QIcon>

--- a/qml/models/options_model.cpp
+++ b/qml/models/options_model.cpp
@@ -8,12 +8,10 @@
 #include <common/settings.h>
 #include <common/system.h>
 #include <interfaces/node.h>
+#include <mapport.h>
 #include <node/caches.h>
 #include <node/chainstatemanager_args.h>
-#include <mapport.h>
-#include <qt/guiconstants.h>
-#include <qt/guiutil.h>
-#include <qt/optionsmodel.h>
+#include <qml/guiconstants.h>
 #include <txdb.h>
 #include <univalue.h>
 #include <util/fs.h>
@@ -25,6 +23,18 @@
 #include <QDebug>
 #include <QDir>
 #include <QSettings>
+
+namespace {
+int PruneMiBtoGB(int64_t mib)
+{
+    return (mib * 1024 * 1024 + GB_BYTES - 1) / GB_BYTES;
+}
+
+int64_t PruneGBtoMiB(int gb)
+{
+    return gb * GB_BYTES / 1024 / 1024;
+}
+} // namespace
 
 OptionsQmlModel::OptionsQmlModel(interfaces::Node& node, bool is_onboarded)
     : m_node{node}

--- a/qml/networkstyle.cpp
+++ b/qml/networkstyle.cpp
@@ -6,11 +6,7 @@
 
 #include <qml/guiconstants.h>
 
-#include <tinyformat.h>
-#include <util/chaintype.h>
-
 #include <QColor>
-#include <QCoreApplication>
 #include <QImage>
 #include <QPixmap>
 
@@ -27,13 +23,10 @@ static const struct {
     {ChainType::REGTEST, QAPP_APP_NAME_REGTEST, 160, 30},
 };
 
-// titleAddText needs to be const char* for tr()
 NetworkStyle::NetworkStyle(const QString& appName,
                            const int iconColorHueShift,
-                           const int iconColorSaturationReduction,
-                           const char* titleAddText)
+                           const int iconColorSaturationReduction)
     : appName(appName)
-    , titleAddText(QCoreApplication::translate("SplashScreen", titleAddText))
 {
     QPixmap pixmap(":/icons/bitcoin");
 
@@ -65,17 +58,12 @@ NetworkStyle::NetworkStyle(const QString& appName,
 
 const NetworkStyle* NetworkStyle::instantiate(const ChainType networkId)
 {
-    const std::string titleAddText = networkId == ChainType::MAIN
-        ? ""
-        : strprintf("[%s]", ChainTypeToString(networkId));
-
     for (const auto& network_style : network_styles) {
         if (networkId == network_style.networkId) {
             return new NetworkStyle(
                 network_style.appName,
                 network_style.iconColorHueShift,
-                network_style.iconColorSaturationReduction,
-                titleAddText.c_str());
+                network_style.iconColorSaturationReduction);
         }
     }
     return nullptr;

--- a/qml/networkstyle.cpp
+++ b/qml/networkstyle.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2014-2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/networkstyle.h>
+
+#include <qml/guiconstants.h>
+
+#include <tinyformat.h>
+#include <util/chaintype.h>
+
+#include <QColor>
+#include <QCoreApplication>
+#include <QImage>
+#include <QPixmap>
+
+static const struct {
+    const ChainType networkId;
+    const char* appName;
+    const int iconColorHueShift;
+    const int iconColorSaturationReduction;
+} network_styles[] = {
+    {ChainType::MAIN, QAPP_APP_NAME_DEFAULT, 0, 0},
+    {ChainType::TESTNET, QAPP_APP_NAME_TESTNET, 70, 30},
+    {ChainType::TESTNET4, QAPP_APP_NAME_TESTNET4, 70, 30},
+    {ChainType::SIGNET, QAPP_APP_NAME_SIGNET, 35, 15},
+    {ChainType::REGTEST, QAPP_APP_NAME_REGTEST, 160, 30},
+};
+
+// titleAddText needs to be const char* for tr()
+NetworkStyle::NetworkStyle(const QString& appName,
+                           const int iconColorHueShift,
+                           const int iconColorSaturationReduction,
+                           const char* titleAddText)
+    : appName(appName)
+    , titleAddText(QCoreApplication::translate("SplashScreen", titleAddText))
+{
+    QPixmap pixmap(":/icons/bitcoin");
+
+    if (iconColorHueShift != 0 && iconColorSaturationReduction != 0) {
+        QImage img = pixmap.toImage();
+
+        int h, s, l, a;
+        for (int y = 0; y < img.height(); y++) {
+            QRgb* scL = reinterpret_cast<QRgb*>(img.scanLine(y));
+            for (int x = 0; x < img.width(); x++) {
+                a = qAlpha(scL[x]);
+                QColor col(scL[x]);
+                col.getHsl(&h, &s, &l);
+
+                h += iconColorHueShift;
+                if (s > iconColorSaturationReduction) {
+                    s -= iconColorSaturationReduction;
+                }
+                col.setHsl(h, s, l, a);
+                scL[x] = col.rgba();
+            }
+        }
+        pixmap.convertFromImage(img);
+    }
+
+    appIcon = QIcon(pixmap);
+    trayAndWindowIcon = QIcon(pixmap.scaled(QSize(256, 256)));
+}
+
+const NetworkStyle* NetworkStyle::instantiate(const ChainType networkId)
+{
+    const std::string titleAddText = networkId == ChainType::MAIN
+        ? ""
+        : strprintf("[%s]", ChainTypeToString(networkId));
+
+    for (const auto& network_style : network_styles) {
+        if (networkId == network_style.networkId) {
+            return new NetworkStyle(
+                network_style.appName,
+                network_style.iconColorHueShift,
+                network_style.iconColorSaturationReduction,
+                titleAddText.c_str());
+        }
+    }
+    return nullptr;
+}

--- a/qml/networkstyle.h
+++ b/qml/networkstyle.h
@@ -21,18 +21,15 @@ public:
     const QString& getAppName() const { return appName; }
     const QIcon& getAppIcon() const { return appIcon; }
     const QIcon& getTrayAndWindowIcon() const { return trayAndWindowIcon; }
-    const QString& getTitleAddText() const { return titleAddText; }
 
 private:
     NetworkStyle(const QString& appName,
                  int iconColorHueShift,
-                 int iconColorSaturationReduction,
-                 const char* titleAddText);
+                 int iconColorSaturationReduction);
 
     QString appName;
     QIcon appIcon;
     QIcon trayAndWindowIcon;
-    QString titleAddText;
 };
 
 #endif // BITCOIN_QML_NETWORKSTYLE_H

--- a/qml/networkstyle.h
+++ b/qml/networkstyle.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2014-2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_NETWORKSTYLE_H
+#define BITCOIN_QML_NETWORKSTYLE_H
+
+#include <util/chaintype.h>
+
+#include <QIcon>
+#include <QPixmap>
+#include <QString>
+
+/* Coin network-specific GUI style information. */
+class NetworkStyle
+{
+public:
+    /** Get style associated with provided network id, or null if not known. */
+    static const NetworkStyle* instantiate(ChainType networkId);
+
+    const QString& getAppName() const { return appName; }
+    const QIcon& getAppIcon() const { return appIcon; }
+    const QIcon& getTrayAndWindowIcon() const { return trayAndWindowIcon; }
+    const QString& getTitleAddText() const { return titleAddText; }
+
+private:
+    NetworkStyle(const QString& appName,
+                 int iconColorHueShift,
+                 int iconColorSaturationReduction,
+                 const char* titleAddText);
+
+    QString appName;
+    QIcon appIcon;
+    QIcon trayAndWindowIcon;
+    QString titleAddText;
+};
+
+#endif // BITCOIN_QML_NETWORKSTYLE_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,14 +2,17 @@ cmake_minimum_required(VERSION 3.22)
 
 # Tests for the QML/Qt6 app
 
-find_package(Qt 6.2 MODULE REQUIRED COMPONENTS Core Test Qml Quick QuickTest)
+find_package(Qt 6.2 MODULE REQUIRED COMPONENTS Core Gui Test Qml Quick QuickTest)
 
 add_executable(bitcoinqml_unit_tests
   test_unit_tests_main.cpp
   test_bitcoinamount.cpp
   test_qmlbitcoinunits.cpp
+  test_networkstyle.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinamount.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinunits.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/networkstyle.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
 )
 
 target_compile_definitions(bitcoinqml_unit_tests
@@ -26,6 +29,8 @@ target_include_directories(bitcoinqml_unit_tests
 target_link_libraries(bitcoinqml_unit_tests
   PRIVATE
     Qt6::Core
+    Qt6::Gui
+    Qt6::Quick
     Qt6::Test
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,9 +8,11 @@ add_executable(bitcoinqml_unit_tests
   test_unit_tests_main.cpp
   test_bitcoinamount.cpp
   test_qmlbitcoinunits.cpp
+  test_imageprovider.cpp
   test_networkstyle.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinamount.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinunits.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/imageprovider.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/networkstyle.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries(bitcoinqml_unit_tests
     Qt6::Test
 )
 
-add_test(NAME bitcoinqml_unit_tests COMMAND bitcoinqml_unit_tests)
+add_test(NAME bitcoinqml_unit_tests COMMAND bitcoinqml_unit_tests -platform offscreen)
 
 add_executable(bitcoinqml_qmltests
   qml/qml_tests_main.cpp

--- a/test/test_imageprovider.cpp
+++ b/test/test_imageprovider.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <qml/imageprovider.h>
+#include <qml/networkstyle.h>
+
+#include <memory>
+
+class ImageProviderTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void requestPixmap_requiresSizePointer();
+    void requestPixmap_requiresValidRequestedSize();
+    void requestPixmap_appId_setsRequestedOutputSize();
+    void requestPixmap_unknownId_returnsNullPixmap();
+};
+
+void ImageProviderTests::requestPixmap_requiresSizePointer()
+{
+    const std::unique_ptr<const NetworkStyle> style{NetworkStyle::instantiate(ChainType::MAIN)};
+    QVERIFY(style != nullptr);
+    ImageProvider provider(style.get());
+
+    const QPixmap pixmap = provider.requestPixmap(QStringLiteral("app"), nullptr, QSize(32, 32));
+    QVERIFY(pixmap.isNull());
+}
+
+void ImageProviderTests::requestPixmap_requiresValidRequestedSize()
+{
+    const std::unique_ptr<const NetworkStyle> style{NetworkStyle::instantiate(ChainType::MAIN)};
+    QVERIFY(style != nullptr);
+    ImageProvider provider(style.get());
+
+    QSize size{7, 9};
+    const QPixmap pixmap = provider.requestPixmap(QStringLiteral("app"), &size, QSize{});
+    QVERIFY(pixmap.isNull());
+    QCOMPARE(size, QSize(7, 9));
+}
+
+void ImageProviderTests::requestPixmap_appId_setsRequestedOutputSize()
+{
+    const std::unique_ptr<const NetworkStyle> style{NetworkStyle::instantiate(ChainType::MAIN)};
+    QVERIFY(style != nullptr);
+    ImageProvider provider(style.get());
+
+    QSize size;
+    const QSize requested_size{40, 24};
+    const QPixmap pixmap = provider.requestPixmap(QStringLiteral("app"), &size, requested_size);
+    Q_UNUSED(pixmap);
+    QCOMPARE(size, requested_size);
+}
+
+void ImageProviderTests::requestPixmap_unknownId_returnsNullPixmap()
+{
+    const std::unique_ptr<const NetworkStyle> style{NetworkStyle::instantiate(ChainType::MAIN)};
+    QVERIFY(style != nullptr);
+    ImageProvider provider(style.get());
+
+    QSize size{3, 5};
+    const QPixmap pixmap = provider.requestPixmap(QStringLiteral("definitely_missing_icon"), &size, QSize(32, 32));
+    QVERIFY(pixmap.isNull());
+    QCOMPARE(size, QSize(3, 5));
+}
+
+int RunImageProviderTests(int argc, char* argv[])
+{
+    ImageProviderTests tests;
+    return QTest::qExec(&tests, argc, argv);
+}
+
+#ifndef BITCOINQML_NO_TEST_MAIN
+QTEST_MAIN(ImageProviderTests)
+#endif
+#include "test_imageprovider.moc"

--- a/test/test_networkstyle.cpp
+++ b/test/test_networkstyle.cpp
@@ -13,7 +13,6 @@ class NetworkStyleTests : public QObject
 
 private Q_SLOTS:
     void instantiate_knownNetworks_haveExpectedNames();
-    void instantiate_nonMainNetwork_hasBracketedChainTitleSuffix();
 };
 
 void NetworkStyleTests::instantiate_knownNetworks_haveExpectedNames()
@@ -21,24 +20,16 @@ void NetworkStyleTests::instantiate_knownNetworks_haveExpectedNames()
     const NetworkStyle* mainnet_style = NetworkStyle::instantiate(ChainType::MAIN);
     QVERIFY(mainnet_style != nullptr);
     QCOMPARE(mainnet_style->getAppName(), QString(QAPP_APP_NAME_DEFAULT));
-    QCOMPARE(mainnet_style->getTitleAddText(), QString());
     delete mainnet_style;
 
     const NetworkStyle* signet_style = NetworkStyle::instantiate(ChainType::SIGNET);
     QVERIFY(signet_style != nullptr);
     QCOMPARE(signet_style->getAppName(), QString(QAPP_APP_NAME_SIGNET));
     delete signet_style;
-}
 
-void NetworkStyleTests::instantiate_nonMainNetwork_hasBracketedChainTitleSuffix()
-{
     const NetworkStyle* regtest_style = NetworkStyle::instantiate(ChainType::REGTEST);
     QVERIFY(regtest_style != nullptr);
-
-    const QString title_suffix = regtest_style->getTitleAddText();
-    QVERIFY(title_suffix.startsWith('['));
-    QVERIFY(title_suffix.endsWith(']'));
-    QVERIFY(title_suffix.contains(QStringLiteral("regtest")));
+    QCOMPARE(regtest_style->getAppName(), QString(QAPP_APP_NAME_REGTEST));
     delete regtest_style;
 }
 

--- a/test/test_networkstyle.cpp
+++ b/test/test_networkstyle.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <qml/guiconstants.h>
+#include <qml/networkstyle.h>
+
+class NetworkStyleTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void instantiate_knownNetworks_haveExpectedNames();
+    void instantiate_nonMainNetwork_hasBracketedChainTitleSuffix();
+};
+
+void NetworkStyleTests::instantiate_knownNetworks_haveExpectedNames()
+{
+    const NetworkStyle* mainnet_style = NetworkStyle::instantiate(ChainType::MAIN);
+    QVERIFY(mainnet_style != nullptr);
+    QCOMPARE(mainnet_style->getAppName(), QString(QAPP_APP_NAME_DEFAULT));
+    QCOMPARE(mainnet_style->getTitleAddText(), QString());
+    delete mainnet_style;
+
+    const NetworkStyle* signet_style = NetworkStyle::instantiate(ChainType::SIGNET);
+    QVERIFY(signet_style != nullptr);
+    QCOMPARE(signet_style->getAppName(), QString(QAPP_APP_NAME_SIGNET));
+    delete signet_style;
+}
+
+void NetworkStyleTests::instantiate_nonMainNetwork_hasBracketedChainTitleSuffix()
+{
+    const NetworkStyle* regtest_style = NetworkStyle::instantiate(ChainType::REGTEST);
+    QVERIFY(regtest_style != nullptr);
+
+    const QString title_suffix = regtest_style->getTitleAddText();
+    QVERIFY(title_suffix.startsWith('['));
+    QVERIFY(title_suffix.endsWith(']'));
+    QVERIFY(title_suffix.contains(QStringLiteral("regtest")));
+    delete regtest_style;
+}
+
+int RunNetworkStyleTests(int argc, char* argv[])
+{
+    NetworkStyleTests tests;
+    return QTest::qExec(&tests, argc, argv);
+}
+
+#ifndef BITCOINQML_NO_TEST_MAIN
+QTEST_MAIN(NetworkStyleTests)
+#endif
+#include "test_networkstyle.moc"

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -2,18 +2,20 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <QCoreApplication>
+#include <QGuiApplication>
 
 int RunBitcoinAmountTests(int argc, char* argv[]);
 int RunQmlBitcoinUnitsTests(int argc, char* argv[]);
+int RunNetworkStyleTests(int argc, char* argv[]);
 
 int main(int argc, char* argv[])
 {
-    QCoreApplication app(argc, argv);
+    QGuiApplication app(argc, argv);
 
     int status = 0;
     status |= RunBitcoinAmountTests(argc, argv);
     status |= RunQmlBitcoinUnitsTests(argc, argv);
+    status |= RunNetworkStyleTests(argc, argv);
 
     return status;
 }

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -6,6 +6,7 @@
 
 int RunBitcoinAmountTests(int argc, char* argv[]);
 int RunQmlBitcoinUnitsTests(int argc, char* argv[]);
+int RunImageProviderTests(int argc, char* argv[]);
 int RunNetworkStyleTests(int argc, char* argv[]);
 
 int main(int argc, char* argv[])
@@ -15,6 +16,7 @@ int main(int argc, char* argv[])
     int status = 0;
     status |= RunBitcoinAmountTests(argc, argv);
     status |= RunQmlBitcoinUnitsTests(argc, argv);
+    status |= RunImageProviderTests(argc, argv);
     status |= RunNetworkStyleTests(argc, argv);
 
     return status;


### PR DESCRIPTION
This PR moves the remaining network-style and related options helpers used by the QML runtime off of `src/qt/`.

Changes include:
- add `qml/networkstyle.h` and use it from QML startup/image provider code
- replace `GUIUtil::LoadFont` usage with Qt-native `QFontDatabase::addApplicationFont`
- remove QML runtime dependencies on `qt/optionsmodel.h` / `qt/guiconstants.h` by using QML-local constants/helpers
- add unit test coverage for `NetworkStyle` and `ImageProvider`, and wire these tests into `bitcoinqml_unit_tests`


Related to #505 