### PR TITLE
Decouple BanListModel from qt BantableModel

### DIFF
--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -18,7 +18,6 @@
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <noui.h>
-#include <qt/guiutil.h>
 #include <qml/appmode.h>
 #include <qml/bitcoinamount.h>
 #include <qml/clipboard.h>

--- a/qml/models/banlistmodel.cpp
+++ b/qml/models/banlistmodel.cpp
@@ -24,12 +24,12 @@ int BanListModel::rowCount(const QModelIndex& parent) const
 QVariant BanListModel::data(const QModelIndex& index, int role) const
 {
     if (!index.isValid() || index.row() >= m_ban_list.size()) return {};
-    const CCombinedBan& entry = m_ban_list.at(index.row());
+    const BanListEntry& entry = m_ban_list.at(index.row());
     switch (static_cast<BanRoles>(role)) {
     case BanRoles::AddressRole:
         return QString::fromStdString(entry.subnet.ToString());
     case BanRoles::BanUntilRole: {
-        QDateTime dt = QDateTime::fromSecsSinceEpoch(entry.banEntry.nBanUntil);
+        QDateTime dt = QDateTime::fromSecsSinceEpoch(entry.ban_entry.nBanUntil);
         return QLocale::system().toString(dt, QStringLiteral("MMMM d, yyyy h:mm AP"));
     }
     }

--- a/qml/models/banlistmodel.h
+++ b/qml/models/banlistmodel.h
@@ -5,12 +5,19 @@
 #ifndef BITCOIN_QML_MODELS_BANLISTMODEL_H
 #define BITCOIN_QML_MODELS_BANLISTMODEL_H
 
-#include <qt/bantablemodel.h>
+#include <net_types.h>
+#include <netaddress.h>
 
 #include <QAbstractListModel>
 #include <QList>
 
 namespace interfaces { class Node; }
+
+struct BanListEntry
+{
+    CSubNet subnet;
+    CBanEntry ban_entry;
+};
 
 class BanListModel : public QAbstractListModel
 {
@@ -41,7 +48,7 @@ Q_SIGNALS:
 
 private:
     interfaces::Node& m_node;
-    QList<CCombinedBan> m_ban_list;
+    QList<BanListEntry> m_ban_list;
 };
 
 #endif // BITCOIN_QML_MODELS_BANLISTMODEL_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(bitcoinqml_unit_tests
   test_networkstyle.cpp
   test_qmlinitexecutor_api.cpp
   test_options_model.cpp
+  test_banlistmodel.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
 )
 

