### PR TITLE
Port initexecutor into gui-qml

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, ubuntu-22.04]
+        os: [macos-14, ubuntu-24.04]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ In addition the following dependencies are required for the GUI and tests:
 
 ```
 sudo apt install \
+  libgmock-dev \
+  libgtest-dev \
   qt6-base-dev \
   qt6-base-dev-tools \
   qt6-tools-dev \

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -19,7 +19,6 @@
 #include <node/interface_ui.h>
 #include <noui.h>
 #include <qt/guiutil.h>
-#include <qt/initexecutor.h>
 #include <qml/appmode.h>
 #include <qml/bitcoinamount.h>
 #include <qml/clipboard.h>
@@ -30,6 +29,7 @@
 #include <qml/controls/linegraph.h>
 #include <qml/guiconstants.h>
 #include <qml/imageprovider.h>
+#include <qml/initexecutor.h>
 #include <qml/models/activitylistmodel.h>
 #include <qml/models/banlistmodel.h>
 #include <qml/models/bitcoinaddress.h>
@@ -269,22 +269,22 @@ int QmlGuiMain(int argc, char* argv[])
     handler_message_box.disconnect();
 
     NodeModel node_model{*node};
-    InitExecutor init_executor{*node};
+    QmlInitExecutor init_executor{*node};
 #ifdef ENABLE_WALLET
     WalletQmlController wallet_controller(*node);
     if (!gArgs.GetBoolArg("-disablewallet", false)) {
-        QObject::connect(&init_executor, &InitExecutor::initializeResult, &wallet_controller, &WalletQmlController::initialize);
+        QObject::connect(&init_executor, &QmlInitExecutor::initializeResult, &wallet_controller, &WalletQmlController::initialize);
     }
 #endif
-    QObject::connect(&node_model, &NodeModel::requestedInitialize, &init_executor, &InitExecutor::initialize);
+    QObject::connect(&node_model, &NodeModel::requestedInitialize, &init_executor, &QmlInitExecutor::initialize);
     QObject::connect(&node_model, &NodeModel::requestedShutdown, [&] {
 #ifdef ENABLE_WALLET
         wallet_controller.unloadWallets();
 #endif
         init_executor.shutdown();
     });
-    QObject::connect(&init_executor, &InitExecutor::initializeResult, &node_model, &NodeModel::initializeResult);
-    QObject::connect(&init_executor, &InitExecutor::shutdownResult, qGuiApp, &QGuiApplication::quit, Qt::QueuedConnection);
+    QObject::connect(&init_executor, &QmlInitExecutor::initializeResult, &node_model, &NodeModel::initializeResult);
+    QObject::connect(&init_executor, &QmlInitExecutor::shutdownResult, qGuiApp, &QGuiApplication::quit, Qt::QueuedConnection);
     // QObject::connect(&init_executor, &InitExecutor::runawayException, &node_model, &NodeModel::handleRunawayException);
 
     NetworkTrafficTower network_traffic_tower{node_model};

--- a/qml/initexecutor.cpp
+++ b/qml/initexecutor.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2014-2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/initexecutor.h>
+
+#include <interfaces/node.h>
+#include <util/exception.h>
+#include <util/threadnames.h>
+
+#include <QDebug>
+#include <QMetaObject>
+#include <QObject>
+#include <QString>
+#include <QThread>
+
+QmlInitExecutor::QmlInitExecutor(interfaces::Node& node)
+    : QObject(), m_node(node)
+{
+    m_context.moveToThread(&m_thread);
+    m_thread.start();
+}
+
+QmlInitExecutor::~QmlInitExecutor()
+{
+    qDebug() << __func__ << ": Stopping thread";
+    m_thread.quit();
+    m_thread.wait();
+    qDebug() << __func__ << ": Stopped thread";
+}
+
+void QmlInitExecutor::handleRunawayException(const std::exception* e)
+{
+    PrintExceptionContinue(e, "Runaway exception");
+    Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings().translated));
+}
+
+void QmlInitExecutor::initialize()
+{
+    QMetaObject::invokeMethod(&m_context, [this] {
+        try {
+            util::ThreadRename("qml-init");
+            qDebug() << "Running initialization in thread";
+            interfaces::BlockAndHeaderTipInfo tip_info;
+            bool rv = m_node.appInitMain(&tip_info);
+            Q_EMIT initializeResult(rv, tip_info);
+        } catch (const std::exception& e) {
+            handleRunawayException(&e);
+        } catch (...) {
+            handleRunawayException(nullptr);
+        }
+    });
+}
+
+void QmlInitExecutor::shutdown()
+{
+    QMetaObject::invokeMethod(&m_context, [this] {
+        try {
+            qDebug() << "Running shutdown in thread";
+            m_node.appShutdown();
+            qDebug() << "Shutdown finished";
+            Q_EMIT shutdownResult();
+        } catch (const std::exception& e) {
+            handleRunawayException(&e);
+        } catch (...) {
+            handleRunawayException(nullptr);
+        }
+    });
+}

--- a/qml/initexecutor.h
+++ b/qml/initexecutor.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2014-2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_INITEXECUTOR_H
+#define BITCOIN_QML_INITEXECUTOR_H
+
+#include <interfaces/node.h>
+
+#include <exception>
+
+#include <QObject>
+#include <QThread>
+
+QT_BEGIN_NAMESPACE
+class QString;
+QT_END_NAMESPACE
+
+/** Runs app initialization and shutdown work off the GUI thread. */
+class QmlInitExecutor : public QObject
+{
+    Q_OBJECT
+public:
+    explicit QmlInitExecutor(interfaces::Node& node);
+    ~QmlInitExecutor();
+
+public Q_SLOTS:
+    void initialize();
+    void shutdown();
+
+Q_SIGNALS:
+    void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
+    void shutdownResult();
+    void runawayException(const QString& message);
+
+private:
+    void handleRunawayException(const std::exception* e);
+
+    interfaces::Node& m_node;
+    QObject m_context;
+    QThread m_thread;
+};
+
+#endif // BITCOIN_QML_INITEXECUTOR_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,10 +10,13 @@ add_executable(bitcoinqml_unit_tests
   test_qmlbitcoinunits.cpp
   test_imageprovider.cpp
   test_networkstyle.cpp
+  test_qmlinitexecutor_api.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinamount.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinunits.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/imageprovider.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/networkstyle.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/initexecutor.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/initexecutor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
 )
 
@@ -30,6 +33,7 @@ target_include_directories(bitcoinqml_unit_tests
 
 target_link_libraries(bitcoinqml_unit_tests
   PRIVATE
+    bitcoin_util
     Qt6::Core
     Qt6::Gui
     Qt6::Quick

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ target_include_directories(bitcoinqml_unit_tests
 target_link_libraries(bitcoinqml_unit_tests
   PRIVATE
     bitcoin_common
+    GTest::gmock
     bitcoin_util
     GTest::gmock
     Qt6::Core

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22)
 # Tests for the QML/Qt6 app
 
 find_package(Qt 6.2 MODULE REQUIRED COMPONENTS Core Gui Test Qml Quick QuickTest)
+find_package(GTest REQUIRED)
 
 add_executable(bitcoinqml_unit_tests
   test_unit_tests_main.cpp
   test_bitcoinamount.cpp
+  test_peerlistmodel.cpp
+  test_peerstatsutil.cpp
   test_qmlbitcoinunits.cpp
   test_imageprovider.cpp
   test_networkstyle.cpp
@@ -18,6 +21,10 @@ add_executable(bitcoinqml_unit_tests
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/initexecutor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/initexecutor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerdetailsmodel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerlistmodel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerlistsortproxy.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/peerstatsutil.cpp
 )
 
 target_compile_definitions(bitcoinqml_unit_tests
@@ -29,11 +36,14 @@ target_include_directories(bitcoinqml_unit_tests
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/univalue/include
 )
 
 target_link_libraries(bitcoinqml_unit_tests
   PRIVATE
+    bitcoin_common
     bitcoin_util
+    GTest::gmock
     Qt6::Core
     Qt6::Gui
     Qt6::Quick

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,10 @@ cmake_minimum_required(VERSION 3.22)
 find_package(Qt 6.2 MODULE REQUIRED COMPONENTS Core Gui Test Qml Quick QuickTest)
 find_package(GTest REQUIRED)
 
+if(NOT TARGET GTest::gmock)
+  message(FATAL_ERROR "GTest::gmock target is required for app unit tests. Ensure gmock is installed and exported by the active GTest package.")
+endif()
+
 add_executable(bitcoinqml_unit_tests
   test_unit_tests_main.cpp
   test_bitcoinamount.cpp
@@ -42,7 +46,6 @@ target_include_directories(bitcoinqml_unit_tests
 target_link_libraries(bitcoinqml_unit_tests
   PRIVATE
     bitcoin_common
-    GTest::gmock
     bitcoin_util
     GTest::gmock
     Qt6::Core

--- a/test/mocks/mocknode.h
+++ b/test/mocks/mocknode.h
@@ -5,9 +5,26 @@
 #ifndef BITCOIN_QML_TEST_MOCKS_MOCKNODE_H
 #define BITCOIN_QML_TEST_MOCKS_MOCKNODE_H
 
+// Bitcoin's util/check.h defines Assert(val), while gMock declares internal
+// Assert(bool, file, line[, msg]) helpers. Some tests include Bitcoin headers
+// before this mock header, so temporarily hide the macro while parsing gMock
+// and restore it afterward.
+#ifdef Assert
+#pragma push_macro("Assert")
+#undef Assert
+#define BITCOIN_QML_RESTORE_ASSERT_MACRO
+#endif
+
 #include <gmock/gmock.h>
+
+#ifdef BITCOIN_QML_RESTORE_ASSERT_MACRO
+#pragma pop_macro("Assert")
+#undef BITCOIN_QML_RESTORE_ASSERT_MACRO
+#endif
+
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
+#include <net_processing.h>
 
 #include <coins.h>
 #include <node/types.h>

--- a/test/test_peerlistmodel.cpp
+++ b/test/test_peerlistmodel.cpp
@@ -13,8 +13,6 @@
 #include <map>
 #include <utility>
 
-const TranslateFn G_TRANSLATION_FUN{nullptr};
-
 namespace {
 interfaces::Node::NodesStats MakeStats(std::initializer_list<CNodeStats> node_stats)
 {

--- a/test/test_qmlinitexecutor_api.cpp
+++ b/test/test_qmlinitexecutor_api.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/initexecutor.h>
+
+#include <QMetaObject>
+#include <QMetaMethod>
+#include <QObject>
+#include <QTest>
+
+#include <type_traits>
+
+class QmlInitExecutorApiTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void exposesExpectedQObjectApi();
+};
+
+static bool HasMethodByName(const QMetaObject& meta, const QByteArray& method_name)
+{
+    for (int i = 0; i < meta.methodCount(); ++i) {
+        if (meta.method(i).name() == method_name) return true;
+    }
+    return false;
+}
+
+void QmlInitExecutorApiTests::exposesExpectedQObjectApi()
+{
+    QVERIFY((std::is_base_of_v<QObject, QmlInitExecutor>));
+    QVERIFY((std::is_constructible_v<QmlInitExecutor, interfaces::Node&>));
+
+    const QMetaObject& meta = QmlInitExecutor::staticMetaObject;
+
+    QVERIFY(HasMethodByName(meta, "initialize"));
+    QVERIFY(HasMethodByName(meta, "shutdown"));
+    QVERIFY(HasMethodByName(meta, "initializeResult"));
+    QVERIFY(HasMethodByName(meta, "shutdownResult"));
+    QVERIFY(HasMethodByName(meta, "runawayException"));
+}
+
+int RunQmlInitExecutorApiTests(int argc, char* argv[])
+{
+    QmlInitExecutorApiTests tc;
+    return QTest::qExec(&tc, argc, argv);
+}
+
+#include <test_qmlinitexecutor_api.moc>

--- a/test/test_qmlinitexecutor_api.cpp
+++ b/test/test_qmlinitexecutor_api.cpp
@@ -2,43 +2,153 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <QtTest/QtTest>
+
+#include <net_processing.h>
+#include <test/mocks/mocknode.h>
 #include <qml/initexecutor.h>
 
-#include <QMetaObject>
-#include <QMetaMethod>
-#include <QObject>
-#include <QTest>
+#include <util/translation.h>
 
-#include <type_traits>
+#include <stdexcept>
+
+Q_DECLARE_METATYPE(interfaces::BlockAndHeaderTipInfo)
+
+namespace {
+constexpr auto SIGNAL_TIMEOUT{5'000};
+}
 
 class QmlInitExecutorApiTests : public QObject
 {
     Q_OBJECT
 
 private Q_SLOTS:
-    void exposesExpectedQObjectApi();
+    void initTestCase();
+    void initializeEmitsResultAndRunsOffMainThread();
+    void initializeEmitsRunawayExceptionOnFailure();
+    void shutdownEmitsResultAndRunsOffMainThread();
+    void shutdownEmitsRunawayExceptionOnFailure();
 };
 
-static bool HasMethodByName(const QMetaObject& meta, const QByteArray& method_name)
+void QmlInitExecutorApiTests::initTestCase()
 {
-    for (int i = 0; i < meta.methodCount(); ++i) {
-        if (meta.method(i).name() == method_name) return true;
-    }
-    return false;
+    qRegisterMetaType<interfaces::BlockAndHeaderTipInfo>("interfaces::BlockAndHeaderTipInfo");
 }
 
-void QmlInitExecutorApiTests::exposesExpectedQObjectApi()
+void QmlInitExecutorApiTests::initializeEmitsResultAndRunsOffMainThread()
 {
-    QVERIFY((std::is_base_of_v<QObject, QmlInitExecutor>));
-    QVERIFY((std::is_constructible_v<QmlInitExecutor, interfaces::Node&>));
+    using ::testing::_;
+    using ::testing::Invoke;
+    using ::testing::StrictMock;
 
-    const QMetaObject& meta = QmlInitExecutor::staticMetaObject;
+    StrictMock<MockNode> node;
+    bool ran_off_main_thread{false};
 
-    QVERIFY(HasMethodByName(meta, "initialize"));
-    QVERIFY(HasMethodByName(meta, "shutdown"));
-    QVERIFY(HasMethodByName(meta, "initializeResult"));
-    QVERIFY(HasMethodByName(meta, "shutdownResult"));
-    QVERIFY(HasMethodByName(meta, "runawayException"));
+    EXPECT_CALL(node, appInitMain(_)).WillOnce(Invoke([&](interfaces::BlockAndHeaderTipInfo* tip_info) {
+        ran_off_main_thread = QThread::currentThread() != QCoreApplication::instance()->thread();
+        tip_info->block_height = 101;
+        tip_info->block_time = 1'700'000'001;
+        tip_info->header_height = 105;
+        tip_info->header_time = 1'700'000'099;
+        tip_info->verification_progress = 0.75;
+        return true;
+    }));
+
+    QmlInitExecutor executor{node};
+    QSignalSpy initialize_spy(&executor, &QmlInitExecutor::initializeResult);
+    QSignalSpy runaway_spy(&executor, &QmlInitExecutor::runawayException);
+
+    executor.initialize();
+
+    QVERIFY(initialize_spy.wait(SIGNAL_TIMEOUT));
+    QCOMPARE(initialize_spy.count(), 1);
+    QCOMPARE(runaway_spy.count(), 0);
+    QVERIFY(ran_off_main_thread);
+
+    const QList<QVariant> arguments = initialize_spy.takeFirst();
+    QCOMPARE(arguments.at(0).toBool(), true);
+
+    const auto tip_info = arguments.at(1).value<interfaces::BlockAndHeaderTipInfo>();
+    QCOMPARE(tip_info.block_height, 101);
+    QCOMPARE(tip_info.block_time, 1'700'000'001LL);
+    QCOMPARE(tip_info.header_height, 105);
+    QCOMPARE(tip_info.header_time, 1'700'000'099LL);
+    QCOMPARE(tip_info.verification_progress, 0.75);
+}
+
+void QmlInitExecutorApiTests::initializeEmitsRunawayExceptionOnFailure()
+{
+    using ::testing::_;
+    using ::testing::Invoke;
+    using ::testing::Return;
+    using ::testing::StrictMock;
+
+    StrictMock<MockNode> node;
+
+    EXPECT_CALL(node, appInitMain(_)).WillOnce(Invoke([](interfaces::BlockAndHeaderTipInfo*) -> bool {
+        throw std::runtime_error{"init failed"};
+    }));
+    EXPECT_CALL(node, getWarnings()).WillOnce(Return(bilingual_str{"Initialization failed", "Translated init failure"}));
+
+    QmlInitExecutor executor{node};
+    QSignalSpy initialize_spy(&executor, &QmlInitExecutor::initializeResult);
+    QSignalSpy runaway_spy(&executor, &QmlInitExecutor::runawayException);
+
+    executor.initialize();
+
+    QVERIFY(runaway_spy.wait(SIGNAL_TIMEOUT));
+    QCOMPARE(runaway_spy.count(), 1);
+    QCOMPARE(initialize_spy.count(), 0);
+    QCOMPARE(runaway_spy.takeFirst().at(0).toString(), QString{"Translated init failure"});
+}
+
+void QmlInitExecutorApiTests::shutdownEmitsResultAndRunsOffMainThread()
+{
+    using ::testing::Invoke;
+    using ::testing::StrictMock;
+
+    StrictMock<MockNode> node;
+    bool ran_off_main_thread{false};
+
+    EXPECT_CALL(node, appShutdown()).WillOnce(Invoke([&] {
+        ran_off_main_thread = QThread::currentThread() != QCoreApplication::instance()->thread();
+    }));
+
+    QmlInitExecutor executor{node};
+    QSignalSpy shutdown_spy(&executor, &QmlInitExecutor::shutdownResult);
+    QSignalSpy runaway_spy(&executor, &QmlInitExecutor::runawayException);
+
+    executor.shutdown();
+
+    QVERIFY(shutdown_spy.wait(SIGNAL_TIMEOUT));
+    QCOMPARE(shutdown_spy.count(), 1);
+    QCOMPARE(runaway_spy.count(), 0);
+    QVERIFY(ran_off_main_thread);
+}
+
+void QmlInitExecutorApiTests::shutdownEmitsRunawayExceptionOnFailure()
+{
+    using ::testing::Invoke;
+    using ::testing::Return;
+    using ::testing::StrictMock;
+
+    StrictMock<MockNode> node;
+
+    EXPECT_CALL(node, appShutdown()).WillOnce(Invoke([] {
+        throw std::runtime_error{"shutdown failed"};
+    }));
+    EXPECT_CALL(node, getWarnings()).WillOnce(Return(bilingual_str{"Shutdown failed", "Translated shutdown failure"}));
+
+    QmlInitExecutor executor{node};
+    QSignalSpy shutdown_spy(&executor, &QmlInitExecutor::shutdownResult);
+    QSignalSpy runaway_spy(&executor, &QmlInitExecutor::runawayException);
+
+    executor.shutdown();
+
+    QVERIFY(runaway_spy.wait(SIGNAL_TIMEOUT));
+    QCOMPARE(runaway_spy.count(), 1);
+    QCOMPARE(shutdown_spy.count(), 0);
+    QCOMPARE(runaway_spy.takeFirst().at(0).toString(), QString{"Translated shutdown failure"});
 }
 
 int RunQmlInitExecutorApiTests(int argc, char* argv[])

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -4,10 +4,15 @@
 
 #include <QGuiApplication>
 
+#include <util/translation.h>
+
+const TranslateFn G_TRANSLATION_FUN{nullptr};
+
 int RunBitcoinAmountTests(int argc, char* argv[]);
 int RunQmlBitcoinUnitsTests(int argc, char* argv[]);
 int RunImageProviderTests(int argc, char* argv[]);
 int RunNetworkStyleTests(int argc, char* argv[]);
+int RunQmlInitExecutorApiTests(int argc, char* argv[]);
 
 int main(int argc, char* argv[])
 {
@@ -18,6 +23,7 @@ int main(int argc, char* argv[])
     status |= RunQmlBitcoinUnitsTests(argc, argv);
     status |= RunImageProviderTests(argc, argv);
     status |= RunNetworkStyleTests(argc, argv);
+    status |= RunQmlInitExecutorApiTests(argc, argv);
 
     return status;
 }

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -9,6 +9,8 @@
 const TranslateFn G_TRANSLATION_FUN{nullptr};
 
 int RunBitcoinAmountTests(int argc, char* argv[]);
+int RunPeerListModelTests(int argc, char* argv[]);
+int RunPeerStatsUtilTests(int argc, char* argv[]);
 int RunQmlBitcoinUnitsTests(int argc, char* argv[]);
 int RunImageProviderTests(int argc, char* argv[]);
 int RunNetworkStyleTests(int argc, char* argv[]);
@@ -20,6 +22,8 @@ int main(int argc, char* argv[])
 
     int status = 0;
     status |= RunBitcoinAmountTests(argc, argv);
+    status |= RunPeerListModelTests(argc, argv);
+    status |= RunPeerStatsUtilTests(argc, argv);
     status |= RunQmlBitcoinUnitsTests(argc, argv);
     status |= RunImageProviderTests(argc, argv);
     status |= RunNetworkStyleTests(argc, argv);


### PR DESCRIPTION
Creates QmlInitExecutor based on qt/initexecutor.cpp and adds basic test coverage

Related to Issue #505 