--- a/test/test_banlistmodel.cpp
+++ b/test/test_banlistmodel.cpp
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <QSet>
+
+#include <test/mocks/mocknode.h>
+#include <qml/models/banlistmodel.h>
+#include <util/translation.h>
+
+#include <netbase.h>
+
+#include <map>
+#include <stdexcept>
+#include <utility>
+
+namespace {
+CSubNet ParseSubnet(const std::string& subnet)
+{
+    CSubNet parsed = LookupSubNet(subnet);
+    if (!parsed.IsValid()) {
+        throw std::runtime_error("failed to parse subnet test fixture");
+    }
+    return parsed;
+}
+
+CBanEntry MakeBanEntry(int64_t ban_until)
+{
+    CBanEntry entry;
+    entry.nBanUntil = ban_until;
+    return entry;
+}
+} // namespace
+
+class BanListModelTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void refreshPopulatesRolesAndRows();
+    void unbanAtTargetsSelectedSubnet();
+    void unbanAtIgnoresInvalidRows();
+};
+
+void BanListModelTests::refreshPopulatesRolesAndRows()
+{
+    using ::testing::_;
+    using ::testing::DoAll;
+    using ::testing::NiceMock;
+    using ::testing::Return;
+    using ::testing::SetArgReferee;
+
+    banmap_t banned;
+    const CSubNet subnet_a = ParseSubnet("10.0.0.0/8");
+    const CSubNet subnet_b = ParseSubnet("127.0.0.1/32");
+    banned.emplace(subnet_a, MakeBanEntry(1'900'000'000));
+    banned.emplace(subnet_b, MakeBanEntry(2'000'000'000));
+
+    NiceMock<MockNode> node;
+    EXPECT_CALL(node, getBanned(_))
+        .Times(1)
+        .WillOnce(DoAll(SetArgReferee<0>(banned), Return(true)));
+
+    BanListModel model{node, nullptr};
+    QSignalSpy count_spy(&model, &BanListModel::countChanged);
+
+    model.refresh();
+
+    QCOMPARE(model.count(), 2);
+    QCOMPARE(model.rowCount(), 2);
+    QCOMPARE(model.rowCount(model.index(0, 0)), 0);
+    QCOMPARE(count_spy.count(), 1);
+
+    const auto roles = model.roleNames();
+    QCOMPARE(roles.value(static_cast<int>(BanListModel::BanRoles::AddressRole)), QByteArray{"address"});
+    QCOMPARE(roles.value(static_cast<int>(BanListModel::BanRoles::BanUntilRole)), QByteArray{"banUntil"});
+
+    QSet<QString> addresses;
+    for (int row = 0; row < model.rowCount(); ++row) {
+        const QModelIndex index = model.index(row, 0);
+        QVERIFY(index.isValid());
+
+        const QString address = model.data(index, static_cast<int>(BanListModel::BanRoles::AddressRole)).toString();
+        QVERIFY(!address.isEmpty());
+        addresses.insert(address);
+
+        const QString ban_until = model.data(index, static_cast<int>(BanListModel::BanRoles::BanUntilRole)).toString();
+        QVERIFY(!ban_until.isEmpty());
+    }
+
+    QVERIFY(addresses.contains(QString::fromStdString(subnet_a.ToString())));
+    QVERIFY(addresses.contains(QString::fromStdString(subnet_b.ToString())));
+}
+
+void BanListModelTests::unbanAtTargetsSelectedSubnet()
+{
+    using ::testing::_;
+    using ::testing::DoAll;
+    using ::testing::NiceMock;
+    using ::testing::Return;
+    using ::testing::SetArgReferee;
+    using ::testing::Truly;
+
+    banmap_t banned;
+    const CSubNet subnet = ParseSubnet("10.0.0.0/8");
+    banned.emplace(subnet, MakeBanEntry(1'900'000'000));
+
+    NiceMock<MockNode> node;
+    EXPECT_CALL(node, getBanned(_))
+        .Times(1)
+        .WillOnce(DoAll(SetArgReferee<0>(banned), Return(true)));
+
+    BanListModel model{node, nullptr};
+    model.refresh();
+
+    EXPECT_CALL(node, unban(Truly([&](const CSubNet& value) {
+        return value.ToString() == subnet.ToString();
+    }))).Times(1).WillOnce(Return(true));
+    model.unbanAt(0);
+}
+
+void BanListModelTests::unbanAtIgnoresInvalidRows()
+{
+    using ::testing::_;
+    using ::testing::DoAll;
+    using ::testing::NiceMock;
+    using ::testing::Return;
+    using ::testing::SetArgReferee;
+
+    banmap_t banned;
+    banned.emplace(ParseSubnet("10.0.0.0/8"), MakeBanEntry(1'900'000'000));
+
+    NiceMock<MockNode> node;
+    EXPECT_CALL(node, getBanned(_))
+        .Times(1)
+        .WillOnce(DoAll(SetArgReferee<0>(banned), Return(true)));
+
+    BanListModel model{node, nullptr};
+    model.refresh();
+
+    EXPECT_CALL(node, unban(_)).Times(0);
+    model.unbanAt(-1);
+    model.unbanAt(42);
+}
+
+int RunBanListModelTests(int argc, char* argv[])
+{
+    BanListModelTests tests;
+    return QTest::qExec(&tests, argc, argv);
+}
+
+#ifndef BITCOINQML_NO_TEST_MAIN
+QTEST_MAIN(BanListModelTests)
+#endif
+#include "test_banlistmodel.moc"

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -16,6 +16,7 @@ int RunImageProviderTests(int argc, char* argv[]);
 int RunNetworkStyleTests(int argc, char* argv[]);
 int RunQmlInitExecutorApiTests(int argc, char* argv[]);
 int RunOptionsModelTests(int argc, char* argv[]);
+int RunBanListModelTests(int argc, char* argv[]);
 
 int main(int argc, char* argv[])
 {
@@ -30,6 +31,7 @@ int main(int argc, char* argv[])
     status |= RunNetworkStyleTests(argc, argv);
     status |= RunQmlInitExecutorApiTests(argc, argv);
     status |= RunOptionsModelTests(argc, argv);
+    status |= RunBanListModelTests(argc, argv);
 
     return status;
 }


### PR DESCRIPTION
Decouples `BanListModel` from `qt/bantablemodel.h` and removes the stale `qt/guiutil.h` include from `qml/bitcoin.cpp`.

Together these remove the remaining `#include <qt/...>` references from the QML runtime source scan.

Related to #505.

Testing:
- `git grep -n -E "#include <qt/|#include <bitcoin/src/qt/|qt/guiutil|GUIUtil|qt/bantablemodel" -- qml test CMakeLists.txt || true`