### PR TITLE
Lang units settings

### DIFF
--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -59,3 +59,4 @@ jobs:
           python3 test/functional/qml_test_peers.py
           python3 test/functional/qml_test_proxy.py
           python3 test/functional/qml_test_debug_log.py
+          python3 test/functional/qml_test_settings_display.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ endif()
 set(QML_QRC "${CMAKE_CURRENT_SOURCE_DIR}/qml/bitcoin_qml.qrc")
 qt6_add_resources(QML_QRC_CPP ${QML_QRC})
 list(APPEND QML_SOURCES ${QML_QRC_CPP})
+
 list(APPEND QML_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/bitcoin/src/init/bitcoin-qt.cpp")
 
 # Build QML library
@@ -115,6 +116,49 @@ target_link_libraries(bitcoinqml
     Qt6::QuickControls2
     Qt6::Widgets
 )
+
+# Compile QML-app-specific translations (.ts → .qm) and embed as resources.
+qt6_add_translation(QML_GUI_QM_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/qml/locale/bitcoin_qml_es.ts
+)
+set_source_files_properties(${QML_GUI_QM_FILES} PROPERTIES
+    QT_RESOURCE_ALIAS "bitcoin_qml_es.qm"
+)
+qt6_add_resources(bitcoinqml "qml_gui_translations"
+    PREFIX "/translations"
+    FILES ${QML_GUI_QM_FILES}
+)
+
+# Embed bitcoin-qt translations built by the bitcoin submodule.
+# The submodule (BUILD_GUI=ON) compiles .ts → .qm files into
+# ${CMAKE_BINARY_DIR}/bitcoin/src/qt/locale/ at build time.
+# We mark each file as GENERATED so CMake does not require it to exist
+# at configure time, and add a dependency on the bitcoin-qt target so
+# the .qm files are built before the resource compiler runs.
+set(BITCOIN_LOCALE_TAGS
+    am ar ast_ES ay az@latin az be bg bn br bs ca cmn cs cy da
+    de_AT de_CH de el en eo es_CL es_CO es_DO es es_SV es_VE et eu
+    fa fil fi fo fr_CM fr_LU fr ga_IE ga gd gl_ES gl gu hak ha he hi
+    hr hu id is it ja ka kk@latin kk kl km kn ko ku_IQ ku ky la lb
+    lt lv mg mi mk ml mn mr_IN mr ms mt my nb ne nl no or pam pa pl
+    ps pt_BR pt ro ru sa sc sd si sk sl sm sn so sq
+    sr@ijekavianlatin sr@latin sr sv sw szl ta te th tk tl tn tr ug uk ur
+    uz@Cyrl uz@Latn uz ve vi yi yo yue zh_CN zh-Hans zh-Hant zh_HK zh zh_TW zu
+)
+set(BITCOIN_QT_QM_FILES)
+foreach(tag IN LISTS BITCOIN_LOCALE_TAGS)
+    set(qm_file "${CMAKE_BINARY_DIR}/bitcoin/src/qt/locale/bitcoin_${tag}.qm")
+    set_source_files_properties(${qm_file} PROPERTIES
+        GENERATED TRUE
+        QT_RESOURCE_ALIAS "bitcoin_${tag}.qm"
+    )
+    list(APPEND BITCOIN_QT_QM_FILES ${qm_file})
+endforeach()
+qt6_add_resources(bitcoinqml "bitcoin_qt_translations"
+    PREFIX "/translations"
+    FILES ${BITCOIN_QT_QM_FILES}
+)
+add_dependencies(bitcoinqml bitcoin-qt)
 
 # Put it all together
 add_executable(bitcoin-core-app main.cpp)

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -68,8 +68,10 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QQuickWindow>
+#include <QSettings>
 #include <QString>
 #include <QStyleHints>
+#include <QTranslator>
 #include <QUrl>
 
 QT_BEGIN_NAMESPACE
@@ -224,6 +226,28 @@ int QmlGuiMain(int argc, char* argv[])
     app.setOrganizationDomain(QAPP_ORG_DOMAIN);
     app.setApplicationName(QAPP_APP_NAME_DEFAULT);
 
+    // Manages translators swapped on runtime language changes.
+    // app_translator: bitcoin-qt strings (shared C++ layer)
+    // qml_translator: QML-app-specific strings
+    std::unique_ptr<QTranslator> app_translator;
+    std::unique_ptr<QTranslator> qml_translator;
+    const auto reset_translator = [](std::unique_ptr<QTranslator>& t) {
+        if (t) { QCoreApplication::removeTranslator(t.get()); t.reset(); }
+    };
+    const auto install_language = [&](const QString& lang) {
+        reset_translator(app_translator);
+        reset_translator(qml_translator);
+        if (!lang.isEmpty()) {
+            auto t = std::make_unique<QTranslator>();
+            if (t->load(QStringLiteral(":/translations/bitcoin_%1.qm").arg(lang)))
+                { QCoreApplication::installTranslator(t.get()); app_translator = std::move(t); }
+
+            auto tq = std::make_unique<QTranslator>();
+            if (tq->load(QStringLiteral(":/translations/bitcoin_qml_%1.qm").arg(lang)))
+                { QCoreApplication::installTranslator(tq.get()); qml_translator = std::move(tq); }
+        }
+    };
+
     // Parse command-line options. We do this after qt in order to show an error if there are problems parsing these.
     SetupServerArgs(gArgs, init->canListenIpc());
 
@@ -352,6 +376,27 @@ int QmlGuiMain(int argc, char* argv[])
     OptionsQmlModel options_model(*node, !need_onboarding.toBool());
     engine.rootContext()->setContextProperty("optionsModel", &options_model);
     engine.rootContext()->setContextProperty("needOnboarding", need_onboarding);
+
+    // -lang CLI flag overrides the persisted setting (bitcoin-qt compatibility).
+    // Must be after gArgs.ParseParameters() and after setupChainQSettings() so
+    // QSettings targets the correct chain-specific file.
+    // Unlike bitcoin-qt which treats -lang as session-only, this persists the
+    // selection so subsequent launches continue using the CLI-specified language.
+    // To reset to system default, use the Settings UI or pass -lang= (empty).
+    const QString cli_lang = QString::fromStdString(gArgs.GetArg("-lang", ""));
+    if (!cli_lang.isEmpty()) {
+        options_model.setLanguage(cli_lang);
+    }
+
+    // Install language before QML engine loads so that all qsTr() calls in QML
+    // pick up the correct locale from the start.
+    install_language(options_model.language());
+
+    // Retranslate the QML UI immediately when the user picks a new language.
+    QObject::connect(&options_model, &OptionsQmlModel::languageChanged, [&]() {
+        install_language(options_model.language());
+        engine.retranslate();
+    });
 
     AppMode app_mode = SetupAppMode();
     BuildInfo build_info;

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -8,8 +8,6 @@
 #include <common/init.h>
 #include <common/system.h>
 #include <chainparams.h>
-#include <common/args.h>
-#include <common/system.h>
 #include <init.h>
 #include <interfaces/chain.h>
 #include <interfaces/init.h>

--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -84,6 +84,8 @@
         <file>pages/onboarding/OnboardingStrengthen.qml</file>
         <file>pages/onboarding/OnboardingWizard.qml</file>
         <file>pages/settings/SettingsAbout.qml</file>
+        <file>pages/settings/SettingsDisplayUnit.qml</file>
+        <file>pages/settings/SettingsLanguage.qml</file>
         <file>pages/settings/SettingsBlockClockDisplayMode.qml</file>
         <file>pages/settings/SettingsConnection.qml</file>
         <file>pages/settings/SettingsDebugLog.qml</file>

--- a/qml/bitcoinamount.cpp
+++ b/qml/bitcoinamount.cpp
@@ -43,8 +43,11 @@ qint64 BitcoinAmount::satoshi() const
 void BitcoinAmount::setSatoshi(qint64 new_amount)
 {
     if (m_satoshi != new_amount || !m_isSet) {
+        const bool label_changes = (m_unit == Unit::SAT) &&
+                                   ((qAbs(m_satoshi) == 1) != (qAbs(new_amount) == 1));
         m_isSet = true;
         m_satoshi = new_amount;
+        if (label_changes) Q_EMIT unitChanged();
         Q_EMIT amountChanged();
     }
 }
@@ -54,8 +57,10 @@ void BitcoinAmount::clear()
     if (!m_isSet && m_satoshi == 0) {
         return;
     }
+    const bool label_changes = (m_unit == Unit::SAT) && (qAbs(m_satoshi) == 1);
     m_satoshi = 0;
     m_isSet = false;
+    if (label_changes) Q_EMIT unitChanged();
     Q_EMIT amountChanged();
 }
 
@@ -75,7 +80,7 @@ QString BitcoinAmount::unitLabel() const
 {
     switch (m_unit) {
     case Unit::BTC: return "₿";
-    case Unit::SAT: return "sat";
+    case Unit::SAT: return (qAbs(m_satoshi) == 1) ? QStringLiteral("sat") : QStringLiteral("sats");
     }
     assert(false);
 }

--- a/qml/components/BitcoinAmountInputField.qml
+++ b/qml/components/BitcoinAmountInputField.qml
@@ -92,13 +92,29 @@ ColumnLayout {
                 }
             }
 
-            CoreText {
+            Loader {
                 id: unitLabel
                 anchors.right: flipIcon.left
                 anchors.verticalCenter: parent.verticalCenter
-                text: root.amount ? root.amount.unitLabel : ""
-                font.pixelSize: 18
-                color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                sourceComponent: root.amount && root.amount.unit === BitcoinAmount.SAT
+                    ? satoshiIconComponent
+                    : btcTextComponent
+            }
+            Component {
+                id: btcTextComponent
+                CoreText {
+                    text: root.amount ? root.amount.unitLabel : ""
+                    font.pixelSize: 18
+                    color: root.enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                }
+            }
+            Component {
+                id: satoshiIconComponent
+                CoreText {
+                    text: "s"
+                    font.pixelSize: 18
+                    color: root.enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                }
             }
 
             Icon {

--- a/qml/components/BitcoinAmountInputField.qml
+++ b/qml/components/BitcoinAmountInputField.qml
@@ -49,7 +49,7 @@ ColumnLayout {
             color: Theme.color.neutral9
             placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
             background: Item {}
-            placeholderText: "0.00000000"
+            placeholderText: root.amount && root.amount.unit === BitcoinAmount.SAT ? "0" : "0.00000000"
             selectByMouse: true
 
             text: root.amount ? root.amount.display : ""
@@ -92,29 +92,13 @@ ColumnLayout {
                 }
             }
 
-            Loader {
+            CoreText {
                 id: unitLabel
                 anchors.right: flipIcon.left
                 anchors.verticalCenter: parent.verticalCenter
-                sourceComponent: root.amount && root.amount.unit === BitcoinAmount.SAT
-                    ? satoshiIconComponent
-                    : btcTextComponent
-            }
-            Component {
-                id: btcTextComponent
-                CoreText {
-                    text: root.amount ? root.amount.unitLabel : ""
-                    font.pixelSize: 18
-                    color: root.enabled ? Theme.color.neutral7 : Theme.color.neutral4
-                }
-            }
-            Component {
-                id: satoshiIconComponent
-                CoreText {
-                    text: "s"
-                    font.pixelSize: 18
-                    color: root.enabled ? Theme.color.neutral7 : Theme.color.neutral4
-                }
+                text: root.amount ? root.amount.unitLabel : ""
+                font.pixelSize: 18
+                color: root.enabled ? Theme.color.neutral7 : Theme.color.neutral4
             }
 
             Icon {

--- a/qml/components/BlockClock.qml
+++ b/qml/components/BlockClock.qml
@@ -226,9 +226,9 @@ Item {
             name: "CONNECTING"; when: !paused && !connected
             PropertyChanges {
                 target: root
-                header: "Connecting"
+                header: qsTr("Connecting")
                 headerSize: dial.width * (3/25)
-                subText: "Please wait"
+                subText: qsTr("Please wait")
                 estimating: false
             }
             PropertyChanges {

--- a/qml/locale/bitcoin_qml.ts
+++ b/qml/locale/bitcoin_qml.ts
@@ -2509,6 +2509,11 @@ If you find it useful, please contribute.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../walletqmlcontroller.cpp" line="286"/>
+        <source>The signer command did not return valid output. Check that the path is correct.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../walletqmlcontroller.cpp" line="317"/>
         <source>This wallet needs to be migrated</source>
         <translation type="unfinished"></translation>

--- a/qml/locale/bitcoin_qml.ts
+++ b/qml/locale/bitcoin_qml.ts
@@ -24,12 +24,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/AboutOptions.qml" line="68"/>
+        <location filename="../components/AboutOptions.qml" line="69"/>
         <source>Developer options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/AboutOptions.qml" line="69"/>
+        <location filename="../components/AboutOptions.qml" line="70"/>
         <source>Only use these if you have development experience</source>
         <translation type="unfinished"></translation>
     </message>
@@ -37,7 +37,7 @@
 <context>
     <name>Activity</name>
     <message>
-        <location filename="../pages/wallet/Activity.qml" line="54"/>
+        <location filename="../pages/wallet/Activity.qml" line="55"/>
         <source>Activity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -45,33 +45,58 @@
 <context>
     <name>ActivityDetails</name>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="55"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="60"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="66"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="71"/>
         <source>Transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="129"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="135"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="138"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="144"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="148"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="154"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="163"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="169"/>
         <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="210"/>
+        <source>This transaction is still unconfirmed. You can speed it up by increasing the fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="211"/>
+        <source>Speed up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="226"/>
+        <source>This transaction was updated with a faster one</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="227"/>
+        <source>You increased the fee while this transaction was still unconfirmed. Only the new one will confirm on-chain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="228"/>
+        <source>View updated transaction</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -117,6 +142,14 @@
     </message>
 </context>
 <context>
+    <name>BitcoinAddressDisplayField</name>
+    <message>
+        <location filename="../components/BitcoinAddressDisplayField.qml" line="14"/>
+        <source>Send to</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BitcoinAddressInputField</name>
     <message>
         <location filename="../components/BitcoinAddressInputField.qml" line="17"/>
@@ -124,8 +157,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BitcoinAddressInputField.qml" line="47"/>
+        <location filename="../components/BitcoinAddressInputField.qml" line="50"/>
         <source>Enter address...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinAmountDisplayField</name>
+    <message>
+        <location filename="../components/BitcoinAmountDisplayField.qml" line="14"/>
+        <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -170,6 +211,39 @@
     <message>
         <location filename="../components/BlockClockDisplayMode.qml" line="35"/>
         <source>A larger block clock for public display on a tablet or other large screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BumpTransactionModel</name>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="72"/>
+        <source>No wallet available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="78"/>
+        <source>Invalid transaction ID.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="95"/>
+        <source>Failed to create bump transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="117"/>
+        <source>Transaction can no longer be bumped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="122"/>
+        <source>Failed to sign transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="129"/>
+        <source>Failed to commit transaction.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -257,7 +331,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ConnectionSettings.qml" line="57"/>
+        <location filename="../components/ConnectionSettings.qml" line="58"/>
         <source>Proxy settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -265,28 +339,23 @@
 <context>
     <name>CreateBackup</name>
     <message>
-        <location filename="../pages/wallet/CreateBackup.qml" line="23"/>
-        <source>Back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/CreateBackup.qml" line="59"/>
+        <location filename="../pages/wallet/CreateBackup.qml" line="52"/>
         <source>Back up your wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateBackup.qml" line="61"/>
+        <location filename="../pages/wallet/CreateBackup.qml" line="54"/>
         <source>Your wallet is a file stored on your hard disk.
 To prevent accidental loss, it is recommended you keep a copy of your wallet file in a secure place, like a dedicated USB Drive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateBackup.qml" line="70"/>
+        <location filename="../pages/wallet/CreateBackup.qml" line="64"/>
         <source>View file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateBackup.qml" line="86"/>
+        <location filename="../pages/wallet/CreateBackup.qml" line="81"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
@@ -294,56 +363,94 @@ To prevent accidental loss, it is recommended you keep a copy of your wallet fil
 <context>
     <name>CreateConfirm</name>
     <message>
-        <location filename="../pages/wallet/CreateConfirm.qml" line="23"/>
-        <source>Back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/CreateConfirm.qml" line="59"/>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="19"/>
         <source>Your wallet has been created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateConfirm.qml" line="61"/>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="20"/>
         <source>It is good practice to make a small test transaction before you actively use this wallet for larger amounts.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateConfirm.qml" line="70"/>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="21"/>
         <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CreateExternalWallet</name>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="35"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="60"/>
+        <source>Create an external wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="65"/>
+        <source>Connected signer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="66"/>
+        <source>Connect one external signer to continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="76"/>
+        <source>This wallet stores public descriptors and uses your external signer device for signing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="87"/>
+        <source>Eg. hardware_wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="119"/>
+        <source>Creating wallet with the connected signer...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="133"/>
+        <source>Creating wallet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="133"/>
+        <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CreateIntro</name>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="23"/>
-        <source>Back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="58"/>
+        <location filename="../pages/wallet/CreateIntro.qml" line="52"/>
         <source>You are about to create 
 a single-key bitcoin wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="67"/>
+        <location filename="../pages/wallet/CreateIntro.qml" line="61"/>
         <source>You can fully control it in this application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="83"/>
+        <location filename="../pages/wallet/CreateIntro.qml" line="77"/>
         <source>Wallet data will be stored locally on your hard drive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="99"/>
+        <location filename="../pages/wallet/CreateIntro.qml" line="93"/>
         <source>You can optionally protect it with a password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="110"/>
+        <location filename="../pages/wallet/CreateIntro.qml" line="105"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -351,35 +458,40 @@ a single-key bitcoin wallet</source>
 <context>
     <name>CreateName</name>
     <message>
-        <location filename="../pages/wallet/CreateName.qml" line="24"/>
-        <source>Back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/CreateName.qml" line="41"/>
+        <location filename="../pages/wallet/CreateName.qml" line="47"/>
         <source>Choose a wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateName.qml" line="51"/>
+        <location filename="../pages/wallet/CreateName.qml" line="50"/>
+        <source>This wallet will use the connected external signer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="62"/>
+        <source>Eg. Hardware wallet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="63"/>
         <source>Eg. My bitcoin wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateName.qml" line="65"/>
+        <location filename="../pages/wallet/CreateName.qml" line="90"/>
         <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="90"/>
+        <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CreatePassword</name>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="25"/>
-        <source>Back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="31"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="28"/>
         <source>Skip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -395,27 +507,27 @@ a single-key bitcoin wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="70"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="71"/>
         <source>Enter password...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="78"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="80"/>
         <source>Confirm password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="86"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="89"/>
         <source>Enter password again...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="94"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="98"/>
         <source>I understand that if I lose or forget this password I might lose access to the bitcoin stored in this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="109"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="123"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -423,60 +535,115 @@ a single-key bitcoin wallet</source>
 <context>
     <name>CreateWalletWizard</name>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="31"/>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="39"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="47"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="34"/>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="50"/>
         <source>Skip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="60"/>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="76"/>
         <source>Add a wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="62"/>
-        <source>In this early stage of development, only wallet.dat files are supported.</source>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="79"/>
+        <source>Supported wallet types are external signer, view-only, single-key,
+and multi-key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="72"/>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="80"/>
+        <source>Supported wallet types are view-only, single-key,
+and multi-key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="91"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="83"/>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="103"/>
         <source>Import wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="125"/>
+        <source>Create external wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="126"/>
+        <source>Create hardware wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="155"/>
+        <source>No external signer is currently detected. Open Wallet settings to verify the signer path and rescan.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="218"/>
+        <source>Your external wallet has been created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="219"/>
+        <source>This wallet uses the connected external signer for addresses and signing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="220"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebugLogModel</name>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="127"/>
+        <source>Debug log file not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="133"/>
+        <source>Could not open debug log file. No application is associated with this file type.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DesktopWallets</name>
     <message>
-        <location filename="../pages/wallet/DesktopWallets.qml" line="66"/>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="74"/>
         <source>Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/DesktopWallets.qml" line="71"/>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="80"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/DesktopWallets.qml" line="76"/>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="86"/>
         <source>Receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/DesktopWallets.qml" line="110"/>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="120"/>
         <source>Paused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/DesktopWallets.qml" line="116"/>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="126"/>
         <source>Connecting</source>
         <translation type="unfinished"></translation>
     </message>
@@ -484,27 +651,27 @@ a single-key bitcoin wallet</source>
 <context>
     <name>DeveloperOptions</name>
     <message>
-        <location filename="../components/DeveloperOptions.qml" line="15"/>
+        <location filename="../components/DeveloperOptions.qml" line="16"/>
         <source>Database cache size (MiB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DeveloperOptions.qml" line="16"/>
+        <location filename="../components/DeveloperOptions.qml" line="17"/>
         <source>This is not a valid cache size. Please choose a value between %1 and %2 MiB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DeveloperOptions.qml" line="40"/>
+        <location filename="../components/DeveloperOptions.qml" line="41"/>
         <source>Script verification threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DeveloperOptions.qml" line="41"/>
+        <location filename="../components/DeveloperOptions.qml" line="42"/>
         <source>This is not a valid thread count. Please choose a value between %1 and %2 threads.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DeveloperOptions.qml" line="64"/>
+        <location filename="../components/DeveloperOptions.qml" line="65"/>
         <source>Dark Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -533,40 +700,187 @@ a single-key bitcoin wallet</source>
     </message>
 </context>
 <context>
+    <name>ExternalSignerReviewActions</name>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="21"/>
+        <source>Signed on external signer. Ready to send.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="22"/>
+        <source>Waiting for approval on external signer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="24"/>
+        <source>Approve on external signer to broadcast this transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="32"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="33"/>
+        <source>Waiting for approval...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="34"/>
+        <source>Retry external signer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="35"/>
+        <source>Approve on external signer</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FeeSelection</name>
     <message>
-        <location filename="../components/FeeSelection.qml" line="27"/>
+        <location filename="../components/FeeSelection.qml" line="24"/>
+        <location filename="../components/FeeSelection.qml" line="391"/>
+        <source>sats/vbyte</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="60"/>
+        <location filename="../components/FeeSelection.qml" line="162"/>
         <source>Fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="202"/>
+        <location filename="../components/FeeSelection.qml" line="60"/>
+        <source>Fee Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="363"/>
+        <source>Include fee in amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="388"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="202"/>
+        <location filename="../components/FeeSelection.qml" line="388"/>
         <source>(~10 mins)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="203"/>
+        <location filename="../components/FeeSelection.qml" line="389"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="203"/>
+        <location filename="../components/FeeSelection.qml" line="389"/>
+        <source>(~20 mins)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="390"/>
         <source>(~60 mins)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="204"/>
+        <location filename="../components/FeeSelection.qml" line="390"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="204"/>
-        <source>(~24 hrs)</source>
+        <location filename="../components/FeeSelection.qml" line="391"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImportWalletOptions</name>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="31"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="36"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="44"/>
+        <source>Wallet backup files (*.bak *.dat)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="44"/>
+        <source>All files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="102"/>
+        <source>Import wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="119"/>
+        <source>Importing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="119"/>
+        <source>Choose a wallet file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="221"/>
+        <source>Choose another file</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImportWalletSuccess</name>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="25"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="59"/>
+        <source>Import complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="62"/>
+        <source>Your wallet was added successfully. We recommend running a health check to make sure that everything works as expected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="81"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="87"/>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="108"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="102"/>
+        <source>Key scheme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="128"/>
+        <source>Go to wallet overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="136"/>
+        <source>View in settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -596,28 +910,51 @@ a single-key bitcoin wallet</source>
 <context>
     <name>MultipleSendReview</name>
     <message>
-        <location filename="../pages/wallet/MultipleSendReview.qml" line="28"/>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="40"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/MultipleSendReview.qml" line="52"/>
-        <source>Transaction details</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/MultipleSendReview.qml" line="102"/>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="253"/>
         <source>Total amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/MultipleSendReview.qml" line="124"/>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="239"/>
         <source>Fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/MultipleSendReview.qml" line="147"/>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="22"/>
+        <source>There is 1 recipient.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="23"/>
+        <source>There are %1 recipients.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="40"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="69"/>
+        <source>Review transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="278"/>
         <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NavigationBar2</name>
+    <message>
+        <location filename="../controls/NavigationBar2.qml" line="16"/>
+        <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -710,43 +1047,53 @@ a single-key bitcoin wallet</source>
 <context>
     <name>NodeSettings</name>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="25"/>
+        <location filename="../pages/node/NodeSettings.qml" line="41"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="29"/>
+        <location filename="../pages/node/NodeSettings.qml" line="45"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="44"/>
+        <location filename="../pages/node/NodeSettings.qml" line="61"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="57"/>
+        <location filename="../pages/node/NodeSettings.qml" line="74"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="69"/>
+        <location filename="../pages/node/NodeSettings.qml" line="86"/>
         <source>Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="81"/>
+        <location filename="../pages/node/NodeSettings.qml" line="100"/>
+        <source>External Signer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="116"/>
         <source>Connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="94"/>
+        <location filename="../pages/node/NodeSettings.qml" line="129"/>
         <source>Peers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="107"/>
+        <location filename="../pages/node/NodeSettings.qml" line="142"/>
         <source>Network Traffic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="155"/>
+        <source>Debug Log</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -795,12 +1142,12 @@ This may take several hours, or even days, based on your connection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/onboarding/OnboardingConnection.qml" line="50"/>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="51"/>
         <source>Connection settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/onboarding/OnboardingConnection.qml" line="55"/>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="56"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
@@ -911,6 +1258,24 @@ Users running nodes is what makes bitcoin so resilient and trustworthy.</source>
     <message>
         <location filename="../controls/OptionButton.qml" line="83"/>
         <source>Recommended</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OptionsQmlModel</name>
+    <message>
+        <location filename="../models/options_model.cpp" line="321"/>
+        <source>The configured signer path does not exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/options_model.cpp" line="324"/>
+        <source>The configured signer path is not a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/options_model.cpp" line="327"/>
+        <source>The configured signer path is not executable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1224,17 +1589,17 @@ Users running nodes is what makes bitcoin so resilient and trustworthy.</source>
     </message>
     <message>
         <location filename="../components/ProxySettings.qml" line="30"/>
-        <location filename="../components/ProxySettings.qml" line="81"/>
+        <location filename="../components/ProxySettings.qml" line="96"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProxySettings.qml" line="70"/>
+        <location filename="../components/ProxySettings.qml" line="85"/>
         <source>Tor Proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProxySettings.qml" line="72"/>
+        <location filename="../components/ProxySettings.qml" line="87"/>
         <source>Run Tor connections through a dedicated proxy.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1242,8 +1607,7 @@ Users running nodes is what makes bitcoin so resilient and trustworthy.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../pages/settings/SettingsDisplay.qml" line="98"/>
-        <location filename="../models/options_model.cpp" line="239"/>
+        <location filename="../models/options_model.cpp" line="437"/>
         <source>System default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1377,58 +1741,96 @@ Users running nodes is what makes bitcoin so resilient and trustworthy.</source>
         <source>%1 GB</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="171"/>
+        <source>Could not open debug log file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="172"/>
+        <source>Debug log file not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="391"/>
+        <source>just now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="392"/>
+        <source>%1 min ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="393"/>
+        <source>%1 hr ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="394"/>
+        <source>%1 d ago</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RequestPayment</name>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="32"/>
-        <location filename="../pages/wallet/RequestPayment.qml" line="221"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="40"/>
         <source>Request a payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="138"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="139"/>
-        <source>Enter label...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="149"/>
-        <source>Message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="150"/>
-        <source>Enter message...</source>
+        <location filename="../pages/wallet/RequestPayment.qml" line="70"/>
+        <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/wallet/RequestPayment.qml" line="168"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="169"/>
+        <source>Enter label...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="185"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="186"/>
+        <source>Enter message...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="210"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="177"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="219"/>
         <source>copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="204"/>
-        <location filename="../pages/wallet/RequestPayment.qml" line="224"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="275"/>
         <source>Create bitcoin address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="214"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="274"/>
         <source>Copy payment request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="238"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="39"/>
+        <source>Payment request #</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="299"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,45 +1838,65 @@ Users running nodes is what makes bitcoin so resilient and trustworthy.</source>
 <context>
     <name>Send</name>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="97"/>
+        <location filename="../pages/wallet/Send.qml" line="132"/>
         <source>Send bitcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="132"/>
+        <location filename="../pages/wallet/Send.qml" line="167"/>
+        <source>Make sure you have your external signer at hand to approve this transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="183"/>
         <source>Recipient %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="211"/>
+        <location filename="../pages/wallet/Send.qml" line="273"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="298"/>
+        <location filename="../pages/wallet/Send.qml" line="377"/>
         <source>Note to self</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="299"/>
+        <location filename="../pages/wallet/Send.qml" line="378"/>
         <source>Enter ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="337"/>
+        <location filename="../pages/wallet/Send.qml" line="440"/>
+        <source>Fee is included in the amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="477"/>
         <source>Review</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="477"/>
+        <source>Review transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="485"/>
+        <source>Amount plus fee exceeds available balance</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SendOptionsPopup</name>
     <message>
-        <location filename="../controls/SendOptionsPopup.qml" line="34"/>
+        <location filename="../controls/SendOptionsPopup.qml" line="36"/>
         <source>Enable Coin control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../controls/SendOptionsPopup.qml" line="45"/>
+        <location filename="../controls/SendOptionsPopup.qml" line="48"/>
         <source>Multiple Recipients</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1482,32 +1904,32 @@ Users running nodes is what makes bitcoin so resilient and trustworthy.</source>
 <context>
     <name>SendRecipient</name>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="117"/>
+        <location filename="../models/sendrecipient.cpp" line="125"/>
         <source>Address is valid for mainnet, not the current network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="119"/>
+        <location filename="../models/sendrecipient.cpp" line="127"/>
         <source>Address is valid for testnet, not the current network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="121"/>
+        <location filename="../models/sendrecipient.cpp" line="129"/>
         <source>Invalid address format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="134"/>
+        <location filename="../models/sendrecipient.cpp" line="142"/>
         <source>Amount must be greater than zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="136"/>
+        <location filename="../models/sendrecipient.cpp" line="144"/>
         <source>Amount exceeds maximum limit of 21,000,000 BTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="138"/>
+        <location filename="../models/sendrecipient.cpp" line="146"/>
         <source>Amount exceeds available balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1515,60 +1937,75 @@ Users running nodes is what makes bitcoin so resilient and trustworthy.</source>
 <context>
     <name>SendResult</name>
     <message>
-        <location filename="../pages/wallet/SendResult.qml" line="56"/>
-        <source>Transaction sent</source>
+        <location filename="../pages/wallet/SendResult.qml" line="64"/>
+        <source>Transaction updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/wallet/SendResult.qml" line="65"/>
+        <source>Transaction sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="17"/>
         <source>Based on your selected fee, it should be confirmed within the next 10 minutes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendResult.qml" line="74"/>
-        <source>Close window</source>
+        <location filename="../pages/wallet/SendResult.qml" line="86"/>
+        <source>View new transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="87"/>
+        <source>View transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="18"/>
+        <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SendReview</name>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="28"/>
+        <location filename="../pages/wallet/SendReview.qml" line="37"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="52"/>
-        <source>Transaction details</source>
+        <location filename="../pages/wallet/SendReview.qml" line="37"/>
+        <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="59"/>
-        <source>Send to</source>
+        <location filename="../pages/wallet/SendReview.qml" line="62"/>
+        <source>Review transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="73"/>
+        <location filename="../pages/wallet/SendReview.qml" line="80"/>
         <source>Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="87"/>
+        <location filename="../pages/wallet/SendReview.qml" line="89"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="101"/>
+        <location filename="../pages/wallet/SendReview.qml" line="98"/>
         <source>Fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="115"/>
-        <source>Total</source>
+        <location filename="../pages/wallet/SendReview.qml" line="112"/>
+        <source>Total amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="131"/>
+        <location filename="../pages/wallet/SendReview.qml" line="137"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1576,13 +2013,13 @@ Users running nodes is what makes bitcoin so resilient and trustworthy.</source>
 <context>
     <name>SettingsAbout</name>
     <message>
-        <location filename="../pages/settings/SettingsAbout.qml" line="18"/>
-        <location filename="../pages/settings/SettingsAbout.qml" line="59"/>
+        <location filename="../pages/settings/SettingsAbout.qml" line="19"/>
+        <location filename="../pages/settings/SettingsAbout.qml" line="60"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsAbout.qml" line="20"/>
+        <location filename="../pages/settings/SettingsAbout.qml" line="21"/>
         <source>Bitcoin Core is an open source project.
 If you find it useful, please contribute.
 
@@ -1590,7 +2027,7 @@ If you find it useful, please contribute.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsAbout.qml" line="50"/>
+        <location filename="../pages/settings/SettingsAbout.qml" line="51"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1622,25 +2059,91 @@ If you find it useful, please contribute.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsConnection.qml" line="78"/>
+        <location filename="../pages/settings/SettingsConnection.qml" line="79"/>
         <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDebugLog</name>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="52"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="161"/>
+        <source>Search...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="162"/>
+        <source>Search debug log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="215"/>
+        <source>1 new entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="216"/>
+        <source>%1 new entries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="285"/>
+        <source>Debug log entries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="307"/>
+        <source>Load more</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDesignSystem</name>
+    <message>
+        <location filename="../pages/settings/SettingsDesignSystem.qml" line="50"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDesignSystem.qml" line="56"/>
+        <source>Design system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDesignSystem.qml" line="78"/>
+        <source>Typography</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDesignSystem.qml" line="121"/>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDesignSystem.qml" line="127"/>
+        <source>Palette tokens for the active theme. Toggle Theme to compare.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingsDeveloper</name>
     <message>
-        <location filename="../pages/settings/SettingsDeveloper.qml" line="16"/>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="17"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDeveloper.qml" line="24"/>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="25"/>
         <source>Developer options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDeveloper.qml" line="51"/>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="52"/>
         <source>Developer settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1668,17 +2171,17 @@ If you find it useful, please contribute.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplay.qml" line="71"/>
-        <source>Ask before opening links</source>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="90"/>
+        <source>System default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplay.qml" line="83"/>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="72"/>
         <source>Display unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplay.qml" line="97"/>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="86"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1696,22 +2199,22 @@ If you find it useful, please contribute.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="49"/>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="44"/>
         <source>BTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="50"/>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="45"/>
         <source>8 decimal places (0.00000001 BTC = 1 sat)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="59"/>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="53"/>
         <source>sat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="60"/>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="54"/>
         <source>Satoshi, the smallest unit (1 sat = 0.00000001 BTC)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1737,13 +2240,18 @@ If you find it useful, please contribute.
 <context>
     <name>SettingsProxy</name>
     <message>
-        <location filename="../pages/settings/SettingsProxy.qml" line="21"/>
+        <location filename="../pages/settings/SettingsProxy.qml" line="25"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsProxy.qml" line="27"/>
+        <location filename="../pages/settings/SettingsProxy.qml" line="31"/>
         <source>Proxy Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsProxy.qml" line="74"/>
+        <source>Restart the application for these changes to take effect.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1773,13 +2281,26 @@ If you find it useful, please contribute.
 <context>
     <name>SettingsTheme</name>
     <message>
-        <location filename="../pages/settings/SettingsTheme.qml" line="24"/>
+        <location filename="../pages/settings/SettingsTheme.qml" line="25"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsTheme.qml" line="30"/>
+        <location filename="../pages/settings/SettingsTheme.qml" line="31"/>
         <source>Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWallet</name>
+    <message>
+        <location filename="../pages/settings/SettingsWallet.qml" line="24"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsWallet.qml" line="30"/>
+        <source>External Signer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1793,6 +2314,39 @@ If you find it useful, please contribute.
     <message>
         <location filename="../pages/node/Shutdown.qml" line="31"/>
         <source>Do not shut down the computer until this is done.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SpeedUpOverlay</name>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="75"/>
+        <source>Speed up transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="87"/>
+        <source>Set a higher transaction fee if you want your transaction to be confirmed faster.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="96"/>
+        <source>Original fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="119"/>
+        <source>New fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="149"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="157"/>
+        <source>Update transaction</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1878,34 +2432,272 @@ If you find it useful, please contribute.
 <context>
     <name>ThemeSettings</name>
     <message>
-        <location filename="../components/ThemeSettings.qml" line="21"/>
+        <location filename="../components/ThemeSettings.qml" line="24"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ThemeSettings.qml" line="36"/>
+        <location filename="../components/ThemeSettings.qml" line="39"/>
         <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ThemeSettings.qml" line="60"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ThemeSettings.qml" line="70"/>
+        <source>Design system</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WalletBadge</name>
     <message>
-        <location filename="../pages/wallet/WalletBadge.qml" line="101"/>
+        <location filename="../pages/wallet/WalletBadge.qml" line="102"/>
         <source>Add Wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/wallet/WalletBadge.qml" line="101"/>
+        <location filename="../pages/wallet/WalletBadge.qml" line="102"/>
         <source>Select Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/WalletBadge.qml" line="147"/>
+        <source>sat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/WalletBadge.qml" line="147"/>
+        <source>sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WalletQmlController</name>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="163"/>
+        <location filename="../walletqmlcontroller.cpp" line="223"/>
+        <source>Wallet creation failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="176"/>
+        <source>Choose a wallet name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="182"/>
+        <source>Set an external signer path in Wallet settings first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="190"/>
+        <source>Connect an external signer and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="194"/>
+        <source>More than one external signer was found. Connect only one device and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="283"/>
+        <source>More than one external signer was found. Connect only one device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="317"/>
+        <source>This wallet needs to be migrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="320"/>
+        <source>We couldn&apos;t find that file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="323"/>
+        <source>A wallet with this name already exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="326"/>
+        <source>This wallet type is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="328"/>
+        <source>This wallet couldn&apos;t be imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="339"/>
+        <source>The selected backup appears to come from a legacy wallet format. It needs to be migrated before it can be used here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="342"/>
+        <source>The selected file is no longer available at that location. Choose the backup file again and retry.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="345"/>
+        <source>Importing this backup would create a wallet that already exists in your wallet directory. Remove or rename the existing wallet first, then try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="348"/>
+        <source>The file looks like a wallet backup, but this application could not verify or open it in a supported format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="350"/>
+        <source>The selected file could not be restored as a wallet. Check that it is a valid wallet backup, then try another file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="361"/>
+        <source>If this is a legacy wallet backup, migrate it with the wallet migration tool before importing it here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="485"/>
+        <source>Choose a wallet backup file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="490"/>
+        <source>The selected wallet path does not exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="519"/>
+        <source>Wallet import failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="635"/>
+        <source>Choose a wallet to open.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="644"/>
+        <location filename="../walletqmlcontroller.cpp" line="698"/>
+        <source>The selected wallet is not available in the wallet directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="674"/>
+        <source>Wallet could not be opened.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="691"/>
+        <source>Choose a wallet to update.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="713"/>
+        <source>Wallet update failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="771"/>
+        <location filename="../walletqmlcontroller.cpp" line="786"/>
+        <source>Single-key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="776"/>
+        <source>External signer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="779"/>
+        <source>Watch-only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="783"/>
+        <source>Multi-key</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WalletQmlModel</name>
+    <message>
+        <location filename="../models/walletqmlmodel.cpp" line="736"/>
+        <source>External signer not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/walletqmlmodel.cpp" line="742"/>
+        <location filename="../models/walletqmlmodel.cpp" line="756"/>
+        <source>Couldn&apos;t prepare transaction for external signing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/walletqmlmodel.cpp" line="768"/>
+        <source>External signer not found. Connect one device and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/walletqmlmodel.cpp" line="771"/>
+        <source>External signer failed to sign. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WalletSelect</name>
     <message>
-        <location filename="../pages/wallet/WalletSelect.qml" line="59"/>
+        <location filename="../pages/wallet/WalletSelect.qml" line="60"/>
         <source>Wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WalletSettings</name>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="33"/>
+        <source>Signer path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="43"/>
+        <source>Enter external signer path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="65"/>
+        <source>The add wallet flow can offer external wallets when exactly one supported signer is connected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="108"/>
+        <source>Detected external signer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="114"/>
+        <source>Path updated. Press Check device to rescan with the current signer command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="117"/>
+        <source>No external signer is currently detected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="119"/>
+        <source>Set the command path for HWI or another external signer tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="130"/>
+        <source>Check device</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1927,6 +2719,30 @@ If you find it useful, please contribute.
     <message>
         <location filename="../pages/main.qml" line="18"/>
         <source>Bitcoin Core App</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/main.qml" line="119"/>
+        <location filename="../pages/main.qml" line="137"/>
+        <source>Approved on external signer. It should be confirmed within the next 10 minutes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/main.qml" line="120"/>
+        <location filename="../pages/main.qml" line="138"/>
+        <source>Based on your selected fee, it should be confirmed within the next 10 minutes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/main.qml" line="121"/>
+        <location filename="../pages/main.qml" line="139"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/main.qml" line="121"/>
+        <location filename="../pages/main.qml" line="139"/>
+        <source>Close window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/qml/locale/bitcoin_qml.ts
+++ b/qml/locale/bitcoin_qml.ts
@@ -1,0 +1,1933 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>AboutOptions</name>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="17"/>
+        <source>Website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="29"/>
+        <source>Source code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="41"/>
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="53"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="68"/>
+        <source>Developer options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="69"/>
+        <source>Only use these if you have development experience</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Activity</name>
+    <message>
+        <location filename="../pages/wallet/Activity.qml" line="54"/>
+        <source>Activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ActivityDetails</name>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="55"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="66"/>
+        <source>Transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="129"/>
+        <source>%1 confirmations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="138"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="148"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="163"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AddWalletButton</name>
+    <message>
+        <location filename="../controls/AddWalletButton.qml" line="49"/>
+        <source>Add Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BannedPeers</name>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="22"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="28"/>
+        <source>Banned peers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="48"/>
+        <source>You banned these peers from connecting to your node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="87"/>
+        <source>Until %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="97"/>
+        <source>Unban</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="110"/>
+        <source>No banned peers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinAddressInputField</name>
+    <message>
+        <location filename="../components/BitcoinAddressInputField.qml" line="17"/>
+        <source>Send to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BitcoinAddressInputField.qml" line="47"/>
+        <source>Enter address...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinAmountInputField</name>
+    <message>
+        <location filename="../components/BitcoinAmountInputField.qml" line="17"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BlockClock</name>
+    <message>
+        <location filename="../components/BlockClock.qml" line="229"/>
+        <source>Connecting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BlockClock.qml" line="231"/>
+        <source>Please wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BlockClockDisplayMode</name>
+    <message>
+        <location filename="../components/BlockClockDisplayMode.qml" line="22"/>
+        <source>Compact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BlockClockDisplayMode.qml" line="23"/>
+        <source>For personal use on a computer or smartphone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BlockClockDisplayMode.qml" line="34"/>
+        <source>Showcase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BlockClockDisplayMode.qml" line="35"/>
+        <source>A larger block clock for public display on a tablet or other large screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelection</name>
+    <message>
+        <location filename="../pages/wallet/CoinSelection.qml" line="25"/>
+        <source>Coin Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CoinSelection.qml" line="28"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CoinSelection.qml" line="55"/>
+        <source>Total selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CoinSelection.qml" line="76"/>
+        <source>Over required amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CoinSelection.qml" line="78"/>
+        <source>Remaining to select</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionOptions</name>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="18"/>
+        <source>Fast always on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="19"/>
+        <source>Loads quickly at all times and uses as much cellular data as needed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="26"/>
+        <source>Slow always on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="27"/>
+        <source>Loads at all times with reduced cellular data usage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="32"/>
+        <source>Only when on Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="33"/>
+        <source>Loads quickly when on wi-fi and pauses when on cellular data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionSettings</name>
+    <message>
+        <location filename="../components/ConnectionSettings.qml" line="16"/>
+        <source>Enable listening</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionSettings.qml" line="17"/>
+        <source>Allows incoming connections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionSettings.qml" line="30"/>
+        <source>Map port using NAT-PMP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionSettings.qml" line="43"/>
+        <source>Enable RPC server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionSettings.qml" line="57"/>
+        <source>Proxy settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CreateBackup</name>
+    <message>
+        <location filename="../pages/wallet/CreateBackup.qml" line="23"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateBackup.qml" line="59"/>
+        <source>Back up your wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateBackup.qml" line="61"/>
+        <source>Your wallet is a file stored on your hard disk.
+To prevent accidental loss, it is recommended you keep a copy of your wallet file in a secure place, like a dedicated USB Drive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateBackup.qml" line="70"/>
+        <source>View file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateBackup.qml" line="86"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CreateConfirm</name>
+    <message>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="23"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="59"/>
+        <source>Your wallet has been created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="61"/>
+        <source>It is good practice to make a small test transaction before you actively use this wallet for larger amounts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="70"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CreateIntro</name>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="23"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="58"/>
+        <source>You are about to create 
+a single-key bitcoin wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="67"/>
+        <source>You can fully control it in this application.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="83"/>
+        <source>Wallet data will be stored locally on your hard drive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="99"/>
+        <source>You can optionally protect it with a password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="110"/>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CreateName</name>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="24"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="41"/>
+        <source>Choose a wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="51"/>
+        <source>Eg. My bitcoin wallet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="65"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CreatePassword</name>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="25"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="31"/>
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="48"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="59"/>
+        <source>Choose a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="50"/>
+        <source>It is recommended to set a password to protect your wallet file from unwanted access from others.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="70"/>
+        <source>Enter password...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="78"/>
+        <source>Confirm password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="86"/>
+        <source>Enter password again...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="94"/>
+        <source>I understand that if I lose or forget this password I might lose access to the bitcoin stored in this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="109"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletWizard</name>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="31"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="34"/>
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="60"/>
+        <source>Add a wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="62"/>
+        <source>In this early stage of development, only wallet.dat files are supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="72"/>
+        <source>Create wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="83"/>
+        <source>Import wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DesktopWallets</name>
+    <message>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="66"/>
+        <source>Activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="71"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="76"/>
+        <source>Receive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="110"/>
+        <source>Paused</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="116"/>
+        <source>Connecting</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeveloperOptions</name>
+    <message>
+        <location filename="../components/DeveloperOptions.qml" line="15"/>
+        <source>Database cache size (MiB)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DeveloperOptions.qml" line="16"/>
+        <source>This is not a valid cache size. Please choose a value between %1 and %2 MiB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DeveloperOptions.qml" line="40"/>
+        <source>Script verification threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DeveloperOptions.qml" line="41"/>
+        <source>This is not a valid thread count. Please choose a value between %1 and %2 threads.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DeveloperOptions.qml" line="64"/>
+        <source>Dark Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExternalPopup</name>
+    <message>
+        <location filename="../components/ExternalPopup.qml" line="31"/>
+        <source>External Link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalPopup.qml" line="46"/>
+        <source>Do you want to open the following website in your browser?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalPopup.qml" line="62"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalPopup.qml" line="69"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FeeSelection</name>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="27"/>
+        <source>Fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="202"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="202"/>
+        <source>(~10 mins)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="203"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="203"/>
+        <source>(~60 mins)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="204"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="204"/>
+        <source>(~24 hrs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LabeledCoinControlButton</name>
+    <message>
+        <location filename="../controls/LabeledCoinControlButton.qml" line="25"/>
+        <source>Inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../controls/LabeledCoinControlButton.qml" line="36"/>
+        <source>No coins available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../controls/LabeledCoinControlButton.qml" line="38"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../controls/LabeledCoinControlButton.qml" line="40"/>
+        <source>%1 input%2 selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultipleSendReview</name>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="28"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="52"/>
+        <source>Transaction details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="102"/>
+        <source>Total amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="124"/>
+        <source>Fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="147"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkIndicator</name>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="52"/>
+        <source>Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="52"/>
+        <source>Test Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="61"/>
+        <source>Signet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="61"/>
+        <source>Signet Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="70"/>
+        <source>Regtest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="70"/>
+        <source>Regtest Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkTraffic</name>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="24"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="30"/>
+        <source>Network traffic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="34"/>
+        <source>Network Traffic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="36"/>
+        <source>How much data you have sent to and received from your peers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="62"/>
+        <source>5 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="78"/>
+        <source>1 hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="94"/>
+        <source>12 hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="110"/>
+        <source>1 day</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="129"/>
+        <source>Received: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="149"/>
+        <source>Sent: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NodeSettings</name>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="25"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="29"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="44"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="57"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="69"/>
+        <source>Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="81"/>
+        <source>Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="94"/>
+        <source>Peers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="107"/>
+        <source>Network Traffic</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingBlockclock</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingBlockclock.qml" line="16"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingBlockclock.qml" line="25"/>
+        <source>The block clock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingBlockclock.qml" line="26"/>
+        <source>The Bitcoin network targets a new block every 10 minutes. Sometimes it&apos;s faster and sometimes slower.
+
+The block clock indicates each block on a dial that represents the current day.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingBlockclock.qml" line="29"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingConnection</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="30"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="41"/>
+        <source>Starting initial download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="43"/>
+        <source>The application will connect to the Bitcoin network and start downloading and verifying transactions.
+
+This may take several hours, or even days, based on your connection.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="50"/>
+        <source>Connection settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="55"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingCover</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingCover.qml" line="47"/>
+        <source>Bitcoin Core App</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingCover.qml" line="49"/>
+        <source>Be part of the Bitcoin network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingCover.qml" line="52"/>
+        <source>100% open-source &amp; open-design</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingCover.qml" line="53"/>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingStorageAmount</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageAmount.qml" line="32"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageAmount.qml" line="37"/>
+        <source>Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageAmount.qml" line="39"/>
+        <source>Data retrieved from the Bitcoin network is stored on your device.
+You have 500GB of storage available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageAmount.qml" line="53"/>
+        <source>Detailed settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageAmount.qml" line="57"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingStorageLocation</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageLocation.qml" line="18"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageLocation.qml" line="23"/>
+        <source>Storage location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageLocation.qml" line="25"/>
+        <source>Where do you want to store the downloaded block data?
+You need a minimum of %1GB of storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageLocation.qml" line="29"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingStrengthen</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStrengthen.qml" line="16"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStrengthen.qml" line="25"/>
+        <source>Strengthen bitcoin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStrengthen.qml" line="26"/>
+        <source>Bitcoin Core runs a full Bitcoin node which verifies the rules of the network are being followed.
+
+Users running nodes is what makes bitcoin so resilient and trustworthy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStrengthen.qml" line="29"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OptionButton</name>
+    <message>
+        <location filename="../controls/OptionButton.qml" line="83"/>
+        <source>Recommended</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PeerDetails</name>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="30"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="36"/>
+        <source>Peer %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="55"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="66"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="67"/>
+        <source>VIA</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="68"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="74"/>
+        <source>Permissions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="94"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="95"/>
+        <source>User agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="96"/>
+        <source>Services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="100"/>
+        <source>Transaction relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="111"/>
+        <source>Address relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="124"/>
+        <source>Mapped AS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="151"/>
+        <source>Block data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="161"/>
+        <source>Starting block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="162"/>
+        <source>Synced headers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="163"/>
+        <source>Synced blocks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="167"/>
+        <source>Network traffic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="177"/>
+        <source>Direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="190"/>
+        <source>Connection time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="191"/>
+        <source>Last send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="191"/>
+        <location filename="../pages/node/PeerDetails.qml" line="192"/>
+        <source> ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="192"/>
+        <source>Last receive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="193"/>
+        <source>Sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="193"/>
+        <location filename="../pages/node/PeerDetails.qml" line="194"/>
+        <source> total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="194"/>
+        <source>Received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="195"/>
+        <source>Ping time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="201"/>
+        <source>Ping wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="231"/>
+        <source>Min ping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="232"/>
+        <source>Time offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="243"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="252"/>
+        <location filename="../pages/node/PeerDetails.qml" line="348"/>
+        <source>Ban</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="276"/>
+        <source>1 hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="277"/>
+        <source>1 day</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="278"/>
+        <source>1 week</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="279"/>
+        <source>1 year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="289"/>
+        <source>Ban this peer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="340"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PeerDetailsModel</name>
+    <message>
+        <location filename="../models/peerdetailsmodel.h" line="70"/>
+        <location filename="../models/peerdetailsmodel.h" line="73"/>
+        <source>N/A</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PeerListModel</name>
+    <message>
+        <location filename="../models/peerlistmodel.cpp" line="62"/>
+        <source>Inbound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/peerlistmodel.cpp" line="62"/>
+        <source>Outbound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Peers</name>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="25"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="31"/>
+        <source>Peers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="60"/>
+        <source>Peers are nodes you exchange data with.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="78"/>
+        <source>ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="87"/>
+        <source>Direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="96"/>
+        <source>User Agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="105"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="114"/>
+        <source>Ip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="123"/>
+        <source>Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="161"/>
+        <source>Looking for %1 more peer(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="174"/>
+        <source>View %1 banned %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="174"/>
+        <source>peer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="174"/>
+        <source>peers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProxySettings</name>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="13"/>
+        <source>IP and Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="14"/>
+        <source>Invalid IP address or port format. Use &apos;255.255.255.255:65535&apos; or &apos;[ffff::]:65535&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="20"/>
+        <source>Default Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="22"/>
+        <source>Run peer connections through a proxy (SOCKS5) for improved privacy. The default proxy supports connections via IPv4, IPv6 and Tor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="30"/>
+        <location filename="../components/ProxySettings.qml" line="81"/>
+        <source>Enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="70"/>
+        <source>Tor Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="72"/>
+        <source>Run Tor connections through a dedicated proxy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="98"/>
+        <location filename="../models/options_model.cpp" line="239"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="25"/>
+        <source>Inbound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="26"/>
+        <source>Outbound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="30"/>
+        <source>Full Relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="31"/>
+        <source>Block Relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="32"/>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="33"/>
+        <source>Feeler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="34"/>
+        <source>Address Fetch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="42"/>
+        <source>Unroutable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="43"/>
+        <source>IPv4</source>
+        <comment>network name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="44"/>
+        <source>IPv6</source>
+        <comment>network name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="45"/>
+        <source>Onion</source>
+        <comment>network name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="46"/>
+        <source>I2P</source>
+        <comment>network name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="47"/>
+        <source>CJDNS</source>
+        <comment>network name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="62"/>
+        <location filename="../peerstatsutil.cpp" line="74"/>
+        <source>%1 d</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="63"/>
+        <location filename="../peerstatsutil.cpp" line="75"/>
+        <source>%1 h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="64"/>
+        <location filename="../peerstatsutil.cpp" line="76"/>
+        <source>%1 m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="66"/>
+        <location filename="../peerstatsutil.cpp" line="77"/>
+        <location filename="../peerstatsutil.cpp" line="102"/>
+        <source>%1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="89"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="95"/>
+        <source>N/A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="97"/>
+        <source>%1 ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="107"/>
+        <source>%1 B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="108"/>
+        <source>%1 kB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="109"/>
+        <source>%1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="110"/>
+        <source>%1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RequestPayment</name>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="32"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="221"/>
+        <source>Request a payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="138"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="139"/>
+        <source>Enter label...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="149"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="150"/>
+        <source>Enter message...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="168"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="177"/>
+        <source>copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="204"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="224"/>
+        <source>Create bitcoin address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="214"/>
+        <source>Copy payment request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="238"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Send</name>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="97"/>
+        <source>Send bitcoin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="132"/>
+        <source>Recipient %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="211"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="298"/>
+        <source>Note to self</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="299"/>
+        <source>Enter ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="337"/>
+        <source>Review</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SendOptionsPopup</name>
+    <message>
+        <location filename="../controls/SendOptionsPopup.qml" line="34"/>
+        <source>Enable Coin control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../controls/SendOptionsPopup.qml" line="45"/>
+        <source>Multiple Recipients</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SendRecipient</name>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="117"/>
+        <source>Address is valid for mainnet, not the current network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="119"/>
+        <source>Address is valid for testnet, not the current network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="121"/>
+        <source>Invalid address format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="134"/>
+        <source>Amount must be greater than zero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="136"/>
+        <source>Amount exceeds maximum limit of 21,000,000 BTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="138"/>
+        <source>Amount exceeds available balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SendResult</name>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="56"/>
+        <source>Transaction sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="65"/>
+        <source>Based on your selected fee, it should be confirmed within the next 10 minutes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="74"/>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SendReview</name>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="28"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="52"/>
+        <source>Transaction details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="59"/>
+        <source>Send to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="73"/>
+        <source>Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="87"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="101"/>
+        <source>Fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="115"/>
+        <source>Total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="131"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsAbout</name>
+    <message>
+        <location filename="../pages/settings/SettingsAbout.qml" line="18"/>
+        <location filename="../pages/settings/SettingsAbout.qml" line="59"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsAbout.qml" line="20"/>
+        <source>Bitcoin Core is an open source project.
+If you find it useful, please contribute.
+
+ This is experimental software.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsAbout.qml" line="50"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsBlockClockDisplayMode</name>
+    <message>
+        <location filename="../pages/settings/SettingsBlockClockDisplayMode.qml" line="24"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsBlockClockDisplayMode.qml" line="30"/>
+        <source>Block clock display mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsConnection</name>
+    <message>
+        <location filename="../pages/settings/SettingsConnection.qml" line="29"/>
+        <location filename="../pages/settings/SettingsConnection.qml" line="71"/>
+        <source>Connection settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsConnection.qml" line="62"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsConnection.qml" line="78"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDeveloper</name>
+    <message>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="16"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="24"/>
+        <source>Developer options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="51"/>
+        <source>Developer settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDisplay</name>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="31"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="37"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="47"/>
+        <source>Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="59"/>
+        <source>Block status size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="71"/>
+        <source>Ask before opening links</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="83"/>
+        <source>Display unit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="97"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDisplayUnit</name>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="26"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="32"/>
+        <source>Display unit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="49"/>
+        <source>BTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="50"/>
+        <source>8 decimal places (0.00000001 BTC = 1 sat)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="59"/>
+        <source>sat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="60"/>
+        <source>Satoshi, the smallest unit (1 sat = 0.00000001 BTC)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsLanguage</name>
+    <message>
+        <location filename="../pages/settings/SettingsLanguage.qml" line="26"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsLanguage.qml" line="32"/>
+        <source>Choose language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsLanguage.qml" line="45"/>
+        <source>Search...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsProxy</name>
+    <message>
+        <location filename="../pages/settings/SettingsProxy.qml" line="21"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsProxy.qml" line="27"/>
+        <source>Proxy Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsStorage</name>
+    <message>
+        <location filename="../pages/settings/SettingsStorage.qml" line="19"/>
+        <source>Storage settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsStorage.qml" line="56"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsStorage.qml" line="65"/>
+        <source>Storage Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsStorage.qml" line="71"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsTheme</name>
+    <message>
+        <location filename="../pages/settings/SettingsTheme.qml" line="24"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsTheme.qml" line="30"/>
+        <source>Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Shutdown</name>
+    <message>
+        <location filename="../pages/node/Shutdown.qml" line="29"/>
+        <source>Saving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Shutdown.qml" line="31"/>
+        <source>Do not shut down the computer until this is done.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StorageLocations</name>
+    <message>
+        <location filename="../components/StorageLocations.qml" line="23"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageLocations.qml" line="24"/>
+        <source>Your application directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageLocations.qml" line="36"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageLocations.qml" line="37"/>
+        <source>Choose the directory and storage device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StorageOptions</name>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="24"/>
+        <source>Reduce storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="25"/>
+        <source>Uses about %1GB. For simple wallet use.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="40"/>
+        <source>Store all data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="42"/>
+        <source>Uses about %1GB. Support the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="55"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="56"/>
+        <source>Storing about %1GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StorageSettings</name>
+    <message>
+        <location filename="../components/StorageSettings.qml" line="17"/>
+        <source>Store recent blocks only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageSettings.qml" line="38"/>
+        <source>Block Storage limit (GB)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageSettings.qml" line="39"/>
+        <source>This is not a valid prune target. Please choose a value that is equal to or larger than 1GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StorageSettings.qml" line="65"/>
+        <source>Data Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThemeSettings</name>
+    <message>
+        <location filename="../components/ThemeSettings.qml" line="21"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ThemeSettings.qml" line="36"/>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WalletBadge</name>
+    <message>
+        <location filename="../pages/wallet/WalletBadge.qml" line="101"/>
+        <source>Add Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/WalletBadge.qml" line="101"/>
+        <source>Select Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WalletSelect</name>
+    <message>
+        <location filename="../pages/wallet/WalletSelect.qml" line="59"/>
+        <source>Wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>initerrormessage</name>
+    <message>
+        <location filename="../pages/initerrormessage.qml" line="27"/>
+        <source>There was an issue starting up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/initerrormessage.qml" line="34"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../pages/main.qml" line="18"/>
+        <source>Bitcoin Core App</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/qml/locale/bitcoin_qml_es.ts
+++ b/qml/locale/bitcoin_qml_es.ts
@@ -24,12 +24,12 @@
         <translation type="unfinished">Versión</translation>
     </message>
     <message>
-        <location filename="../components/AboutOptions.qml" line="68"/>
+        <location filename="../components/AboutOptions.qml" line="69"/>
         <source>Developer options</source>
         <translation type="unfinished">Opciones de desarrollador</translation>
     </message>
     <message>
-        <location filename="../components/AboutOptions.qml" line="69"/>
+        <location filename="../components/AboutOptions.qml" line="70"/>
         <source>Only use these if you have development experience</source>
         <translation type="unfinished">Úsalas solo si tienes experiencia en desarrollo</translation>
     </message>
@@ -37,7 +37,7 @@
 <context>
     <name>Activity</name>
     <message>
-        <location filename="../pages/wallet/Activity.qml" line="54"/>
+        <location filename="../pages/wallet/Activity.qml" line="55"/>
         <source>Activity</source>
         <translation type="unfinished">Actividad</translation>
     </message>
@@ -45,34 +45,59 @@
 <context>
     <name>ActivityDetails</name>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="55"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="60"/>
         <source>Back</source>
         <translation type="unfinished">Atrás</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="66"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="71"/>
         <source>Transaction</source>
         <translation type="unfinished">Transacción</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="129"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="135"/>
         <source>%1 confirmations</source>
         <translation type="unfinished">%1 confirmaciones</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="138"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="144"/>
         <source>Label</source>
         <translation type="unfinished">Etiqueta</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="148"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="154"/>
         <source>Message</source>
         <translation type="unfinished">Mensaje</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/ActivityDetails.qml" line="163"/>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="169"/>
         <source>Address</source>
         <translation type="unfinished">Dirección</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="210"/>
+        <source>This transaction is still unconfirmed. You can speed it up by increasing the fee.</source>
+        <translation type="unfinished">Esta transacción aún no está confirmada. Puedes acelerarla aumentando la comisión.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="211"/>
+        <source>Speed up</source>
+        <translation type="unfinished">Acelerar</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="226"/>
+        <source>This transaction was updated with a faster one</source>
+        <translation type="unfinished">Esta transacción fue reemplazada por una más rápida</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="227"/>
+        <source>You increased the fee while this transaction was still unconfirmed. Only the new one will confirm on-chain.</source>
+        <translation type="unfinished">Aumentaste la comisión mientras esta transacción aún no estaba confirmada. Solo la nueva se confirmará en la cadena.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="228"/>
+        <source>View updated transaction</source>
+        <translation type="unfinished">Ver transacción actualizada</translation>
     </message>
 </context>
 <context>
@@ -117,6 +142,14 @@
     </message>
 </context>
 <context>
+    <name>BitcoinAddressDisplayField</name>
+    <message>
+        <location filename="../components/BitcoinAddressDisplayField.qml" line="14"/>
+        <source>Send to</source>
+        <translation type="unfinished">Enviar a</translation>
+    </message>
+</context>
+<context>
     <name>BitcoinAddressInputField</name>
     <message>
         <location filename="../components/BitcoinAddressInputField.qml" line="17"/>
@@ -124,9 +157,17 @@
         <translation type="unfinished">Enviar a</translation>
     </message>
     <message>
-        <location filename="../components/BitcoinAddressInputField.qml" line="47"/>
+        <location filename="../components/BitcoinAddressInputField.qml" line="50"/>
         <source>Enter address...</source>
         <translation type="unfinished">Introducir dirección...</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinAmountDisplayField</name>
+    <message>
+        <location filename="../components/BitcoinAmountDisplayField.qml" line="14"/>
+        <source>Amount</source>
+        <translation type="unfinished">Importe</translation>
     </message>
 </context>
 <context>
@@ -171,6 +212,39 @@
         <location filename="../components/BlockClockDisplayMode.qml" line="35"/>
         <source>A larger block clock for public display on a tablet or other large screen.</source>
         <translation type="unfinished">Un reloj de bloques más grande para visualización pública en tableta u otra pantalla grande.</translation>
+    </message>
+</context>
+<context>
+    <name>BumpTransactionModel</name>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="72"/>
+        <source>No wallet available.</source>
+        <translation type="unfinished">No hay billetera disponible.</translation>
+    </message>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="78"/>
+        <source>Invalid transaction ID.</source>
+        <translation type="unfinished">ID de transacción no válido.</translation>
+    </message>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="95"/>
+        <source>Failed to create bump transaction.</source>
+        <translation type="unfinished">No se pudo crear la transacción de aumento de comisión.</translation>
+    </message>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="117"/>
+        <source>Transaction can no longer be bumped.</source>
+        <translation type="unfinished">La transacción ya no se puede acelerar.</translation>
+    </message>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="122"/>
+        <source>Failed to sign transaction.</source>
+        <translation type="unfinished">No se pudo firmar la transacción.</translation>
+    </message>
+    <message>
+        <location filename="../models/bumptransactionmodel.cpp" line="129"/>
+        <source>Failed to commit transaction.</source>
+        <translation type="unfinished">No se pudo confirmar la transacción.</translation>
     </message>
 </context>
 <context>
@@ -257,7 +331,7 @@
         <translation type="unfinished">Activar servidor RPC</translation>
     </message>
     <message>
-        <location filename="../components/ConnectionSettings.qml" line="57"/>
+        <location filename="../components/ConnectionSettings.qml" line="58"/>
         <source>Proxy settings</source>
         <translation type="unfinished">Ajustes de proxy</translation>
     </message>
@@ -265,29 +339,24 @@
 <context>
     <name>CreateBackup</name>
     <message>
-        <location filename="../pages/wallet/CreateBackup.qml" line="23"/>
-        <source>Back</source>
-        <translation type="unfinished">Atrás</translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/CreateBackup.qml" line="59"/>
+        <location filename="../pages/wallet/CreateBackup.qml" line="52"/>
         <source>Back up your wallet</source>
         <translation type="unfinished">Haz una copia de seguridad de tu cartera</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateBackup.qml" line="61"/>
+        <location filename="../pages/wallet/CreateBackup.qml" line="54"/>
         <source>Your wallet is a file stored on your hard disk.
 To prevent accidental loss, it is recommended you keep a copy of your wallet file in a secure place, like a dedicated USB Drive.</source>
         <translation type="unfinished">Tu cartera es un archivo almacenado en tu disco duro.
 Para evitar pérdidas accidentales, se recomienda guardar una copia en un lugar seguro, como una memoria USB dedicada.</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateBackup.qml" line="70"/>
+        <location filename="../pages/wallet/CreateBackup.qml" line="64"/>
         <source>View file</source>
         <translation type="unfinished">Ver archivo</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateBackup.qml" line="86"/>
+        <location filename="../pages/wallet/CreateBackup.qml" line="81"/>
         <source>Done</source>
         <translation type="unfinished">Listo</translation>
     </message>
@@ -295,57 +364,95 @@ Para evitar pérdidas accidentales, se recomienda guardar una copia en un lugar 
 <context>
     <name>CreateConfirm</name>
     <message>
-        <location filename="../pages/wallet/CreateConfirm.qml" line="23"/>
-        <source>Back</source>
-        <translation type="unfinished">Atrás</translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/CreateConfirm.qml" line="59"/>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="19"/>
         <source>Your wallet has been created</source>
         <translation type="unfinished">Tu cartera ha sido creada</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateConfirm.qml" line="61"/>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="20"/>
         <source>It is good practice to make a small test transaction before you actively use this wallet for larger amounts.</source>
         <translation type="unfinished">Es buena práctica realizar una pequeña transacción de prueba antes de usar esta cartera para importes mayores.</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateConfirm.qml" line="70"/>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="21"/>
         <source>Next</source>
         <translation type="unfinished">Siguiente</translation>
     </message>
 </context>
 <context>
-    <name>CreateIntro</name>
+    <name>CreateExternalWallet</name>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="23"/>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="35"/>
         <source>Back</source>
         <translation type="unfinished">Atrás</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="58"/>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="60"/>
+        <source>Create an external wallet</source>
+        <translation type="unfinished">Crear una billetera externa</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="65"/>
+        <source>Connected signer: %1</source>
+        <translation type="unfinished">Firmante conectado: %1</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="66"/>
+        <source>Connect one external signer to continue.</source>
+        <translation type="unfinished">Conecta un firmante externo para continuar.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="76"/>
+        <source>This wallet stores public descriptors and uses your external signer device for signing.</source>
+        <translation type="unfinished">Esta billetera almacena descriptores públicos y usa tu dispositivo firmante externo para firmar.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="87"/>
+        <source>Eg. hardware_wallet</source>
+        <translation type="unfinished">Ej. billetera_hardware</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="119"/>
+        <source>Creating wallet with the connected signer...</source>
+        <translation type="unfinished">Creando billetera con el firmante conectado...</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="133"/>
+        <source>Creating wallet...</source>
+        <translation type="unfinished">Creando billetera...</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateExternalWallet.qml" line="133"/>
+        <source>Create wallet</source>
+        <translation type="unfinished">Crear cartera</translation>
+    </message>
+</context>
+<context>
+    <name>CreateIntro</name>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="52"/>
         <source>You are about to create 
 a single-key bitcoin wallet</source>
         <translation type="unfinished">Estás a punto de crear 
 una cartera Bitcoin de clave única</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="67"/>
+        <location filename="../pages/wallet/CreateIntro.qml" line="61"/>
         <source>You can fully control it in this application.</source>
         <translation type="unfinished">Puedes controlarlo completamente en esta aplicación.</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="83"/>
+        <location filename="../pages/wallet/CreateIntro.qml" line="77"/>
         <source>Wallet data will be stored locally on your hard drive.</source>
         <translation type="unfinished">Los datos de la cartera se almacenarán localmente en tu disco duro.</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="99"/>
+        <location filename="../pages/wallet/CreateIntro.qml" line="93"/>
         <source>You can optionally protect it with a password.</source>
         <translation type="unfinished">Opcionalmente puedes protegerlo con una contraseña.</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateIntro.qml" line="110"/>
+        <location filename="../pages/wallet/CreateIntro.qml" line="105"/>
         <source>Start</source>
         <translation type="unfinished">Iniciar</translation>
     </message>
@@ -353,35 +460,40 @@ una cartera Bitcoin de clave única</translation>
 <context>
     <name>CreateName</name>
     <message>
-        <location filename="../pages/wallet/CreateName.qml" line="24"/>
-        <source>Back</source>
-        <translation type="unfinished">Atrás</translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/CreateName.qml" line="41"/>
+        <location filename="../pages/wallet/CreateName.qml" line="47"/>
         <source>Choose a wallet name</source>
         <translation type="unfinished">Elige un nombre para la cartera</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateName.qml" line="51"/>
+        <location filename="../pages/wallet/CreateName.qml" line="50"/>
+        <source>This wallet will use the connected external signer.</source>
+        <translation type="unfinished">Esta billetera usará el firmante externo conectado.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="62"/>
+        <source>Eg. Hardware wallet...</source>
+        <translation type="unfinished">Ej. Billetera hardware...</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="63"/>
         <source>Eg. My bitcoin wallet...</source>
         <translation type="unfinished">Ej. Mi cartera Bitcoin...</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateName.qml" line="65"/>
+        <location filename="../pages/wallet/CreateName.qml" line="90"/>
         <source>Continue</source>
         <translation type="unfinished">Continuar</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="90"/>
+        <source>Create wallet</source>
+        <translation type="unfinished">Crear cartera</translation>
     </message>
 </context>
 <context>
     <name>CreatePassword</name>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="25"/>
-        <source>Back</source>
-        <translation type="unfinished">Atrás</translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="31"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="28"/>
         <source>Skip</source>
         <translation type="unfinished">Omitir</translation>
     </message>
@@ -397,27 +509,27 @@ una cartera Bitcoin de clave única</translation>
         <translation type="unfinished">Se recomienda establecer una contraseña para proteger tu archivo de cartera del acceso no deseado.</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="70"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="71"/>
         <source>Enter password...</source>
         <translation type="unfinished">Introducir contraseña...</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="78"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="80"/>
         <source>Confirm password</source>
         <translation type="unfinished">Confirmar contraseña</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="86"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="89"/>
         <source>Enter password again...</source>
         <translation type="unfinished">Introducir contraseña de nuevo...</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="94"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="98"/>
         <source>I understand that if I lose or forget this password I might lose access to the bitcoin stored in this wallet.</source>
         <translation type="unfinished">Entiendo que si pierdo u olvido esta contraseña podría perder el acceso al bitcoin de esta cartera.</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreatePassword.qml" line="109"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="123"/>
         <source>Continue</source>
         <translation type="unfinished">Continuar</translation>
     </message>
@@ -425,60 +537,117 @@ una cartera Bitcoin de clave única</translation>
 <context>
     <name>CreateWalletWizard</name>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="31"/>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="39"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="47"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="34"/>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="50"/>
         <source>Skip</source>
         <translation type="unfinished">Omitir</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="60"/>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="76"/>
         <source>Add a wallet</source>
         <translation type="unfinished">Añadir una cartera</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="62"/>
-        <source>In this early stage of development, only wallet.dat files are supported.</source>
-        <translation type="unfinished">En esta etapa de desarrollo, solo se admiten archivos wallet.dat.</translation>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="79"/>
+        <source>Supported wallet types are external signer, view-only, single-key,
+and multi-key.</source>
+        <translation type="unfinished">Los tipos de billetera compatibles son firmante externo, solo lectura, clave única
+y multiclave.</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="72"/>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="80"/>
+        <source>Supported wallet types are view-only, single-key,
+and multi-key.</source>
+        <translation type="unfinished">Los tipos de billetera compatibles son solo lectura, clave única
+y multiclave.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="125"/>
+        <source>Create external wallet</source>
+        <translation type="unfinished">Crear billetera externa</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="126"/>
+        <source>Create hardware wallet</source>
+        <translation type="unfinished">Crear billetera hardware</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="155"/>
+        <source>No external signer is currently detected. Open Wallet settings to verify the signer path and rescan.</source>
+        <translation type="unfinished">No se detecta ningún firmante externo. Abre los ajustes de billetera para verificar la ruta del firmante y volver a escanear.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="218"/>
+        <source>Your external wallet has been created</source>
+        <translation type="unfinished">Tu billetera externa ha sido creada</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="219"/>
+        <source>This wallet uses the connected external signer for addresses and signing.</source>
+        <translation type="unfinished">Esta billetera usa el firmante externo conectado para direcciones y firmas.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="220"/>
+        <source>Done</source>
+        <translation type="unfinished">Listo</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="91"/>
         <source>Create wallet</source>
         <translation type="unfinished">Crear cartera</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/CreateWalletWizard.qml" line="83"/>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="103"/>
         <source>Import wallet</source>
         <translation type="unfinished">Importar cartera</translation>
     </message>
 </context>
 <context>
+    <name>DebugLogModel</name>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="127"/>
+        <source>Debug log file not found: %1</source>
+        <translation type="unfinished">Archivo de registro de depuración no encontrado: %1</translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="133"/>
+        <source>Could not open debug log file. No application is associated with this file type.</source>
+        <translation type="unfinished">No se pudo abrir el archivo de registro de depuración. Ninguna aplicación está asociada con este tipo de archivo.</translation>
+    </message>
+</context>
+<context>
     <name>DesktopWallets</name>
     <message>
-        <location filename="../pages/wallet/DesktopWallets.qml" line="66"/>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="74"/>
         <source>Activity</source>
         <translation type="unfinished">Actividad</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/DesktopWallets.qml" line="71"/>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="80"/>
         <source>Send</source>
         <translation type="unfinished">Enviar</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/DesktopWallets.qml" line="76"/>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="86"/>
         <source>Receive</source>
         <translation type="unfinished">Recibir</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/DesktopWallets.qml" line="110"/>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="120"/>
         <source>Paused</source>
         <translation type="unfinished">En pausa</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/DesktopWallets.qml" line="116"/>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="126"/>
         <source>Connecting</source>
         <translation type="unfinished">Conectando</translation>
     </message>
@@ -486,27 +655,27 @@ una cartera Bitcoin de clave única</translation>
 <context>
     <name>DeveloperOptions</name>
     <message>
-        <location filename="../components/DeveloperOptions.qml" line="15"/>
+        <location filename="../components/DeveloperOptions.qml" line="16"/>
         <source>Database cache size (MiB)</source>
         <translation type="unfinished">Tamaño de caché de base de datos (MiB)</translation>
     </message>
     <message>
-        <location filename="../components/DeveloperOptions.qml" line="16"/>
+        <location filename="../components/DeveloperOptions.qml" line="17"/>
         <source>This is not a valid cache size. Please choose a value between %1 and %2 MiB.</source>
         <translation type="unfinished">No es un tamaño de caché válido. Elige un valor entre %1 y %2 MiB.</translation>
     </message>
     <message>
-        <location filename="../components/DeveloperOptions.qml" line="40"/>
+        <location filename="../components/DeveloperOptions.qml" line="41"/>
         <source>Script verification threads</source>
         <translation type="unfinished">Hilos de verificación de scripts</translation>
     </message>
     <message>
-        <location filename="../components/DeveloperOptions.qml" line="41"/>
+        <location filename="../components/DeveloperOptions.qml" line="42"/>
         <source>This is not a valid thread count. Please choose a value between %1 and %2 threads.</source>
         <translation type="unfinished">No es un número de hilos válido. Elige un valor entre %1 y %2 hilos.</translation>
     </message>
     <message>
-        <location filename="../components/DeveloperOptions.qml" line="64"/>
+        <location filename="../components/DeveloperOptions.qml" line="65"/>
         <source>Dark Mode</source>
         <translation type="unfinished">Modo oscuro</translation>
     </message>
@@ -535,41 +704,188 @@ una cartera Bitcoin de clave única</translation>
     </message>
 </context>
 <context>
+    <name>ExternalSignerReviewActions</name>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="21"/>
+        <source>Signed on external signer. Ready to send.</source>
+        <translation type="unfinished">Firmado en el firmante externo. Listo para enviar.</translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="22"/>
+        <source>Waiting for approval on external signer.</source>
+        <translation type="unfinished">Esperando aprobación en el firmante externo.</translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="24"/>
+        <source>Approve on external signer to broadcast this transaction.</source>
+        <translation type="unfinished">Aprueba en el firmante externo para transmitir esta transacción.</translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="32"/>
+        <source>Send</source>
+        <translation type="unfinished">Enviar</translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="33"/>
+        <source>Waiting for approval...</source>
+        <translation type="unfinished">Esperando aprobación...</translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="34"/>
+        <source>Retry external signer</source>
+        <translation type="unfinished">Reintentar firmante externo</translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalSignerReviewActions.qml" line="35"/>
+        <source>Approve on external signer</source>
+        <translation type="unfinished">Aprobar en el firmante externo</translation>
+    </message>
+</context>
+<context>
     <name>FeeSelection</name>
     <message>
-        <location filename="../components/FeeSelection.qml" line="27"/>
+        <location filename="../components/FeeSelection.qml" line="24"/>
+        <location filename="../components/FeeSelection.qml" line="391"/>
+        <source>sats/vbyte</source>
+        <translation type="unfinished">sats/vbyte</translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="60"/>
+        <location filename="../components/FeeSelection.qml" line="162"/>
         <source>Fee</source>
         <translation type="unfinished">Tarifa</translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="202"/>
+        <location filename="../components/FeeSelection.qml" line="60"/>
+        <source>Fee Rate</source>
+        <translation type="unfinished">Tasa de comisión</translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="363"/>
+        <source>Include fee in amount</source>
+        <translation type="unfinished">Incluir comisión en el monto</translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="388"/>
         <source>High</source>
         <translation type="unfinished">Alto</translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="202"/>
+        <location filename="../components/FeeSelection.qml" line="388"/>
         <source>(~10 mins)</source>
         <translation type="unfinished">(~10 min)</translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="203"/>
+        <location filename="../components/FeeSelection.qml" line="389"/>
         <source>Default</source>
         <translation type="unfinished">Predeterminado</translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="203"/>
+        <location filename="../components/FeeSelection.qml" line="389"/>
+        <source>(~20 mins)</source>
+        <translation type="unfinished">(~20 min)</translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="390"/>
         <source>(~60 mins)</source>
         <translation type="unfinished">(~60 min)</translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="204"/>
+        <location filename="../components/FeeSelection.qml" line="390"/>
         <source>Low</source>
         <translation type="unfinished">Bajo</translation>
     </message>
     <message>
-        <location filename="../components/FeeSelection.qml" line="204"/>
-        <source>(~24 hrs)</source>
-        <translation type="unfinished">(~24 h)</translation>
+        <location filename="../components/FeeSelection.qml" line="391"/>
+        <source>Custom</source>
+        <translation type="unfinished">Personalizado</translation>
+    </message>
+</context>
+<context>
+    <name>ImportWalletOptions</name>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="31"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="36"/>
+        <source>Done</source>
+        <translation type="unfinished">Listo</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="44"/>
+        <source>Wallet backup files (*.bak *.dat)</source>
+        <translation type="unfinished">Archivos de respaldo de billetera (*.bak *.dat)</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="44"/>
+        <source>All files (*)</source>
+        <translation type="unfinished">Todos los archivos (*)</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="102"/>
+        <source>Import wallet</source>
+        <translation type="unfinished">Importar cartera</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="119"/>
+        <source>Importing...</source>
+        <translation type="unfinished">Importando...</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="119"/>
+        <source>Choose a wallet file</source>
+        <translation type="unfinished">Elige un archivo de billetera</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletOptions.qml" line="221"/>
+        <source>Choose another file</source>
+        <translation type="unfinished">Elige otro archivo</translation>
+    </message>
+</context>
+<context>
+    <name>ImportWalletSuccess</name>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="25"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="59"/>
+        <source>Import complete</source>
+        <translation type="unfinished">Importación completada</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="62"/>
+        <source>Your wallet was added successfully. We recommend running a health check to make sure that everything works as expected.</source>
+        <translation type="unfinished">Tu billetera se añadió correctamente. Recomendamos ejecutar una verificación de estado para asegurar que todo funciona como se espera.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="81"/>
+        <source>Wallet name</source>
+        <translation type="unfinished">Nombre de billetera</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="87"/>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="108"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Desconocido</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="102"/>
+        <source>Key scheme</source>
+        <translation type="unfinished">Esquema de claves</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="128"/>
+        <source>Go to wallet overview</source>
+        <translation type="unfinished">Ir al resumen de la billetera</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ImportWalletSuccess.qml" line="136"/>
+        <source>View in settings</source>
+        <translation type="unfinished">Ver en ajustes</translation>
     </message>
 </context>
 <context>
@@ -598,29 +914,52 @@ una cartera Bitcoin de clave única</translation>
 <context>
     <name>MultipleSendReview</name>
     <message>
-        <location filename="../pages/wallet/MultipleSendReview.qml" line="28"/>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="40"/>
         <source>Back</source>
         <translation type="unfinished">Atrás</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/MultipleSendReview.qml" line="52"/>
-        <source>Transaction details</source>
-        <translation type="unfinished">Detalles de la transacción</translation>
-    </message>
-    <message>
-        <location filename="../pages/wallet/MultipleSendReview.qml" line="102"/>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="253"/>
         <source>Total amount</source>
         <translation type="unfinished">Importe total</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/MultipleSendReview.qml" line="124"/>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="239"/>
         <source>Fee</source>
         <translation type="unfinished">Tarifa</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/MultipleSendReview.qml" line="147"/>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="22"/>
+        <source>There is 1 recipient.</source>
+        <translation type="unfinished">Hay 1 destinatario.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="23"/>
+        <source>There are %1 recipients.</source>
+        <translation type="unfinished">Hay %1 destinatarios.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="40"/>
+        <source>Edit</source>
+        <translation type="unfinished">Editar</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="69"/>
+        <source>Review transaction</source>
+        <translation type="unfinished">Revisar transacción</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="278"/>
         <source>Send</source>
         <translation type="unfinished">Enviar</translation>
+    </message>
+</context>
+<context>
+    <name>NavigationBar2</name>
+    <message>
+        <location filename="../controls/NavigationBar2.qml" line="16"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
     </message>
 </context>
 <context>
@@ -712,44 +1051,54 @@ una cartera Bitcoin de clave única</translation>
 <context>
     <name>NodeSettings</name>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="25"/>
+        <location filename="../pages/node/NodeSettings.qml" line="41"/>
         <source>Settings</source>
         <translation type="unfinished">Configuración</translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="29"/>
+        <location filename="../pages/node/NodeSettings.qml" line="45"/>
         <source>Done</source>
         <translation type="unfinished">Listo</translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="44"/>
+        <location filename="../pages/node/NodeSettings.qml" line="61"/>
         <source>About</source>
         <translation type="unfinished">Acerca de</translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="57"/>
+        <location filename="../pages/node/NodeSettings.qml" line="74"/>
         <source>Display</source>
         <translation type="unfinished">Pantalla</translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="69"/>
+        <location filename="../pages/node/NodeSettings.qml" line="86"/>
         <source>Storage</source>
         <translation type="unfinished">Almacenamiento</translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="81"/>
+        <location filename="../pages/node/NodeSettings.qml" line="100"/>
+        <source>External Signer</source>
+        <translation type="unfinished">Firmante externo</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="116"/>
         <source>Connection</source>
         <translation type="unfinished">Conexión</translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="94"/>
+        <location filename="../pages/node/NodeSettings.qml" line="129"/>
         <source>Peers</source>
         <translation type="unfinished">Pares</translation>
     </message>
     <message>
-        <location filename="../pages/node/NodeSettings.qml" line="107"/>
+        <location filename="../pages/node/NodeSettings.qml" line="142"/>
         <source>Network Traffic</source>
         <translation type="unfinished">Tráfico de red</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="155"/>
+        <source>Debug Log</source>
+        <translation type="unfinished">Registro de depuración</translation>
     </message>
 </context>
 <context>
@@ -801,12 +1150,12 @@ This may take several hours, or even days, based on your connection.</source>
 Esto puede llevar varias horas, o incluso días, según tu conexión.</translation>
     </message>
     <message>
-        <location filename="../pages/onboarding/OnboardingConnection.qml" line="50"/>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="51"/>
         <source>Connection settings</source>
         <translation type="unfinished">Ajustes de conexión</translation>
     </message>
     <message>
-        <location filename="../pages/onboarding/OnboardingConnection.qml" line="55"/>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="56"/>
         <source>Next</source>
         <translation type="unfinished">Siguiente</translation>
     </message>
@@ -922,6 +1271,24 @@ Que los usuarios ejecuten nodos es lo que hace que bitcoin sea tan resistente y 
         <location filename="../controls/OptionButton.qml" line="83"/>
         <source>Recommended</source>
         <translation type="unfinished">Recomendado</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsQmlModel</name>
+    <message>
+        <location filename="../models/options_model.cpp" line="321"/>
+        <source>The configured signer path does not exist.</source>
+        <translation type="unfinished">La ruta configurada del firmante no existe.</translation>
+    </message>
+    <message>
+        <location filename="../models/options_model.cpp" line="324"/>
+        <source>The configured signer path is not a file.</source>
+        <translation type="unfinished">La ruta configurada del firmante no es un archivo.</translation>
+    </message>
+    <message>
+        <location filename="../models/options_model.cpp" line="327"/>
+        <source>The configured signer path is not executable.</source>
+        <translation type="unfinished">La ruta configurada del firmante no es ejecutable.</translation>
     </message>
 </context>
 <context>
@@ -1234,17 +1601,17 @@ Que los usuarios ejecuten nodos es lo que hace que bitcoin sea tan resistente y 
     </message>
     <message>
         <location filename="../components/ProxySettings.qml" line="30"/>
-        <location filename="../components/ProxySettings.qml" line="81"/>
+        <location filename="../components/ProxySettings.qml" line="96"/>
         <source>Enable</source>
         <translation type="unfinished">Activar</translation>
     </message>
     <message>
-        <location filename="../components/ProxySettings.qml" line="70"/>
+        <location filename="../components/ProxySettings.qml" line="85"/>
         <source>Tor Proxy</source>
         <translation type="unfinished">Proxy Tor</translation>
     </message>
     <message>
-        <location filename="../components/ProxySettings.qml" line="72"/>
+        <location filename="../components/ProxySettings.qml" line="87"/>
         <source>Run Tor connections through a dedicated proxy.</source>
         <translation type="unfinished">Ejecutar conexiones Tor a través de un proxy dedicado.</translation>
     </message>
@@ -1252,8 +1619,7 @@ Que los usuarios ejecuten nodos es lo que hace que bitcoin sea tan resistente y 
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../pages/settings/SettingsDisplay.qml" line="98"/>
-        <location filename="../models/options_model.cpp" line="239"/>
+        <location filename="../models/options_model.cpp" line="437"/>
         <source>System default</source>
         <translation type="unfinished">Predeterminado del sistema</translation>
     </message>
@@ -1387,58 +1753,96 @@ Que los usuarios ejecuten nodos es lo que hace que bitcoin sea tan resistente y 
         <source>%1 GB</source>
         <translation type="unfinished">%1 GB</translation>
     </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="171"/>
+        <source>Could not open debug log file: %1</source>
+        <translation type="unfinished">No se pudo abrir el archivo de registro de depuración: %1</translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="172"/>
+        <source>Debug log file not found: %1</source>
+        <translation type="unfinished">Archivo de registro de depuración no encontrado: %1</translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="391"/>
+        <source>just now</source>
+        <translation type="unfinished">ahora mismo</translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="392"/>
+        <source>%1 min ago</source>
+        <translation type="unfinished">hace %1 min</translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="393"/>
+        <source>%1 hr ago</source>
+        <translation type="unfinished">hace %1 h</translation>
+    </message>
+    <message>
+        <location filename="../models/debuglogmodel.cpp" line="394"/>
+        <source>%1 d ago</source>
+        <translation type="unfinished">hace %1 d</translation>
+    </message>
 </context>
 <context>
     <name>RequestPayment</name>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="32"/>
-        <location filename="../pages/wallet/RequestPayment.qml" line="221"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="40"/>
         <source>Request a payment</source>
         <translation type="unfinished">Solicitar un pago</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="138"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="70"/>
+        <source>Amount</source>
+        <translation type="unfinished">Importe</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="168"/>
         <source>Label</source>
         <translation type="unfinished">Etiqueta</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="139"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="169"/>
         <source>Enter label...</source>
         <translation type="unfinished">Introducir etiqueta...</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="149"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="185"/>
         <source>Message</source>
         <translation type="unfinished">Mensaje</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="150"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="186"/>
         <source>Enter message...</source>
         <translation type="unfinished">Introducir mensaje...</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="168"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="210"/>
         <source>Address</source>
         <translation type="unfinished">Dirección</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="177"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="219"/>
         <source>copy</source>
         <translation type="unfinished">copiar</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="204"/>
-        <location filename="../pages/wallet/RequestPayment.qml" line="224"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="275"/>
         <source>Create bitcoin address</source>
         <translation type="unfinished">Crear dirección Bitcoin</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="214"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="274"/>
         <source>Copy payment request</source>
         <translation type="unfinished">Copiar solicitud de pago</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/RequestPayment.qml" line="238"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="39"/>
+        <source>Payment request #</source>
+        <translation type="unfinished">Solicitud de pago #</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="299"/>
         <source>Clear</source>
         <translation type="unfinished">Borrar</translation>
     </message>
@@ -1446,45 +1850,65 @@ Que los usuarios ejecuten nodos es lo que hace que bitcoin sea tan resistente y 
 <context>
     <name>Send</name>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="97"/>
+        <location filename="../pages/wallet/Send.qml" line="132"/>
         <source>Send bitcoin</source>
         <translation type="unfinished">Enviar bitcoin</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="132"/>
+        <location filename="../pages/wallet/Send.qml" line="167"/>
+        <source>Make sure you have your external signer at hand to approve this transaction.</source>
+        <translation type="unfinished">Asegúrate de tener tu firmante externo a mano para aprobar esta transacción.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="183"/>
         <source>Recipient %1 of %2</source>
         <translation type="unfinished">Destinatario %1 de %2</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="211"/>
+        <location filename="../pages/wallet/Send.qml" line="273"/>
         <source>Amount</source>
         <translation type="unfinished">Importe</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="298"/>
+        <location filename="../pages/wallet/Send.qml" line="377"/>
         <source>Note to self</source>
         <translation type="unfinished">Nota personal</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="299"/>
+        <location filename="../pages/wallet/Send.qml" line="378"/>
         <source>Enter ...</source>
         <translation type="unfinished">Introducir...</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/Send.qml" line="337"/>
+        <location filename="../pages/wallet/Send.qml" line="440"/>
+        <source>Fee is included in the amount</source>
+        <translation type="unfinished">La comisión está incluida en el monto</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="477"/>
         <source>Review</source>
         <translation type="unfinished">Revisar</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="477"/>
+        <source>Review transaction</source>
+        <translation type="unfinished">Revisar transacción</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="485"/>
+        <source>Amount plus fee exceeds available balance</source>
+        <translation type="unfinished">El monto más la comisión excede el saldo disponible</translation>
     </message>
 </context>
 <context>
     <name>SendOptionsPopup</name>
     <message>
-        <location filename="../controls/SendOptionsPopup.qml" line="34"/>
+        <location filename="../controls/SendOptionsPopup.qml" line="36"/>
         <source>Enable Coin control</source>
         <translation type="unfinished">Activar control de monedas</translation>
     </message>
     <message>
-        <location filename="../controls/SendOptionsPopup.qml" line="45"/>
+        <location filename="../controls/SendOptionsPopup.qml" line="48"/>
         <source>Multiple Recipients</source>
         <translation type="unfinished">Varios destinatarios</translation>
     </message>
@@ -1492,32 +1916,32 @@ Que los usuarios ejecuten nodos es lo que hace que bitcoin sea tan resistente y 
 <context>
     <name>SendRecipient</name>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="117"/>
+        <location filename="../models/sendrecipient.cpp" line="125"/>
         <source>Address is valid for mainnet, not the current network</source>
         <translation type="unfinished">La dirección es válida para la red principal, no para la red actual</translation>
     </message>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="119"/>
+        <location filename="../models/sendrecipient.cpp" line="127"/>
         <source>Address is valid for testnet, not the current network</source>
         <translation type="unfinished">La dirección es válida para la red de pruebas, no para la red actual</translation>
     </message>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="121"/>
+        <location filename="../models/sendrecipient.cpp" line="129"/>
         <source>Invalid address format</source>
         <translation type="unfinished">Formato de dirección no válido</translation>
     </message>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="134"/>
+        <location filename="../models/sendrecipient.cpp" line="142"/>
         <source>Amount must be greater than zero</source>
         <translation type="unfinished">El importe debe ser mayor que cero</translation>
     </message>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="136"/>
+        <location filename="../models/sendrecipient.cpp" line="144"/>
         <source>Amount exceeds maximum limit of 21,000,000 BTC</source>
         <translation type="unfinished">El importe supera el límite máximo de 21.000.000 BTC</translation>
     </message>
     <message>
-        <location filename="../models/sendrecipient.cpp" line="138"/>
+        <location filename="../models/sendrecipient.cpp" line="146"/>
         <source>Amount exceeds available balance</source>
         <translation type="unfinished">El importe supera el saldo disponible</translation>
     </message>
@@ -1525,60 +1949,75 @@ Que los usuarios ejecuten nodos es lo que hace que bitcoin sea tan resistente y 
 <context>
     <name>SendResult</name>
     <message>
-        <location filename="../pages/wallet/SendResult.qml" line="56"/>
+        <location filename="../pages/wallet/SendResult.qml" line="64"/>
+        <source>Transaction updated</source>
+        <translation type="unfinished">Transacción actualizada</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="65"/>
         <source>Transaction sent</source>
         <translation type="unfinished">Transacción enviada</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendResult.qml" line="65"/>
+        <location filename="../pages/wallet/SendResult.qml" line="17"/>
         <source>Based on your selected fee, it should be confirmed within the next 10 minutes.</source>
         <translation type="unfinished">Con la tarifa seleccionada, debería confirmarse en los próximos 10 minutos.</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendResult.qml" line="74"/>
-        <source>Close window</source>
-        <translation type="unfinished">Cerrar ventana</translation>
+        <location filename="../pages/wallet/SendResult.qml" line="86"/>
+        <source>View new transaction</source>
+        <translation type="unfinished">Ver nueva transacción</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="87"/>
+        <source>View transaction</source>
+        <translation type="unfinished">Ver transacción</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="18"/>
+        <source>Done</source>
+        <translation type="unfinished">Listo</translation>
     </message>
 </context>
 <context>
     <name>SendReview</name>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="28"/>
+        <location filename="../pages/wallet/SendReview.qml" line="37"/>
         <source>Back</source>
         <translation type="unfinished">Atrás</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="52"/>
-        <source>Transaction details</source>
-        <translation type="unfinished">Detalles de la transacción</translation>
+        <location filename="../pages/wallet/SendReview.qml" line="37"/>
+        <source>Edit</source>
+        <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="59"/>
-        <source>Send to</source>
-        <translation type="unfinished">Enviar a</translation>
+        <location filename="../pages/wallet/SendReview.qml" line="62"/>
+        <source>Review transaction</source>
+        <translation type="unfinished">Revisar transacción</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="73"/>
+        <location filename="../pages/wallet/SendReview.qml" line="80"/>
         <source>Note</source>
         <translation type="unfinished">Nota</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="87"/>
+        <location filename="../pages/wallet/SendReview.qml" line="89"/>
         <source>Amount</source>
         <translation type="unfinished">Importe</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="101"/>
+        <location filename="../pages/wallet/SendReview.qml" line="98"/>
         <source>Fee</source>
         <translation type="unfinished">Tarifa</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="115"/>
-        <source>Total</source>
-        <translation type="unfinished">Total</translation>
+        <location filename="../pages/wallet/SendReview.qml" line="112"/>
+        <source>Total amount</source>
+        <translation type="unfinished">Importe total</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/SendReview.qml" line="131"/>
+        <location filename="../pages/wallet/SendReview.qml" line="137"/>
         <source>Send</source>
         <translation type="unfinished">Enviar</translation>
     </message>
@@ -1586,13 +2025,13 @@ Que los usuarios ejecuten nodos es lo que hace que bitcoin sea tan resistente y 
 <context>
     <name>SettingsAbout</name>
     <message>
-        <location filename="../pages/settings/SettingsAbout.qml" line="18"/>
-        <location filename="../pages/settings/SettingsAbout.qml" line="59"/>
+        <location filename="../pages/settings/SettingsAbout.qml" line="19"/>
+        <location filename="../pages/settings/SettingsAbout.qml" line="60"/>
         <source>About</source>
         <translation type="unfinished">Acerca de</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsAbout.qml" line="20"/>
+        <location filename="../pages/settings/SettingsAbout.qml" line="21"/>
         <source>Bitcoin Core is an open source project.
 If you find it useful, please contribute.
 
@@ -1603,7 +2042,7 @@ Si lo encuentras útil, por favor contribuye.
  Este es software experimental.</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsAbout.qml" line="50"/>
+        <location filename="../pages/settings/SettingsAbout.qml" line="51"/>
         <source>Back</source>
         <translation type="unfinished">Atrás</translation>
     </message>
@@ -1635,25 +2074,91 @@ Si lo encuentras útil, por favor contribuye.
         <translation type="unfinished">Atrás</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsConnection.qml" line="78"/>
+        <location filename="../pages/settings/SettingsConnection.qml" line="79"/>
         <source>Done</source>
         <translation type="unfinished">Listo</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDeveloper</name>
+    <name>SettingsDebugLog</name>
     <message>
-        <location filename="../pages/settings/SettingsDeveloper.qml" line="16"/>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="52"/>
         <source>Back</source>
         <translation type="unfinished">Atrás</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDeveloper.qml" line="24"/>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="161"/>
+        <source>Search...</source>
+        <translation type="unfinished">Buscar...</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="162"/>
+        <source>Search debug log</source>
+        <translation type="unfinished">Buscar en el registro de depuración</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="215"/>
+        <source>1 new entry</source>
+        <translation type="unfinished">1 entrada nueva</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="216"/>
+        <source>%1 new entries</source>
+        <translation type="unfinished">%1 entradas nuevas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="285"/>
+        <source>Debug log entries</source>
+        <translation type="unfinished">Entradas del registro de depuración</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDebugLog.qml" line="307"/>
+        <source>Load more</source>
+        <translation type="unfinished">Cargar más</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDesignSystem</name>
+    <message>
+        <location filename="../pages/settings/SettingsDesignSystem.qml" line="50"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDesignSystem.qml" line="56"/>
+        <source>Design system</source>
+        <translation type="unfinished">Sistema de diseño</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDesignSystem.qml" line="78"/>
+        <source>Typography</source>
+        <translation type="unfinished">Tipografía</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDesignSystem.qml" line="121"/>
+        <source>Colors</source>
+        <translation type="unfinished">Colores</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDesignSystem.qml" line="127"/>
+        <source>Palette tokens for the active theme. Toggle Theme to compare.</source>
+        <translation type="unfinished">Tokens de la paleta del tema activo. Cambia el tema para comparar.</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDeveloper</name>
+    <message>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="17"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="25"/>
         <source>Developer options</source>
         <translation type="unfinished">Opciones de desarrollador</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDeveloper.qml" line="51"/>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="52"/>
         <source>Developer settings</source>
         <translation type="unfinished">Ajustes de desarrollador</translation>
     </message>
@@ -1681,17 +2186,17 @@ Si lo encuentras útil, por favor contribuye.
         <translation type="unfinished">Tamaño del estado de bloques</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplay.qml" line="71"/>
-        <source>Ask before opening links</source>
-        <translation type="unfinished">Preguntar antes de abrir enlaces</translation>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="90"/>
+        <source>System default</source>
+        <translation type="unfinished">Predeterminado del sistema</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplay.qml" line="83"/>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="72"/>
         <source>Display unit</source>
         <translation type="unfinished">Unidad de visualización</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplay.qml" line="97"/>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="86"/>
         <source>Language</source>
         <translation type="unfinished">Idioma</translation>
     </message>
@@ -1709,22 +2214,22 @@ Si lo encuentras útil, por favor contribuye.
         <translation type="unfinished">Unidad de visualización</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="49"/>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="44"/>
         <source>BTC</source>
         <translation type="unfinished">BTC</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="50"/>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="45"/>
         <source>8 decimal places (0.00000001 BTC = 1 sat)</source>
         <translation type="unfinished">8 decimales (0.00000001 BTC = 1 sat)</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="59"/>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="53"/>
         <source>sat</source>
         <translation type="unfinished">sat</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="60"/>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="54"/>
         <source>Satoshi, the smallest unit (1 sat = 0.00000001 BTC)</source>
         <translation type="unfinished">Satoshi, la unidad más pequeña (1 sat = 0.00000001 BTC)</translation>
     </message>
@@ -1750,14 +2255,19 @@ Si lo encuentras útil, por favor contribuye.
 <context>
     <name>SettingsProxy</name>
     <message>
-        <location filename="../pages/settings/SettingsProxy.qml" line="21"/>
+        <location filename="../pages/settings/SettingsProxy.qml" line="25"/>
         <source>Back</source>
         <translation type="unfinished">Atrás</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsProxy.qml" line="27"/>
+        <location filename="../pages/settings/SettingsProxy.qml" line="31"/>
         <source>Proxy Settings</source>
         <translation type="unfinished">Ajustes de proxy</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsProxy.qml" line="74"/>
+        <source>Restart the application for these changes to take effect.</source>
+        <translation type="unfinished">Reinicia la aplicación para que los cambios surtan efecto.</translation>
     </message>
 </context>
 <context>
@@ -1786,14 +2296,27 @@ Si lo encuentras útil, por favor contribuye.
 <context>
     <name>SettingsTheme</name>
     <message>
-        <location filename="../pages/settings/SettingsTheme.qml" line="24"/>
+        <location filename="../pages/settings/SettingsTheme.qml" line="25"/>
         <source>Back</source>
         <translation type="unfinished">Atrás</translation>
     </message>
     <message>
-        <location filename="../pages/settings/SettingsTheme.qml" line="30"/>
+        <location filename="../pages/settings/SettingsTheme.qml" line="31"/>
         <source>Theme</source>
         <translation type="unfinished">Tema</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWallet</name>
+    <message>
+        <location filename="../pages/settings/SettingsWallet.qml" line="24"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsWallet.qml" line="30"/>
+        <source>External Signer</source>
+        <translation type="unfinished">Firmante externo</translation>
     </message>
 </context>
 <context>
@@ -1807,6 +2330,39 @@ Si lo encuentras útil, por favor contribuye.
         <location filename="../pages/node/Shutdown.qml" line="31"/>
         <source>Do not shut down the computer until this is done.</source>
         <translation type="unfinished">No apagues el ordenador hasta que esto esté listo.</translation>
+    </message>
+</context>
+<context>
+    <name>SpeedUpOverlay</name>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="75"/>
+        <source>Speed up transaction</source>
+        <translation type="unfinished">Acelerar transacción</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="87"/>
+        <source>Set a higher transaction fee if you want your transaction to be confirmed faster.</source>
+        <translation type="unfinished">Establece una comisión más alta si quieres que tu transacción se confirme más rápido.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="96"/>
+        <source>Original fee</source>
+        <translation type="unfinished">Comisión original</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="119"/>
+        <source>New fee</source>
+        <translation type="unfinished">Nueva comisión</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="149"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SpeedUpOverlay.qml" line="157"/>
+        <source>Update transaction</source>
+        <translation type="unfinished">Actualizar transacción</translation>
     </message>
 </context>
 <context>
@@ -1891,35 +2447,273 @@ Si lo encuentras útil, por favor contribuye.
 <context>
     <name>ThemeSettings</name>
     <message>
-        <location filename="../components/ThemeSettings.qml" line="21"/>
+        <location filename="../components/ThemeSettings.qml" line="24"/>
         <source>Light</source>
         <translation type="unfinished">Claro</translation>
     </message>
     <message>
-        <location filename="../components/ThemeSettings.qml" line="36"/>
+        <location filename="../components/ThemeSettings.qml" line="39"/>
         <source>Dark</source>
         <translation type="unfinished">Oscuro</translation>
+    </message>
+    <message>
+        <location filename="../components/ThemeSettings.qml" line="60"/>
+        <source>Developer</source>
+        <translation type="unfinished">Desarrollador</translation>
+    </message>
+    <message>
+        <location filename="../components/ThemeSettings.qml" line="70"/>
+        <source>Design system</source>
+        <translation type="unfinished">Sistema de diseño</translation>
     </message>
 </context>
 <context>
     <name>WalletBadge</name>
     <message>
-        <location filename="../pages/wallet/WalletBadge.qml" line="101"/>
+        <location filename="../pages/wallet/WalletBadge.qml" line="102"/>
         <source>Add Wallet</source>
         <translation type="unfinished">Añadir cartera</translation>
     </message>
     <message>
-        <location filename="../pages/wallet/WalletBadge.qml" line="101"/>
+        <location filename="../pages/wallet/WalletBadge.qml" line="102"/>
         <source>Select Wallet</source>
         <translation type="unfinished">Seleccionar cartera</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/WalletBadge.qml" line="147"/>
+        <source>sat</source>
+        <translation type="unfinished">sat</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/WalletBadge.qml" line="147"/>
+        <source>sats</source>
+        <translation type="unfinished">sats</translation>
+    </message>
+</context>
+<context>
+    <name>WalletQmlController</name>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="163"/>
+        <location filename="../walletqmlcontroller.cpp" line="223"/>
+        <source>Wallet creation failed.</source>
+        <translation type="unfinished">No se pudo crear la billetera.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="176"/>
+        <source>Choose a wallet name.</source>
+        <translation type="unfinished">Elige un nombre de billetera.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="182"/>
+        <source>Set an external signer path in Wallet settings first.</source>
+        <translation type="unfinished">Primero establece la ruta del firmante externo en los ajustes de billetera.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="190"/>
+        <source>Connect an external signer and try again.</source>
+        <translation type="unfinished">Conecta un firmante externo e inténtalo de nuevo.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="194"/>
+        <source>More than one external signer was found. Connect only one device and try again.</source>
+        <translation type="unfinished">Se encontró más de un firmante externo. Conecta solo un dispositivo e inténtalo de nuevo.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="283"/>
+        <source>More than one external signer was found. Connect only one device.</source>
+        <translation type="unfinished">Se encontró más de un firmante externo. Conecta solo un dispositivo.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="317"/>
+        <source>This wallet needs to be migrated</source>
+        <translation type="unfinished">Esta billetera necesita ser migrada</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="320"/>
+        <source>We couldn&apos;t find that file</source>
+        <translation type="unfinished">No pudimos encontrar ese archivo</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="323"/>
+        <source>A wallet with this name already exists</source>
+        <translation type="unfinished">Ya existe una billetera con este nombre</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="326"/>
+        <source>This wallet type is not supported</source>
+        <translation type="unfinished">Este tipo de billetera no es compatible</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="328"/>
+        <source>This wallet couldn&apos;t be imported</source>
+        <translation type="unfinished">No se pudo importar esta billetera</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="339"/>
+        <source>The selected backup appears to come from a legacy wallet format. It needs to be migrated before it can be used here.</source>
+        <translation type="unfinished">El respaldo seleccionado parece provenir de un formato de billetera antiguo. Necesita ser migrado antes de poder usarse aquí.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="342"/>
+        <source>The selected file is no longer available at that location. Choose the backup file again and retry.</source>
+        <translation type="unfinished">El archivo seleccionado ya no está disponible en esa ubicación. Elige el archivo de respaldo de nuevo e inténtalo otra vez.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="345"/>
+        <source>Importing this backup would create a wallet that already exists in your wallet directory. Remove or rename the existing wallet first, then try again.</source>
+        <translation type="unfinished">Importar este respaldo crearía una billetera que ya existe en tu directorio de billeteras. Elimina o cambia el nombre de la billetera existente primero, luego inténtalo de nuevo.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="348"/>
+        <source>The file looks like a wallet backup, but this application could not verify or open it in a supported format.</source>
+        <translation type="unfinished">El archivo parece ser un respaldo de billetera, pero esta aplicación no pudo verificarlo o abrirlo en un formato compatible.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="350"/>
+        <source>The selected file could not be restored as a wallet. Check that it is a valid wallet backup, then try another file.</source>
+        <translation type="unfinished">El archivo seleccionado no se pudo restaurar como billetera. Verifica que sea un respaldo de billetera válido, luego intenta con otro archivo.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="361"/>
+        <source>If this is a legacy wallet backup, migrate it with the wallet migration tool before importing it here.</source>
+        <translation type="unfinished">Si este es un respaldo de billetera antiguo, mígralo con la herramienta de migración de billeteras antes de importarlo aquí.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="485"/>
+        <source>Choose a wallet backup file.</source>
+        <translation type="unfinished">Elige un archivo de respaldo de billetera.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="490"/>
+        <source>The selected wallet path does not exist.</source>
+        <translation type="unfinished">La ruta de billetera seleccionada no existe.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="519"/>
+        <source>Wallet import failed.</source>
+        <translation type="unfinished">No se pudo importar la billetera.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="635"/>
+        <source>Choose a wallet to open.</source>
+        <translation type="unfinished">Elige una billetera para abrir.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="644"/>
+        <location filename="../walletqmlcontroller.cpp" line="698"/>
+        <source>The selected wallet is not available in the wallet directory.</source>
+        <translation type="unfinished">La billetera seleccionada no está disponible en el directorio de billeteras.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="674"/>
+        <source>Wallet could not be opened.</source>
+        <translation type="unfinished">No se pudo abrir la billetera.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="691"/>
+        <source>Choose a wallet to update.</source>
+        <translation type="unfinished">Elige una billetera para actualizar.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="713"/>
+        <source>Wallet update failed.</source>
+        <translation type="unfinished">No se pudo actualizar la billetera.</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="771"/>
+        <location filename="../walletqmlcontroller.cpp" line="786"/>
+        <source>Single-key</source>
+        <translation type="unfinished">Clave única</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="776"/>
+        <source>External signer</source>
+        <translation type="unfinished">Firmante externo</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="779"/>
+        <source>Watch-only</source>
+        <translation type="unfinished">Solo lectura</translation>
+    </message>
+    <message>
+        <location filename="../walletqmlcontroller.cpp" line="783"/>
+        <source>Multi-key</source>
+        <translation type="unfinished">Multiclave</translation>
+    </message>
+</context>
+<context>
+    <name>WalletQmlModel</name>
+    <message>
+        <location filename="../models/walletqmlmodel.cpp" line="736"/>
+        <source>External signer not available.</source>
+        <translation type="unfinished">Firmante externo no disponible.</translation>
+    </message>
+    <message>
+        <location filename="../models/walletqmlmodel.cpp" line="742"/>
+        <location filename="../models/walletqmlmodel.cpp" line="756"/>
+        <source>Couldn&apos;t prepare transaction for external signing.</source>
+        <translation type="unfinished">No se pudo preparar la transacción para firma externa.</translation>
+    </message>
+    <message>
+        <location filename="../models/walletqmlmodel.cpp" line="768"/>
+        <source>External signer not found. Connect one device and try again.</source>
+        <translation type="unfinished">Firmante externo no encontrado. Conecta un dispositivo e inténtalo de nuevo.</translation>
+    </message>
+    <message>
+        <location filename="../models/walletqmlmodel.cpp" line="771"/>
+        <source>External signer failed to sign. Try again.</source>
+        <translation type="unfinished">El firmante externo no pudo firmar. Inténtalo de nuevo.</translation>
     </message>
 </context>
 <context>
     <name>WalletSelect</name>
     <message>
-        <location filename="../pages/wallet/WalletSelect.qml" line="59"/>
+        <location filename="../pages/wallet/WalletSelect.qml" line="60"/>
         <source>Wallets</source>
         <translation type="unfinished">Carteras</translation>
+    </message>
+</context>
+<context>
+    <name>WalletSettings</name>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="33"/>
+        <source>Signer path</source>
+        <translation type="unfinished">Ruta del firmante</translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="43"/>
+        <source>Enter external signer path</source>
+        <translation type="unfinished">Introduce la ruta del firmante externo</translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="65"/>
+        <source>The add wallet flow can offer external wallets when exactly one supported signer is connected.</source>
+        <translation type="unfinished">El proceso de añadir billetera puede ofrecer billeteras externas cuando hay exactamente un firmante compatible conectado.</translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="108"/>
+        <source>Detected external signer: %1</source>
+        <translation type="unfinished">Firmante externo detectado: %1</translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="114"/>
+        <source>Path updated. Press Check device to rescan with the current signer command.</source>
+        <translation type="unfinished">Ruta actualizada. Pulsa Verificar dispositivo para volver a escanear con el comando de firmante actual.</translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="117"/>
+        <source>No external signer is currently detected.</source>
+        <translation type="unfinished">No se detecta ningún firmante externo actualmente.</translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="119"/>
+        <source>Set the command path for HWI or another external signer tool.</source>
+        <translation type="unfinished">Establece la ruta del comando para HWI u otra herramienta de firmante externo.</translation>
+    </message>
+    <message>
+        <location filename="../components/WalletSettings.qml" line="130"/>
+        <source>Check device</source>
+        <translation type="unfinished">Verificar dispositivo</translation>
     </message>
 </context>
 <context>
@@ -1941,6 +2735,30 @@ Si lo encuentras útil, por favor contribuye.
         <location filename="../pages/main.qml" line="18"/>
         <source>Bitcoin Core App</source>
         <translation type="unfinished">Aplicación Bitcoin Core</translation>
+    </message>
+    <message>
+        <location filename="../pages/main.qml" line="119"/>
+        <location filename="../pages/main.qml" line="137"/>
+        <source>Approved on external signer. It should be confirmed within the next 10 minutes.</source>
+        <translation type="unfinished">Aprobado en el firmante externo. Debería confirmarse en los próximos 10 minutos.</translation>
+    </message>
+    <message>
+        <location filename="../pages/main.qml" line="120"/>
+        <location filename="../pages/main.qml" line="138"/>
+        <source>Based on your selected fee, it should be confirmed within the next 10 minutes.</source>
+        <translation type="unfinished">Con la tarifa seleccionada, debería confirmarse en los próximos 10 minutos.</translation>
+    </message>
+    <message>
+        <location filename="../pages/main.qml" line="121"/>
+        <location filename="../pages/main.qml" line="139"/>
+        <source>Done</source>
+        <translation type="unfinished">Listo</translation>
+    </message>
+    <message>
+        <location filename="../pages/main.qml" line="121"/>
+        <location filename="../pages/main.qml" line="139"/>
+        <source>Close window</source>
+        <translation type="unfinished">Cerrar ventana</translation>
     </message>
 </context>
 </TS>

--- a/qml/locale/bitcoin_qml_es.ts
+++ b/qml/locale/bitcoin_qml_es.ts
@@ -1,0 +1,1946 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
+<context>
+    <name>AboutOptions</name>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="17"/>
+        <source>Website</source>
+        <translation type="unfinished">Sitio web</translation>
+    </message>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="29"/>
+        <source>Source code</source>
+        <translation type="unfinished">Código fuente</translation>
+    </message>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="41"/>
+        <source>License</source>
+        <translation type="unfinished">Licencia</translation>
+    </message>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="53"/>
+        <source>Version</source>
+        <translation type="unfinished">Versión</translation>
+    </message>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="68"/>
+        <source>Developer options</source>
+        <translation type="unfinished">Opciones de desarrollador</translation>
+    </message>
+    <message>
+        <location filename="../components/AboutOptions.qml" line="69"/>
+        <source>Only use these if you have development experience</source>
+        <translation type="unfinished">Úsalas solo si tienes experiencia en desarrollo</translation>
+    </message>
+</context>
+<context>
+    <name>Activity</name>
+    <message>
+        <location filename="../pages/wallet/Activity.qml" line="54"/>
+        <source>Activity</source>
+        <translation type="unfinished">Actividad</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityDetails</name>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="55"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="66"/>
+        <source>Transaction</source>
+        <translation type="unfinished">Transacción</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="129"/>
+        <source>%1 confirmations</source>
+        <translation type="unfinished">%1 confirmaciones</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="138"/>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="148"/>
+        <source>Message</source>
+        <translation type="unfinished">Mensaje</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/ActivityDetails.qml" line="163"/>
+        <source>Address</source>
+        <translation type="unfinished">Dirección</translation>
+    </message>
+</context>
+<context>
+    <name>AddWalletButton</name>
+    <message>
+        <location filename="../controls/AddWalletButton.qml" line="49"/>
+        <source>Add Wallet</source>
+        <translation type="unfinished">Añadir cartera</translation>
+    </message>
+</context>
+<context>
+    <name>BannedPeers</name>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="22"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="28"/>
+        <source>Banned peers</source>
+        <translation type="unfinished">Pares bloqueados</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="48"/>
+        <source>You banned these peers from connecting to your node.</source>
+        <translation type="unfinished">Has bloqueado estos pares para que no se conecten a tu nodo.</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="87"/>
+        <source>Until %1</source>
+        <translation type="unfinished">Hasta %1</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="97"/>
+        <source>Unban</source>
+        <translation type="unfinished">Desbloquear</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/BannedPeers.qml" line="110"/>
+        <source>No banned peers.</source>
+        <translation type="unfinished">No hay pares bloqueados.</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinAddressInputField</name>
+    <message>
+        <location filename="../components/BitcoinAddressInputField.qml" line="17"/>
+        <source>Send to</source>
+        <translation type="unfinished">Enviar a</translation>
+    </message>
+    <message>
+        <location filename="../components/BitcoinAddressInputField.qml" line="47"/>
+        <source>Enter address...</source>
+        <translation type="unfinished">Introducir dirección...</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinAmountInputField</name>
+    <message>
+        <location filename="../components/BitcoinAmountInputField.qml" line="17"/>
+        <source>Amount</source>
+        <translation type="unfinished">Importe</translation>
+    </message>
+</context>
+<context>
+    <name>BlockClock</name>
+    <message>
+        <location filename="../components/BlockClock.qml" line="229"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Conectando</translation>
+    </message>
+    <message>
+        <location filename="../components/BlockClock.qml" line="231"/>
+        <source>Please wait</source>
+        <translation type="unfinished">Por favor espere</translation>
+    </message>
+</context>
+<context>
+    <name>BlockClockDisplayMode</name>
+    <message>
+        <location filename="../components/BlockClockDisplayMode.qml" line="22"/>
+        <source>Compact</source>
+        <translation type="unfinished">Compacto</translation>
+    </message>
+    <message>
+        <location filename="../components/BlockClockDisplayMode.qml" line="23"/>
+        <source>For personal use on a computer or smartphone.</source>
+        <translation type="unfinished">Para uso personal en ordenador o teléfono inteligente.</translation>
+    </message>
+    <message>
+        <location filename="../components/BlockClockDisplayMode.qml" line="34"/>
+        <source>Showcase</source>
+        <translation type="unfinished">Presentación</translation>
+    </message>
+    <message>
+        <location filename="../components/BlockClockDisplayMode.qml" line="35"/>
+        <source>A larger block clock for public display on a tablet or other large screen.</source>
+        <translation type="unfinished">Un reloj de bloques más grande para visualización pública en tableta u otra pantalla grande.</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelection</name>
+    <message>
+        <location filename="../pages/wallet/CoinSelection.qml" line="25"/>
+        <source>Coin Selection</source>
+        <translation type="unfinished">Selección de monedas</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CoinSelection.qml" line="28"/>
+        <source>Done</source>
+        <translation type="unfinished">Listo</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CoinSelection.qml" line="55"/>
+        <source>Total selected</source>
+        <translation type="unfinished">Total seleccionado</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CoinSelection.qml" line="76"/>
+        <source>Over required amount</source>
+        <translation type="unfinished">Por encima del importe requerido</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CoinSelection.qml" line="78"/>
+        <source>Remaining to select</source>
+        <translation type="unfinished">Pendiente de seleccionar</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionOptions</name>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="18"/>
+        <source>Fast always on</source>
+        <translation type="unfinished">Rápido, siempre activo</translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="19"/>
+        <source>Loads quickly at all times and uses as much cellular data as needed.</source>
+        <translation type="unfinished">Se carga rápidamente siempre y usa los datos móviles necesarios.</translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="26"/>
+        <source>Slow always on</source>
+        <translation type="unfinished">Lento, siempre activo</translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="27"/>
+        <source>Loads at all times with reduced cellular data usage.</source>
+        <translation type="unfinished">Se carga siempre con uso reducido de datos móviles.</translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="32"/>
+        <source>Only when on Wi-Fi</source>
+        <translation type="unfinished">Solo con Wi-Fi</translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionOptions.qml" line="33"/>
+        <source>Loads quickly when on wi-fi and pauses when on cellular data.</source>
+        <translation type="unfinished">Se carga rápidamente con Wi-Fi y se pausa con datos móviles.</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionSettings</name>
+    <message>
+        <location filename="../components/ConnectionSettings.qml" line="16"/>
+        <source>Enable listening</source>
+        <translation type="unfinished">Activar escucha</translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionSettings.qml" line="17"/>
+        <source>Allows incoming connections</source>
+        <translation type="unfinished">Permite conexiones entrantes</translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionSettings.qml" line="30"/>
+        <source>Map port using NAT-PMP</source>
+        <translation type="unfinished">Mapear puerto usando NAT-PMP</translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionSettings.qml" line="43"/>
+        <source>Enable RPC server</source>
+        <translation type="unfinished">Activar servidor RPC</translation>
+    </message>
+    <message>
+        <location filename="../components/ConnectionSettings.qml" line="57"/>
+        <source>Proxy settings</source>
+        <translation type="unfinished">Ajustes de proxy</translation>
+    </message>
+</context>
+<context>
+    <name>CreateBackup</name>
+    <message>
+        <location filename="../pages/wallet/CreateBackup.qml" line="23"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateBackup.qml" line="59"/>
+        <source>Back up your wallet</source>
+        <translation type="unfinished">Haz una copia de seguridad de tu cartera</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateBackup.qml" line="61"/>
+        <source>Your wallet is a file stored on your hard disk.
+To prevent accidental loss, it is recommended you keep a copy of your wallet file in a secure place, like a dedicated USB Drive.</source>
+        <translation type="unfinished">Tu cartera es un archivo almacenado en tu disco duro.
+Para evitar pérdidas accidentales, se recomienda guardar una copia en un lugar seguro, como una memoria USB dedicada.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateBackup.qml" line="70"/>
+        <source>View file</source>
+        <translation type="unfinished">Ver archivo</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateBackup.qml" line="86"/>
+        <source>Done</source>
+        <translation type="unfinished">Listo</translation>
+    </message>
+</context>
+<context>
+    <name>CreateConfirm</name>
+    <message>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="23"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="59"/>
+        <source>Your wallet has been created</source>
+        <translation type="unfinished">Tu cartera ha sido creada</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="61"/>
+        <source>It is good practice to make a small test transaction before you actively use this wallet for larger amounts.</source>
+        <translation type="unfinished">Es buena práctica realizar una pequeña transacción de prueba antes de usar esta cartera para importes mayores.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateConfirm.qml" line="70"/>
+        <source>Next</source>
+        <translation type="unfinished">Siguiente</translation>
+    </message>
+</context>
+<context>
+    <name>CreateIntro</name>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="23"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="58"/>
+        <source>You are about to create 
+a single-key bitcoin wallet</source>
+        <translation type="unfinished">Estás a punto de crear 
+una cartera Bitcoin de clave única</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="67"/>
+        <source>You can fully control it in this application.</source>
+        <translation type="unfinished">Puedes controlarlo completamente en esta aplicación.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="83"/>
+        <source>Wallet data will be stored locally on your hard drive.</source>
+        <translation type="unfinished">Los datos de la cartera se almacenarán localmente en tu disco duro.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="99"/>
+        <source>You can optionally protect it with a password.</source>
+        <translation type="unfinished">Opcionalmente puedes protegerlo con una contraseña.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateIntro.qml" line="110"/>
+        <source>Start</source>
+        <translation type="unfinished">Iniciar</translation>
+    </message>
+</context>
+<context>
+    <name>CreateName</name>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="24"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="41"/>
+        <source>Choose a wallet name</source>
+        <translation type="unfinished">Elige un nombre para la cartera</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="51"/>
+        <source>Eg. My bitcoin wallet...</source>
+        <translation type="unfinished">Ej. Mi cartera Bitcoin...</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateName.qml" line="65"/>
+        <source>Continue</source>
+        <translation type="unfinished">Continuar</translation>
+    </message>
+</context>
+<context>
+    <name>CreatePassword</name>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="25"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="31"/>
+        <source>Skip</source>
+        <translation type="unfinished">Omitir</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="48"/>
+        <location filename="../pages/wallet/CreatePassword.qml" line="59"/>
+        <source>Choose a password</source>
+        <translation type="unfinished">Elige una contraseña</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="50"/>
+        <source>It is recommended to set a password to protect your wallet file from unwanted access from others.</source>
+        <translation type="unfinished">Se recomienda establecer una contraseña para proteger tu archivo de cartera del acceso no deseado.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="70"/>
+        <source>Enter password...</source>
+        <translation type="unfinished">Introducir contraseña...</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="78"/>
+        <source>Confirm password</source>
+        <translation type="unfinished">Confirmar contraseña</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="86"/>
+        <source>Enter password again...</source>
+        <translation type="unfinished">Introducir contraseña de nuevo...</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="94"/>
+        <source>I understand that if I lose or forget this password I might lose access to the bitcoin stored in this wallet.</source>
+        <translation type="unfinished">Entiendo que si pierdo u olvido esta contraseña podría perder el acceso al bitcoin de esta cartera.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreatePassword.qml" line="109"/>
+        <source>Continue</source>
+        <translation type="unfinished">Continuar</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletWizard</name>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="34"/>
+        <source>Skip</source>
+        <translation type="unfinished">Omitir</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="60"/>
+        <source>Add a wallet</source>
+        <translation type="unfinished">Añadir una cartera</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="62"/>
+        <source>In this early stage of development, only wallet.dat files are supported.</source>
+        <translation type="unfinished">En esta etapa de desarrollo, solo se admiten archivos wallet.dat.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="72"/>
+        <source>Create wallet</source>
+        <translation type="unfinished">Crear cartera</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/CreateWalletWizard.qml" line="83"/>
+        <source>Import wallet</source>
+        <translation type="unfinished">Importar cartera</translation>
+    </message>
+</context>
+<context>
+    <name>DesktopWallets</name>
+    <message>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="66"/>
+        <source>Activity</source>
+        <translation type="unfinished">Actividad</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="71"/>
+        <source>Send</source>
+        <translation type="unfinished">Enviar</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="76"/>
+        <source>Receive</source>
+        <translation type="unfinished">Recibir</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="110"/>
+        <source>Paused</source>
+        <translation type="unfinished">En pausa</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/DesktopWallets.qml" line="116"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Conectando</translation>
+    </message>
+</context>
+<context>
+    <name>DeveloperOptions</name>
+    <message>
+        <location filename="../components/DeveloperOptions.qml" line="15"/>
+        <source>Database cache size (MiB)</source>
+        <translation type="unfinished">Tamaño de caché de base de datos (MiB)</translation>
+    </message>
+    <message>
+        <location filename="../components/DeveloperOptions.qml" line="16"/>
+        <source>This is not a valid cache size. Please choose a value between %1 and %2 MiB.</source>
+        <translation type="unfinished">No es un tamaño de caché válido. Elige un valor entre %1 y %2 MiB.</translation>
+    </message>
+    <message>
+        <location filename="../components/DeveloperOptions.qml" line="40"/>
+        <source>Script verification threads</source>
+        <translation type="unfinished">Hilos de verificación de scripts</translation>
+    </message>
+    <message>
+        <location filename="../components/DeveloperOptions.qml" line="41"/>
+        <source>This is not a valid thread count. Please choose a value between %1 and %2 threads.</source>
+        <translation type="unfinished">No es un número de hilos válido. Elige un valor entre %1 y %2 hilos.</translation>
+    </message>
+    <message>
+        <location filename="../components/DeveloperOptions.qml" line="64"/>
+        <source>Dark Mode</source>
+        <translation type="unfinished">Modo oscuro</translation>
+    </message>
+</context>
+<context>
+    <name>ExternalPopup</name>
+    <message>
+        <location filename="../components/ExternalPopup.qml" line="31"/>
+        <source>External Link</source>
+        <translation type="unfinished">Enlace externo</translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalPopup.qml" line="46"/>
+        <source>Do you want to open the following website in your browser?</source>
+        <translation type="unfinished">¿Quieres abrir el siguiente sitio web en tu navegador?</translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalPopup.qml" line="62"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../components/ExternalPopup.qml" line="69"/>
+        <source>Ok</source>
+        <translation type="unfinished">Aceptar</translation>
+    </message>
+</context>
+<context>
+    <name>FeeSelection</name>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="27"/>
+        <source>Fee</source>
+        <translation type="unfinished">Tarifa</translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="202"/>
+        <source>High</source>
+        <translation type="unfinished">Alto</translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="202"/>
+        <source>(~10 mins)</source>
+        <translation type="unfinished">(~10 min)</translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="203"/>
+        <source>Default</source>
+        <translation type="unfinished">Predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="203"/>
+        <source>(~60 mins)</source>
+        <translation type="unfinished">(~60 min)</translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="204"/>
+        <source>Low</source>
+        <translation type="unfinished">Bajo</translation>
+    </message>
+    <message>
+        <location filename="../components/FeeSelection.qml" line="204"/>
+        <source>(~24 hrs)</source>
+        <translation type="unfinished">(~24 h)</translation>
+    </message>
+</context>
+<context>
+    <name>LabeledCoinControlButton</name>
+    <message>
+        <location filename="../controls/LabeledCoinControlButton.qml" line="25"/>
+        <source>Inputs</source>
+        <translation type="unfinished">Entradas</translation>
+    </message>
+    <message>
+        <location filename="../controls/LabeledCoinControlButton.qml" line="36"/>
+        <source>No coins available</source>
+        <translation type="unfinished">No hay monedas disponibles</translation>
+    </message>
+    <message>
+        <location filename="../controls/LabeledCoinControlButton.qml" line="38"/>
+        <source>Select</source>
+        <translation type="unfinished">Seleccionar</translation>
+    </message>
+    <message>
+        <location filename="../controls/LabeledCoinControlButton.qml" line="40"/>
+        <source>%1 input%2 selected</source>
+        <translation type="unfinished">%1 entrada%2 seleccionada</translation>
+    </message>
+</context>
+<context>
+    <name>MultipleSendReview</name>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="28"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="52"/>
+        <source>Transaction details</source>
+        <translation type="unfinished">Detalles de la transacción</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="102"/>
+        <source>Total amount</source>
+        <translation type="unfinished">Importe total</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="124"/>
+        <source>Fee</source>
+        <translation type="unfinished">Tarifa</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/MultipleSendReview.qml" line="147"/>
+        <source>Send</source>
+        <translation type="unfinished">Enviar</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkIndicator</name>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="52"/>
+        <source>Testnet</source>
+        <translation type="unfinished">Testnet</translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="52"/>
+        <source>Test Network</source>
+        <translation type="unfinished">Red de pruebas</translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="61"/>
+        <source>Signet</source>
+        <translation type="unfinished">Signet</translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="61"/>
+        <source>Signet Network</source>
+        <translation type="unfinished">Red Signet</translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="70"/>
+        <source>Regtest</source>
+        <translation type="unfinished">Regtest</translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkIndicator.qml" line="70"/>
+        <source>Regtest Mode</source>
+        <translation type="unfinished">Modo Regtest</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkTraffic</name>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="24"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="30"/>
+        <source>Network traffic</source>
+        <translation type="unfinished">Tráfico de red</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="34"/>
+        <source>Network Traffic</source>
+        <translation type="unfinished">Tráfico de red</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="36"/>
+        <source>How much data you have sent to and received from your peers.</source>
+        <translation type="unfinished">Cuántos datos has enviado a y recibido de tus pares.</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="62"/>
+        <source>5 min</source>
+        <translation type="unfinished">5 min</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="78"/>
+        <source>1 hour</source>
+        <translation type="unfinished">1 hora</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="94"/>
+        <source>12 hours</source>
+        <translation type="unfinished">12 horas</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="110"/>
+        <source>1 day</source>
+        <translation type="unfinished">1 día</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="129"/>
+        <source>Received: %1</source>
+        <translation type="unfinished">Recibido: %1</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NetworkTraffic.qml" line="149"/>
+        <source>Sent: %1</source>
+        <translation type="unfinished">Enviado: %1</translation>
+    </message>
+</context>
+<context>
+    <name>NodeSettings</name>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="25"/>
+        <source>Settings</source>
+        <translation type="unfinished">Configuración</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="29"/>
+        <source>Done</source>
+        <translation type="unfinished">Listo</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="44"/>
+        <source>About</source>
+        <translation type="unfinished">Acerca de</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="57"/>
+        <source>Display</source>
+        <translation type="unfinished">Pantalla</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="69"/>
+        <source>Storage</source>
+        <translation type="unfinished">Almacenamiento</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="81"/>
+        <source>Connection</source>
+        <translation type="unfinished">Conexión</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="94"/>
+        <source>Peers</source>
+        <translation type="unfinished">Pares</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/NodeSettings.qml" line="107"/>
+        <source>Network Traffic</source>
+        <translation type="unfinished">Tráfico de red</translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingBlockclock</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingBlockclock.qml" line="16"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingBlockclock.qml" line="25"/>
+        <source>The block clock</source>
+        <translation type="unfinished">El reloj de bloques</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingBlockclock.qml" line="26"/>
+        <source>The Bitcoin network targets a new block every 10 minutes. Sometimes it&apos;s faster and sometimes slower.
+
+The block clock indicates each block on a dial that represents the current day.</source>
+        <translation type="unfinished">La red Bitcoin apunta a un nuevo bloque cada 10 minutos. A veces es más rápido y a veces más lento.
+
+El reloj de bloques indica cada bloque en un dial que representa el día actual.</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingBlockclock.qml" line="29"/>
+        <source>Next</source>
+        <translation type="unfinished">Siguiente</translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingConnection</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="30"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="41"/>
+        <source>Starting initial download</source>
+        <translation type="unfinished">Iniciando descarga inicial</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="43"/>
+        <source>The application will connect to the Bitcoin network and start downloading and verifying transactions.
+
+This may take several hours, or even days, based on your connection.</source>
+        <translation type="unfinished">La aplicación se conectará a la red Bitcoin y comenzará a descargar y verificar transacciones.
+
+Esto puede llevar varias horas, o incluso días, según tu conexión.</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="50"/>
+        <source>Connection settings</source>
+        <translation type="unfinished">Ajustes de conexión</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingConnection.qml" line="55"/>
+        <source>Next</source>
+        <translation type="unfinished">Siguiente</translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingCover</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingCover.qml" line="47"/>
+        <source>Bitcoin Core App</source>
+        <translation type="unfinished">Aplicación Bitcoin Core</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingCover.qml" line="49"/>
+        <source>Be part of the Bitcoin network.</source>
+        <translation type="unfinished">Forma parte de la red Bitcoin.</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingCover.qml" line="52"/>
+        <source>100% open-source &amp; open-design</source>
+        <translation type="unfinished">100% código abierto y diseño abierto</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingCover.qml" line="53"/>
+        <source>Start</source>
+        <translation type="unfinished">Iniciar</translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingStorageAmount</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageAmount.qml" line="32"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageAmount.qml" line="37"/>
+        <source>Storage</source>
+        <translation type="unfinished">Almacenamiento</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageAmount.qml" line="39"/>
+        <source>Data retrieved from the Bitcoin network is stored on your device.
+You have 500GB of storage available.</source>
+        <translation type="unfinished">Los datos de la red Bitcoin se almacenan en tu dispositivo.
+Tienes 500 GB de almacenamiento disponible.</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageAmount.qml" line="53"/>
+        <source>Detailed settings</source>
+        <translation type="unfinished">Ajustes detallados</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageAmount.qml" line="57"/>
+        <source>Next</source>
+        <translation type="unfinished">Siguiente</translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingStorageLocation</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageLocation.qml" line="18"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageLocation.qml" line="23"/>
+        <source>Storage location</source>
+        <translation type="unfinished">Ubicación de almacenamiento</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageLocation.qml" line="25"/>
+        <source>Where do you want to store the downloaded block data?
+You need a minimum of %1GB of storage.</source>
+        <translation type="unfinished">¿Dónde quieres almacenar los datos de bloques descargados?
+Necesitas un mínimo de %1 GB de almacenamiento.</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStorageLocation.qml" line="29"/>
+        <source>Next</source>
+        <translation type="unfinished">Siguiente</translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingStrengthen</name>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStrengthen.qml" line="16"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStrengthen.qml" line="25"/>
+        <source>Strengthen bitcoin</source>
+        <translation type="unfinished">Fortalecer bitcoin</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStrengthen.qml" line="26"/>
+        <source>Bitcoin Core runs a full Bitcoin node which verifies the rules of the network are being followed.
+
+Users running nodes is what makes bitcoin so resilient and trustworthy.</source>
+        <translation type="unfinished">Bitcoin Core ejecuta un nodo Bitcoin completo que verifica que se siguen las reglas de la red.
+
+Que los usuarios ejecuten nodos es lo que hace que bitcoin sea tan resistente y fiable.</translation>
+    </message>
+    <message>
+        <location filename="../pages/onboarding/OnboardingStrengthen.qml" line="29"/>
+        <source>Next</source>
+        <translation type="unfinished">Siguiente</translation>
+    </message>
+</context>
+<context>
+    <name>OptionButton</name>
+    <message>
+        <location filename="../controls/OptionButton.qml" line="83"/>
+        <source>Recommended</source>
+        <translation type="unfinished">Recomendado</translation>
+    </message>
+</context>
+<context>
+    <name>PeerDetails</name>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="30"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="36"/>
+        <source>Peer %1</source>
+        <translation type="unfinished">Par %1</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="55"/>
+        <source>Information</source>
+        <translation type="unfinished">Información</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="66"/>
+        <source>Address</source>
+        <translation type="unfinished">Dirección</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="67"/>
+        <source>VIA</source>
+        <translation type="unfinished">VÍA</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="68"/>
+        <source>Type</source>
+        <translation type="unfinished">Tipo</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="74"/>
+        <source>Permissions</source>
+        <translation type="unfinished">Permisos</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="94"/>
+        <source>Version</source>
+        <translation type="unfinished">Versión</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="95"/>
+        <source>User agent</source>
+        <translation type="unfinished">Agente de usuario</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="96"/>
+        <source>Services</source>
+        <translation type="unfinished">Servicios</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="100"/>
+        <source>Transaction relay</source>
+        <translation type="unfinished">Retransmisión de transacciones</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="111"/>
+        <source>Address relay</source>
+        <translation type="unfinished">Retransmisión de direcciones</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="124"/>
+        <source>Mapped AS</source>
+        <translation type="unfinished">Sistema autónomo asignado</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="151"/>
+        <source>Block data</source>
+        <translation type="unfinished">Datos de bloques</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="161"/>
+        <source>Starting block</source>
+        <translation type="unfinished">Bloque inicial</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="162"/>
+        <source>Synced headers</source>
+        <translation type="unfinished">Cabeceras sincronizadas</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="163"/>
+        <source>Synced blocks</source>
+        <translation type="unfinished">Bloques sincronizados</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="167"/>
+        <source>Network traffic</source>
+        <translation type="unfinished">Tráfico de red</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="177"/>
+        <source>Direction</source>
+        <translation type="unfinished">Sentido</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="190"/>
+        <source>Connection time</source>
+        <translation type="unfinished">Tiempo de conexión</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="191"/>
+        <source>Last send</source>
+        <translation type="unfinished">Último envío</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="191"/>
+        <location filename="../pages/node/PeerDetails.qml" line="192"/>
+        <source> ago</source>
+        <translation type="unfinished"> atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="192"/>
+        <source>Last receive</source>
+        <translation type="unfinished">Última recepción</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="193"/>
+        <source>Sent</source>
+        <translation type="unfinished">Enviado</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="193"/>
+        <location filename="../pages/node/PeerDetails.qml" line="194"/>
+        <source> total</source>
+        <translation type="unfinished"> total</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="194"/>
+        <source>Received</source>
+        <translation type="unfinished">Recibido</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="195"/>
+        <source>Ping time</source>
+        <translation type="unfinished">Tiempo de ping</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="201"/>
+        <source>Ping wait</source>
+        <translation type="unfinished">Espera de ping</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="231"/>
+        <source>Min ping</source>
+        <translation type="unfinished">Ping mínimo</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="232"/>
+        <source>Time offset</source>
+        <translation type="unfinished">Desfase de tiempo</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="243"/>
+        <source>Disconnect</source>
+        <translation type="unfinished">Desconectar</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="252"/>
+        <location filename="../pages/node/PeerDetails.qml" line="348"/>
+        <source>Ban</source>
+        <translation type="unfinished">Bloquear</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="276"/>
+        <source>1 hour</source>
+        <translation type="unfinished">1 hora</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="277"/>
+        <source>1 day</source>
+        <translation type="unfinished">1 día</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="278"/>
+        <source>1 week</source>
+        <translation type="unfinished">1 semana</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="279"/>
+        <source>1 year</source>
+        <translation type="unfinished">1 año</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="289"/>
+        <source>Ban this peer</source>
+        <translation type="unfinished">Bloquear este par</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/PeerDetails.qml" line="340"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>PeerDetailsModel</name>
+    <message>
+        <location filename="../models/peerdetailsmodel.h" line="70"/>
+        <location filename="../models/peerdetailsmodel.h" line="73"/>
+        <source>N/A</source>
+        <translation type="unfinished">N/D</translation>
+    </message>
+</context>
+<context>
+    <name>PeerListModel</name>
+    <message>
+        <location filename="../models/peerlistmodel.cpp" line="62"/>
+        <source>Inbound</source>
+        <translation type="unfinished">Entrante</translation>
+    </message>
+    <message>
+        <location filename="../models/peerlistmodel.cpp" line="62"/>
+        <source>Outbound</source>
+        <translation type="unfinished">Saliente</translation>
+    </message>
+</context>
+<context>
+    <name>Peers</name>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="25"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="31"/>
+        <source>Peers</source>
+        <translation type="unfinished">Pares</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="60"/>
+        <source>Peers are nodes you exchange data with.</source>
+        <translation type="unfinished">Los pares son nodos con los que intercambias datos.</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="78"/>
+        <source>ID</source>
+        <translation type="unfinished">ID</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="87"/>
+        <source>Direction</source>
+        <translation type="unfinished">Sentido</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="96"/>
+        <source>User Agent</source>
+        <translation type="unfinished">Agente de usuario</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="105"/>
+        <source>Type</source>
+        <translation type="unfinished">Tipo</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="114"/>
+        <source>Ip</source>
+        <translation type="unfinished">Ip</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="123"/>
+        <source>Network</source>
+        <translation type="unfinished">Red</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="161"/>
+        <source>Looking for %1 more peer(s)</source>
+        <translation type="unfinished">Buscando %1 par(es) más</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="174"/>
+        <source>View %1 banned %2</source>
+        <translation type="unfinished">Ver %1 bloqueado(s) %2</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="174"/>
+        <source>peer</source>
+        <translation type="unfinished">par</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Peers.qml" line="174"/>
+        <source>peers</source>
+        <translation type="unfinished">pares</translation>
+    </message>
+</context>
+<context>
+    <name>ProxySettings</name>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="13"/>
+        <source>IP and Port</source>
+        <translation type="unfinished">IP y Puerto</translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="14"/>
+        <source>Invalid IP address or port format. Use &apos;255.255.255.255:65535&apos; or &apos;[ffff::]:65535&apos;</source>
+        <translation type="unfinished">Formato de dirección IP o puerto no válido. Use &apos;255.255.255.255:65535&apos; o &apos;[ffff::]:65535&apos;</translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="20"/>
+        <source>Default Proxy</source>
+        <translation type="unfinished">Proxy predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="22"/>
+        <source>Run peer connections through a proxy (SOCKS5) for improved privacy. The default proxy supports connections via IPv4, IPv6 and Tor.</source>
+        <translation type="unfinished">Ejecutar conexiones con pares mediante un proxy (SOCKS5) para mayor privacidad. El proxy predeterminado admite conexiones IPv4, IPv6 y Tor.</translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="30"/>
+        <location filename="../components/ProxySettings.qml" line="81"/>
+        <source>Enable</source>
+        <translation type="unfinished">Activar</translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="70"/>
+        <source>Tor Proxy</source>
+        <translation type="unfinished">Proxy Tor</translation>
+    </message>
+    <message>
+        <location filename="../components/ProxySettings.qml" line="72"/>
+        <source>Run Tor connections through a dedicated proxy.</source>
+        <translation type="unfinished">Ejecutar conexiones Tor a través de un proxy dedicado.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="98"/>
+        <location filename="../models/options_model.cpp" line="239"/>
+        <source>System default</source>
+        <translation type="unfinished">Predeterminado del sistema</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="25"/>
+        <source>Inbound</source>
+        <translation type="unfinished">Entrante</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="26"/>
+        <source>Outbound</source>
+        <translation type="unfinished">Saliente</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="30"/>
+        <source>Full Relay</source>
+        <translation type="unfinished">Retransmisión completa</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="31"/>
+        <source>Block Relay</source>
+        <translation type="unfinished">Retransmisión de bloques</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="32"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manual</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="33"/>
+        <source>Feeler</source>
+        <translation type="unfinished">Sensor</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="34"/>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Recuperación de direcciones</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="42"/>
+        <source>Unroutable</source>
+        <translation type="unfinished">No enrutable</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="43"/>
+        <source>IPv4</source>
+        <comment>network name</comment>
+        <translation type="unfinished">IPv4</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="44"/>
+        <source>IPv6</source>
+        <comment>network name</comment>
+        <translation type="unfinished">IPv6</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="45"/>
+        <source>Onion</source>
+        <comment>network name</comment>
+        <translation type="unfinished">Onion</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="46"/>
+        <source>I2P</source>
+        <comment>network name</comment>
+        <translation type="unfinished">I2P</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="47"/>
+        <source>CJDNS</source>
+        <comment>network name</comment>
+        <translation type="unfinished">CJDNS</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="62"/>
+        <location filename="../peerstatsutil.cpp" line="74"/>
+        <source>%1 d</source>
+        <translation type="unfinished">%1 d</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="63"/>
+        <location filename="../peerstatsutil.cpp" line="75"/>
+        <source>%1 h</source>
+        <translation type="unfinished">%1 h</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="64"/>
+        <location filename="../peerstatsutil.cpp" line="76"/>
+        <source>%1 m</source>
+        <translation type="unfinished">%1 m</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="66"/>
+        <location filename="../peerstatsutil.cpp" line="77"/>
+        <location filename="../peerstatsutil.cpp" line="102"/>
+        <source>%1 s</source>
+        <translation type="unfinished">%1 s</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="89"/>
+        <source>None</source>
+        <translation type="unfinished">Ninguno</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="95"/>
+        <source>N/A</source>
+        <translation type="unfinished">N/D</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="97"/>
+        <source>%1 ms</source>
+        <translation type="unfinished">%1 ms</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="107"/>
+        <source>%1 B</source>
+        <translation type="unfinished">%1 B</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="108"/>
+        <source>%1 kB</source>
+        <translation type="unfinished">%1 kB</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="109"/>
+        <source>%1 MB</source>
+        <translation type="unfinished">%1 MB</translation>
+    </message>
+    <message>
+        <location filename="../peerstatsutil.cpp" line="110"/>
+        <source>%1 GB</source>
+        <translation type="unfinished">%1 GB</translation>
+    </message>
+</context>
+<context>
+    <name>RequestPayment</name>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="32"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="221"/>
+        <source>Request a payment</source>
+        <translation type="unfinished">Solicitar un pago</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="138"/>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="139"/>
+        <source>Enter label...</source>
+        <translation type="unfinished">Introducir etiqueta...</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="149"/>
+        <source>Message</source>
+        <translation type="unfinished">Mensaje</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="150"/>
+        <source>Enter message...</source>
+        <translation type="unfinished">Introducir mensaje...</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="168"/>
+        <source>Address</source>
+        <translation type="unfinished">Dirección</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="177"/>
+        <source>copy</source>
+        <translation type="unfinished">copiar</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="204"/>
+        <location filename="../pages/wallet/RequestPayment.qml" line="224"/>
+        <source>Create bitcoin address</source>
+        <translation type="unfinished">Crear dirección Bitcoin</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="214"/>
+        <source>Copy payment request</source>
+        <translation type="unfinished">Copiar solicitud de pago</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/RequestPayment.qml" line="238"/>
+        <source>Clear</source>
+        <translation type="unfinished">Borrar</translation>
+    </message>
+</context>
+<context>
+    <name>Send</name>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="97"/>
+        <source>Send bitcoin</source>
+        <translation type="unfinished">Enviar bitcoin</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="132"/>
+        <source>Recipient %1 of %2</source>
+        <translation type="unfinished">Destinatario %1 de %2</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="211"/>
+        <source>Amount</source>
+        <translation type="unfinished">Importe</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="298"/>
+        <source>Note to self</source>
+        <translation type="unfinished">Nota personal</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="299"/>
+        <source>Enter ...</source>
+        <translation type="unfinished">Introducir...</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/Send.qml" line="337"/>
+        <source>Review</source>
+        <translation type="unfinished">Revisar</translation>
+    </message>
+</context>
+<context>
+    <name>SendOptionsPopup</name>
+    <message>
+        <location filename="../controls/SendOptionsPopup.qml" line="34"/>
+        <source>Enable Coin control</source>
+        <translation type="unfinished">Activar control de monedas</translation>
+    </message>
+    <message>
+        <location filename="../controls/SendOptionsPopup.qml" line="45"/>
+        <source>Multiple Recipients</source>
+        <translation type="unfinished">Varios destinatarios</translation>
+    </message>
+</context>
+<context>
+    <name>SendRecipient</name>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="117"/>
+        <source>Address is valid for mainnet, not the current network</source>
+        <translation type="unfinished">La dirección es válida para la red principal, no para la red actual</translation>
+    </message>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="119"/>
+        <source>Address is valid for testnet, not the current network</source>
+        <translation type="unfinished">La dirección es válida para la red de pruebas, no para la red actual</translation>
+    </message>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="121"/>
+        <source>Invalid address format</source>
+        <translation type="unfinished">Formato de dirección no válido</translation>
+    </message>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="134"/>
+        <source>Amount must be greater than zero</source>
+        <translation type="unfinished">El importe debe ser mayor que cero</translation>
+    </message>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="136"/>
+        <source>Amount exceeds maximum limit of 21,000,000 BTC</source>
+        <translation type="unfinished">El importe supera el límite máximo de 21.000.000 BTC</translation>
+    </message>
+    <message>
+        <location filename="../models/sendrecipient.cpp" line="138"/>
+        <source>Amount exceeds available balance</source>
+        <translation type="unfinished">El importe supera el saldo disponible</translation>
+    </message>
+</context>
+<context>
+    <name>SendResult</name>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="56"/>
+        <source>Transaction sent</source>
+        <translation type="unfinished">Transacción enviada</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="65"/>
+        <source>Based on your selected fee, it should be confirmed within the next 10 minutes.</source>
+        <translation type="unfinished">Con la tarifa seleccionada, debería confirmarse en los próximos 10 minutos.</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendResult.qml" line="74"/>
+        <source>Close window</source>
+        <translation type="unfinished">Cerrar ventana</translation>
+    </message>
+</context>
+<context>
+    <name>SendReview</name>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="28"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="52"/>
+        <source>Transaction details</source>
+        <translation type="unfinished">Detalles de la transacción</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="59"/>
+        <source>Send to</source>
+        <translation type="unfinished">Enviar a</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="73"/>
+        <source>Note</source>
+        <translation type="unfinished">Nota</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="87"/>
+        <source>Amount</source>
+        <translation type="unfinished">Importe</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="101"/>
+        <source>Fee</source>
+        <translation type="unfinished">Tarifa</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="115"/>
+        <source>Total</source>
+        <translation type="unfinished">Total</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/SendReview.qml" line="131"/>
+        <source>Send</source>
+        <translation type="unfinished">Enviar</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsAbout</name>
+    <message>
+        <location filename="../pages/settings/SettingsAbout.qml" line="18"/>
+        <location filename="../pages/settings/SettingsAbout.qml" line="59"/>
+        <source>About</source>
+        <translation type="unfinished">Acerca de</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsAbout.qml" line="20"/>
+        <source>Bitcoin Core is an open source project.
+If you find it useful, please contribute.
+
+ This is experimental software.</source>
+        <translation type="unfinished">Bitcoin Core es un proyecto de código abierto.
+Si lo encuentras útil, por favor contribuye.
+
+ Este es software experimental.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsAbout.qml" line="50"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsBlockClockDisplayMode</name>
+    <message>
+        <location filename="../pages/settings/SettingsBlockClockDisplayMode.qml" line="24"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsBlockClockDisplayMode.qml" line="30"/>
+        <source>Block clock display mode</source>
+        <translation type="unfinished">Modo del reloj de bloques</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsConnection</name>
+    <message>
+        <location filename="../pages/settings/SettingsConnection.qml" line="29"/>
+        <location filename="../pages/settings/SettingsConnection.qml" line="71"/>
+        <source>Connection settings</source>
+        <translation type="unfinished">Ajustes de conexión</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsConnection.qml" line="62"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsConnection.qml" line="78"/>
+        <source>Done</source>
+        <translation type="unfinished">Listo</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDeveloper</name>
+    <message>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="16"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="24"/>
+        <source>Developer options</source>
+        <translation type="unfinished">Opciones de desarrollador</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDeveloper.qml" line="51"/>
+        <source>Developer settings</source>
+        <translation type="unfinished">Ajustes de desarrollador</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDisplay</name>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="31"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="37"/>
+        <source>Display</source>
+        <translation type="unfinished">Pantalla</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="47"/>
+        <source>Theme</source>
+        <translation type="unfinished">Tema</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="59"/>
+        <source>Block status size</source>
+        <translation type="unfinished">Tamaño del estado de bloques</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="71"/>
+        <source>Ask before opening links</source>
+        <translation type="unfinished">Preguntar antes de abrir enlaces</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="83"/>
+        <source>Display unit</source>
+        <translation type="unfinished">Unidad de visualización</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplay.qml" line="97"/>
+        <source>Language</source>
+        <translation type="unfinished">Idioma</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDisplayUnit</name>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="26"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="32"/>
+        <source>Display unit</source>
+        <translation type="unfinished">Unidad de visualización</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="49"/>
+        <source>BTC</source>
+        <translation type="unfinished">BTC</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="50"/>
+        <source>8 decimal places (0.00000001 BTC = 1 sat)</source>
+        <translation type="unfinished">8 decimales (0.00000001 BTC = 1 sat)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="59"/>
+        <source>sat</source>
+        <translation type="unfinished">sat</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsDisplayUnit.qml" line="60"/>
+        <source>Satoshi, the smallest unit (1 sat = 0.00000001 BTC)</source>
+        <translation type="unfinished">Satoshi, la unidad más pequeña (1 sat = 0.00000001 BTC)</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsLanguage</name>
+    <message>
+        <location filename="../pages/settings/SettingsLanguage.qml" line="26"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsLanguage.qml" line="32"/>
+        <source>Choose language</source>
+        <translation type="unfinished">Elegir idioma</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsLanguage.qml" line="45"/>
+        <source>Search...</source>
+        <translation type="unfinished">Buscar...</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsProxy</name>
+    <message>
+        <location filename="../pages/settings/SettingsProxy.qml" line="21"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsProxy.qml" line="27"/>
+        <source>Proxy Settings</source>
+        <translation type="unfinished">Ajustes de proxy</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsStorage</name>
+    <message>
+        <location filename="../pages/settings/SettingsStorage.qml" line="19"/>
+        <source>Storage settings</source>
+        <translation type="unfinished">Ajustes de almacenamiento</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsStorage.qml" line="56"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsStorage.qml" line="65"/>
+        <source>Storage Settings</source>
+        <translation type="unfinished">Ajustes de almacenamiento</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsStorage.qml" line="71"/>
+        <source>Done</source>
+        <translation type="unfinished">Listo</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsTheme</name>
+    <message>
+        <location filename="../pages/settings/SettingsTheme.qml" line="24"/>
+        <source>Back</source>
+        <translation type="unfinished">Atrás</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/SettingsTheme.qml" line="30"/>
+        <source>Theme</source>
+        <translation type="unfinished">Tema</translation>
+    </message>
+</context>
+<context>
+    <name>Shutdown</name>
+    <message>
+        <location filename="../pages/node/Shutdown.qml" line="29"/>
+        <source>Saving...</source>
+        <translation type="unfinished">Guardando...</translation>
+    </message>
+    <message>
+        <location filename="../pages/node/Shutdown.qml" line="31"/>
+        <source>Do not shut down the computer until this is done.</source>
+        <translation type="unfinished">No apagues el ordenador hasta que esto esté listo.</translation>
+    </message>
+</context>
+<context>
+    <name>StorageLocations</name>
+    <message>
+        <location filename="../components/StorageLocations.qml" line="23"/>
+        <source>Default</source>
+        <translation type="unfinished">Predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageLocations.qml" line="24"/>
+        <source>Your application directory.</source>
+        <translation type="unfinished">Tu directorio de aplicación.</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageLocations.qml" line="36"/>
+        <source>Custom</source>
+        <translation type="unfinished">Personalizado</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageLocations.qml" line="37"/>
+        <source>Choose the directory and storage device.</source>
+        <translation type="unfinished">Elige el directorio y dispositivo de almacenamiento.</translation>
+    </message>
+</context>
+<context>
+    <name>StorageOptions</name>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="24"/>
+        <source>Reduce storage</source>
+        <translation type="unfinished">Reducir almacenamiento</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="25"/>
+        <source>Uses about %1GB. For simple wallet use.</source>
+        <translation type="unfinished">Usa aproximadamente %1 GB. Para uso básico de cartera.</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="40"/>
+        <source>Store all data</source>
+        <translation type="unfinished">Almacenar todos los datos</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="42"/>
+        <source>Uses about %1GB. Support the network.</source>
+        <translation type="unfinished">Usa aproximadamente %1 GB. Apoya la red.</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="55"/>
+        <source>Custom</source>
+        <translation type="unfinished">Personalizado</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageOptions.qml" line="56"/>
+        <source>Storing about %1GB of data.</source>
+        <translation type="unfinished">Almacenando aproximadamente %1 GB de datos.</translation>
+    </message>
+</context>
+<context>
+    <name>StorageSettings</name>
+    <message>
+        <location filename="../components/StorageSettings.qml" line="17"/>
+        <source>Store recent blocks only</source>
+        <translation type="unfinished">Almacenar solo bloques recientes</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageSettings.qml" line="38"/>
+        <source>Block Storage limit (GB)</source>
+        <translation type="unfinished">Límite de almacenamiento de bloques (GB)</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageSettings.qml" line="39"/>
+        <source>This is not a valid prune target. Please choose a value that is equal to or larger than 1GB</source>
+        <translation type="unfinished">No es un objetivo de poda válido. Elige un valor igual o mayor a 1 GB.</translation>
+    </message>
+    <message>
+        <location filename="../components/StorageSettings.qml" line="65"/>
+        <source>Data Directory</source>
+        <translation type="unfinished">Directorio de datos</translation>
+    </message>
+</context>
+<context>
+    <name>ThemeSettings</name>
+    <message>
+        <location filename="../components/ThemeSettings.qml" line="21"/>
+        <source>Light</source>
+        <translation type="unfinished">Claro</translation>
+    </message>
+    <message>
+        <location filename="../components/ThemeSettings.qml" line="36"/>
+        <source>Dark</source>
+        <translation type="unfinished">Oscuro</translation>
+    </message>
+</context>
+<context>
+    <name>WalletBadge</name>
+    <message>
+        <location filename="../pages/wallet/WalletBadge.qml" line="101"/>
+        <source>Add Wallet</source>
+        <translation type="unfinished">Añadir cartera</translation>
+    </message>
+    <message>
+        <location filename="../pages/wallet/WalletBadge.qml" line="101"/>
+        <source>Select Wallet</source>
+        <translation type="unfinished">Seleccionar cartera</translation>
+    </message>
+</context>
+<context>
+    <name>WalletSelect</name>
+    <message>
+        <location filename="../pages/wallet/WalletSelect.qml" line="59"/>
+        <source>Wallets</source>
+        <translation type="unfinished">Carteras</translation>
+    </message>
+</context>
+<context>
+    <name>initerrormessage</name>
+    <message>
+        <location filename="../pages/initerrormessage.qml" line="27"/>
+        <source>There was an issue starting up.</source>
+        <translation type="unfinished">Hubo un problema al iniciar.</translation>
+    </message>
+    <message>
+        <location filename="../pages/initerrormessage.qml" line="34"/>
+        <source>Close</source>
+        <translation type="unfinished">Cerrar</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../pages/main.qml" line="18"/>
+        <source>Bitcoin Core App</source>
+        <translation type="unfinished">Aplicación Bitcoin Core</translation>
+    </message>
+</context>
+</TS>

--- a/qml/locale/bitcoin_qml_es.ts
+++ b/qml/locale/bitcoin_qml_es.ts
@@ -2524,6 +2524,11 @@ Si lo encuentras útil, por favor contribuye.
         <translation type="unfinished">Se encontró más de un firmante externo. Conecta solo un dispositivo.</translation>
     </message>
     <message>
+        <location filename="../walletqmlcontroller.cpp" line="286"/>
+        <source>The signer command did not return valid output. Check that the path is correct.</source>
+        <translation type="unfinished">El comando del firmante no devolvió una salida válida. Verifica que la ruta sea correcta.</translation>
+    </message>
+    <message>
         <location filename="../walletqmlcontroller.cpp" line="317"/>
         <source>This wallet needs to be migrated</source>
         <translation type="unfinished">Esta billetera necesita ser migrada</translation>

--- a/qml/models/activitylistmodel.cpp
+++ b/qml/models/activitylistmodel.cpp
@@ -12,7 +12,7 @@ ActivityListModel::ActivityListModel(WalletQmlModel *parent)
 {
     if (m_wallet_model != nullptr) {
         refreshWallet();
-        subsctribeToCoreSignals();
+        subscribeToCoreSignals();
     }
 }
 
@@ -63,7 +63,7 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
     case AddressRole:
         return tx->address;
     case AmountRole:
-        return tx->prettyAmount();
+        return tx->prettyAmount(m_display_unit);
     case DateTimeRole:
         return tx->dateTimeString();
     case DepthRole:
@@ -136,6 +136,16 @@ QVariantMap ActivityListModel::transactionDetails(const QString& txid) const
     return {};
 }
 
+void ActivityListModel::setDisplayUnit(int unit)
+{
+    if (unit != m_display_unit) {
+        m_display_unit = unit;
+        if (!m_transactions.isEmpty()) {
+            Q_EMIT dataChanged(index(0), index(m_transactions.size() - 1), {AmountRole});
+        }
+    }
+}
+
 void ActivityListModel::refreshWallet()
 {
     if (m_wallet_model == nullptr) {
@@ -193,7 +203,7 @@ int ActivityListModel::findTransactionIndex(const uint256& hash) const
     return -1;
 }
 
-void ActivityListModel::subsctribeToCoreSignals()
+void ActivityListModel::subscribeToCoreSignals()
 {
     // Connect signals to wallet
     m_handler_transaction_changed = m_wallet_model->handleTransactionChanged([this](const uint256& hash, ChangeType status) {

--- a/qml/models/activitylistmodel.h
+++ b/qml/models/activitylistmodel.h
@@ -45,16 +45,19 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QHash<int, QByteArray> roleNames() const override;
 
+    void setDisplayUnit(int unit);
+
 private:
     void refreshWallet();
     void updateTransactionStatus(QSharedPointer<Transaction> tx) const;
     void updateTransactionLabel(QSharedPointer<Transaction> tx) const;
-    void subsctribeToCoreSignals();
+    void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
     void updateTransaction(const uint256& hash, const interfaces::WalletTxStatus& wtx,
                            int num_blocks, int64_t block_time);
     int findTransactionIndex(const uint256& hash) const;
 
+    int m_display_unit{0};
     QList<QSharedPointer<Transaction>> m_transactions;
     WalletQmlModel* m_wallet_model;
     std::unique_ptr<interfaces::Handler> m_handler_transaction_changed;

--- a/qml/models/options_model.cpp
+++ b/qml/models/options_model.cpp
@@ -408,6 +408,8 @@ void OptionsQmlModel::buildAvailableLanguages()
         QString tag = file;
         tag.remove(0, 8);       // remove "bitcoin_"
         tag.chop(3);            // remove ".qm"
+        // Skip QML-app-specific translation resources (e.g. "qml_es").
+        if (tag.startsWith(QStringLiteral("qml_"))) continue;
         tags << tag;
     }
     tags.sort(Qt::CaseInsensitive);

--- a/qml/models/options_model.cpp
+++ b/qml/models/options_model.cpp
@@ -23,8 +23,10 @@
 #include <QDebug>
 #include <QDir>
 #include <QFileInfo>
+#include <QLocale>
 #include <QRegularExpression>
 #include <QSettings>
+#include <QStringList>
 
 namespace {
 int PruneMiBtoGB(int64_t mib)
@@ -124,6 +126,12 @@ OptionsQmlModel::OptionsQmlModel(interfaces::Node& node, bool is_onboarded)
     m_initial_tor_enabled   = m_tor_enabled;
     m_initial_tor_address   = m_tor_address;
     m_initial_external_signer_path = m_external_signer_path;
+
+    QSettings settings;
+    m_language = settings.value(SettingsKeys::LANGUAGE, "").toString();
+    m_display_unit = settings.value(SettingsKeys::DISPLAY_UNIT, 0).toInt();
+
+    buildAvailableLanguages();
 }
 
 void OptionsQmlModel::setDbcacheSizeMiB(int new_dbcache_size_mib)
@@ -386,6 +394,80 @@ void OptionsQmlModel::setDataDir(QString new_data_dir)
         Q_EMIT dataDirChanged(new_data_dir);
     }
 }
+
+void OptionsQmlModel::buildAvailableLanguages()
+{
+    m_available_languages.clear();
+    m_available_languages << "";  // empty = system default
+
+    QDir translations_dir(":/translations");
+    QStringList files = translations_dir.entryList({"bitcoin_*.qm"}, QDir::Files);
+    QStringList tags;
+    for (const QString& file : files) {
+        // Strip "bitcoin_" prefix and ".qm" suffix to get locale tag.
+        QString tag = file;
+        tag.remove(0, 8);       // remove "bitcoin_"
+        tag.chop(3);            // remove ".qm"
+        tags << tag;
+    }
+    tags.sort(Qt::CaseInsensitive);
+    m_available_languages << tags;
+}
+
+void OptionsQmlModel::setLanguage(const QString& new_language)
+{
+    if (new_language != m_language) {
+        m_language = new_language;
+        QSettings settings;
+        settings.setValue(SettingsKeys::LANGUAGE, m_language);
+        Q_EMIT languageChanged();
+    }
+}
+
+QString OptionsQmlModel::languageSummary() const
+{
+    return languageLabel(m_language);
+}
+
+QString OptionsQmlModel::languageLabel(const QString& locale_tag) const
+{
+    if (locale_tag.isEmpty()) {
+        return QObject::tr("System default");
+    }
+    QLocale locale(locale_tag);
+    QString native = locale.nativeLanguageName();
+    if (native.isEmpty()) {
+        return locale_tag;
+    }
+    // Capitalize first letter of native name.
+    native[0] = native[0].toUpper();
+    QString english = QLocale::languageToString(locale.language());
+    // Append territory disambiguation when the tag includes a territory code.
+    if (locale_tag.contains('_')) {
+        QString native_territory = locale.nativeTerritoryName();
+        if (!native_territory.isEmpty()) {
+            native += QStringLiteral(" (%1)").arg(native_territory);
+        }
+        english += QStringLiteral(" (%1)").arg(QLocale::territoryToString(locale.territory()));
+    }
+    return QStringLiteral("%1 \u2014 %2").arg(native, english);
+}
+
+void OptionsQmlModel::setDisplayUnit(int new_display_unit)
+{
+    if (new_display_unit != m_display_unit) {
+        m_display_unit = new_display_unit;
+        QSettings settings;
+        settings.setValue(SettingsKeys::DISPLAY_UNIT, m_display_unit);
+        Q_EMIT displayUnitChanged(m_display_unit);
+    }
+}
+
+QString OptionsQmlModel::displayUnitLabel() const
+{
+    return (m_display_unit == 1) ? QStringLiteral("sat") : QStringLiteral("BTC");
+}
+
 
 void OptionsQmlModel::onboard()
 {

--- a/qml/models/options_model.cpp
+++ b/qml/models/options_model.cpp
@@ -470,6 +470,12 @@ QString OptionsQmlModel::displayUnitLabel() const
     return (m_display_unit == 1) ? QStringLiteral("sat") : QStringLiteral("BTC");
 }
 
+QString OptionsQmlModel::displayUnitLabelForAmount(qint64 satoshi) const
+{
+    if (m_display_unit != 1) return QStringLiteral("₿");
+    return (qAbs(satoshi) == 1) ? QStringLiteral("sat") : QStringLiteral("sats");
+}
+
 
 void OptionsQmlModel::onboard()
 {

--- a/qml/models/options_model.h
+++ b/qml/models/options_model.h
@@ -12,8 +12,11 @@
 #include <common/system.h>
 #include <validation.h>
 
+#include <qml/models/settings_keys.h>
+
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QUrl>
 
 namespace interfaces {
@@ -45,6 +48,11 @@ class OptionsQmlModel : public QObject
     Q_PROPERTY(QString externalSignerPath READ externalSignerPath WRITE setExternalSignerPath NOTIFY externalSignerPathChanged)
     Q_PROPERTY(bool proxySettingsDirty READ proxySettingsDirty NOTIFY proxySettingsDirtyChanged)
     Q_PROPERTY(bool walletSettingsDirty READ walletSettingsDirty NOTIFY walletSettingsDirtyChanged)
+    Q_PROPERTY(QString language READ language WRITE setLanguage NOTIFY languageChanged)
+    Q_PROPERTY(QString languageSummary READ languageSummary NOTIFY languageChanged)
+    Q_PROPERTY(QStringList availableLanguages READ availableLanguages CONSTANT)
+    Q_PROPERTY(int displayUnit READ displayUnit WRITE setDisplayUnit NOTIFY displayUnitChanged)
+    Q_PROPERTY(QString displayUnitLabel READ displayUnitLabel NOTIFY displayUnitChanged)
 
 public:
     explicit OptionsQmlModel(interfaces::Node& node, bool is_onboarded);
@@ -96,6 +104,14 @@ public:
         if (!m_onboarded) return false;
         return m_external_signer_path != m_initial_external_signer_path;
     }
+    QString language() const { return m_language; }
+    void setLanguage(const QString& new_language);
+    QString languageSummary() const;
+    QStringList availableLanguages() const { return m_available_languages; }
+    Q_INVOKABLE QString languageLabel(const QString& locale_tag) const;
+    int displayUnit() const { return m_display_unit; }
+    void setDisplayUnit(int new_display_unit);
+    QString displayUnitLabel() const;
 
 public Q_SLOTS:
     void setCustomDataDirString(const QString &new_custom_datadir_string) {
@@ -120,6 +136,8 @@ Q_SIGNALS:
     void externalSignerPathChanged(QString path);
     void proxySettingsDirtyChanged();
     void walletSettingsDirtyChanged();
+    void languageChanged();
+    void displayUnitChanged(int new_display_unit);
 
 private:
     interfaces::Node& m_node;
@@ -149,8 +167,12 @@ private:
     bool m_initial_tor_enabled;
     QString m_initial_tor_address;
     QString m_initial_external_signer_path;
+    QString m_language;
+    QStringList m_available_languages;
+    int m_display_unit{0};
 
     common::SettingsValue pruneSetting() const;
+    void buildAvailableLanguages();
 };
 
 #endif // BITCOIN_QML_MODELS_OPTIONS_MODEL_H

--- a/qml/models/options_model.h
+++ b/qml/models/options_model.h
@@ -112,6 +112,7 @@ public:
     int displayUnit() const { return m_display_unit; }
     void setDisplayUnit(int new_display_unit);
     QString displayUnitLabel() const;
+    Q_INVOKABLE QString displayUnitLabelForAmount(qint64 satoshi) const;
 
 public Q_SLOTS:
     void setCustomDataDirString(const QString &new_custom_datadir_string) {

--- a/qml/models/settings_keys.h
+++ b/qml/models/settings_keys.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_SETTINGS_KEYS_H
+#define BITCOIN_QML_MODELS_SETTINGS_KEYS_H
+
+// QSettings key names for display settings persisted by OptionsQmlModel.
+// Defined in a standalone header (no bitcoin build dependencies) so that
+// unit tests can reference them without pulling in bitcoin internals.
+namespace SettingsKeys {
+    inline constexpr const char* LANGUAGE     = "language";
+    inline constexpr const char* DISPLAY_UNIT = "displayUnit";
+} // namespace SettingsKeys
+
+#endif // BITCOIN_QML_MODELS_SETTINGS_KEYS_H

--- a/qml/models/transaction.cpp
+++ b/qml/models/transaction.cpp
@@ -4,6 +4,7 @@
 
 #include <qml/models/transaction.h>
 
+#include <qml/bitcoinunits.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
 #include <wallet/types.h>
@@ -45,21 +46,14 @@ Transaction::Transaction(uint256 hash, qint64 time)
 {
 }
 
-QString Transaction::prettyAmount() const
+QString Transaction::prettyAmount(int display_unit) const
 {
     CAmount net = credit - debit;
-    QString sign = (net > 0) ? "+" : (net < 0) ? "-" : "";
-    net = std::abs(net);
-
-    qint64 bitcoins = net / 100000000;
-    qint64 remainder = net % 100000000;
-
-    QString result = QString("₿ %1%2.%3")
-        .arg(sign)
-        .arg(bitcoins)
-        .arg(remainder, 8, 10, QChar('0'));
-
-    return result;
+    bool plus_sign = (net > 0);
+    QmlBitcoinUnits::Unit unit = (display_unit == 1)
+        ? QmlBitcoinUnits::Unit::SAT
+        : QmlBitcoinUnits::Unit::BTC;
+    return QmlBitcoinUnits::format(unit, net, plus_sign);
 }
 
 QString Transaction::dateTimeString() const

--- a/qml/models/transaction.h
+++ b/qml/models/transaction.h
@@ -47,7 +47,7 @@ public:
 
     Transaction(uint256 hash, qint64 time);
 
-    QString prettyAmount() const;
+    QString prettyAmount(int display_unit = 0) const;
     QString dateTimeString() const;
     void updateStatus(const interfaces::WalletTxStatus& wtx, int num_blocks, int64_t block_time);
 

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -722,6 +722,7 @@ bool WalletQmlModel::prepareTransaction()
         if (subtract_fee_from_amount) {
             m_current_transaction->reassignAmounts(nChangePosRet);
         }
+        m_current_transaction->setDisplayUnit(m_display_unit);
         Q_EMIT currentTransactionChanged();
         return true;
     } else {
@@ -929,6 +930,9 @@ void WalletQmlModel::setDisplayUnit(int unit)
         m_display_unit = unit;
         if (m_activity_list_model) {
             m_activity_list_model->setDisplayUnit(unit);
+        }
+        if (m_current_transaction) {
+            m_current_transaction->setDisplayUnit(unit);
         }
         Q_EMIT balanceChanged();
         Q_EMIT displayUnitChanged(unit);

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -321,7 +321,10 @@ QString WalletQmlModel::balance() const
     if (!m_wallet) {
         return "0";
     }
-    return QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, m_wallet->getBalance());
+    QmlBitcoinUnits::Unit unit = (m_display_unit == 1)
+        ? QmlBitcoinUnits::Unit::SAT
+        : QmlBitcoinUnits::Unit::BTC;
+    return QmlBitcoinUnits::format(unit, m_wallet->getBalance());
 }
 
 CAmount WalletQmlModel::balanceSatoshi() const
@@ -918,4 +921,16 @@ void WalletQmlModel::setCustomFeeRate(const QString& fee_rate)
     }
     Q_EMIT estimatedFeeChanged();
     scheduleFeeEstimates();
+}
+
+void WalletQmlModel::setDisplayUnit(int unit)
+{
+    if (unit != m_display_unit) {
+        m_display_unit = unit;
+        if (m_activity_list_model) {
+            m_activity_list_model->setDisplayUnit(unit);
+        }
+        Q_EMIT balanceChanged();
+        Q_EMIT displayUnitChanged(unit);
+    }
 }

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -327,7 +327,7 @@ QString WalletQmlModel::balance() const
     return QmlBitcoinUnits::format(unit, m_wallet->getBalance());
 }
 
-CAmount WalletQmlModel::balanceSatoshi() const
+qint64 WalletQmlModel::balanceSatoshi() const
 {
     if (!m_wallet) {
         return 0;

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -45,6 +45,7 @@ class WalletQmlModel : public QObject
     Q_PROPERTY(int feeEstimateRevision READ feeEstimateRevision NOTIFY feeEstimateRevisionChanged)
     Q_PROPERTY(BumpTransactionModel* bumpModel READ bumpModel CONSTANT)
     Q_PROPERTY(bool isWalletLoaded READ isWalletLoaded NOTIFY walletIsLoadedChanged)
+    Q_PROPERTY(int displayUnit READ displayUnit WRITE setDisplayUnit NOTIFY displayUnitChanged)
 
 public:
     WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObject* parent = nullptr);
@@ -108,6 +109,8 @@ public:
 
     bool isWalletLoaded() const { return m_is_wallet_loaded; }
     void setWalletLoaded(bool loaded);
+    int displayUnit() const { return m_display_unit; }
+    void setDisplayUnit(int unit);
 
 Q_SIGNALS:
     void nameChanged();
@@ -123,6 +126,7 @@ Q_SIGNALS:
     void walletIsLoadedChanged();
     void externalSignerApprovalSucceeded();
     void externalSignerApprovalFailed(const QString& message, bool signerNotFound);
+    void displayUnitChanged(int unit);
 
 private:
     void initializeFeeEstimator();
@@ -156,6 +160,7 @@ private:
     bool m_is_wallet_loaded{false};
     std::unique_ptr<interfaces::Handler> m_handler_status_changed;
     std::unique_ptr<interfaces::Handler> m_handler_transaction_changed;
+    int m_display_unit{0};
 };
 
 #endif // BITCOIN_QML_MODELS_WALLETQMLMODEL_H

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -30,6 +30,7 @@ class WalletQmlModel : public QObject
     Q_OBJECT
     Q_PROPERTY(QString name READ name NOTIFY nameChanged)
     Q_PROPERTY(QString balance READ balance NOTIFY balanceChanged)
+    Q_PROPERTY(qint64 balanceSatoshi READ balanceSatoshi NOTIFY balanceChanged)
     Q_PROPERTY(bool hasExternalSigner READ hasExternalSigner CONSTANT)
     Q_PROPERTY(ActivityListModel* activityListModel READ activityListModel CONSTANT)
     Q_PROPERTY(CoinsListModel* coinsListModel READ coinsListModel CONSTANT)
@@ -54,7 +55,7 @@ public:
 
     QString name() const;
     QString balance() const;
-    CAmount balanceSatoshi() const;
+    qint64 balanceSatoshi() const;
     bool hasExternalSigner() const { return m_wallet && m_wallet->hasExternalSigner(); }
     Q_INVOKABLE void commitPaymentRequest();
 

--- a/qml/models/walletqmlmodeltransaction.cpp
+++ b/qml/models/walletqmlmodeltransaction.cpp
@@ -4,6 +4,7 @@
 
 #include <qml/models/walletqmlmodeltransaction.h>
 
+#include <qml/bitcoinunits.h>
 #include <qml/models/sendrecipient.h>
 #include <qml/models/sendrecipientslistmodel.h>
 
@@ -32,6 +33,21 @@ BitcoinAmount* WalletQmlModelTransaction::amountAmount() const
     return m_amount_amount;
 }
 
+QString WalletQmlModelTransaction::formatWithUnit(CAmount value, int display_unit)
+{
+    auto unit = (display_unit == 1) ? QmlBitcoinUnits::Unit::SAT : QmlBitcoinUnits::Unit::BTC;
+    QString num = QmlBitcoinUnits::format(unit, value, false, QmlBitcoinUnits::SeparatorStyle::STANDARD);
+    if (display_unit == 1) {
+        return num + " " + ((qAbs(value) == 1) ? QStringLiteral("sat") : QStringLiteral("sats"));
+    }
+    return num + " ₿";
+}
+
+QString WalletQmlModelTransaction::amount() const
+{
+    return formatWithUnit(m_amount, m_display_unit);
+}
+
 BitcoinAmount* WalletQmlModelTransaction::feeAmount() const
 {
     return m_fee_amount;
@@ -42,6 +58,31 @@ BitcoinAmount* WalletQmlModelTransaction::totalAmount() const
     return m_total_amount;
 }
 
+QString WalletQmlModelTransaction::fee() const
+{
+    return formatWithUnit(m_fee, m_display_unit);
+}
+
+QString WalletQmlModelTransaction::total() const
+{
+    return formatWithUnit(m_amount + m_fee, m_display_unit);
+}
+
+QString WalletQmlModelTransaction::label() const
+{
+    return m_label;
+}
+
+void WalletQmlModelTransaction::setDisplayUnit(int unit)
+{
+    if (unit != m_display_unit) {
+        m_display_unit = unit;
+        Q_EMIT amountChanged();
+        Q_EMIT feeChanged();
+        Q_EMIT totalChanged();
+    }
+}
+
 CTransactionRef& WalletQmlModelTransaction::getWtx()
 {
     return m_wtx;
@@ -50,6 +91,16 @@ CTransactionRef& WalletQmlModelTransaction::getWtx()
 void WalletQmlModelTransaction::setWtx(const CTransactionRef& newTx)
 {
     m_wtx = newTx;
+}
+
+CAmount WalletQmlModelTransaction::getTransactionFee() const
+{
+    return m_fee;
+}
+
+CAmount WalletQmlModelTransaction::getTotalTransactionAmount() const
+{
+    return m_amount + m_fee;
 }
 
 void WalletQmlModelTransaction::setTransactionFee(const CAmount& newFee)

--- a/qml/models/walletqmlmodeltransaction.h
+++ b/qml/models/walletqmlmodeltransaction.h
@@ -18,26 +18,50 @@ class WalletQmlModelTransaction : public QObject
     Q_PROPERTY(BitcoinAmount* amountAmount READ amountAmount CONSTANT)
     Q_PROPERTY(BitcoinAmount* feeAmount READ feeAmount CONSTANT)
     Q_PROPERTY(BitcoinAmount* totalAmount READ totalAmount CONSTANT)
+    Q_PROPERTY(QString amount READ amount NOTIFY amountChanged)
+    Q_PROPERTY(QString fee READ fee NOTIFY feeChanged)
+    Q_PROPERTY(QString total READ total NOTIFY totalChanged)
+    Q_PROPERTY(QString label READ label CONSTANT)
 public:
     explicit WalletQmlModelTransaction(const SendRecipientsListModel* recipient, QObject* parent = nullptr);
 
     BitcoinAmount* amountAmount() const;
     BitcoinAmount* feeAmount() const;
     BitcoinAmount* totalAmount() const;
+    QString amount() const;
+    QString fee() const;
+    QString total() const;
+    QString label() const;
 
     CTransactionRef& getWtx();
     void setWtx(const CTransactionRef&);
 
     void setTransactionFee(const CAmount& newFee);
+    CAmount getTransactionFee() const;
+
+    CAmount getTotalTransactionAmount() const;
+
+    void setDisplayUnit(int unit);
+
     void reassignAmounts(int nChangePosRet); // needed for the subtract-fee-from-amount feature
 
+Q_SIGNALS:
+    void amountChanged();
+    void feeChanged();
+    void totalChanged();
+
 private:
+    static QString formatWithUnit(CAmount value, int display_unit);
+
+    QString m_address;
+    QString m_label;
     CAmount m_amount;
     CAmount m_fee;
     BitcoinAmount* m_amount_amount;
     BitcoinAmount* m_fee_amount;
     BitcoinAmount* m_total_amount;
     CTransactionRef m_wtx;
+    int m_display_unit{0};
 };
 
 #endif // BITCOIN_QML_MODELS_WALLETQMLMODELTRANSACTION_H

--- a/qml/pages/main.qml
+++ b/qml/pages/main.qml
@@ -15,7 +15,7 @@ import "./wallet"
 
 ApplicationWindow {
     id: appWindow
-    title: "Bitcoin Core App"
+    title: qsTr("Bitcoin Core App")
     minimumWidth: 640
     minimumHeight: 665
     color: Theme.color.background

--- a/qml/pages/node/NodeSettings.qml
+++ b/qml/pages/node/NodeSettings.qml
@@ -38,7 +38,7 @@ PageStack {
             centerItem: Header {
                 headerBold: true
                 headerSize: 18
-                header: "Settings"
+                header: qsTr("Settings")
             }
             rightItem: NavButton {
                 id: doneButton
@@ -69,6 +69,7 @@ PageStack {
                 Separator { Layout.fillWidth: true }
                 Setting {
                     id: gotoDisplay
+                    objectName: "gotoDisplay"
                     Layout.fillWidth: true
                     header: qsTr("Display")
                     actionItem: CaretRightIcon {

--- a/qml/pages/settings/SettingsDebugLog.qml
+++ b/qml/pages/settings/SettingsDebugLog.qml
@@ -55,7 +55,7 @@ Page {
         centerItem: Header {
             headerBold: true
             headerSize: 18
-            header: qsTr("debug.log")
+            header: "debug.log"
         }
         rightItem: RowLayout {
             spacing: 0

--- a/qml/pages/settings/SettingsDisplay.qml
+++ b/qml/pages/settings/SettingsDisplay.qml
@@ -34,7 +34,7 @@ Item {
                 centerItem: Header {
                     headerBold: true
                     headerSize: 18
-                    header: qsTr("Display settings")
+                    header: qsTr("Display")
                 }
             }
             ColumnLayout {
@@ -56,12 +56,43 @@ Item {
                 Setting {
                     id: gotoBlockClockSize
                     Layout.fillWidth: true
-                    header: qsTr("Block clock display mode")
+                    header: qsTr("Block status size")
                     actionItem: CaretRightIcon {
                         color: gotoBlockClockSize.stateColor
                     }
                     onClicked: {
                         displaySettingsView.push(blockclocksize_page)
+                    }
+                }
+                Separator { Layout.fillWidth: true }
+                Setting {
+                    id: gotoDisplayUnit
+                    objectName: "gotoDisplayUnit"
+                    Layout.fillWidth: true
+                    header: qsTr("Display unit")
+                    description: optionsModel.displayUnitLabel
+                    actionItem: CaretRightIcon {
+                        color: gotoDisplayUnit.stateColor
+                    }
+                    onClicked: {
+                        displaySettingsView.push(displayunit_page)
+                    }
+                }
+                Separator { Layout.fillWidth: true }
+                Setting {
+                    id: gotoLanguage
+                    objectName: "gotoLanguage"
+                    Layout.fillWidth: true
+                    header: qsTr("Language")
+                    // Use qsTr() directly for the system-default label so engine.retranslate()
+                    // refreshes it when switching back from a non-default language. C++ tr()
+                    // calls in property getters are not re-evaluated by retranslate().
+                    description: optionsModel.language === "" ? qsTr("System default") : optionsModel.languageSummary
+                    actionItem: CaretRightIcon {
+                        color: gotoLanguage.stateColor
+                    }
+                    onClicked: {
+                        displaySettingsView.push(language_page)
                     }
                 }
             }
@@ -89,6 +120,22 @@ Item {
     Component {
         id: design_system_page
         SettingsDesignSystem {
+            onBack: {
+                displaySettingsView.pop()
+            }
+        }
+    }
+    Component {
+        id: displayunit_page
+        SettingsDisplayUnit {
+            onBack: {
+                displaySettingsView.pop()
+            }
+        }
+    }
+    Component {
+        id: language_page
+        SettingsLanguage {
             onBack: {
                 displaySettingsView.pop()
             }

--- a/qml/pages/settings/SettingsDisplayUnit.qml
+++ b/qml/pages/settings/SettingsDisplayUnit.qml
@@ -38,14 +38,9 @@ Page {
         width: Math.min(parent.width, 450)
         anchors.horizontalCenter: parent.horizontalCenter
 
-        ButtonGroup {
-            id: unitGroup
-        }
-
         OptionButton {
             objectName: "displayUnitBTC"
             Layout.fillWidth: true
-            ButtonGroup.group: unitGroup
             text: qsTr("BTC")
             description: qsTr("8 decimal places (0.00000001 BTC = 1 sat)")
             checked: optionsModel.displayUnit === 0
@@ -55,7 +50,6 @@ Page {
         OptionButton {
             objectName: "displayUnitSAT"
             Layout.fillWidth: true
-            ButtonGroup.group: unitGroup
             text: qsTr("sat")
             description: qsTr("Satoshi, the smallest unit (1 sat = 0.00000001 BTC)")
             checked: optionsModel.displayUnit === 1

--- a/qml/pages/settings/SettingsDisplayUnit.qml
+++ b/qml/pages/settings/SettingsDisplayUnit.qml
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../../controls"
+import "../../components"
+
+Page {
+    id: root
+    signal back
+
+    objectName: "settingsDisplayUnitPage"
+    background: null
+    implicitWidth: 450
+    leftPadding: 20
+    rightPadding: 20
+    topPadding: 30
+
+    header: NavigationBar2 {
+        leftItem: NavButton {
+            objectName: "settingsDisplayUnitBack"
+            iconSource: "image://images/caret-left"
+            text: qsTr("Back")
+            onClicked: root.back()
+        }
+        centerItem: Header {
+            headerBold: true
+            headerSize: 18
+            header: qsTr("Display unit")
+        }
+    }
+
+    ColumnLayout {
+        spacing: 15
+        width: Math.min(parent.width, 450)
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        ButtonGroup {
+            id: unitGroup
+        }
+
+        OptionButton {
+            objectName: "displayUnitBTC"
+            Layout.fillWidth: true
+            ButtonGroup.group: unitGroup
+            text: qsTr("BTC")
+            description: qsTr("8 decimal places (0.00000001 BTC = 1 sat)")
+            checked: optionsModel.displayUnit === 0
+            onClicked: optionsModel.displayUnit = 0
+        }
+
+        OptionButton {
+            objectName: "displayUnitSAT"
+            Layout.fillWidth: true
+            ButtonGroup.group: unitGroup
+            text: qsTr("sat")
+            description: qsTr("Satoshi, the smallest unit (1 sat = 0.00000001 BTC)")
+            checked: optionsModel.displayUnit === 1
+            onClicked: optionsModel.displayUnit = 1
+        }
+    }
+}

--- a/qml/pages/settings/SettingsLanguage.qml
+++ b/qml/pages/settings/SettingsLanguage.qml
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../../controls"
+import "../../components"
+
+Page {
+    id: root
+    signal back
+
+    objectName: "settingsLanguagePage"
+    background: null
+    implicitWidth: 450
+    leftPadding: 20
+    rightPadding: 20
+    topPadding: 30
+
+    header: NavigationBar2 {
+        leftItem: NavButton {
+            objectName: "settingsLanguageBack"
+            iconSource: "image://images/caret-left"
+            text: qsTr("Back")
+            onClicked: root.back()
+        }
+        centerItem: Header {
+            headerBold: true
+            headerSize: 18
+            header: qsTr("Choose language")
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        CoreTextField {
+            id: searchField
+            objectName: "languageSearch"
+            Layout.fillWidth: true
+            Layout.bottomMargin: 8
+            placeholderText: qsTr("Search...")
+        }
+
+        Separator {
+            Layout.fillWidth: true
+        }
+
+        ListView {
+            id: languageList
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            model: {
+                const all = optionsModel.availableLanguages
+                if (searchField.text.length === 0) return all
+                const query = searchField.text.toLowerCase()
+                return all.filter(function(tag) {
+                    return optionsModel.languageLabel(tag).toLowerCase().indexOf(query) !== -1
+                })
+            }
+
+            delegate: ItemDelegate {
+                id: delegate
+                // Declare modelData as a required property so Qt properly binds the
+                // list element value (a language tag string) into this delegate and
+                // all of its children. This avoids the delegate-scope leakage that
+                // occurs when model roles are referenced inside a Loader.sourceComponent.
+                required property string modelData
+
+                objectName: "language_" + delegate.modelData
+                Accessible.role: Accessible.ListItem
+                Accessible.name: optionsModel.languageLabel(delegate.modelData)
+                leftPadding: 0
+                rightPadding: 0
+                topPadding: 0
+                bottomPadding: 0
+                width: languageList.width
+
+                background: Item {
+                    Separator {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                    }
+                }
+
+                contentItem: RowLayout {
+                    spacing: 0
+
+                    CoreText {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 14
+                        Layout.bottomMargin: 14
+                        text: optionsModel.languageLabel(delegate.modelData)
+                        font.pixelSize: 18
+                        color: Theme.color.neutral9
+                        horizontalAlignment: Text.AlignLeft
+                        wrap: false
+                        elide: Text.ElideRight
+                    }
+
+                    Icon {
+                        visible: delegate.modelData === optionsModel.language
+                        source: "image://images/check"
+                        color: Theme.color.orange
+                        size: 24
+                    }
+                }
+
+                onClicked: {
+                    optionsModel.language = delegate.modelData
+                    root.back()
+                }
+            }
+        }
+    }
+}

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -32,6 +32,13 @@ PageStack {
         }
     }
 
+    Binding {
+        target: walletController.selectedWallet
+        property: "displayUnit"
+        value: optionsModel.displayUnit
+        when: walletController.selectedWallet !== null
+    }
+
     initialItem: RowLayout {
         Page {
             Layout.alignment: Qt.AlignCenter

--- a/qml/pages/wallet/DesktopWallets.qml
+++ b/qml/pages/wallet/DesktopWallets.qml
@@ -38,6 +38,7 @@ Page {
             implicitHeight: 46
             text: walletController.selectedWallet.name
             balance: walletController.selectedWallet.balance
+            balanceSatoshi: walletController.selectedWallet.balanceSatoshi
             loading: !walletController.initialized
             noWalletLoaded: !walletController.isWalletLoaded
             noWalletsFound: walletController.noWalletsFound

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -120,13 +120,28 @@ Page {
                                 }
                             }
                         }
-                        CoreText {
+                        Loader {
                             id: unitLabel
                             anchors.right: flipIcon.left
                             anchors.verticalCenter: parent.verticalCenter
-                            text: root.request ? root.request.amount.unitLabel : ""
-                            font.pixelSize: 18
-                            color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                            sourceComponent: root.request && root.request.amount.unit === BitcoinAmount.SAT
+                                ? satoshiIconComponent : btcTextComponent
+                        }
+                        Component {
+                            id: btcTextComponent
+                            CoreText {
+                                text: root.request ? root.request.amount.unitLabel : ""
+                                font.pixelSize: 18
+                                color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                            }
+                        }
+                        Component {
+                            id: satoshiIconComponent
+                            CoreText {
+                                text: "s"
+                                font.pixelSize: 18
+                                color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                            }
                         }
                         Icon {
                             id: flipIcon

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -18,6 +18,12 @@ Page {
     property WalletQmlModel wallet: walletController.selectedWallet
     property PaymentRequest request: wallet ? wallet.currentPaymentRequest : null
 
+    Binding {
+        target: root.request ? root.request.amount : null
+        property: "unit"
+        value: optionsModel.displayUnit
+    }
+
     ScrollView {
         clip: true
         width: parent.width

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -82,7 +82,7 @@ Page {
                         color: Theme.color.neutral9
                         placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
                         background: Item {}
-                        placeholderText: "0.00000000"
+                        placeholderText: root.request && root.request.amount.unit === BitcoinAmount.SAT ? "0" : "0.00000000"
                         selectByMouse: true
                         text: root.request ? root.request.amount.display : ""
                         onTextEdited: {
@@ -120,28 +120,13 @@ Page {
                                 }
                             }
                         }
-                        Loader {
+                        CoreText {
                             id: unitLabel
                             anchors.right: flipIcon.left
                             anchors.verticalCenter: parent.verticalCenter
-                            sourceComponent: root.request && root.request.amount.unit === BitcoinAmount.SAT
-                                ? satoshiIconComponent : btcTextComponent
-                        }
-                        Component {
-                            id: btcTextComponent
-                            CoreText {
-                                text: root.request ? root.request.amount.unitLabel : ""
-                                font.pixelSize: 18
-                                color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
-                            }
-                        }
-                        Component {
-                            id: satoshiIconComponent
-                            CoreText {
-                                text: "s"
-                                font.pixelSize: 18
-                                color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
-                            }
+                            text: root.request ? root.request.amount.unitLabel : ""
+                            font.pixelSize: 18
+                            color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
                         }
                         Icon {
                             id: flipIcon

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -79,6 +79,13 @@ PageStack {
         }
     }
 
+    Binding {
+        target: root.recipient ? root.recipient.amount : null
+        property: "unit"
+        value: optionsModel.displayUnit
+        when: root.recipient !== null
+    }
+
     initialItem: Page {
         background: null
 

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -286,7 +286,7 @@ PageStack {
                             color: Theme.color.neutral9
                             placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
                             background: Item {}
-                            placeholderText: "0.00000000"
+                            placeholderText: root.recipient.amount.unit === BitcoinAmount.SAT ? "0" : "0.00000000"
                             selectByMouse: true
                             text: root.recipient.amount.display
                             onTextChanged: {
@@ -325,29 +325,14 @@ PageStack {
                                 anchors.fill: parent
                                 onClicked: root.recipient.amount.flipUnit()
                             }
-                            Loader {
+                            CoreText {
                                 id: unitLabel
                                 objectName: "sendAmountUnitLabel"
                                 anchors.right: flipIcon.left
                                 anchors.verticalCenter: parent.verticalCenter
-                                sourceComponent: root.recipient.amount.unit === BitcoinAmount.SAT
-                                    ? satoshiIconComponent : btcTextComponent
-                            }
-                            Component {
-                                id: btcTextComponent
-                                CoreText {
-                                    text: root.recipient.amount.unitLabel
-                                    font.pixelSize: 18
-                                    color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
-                                }
-                            }
-                            Component {
-                                id: satoshiIconComponent
-                                CoreText {
-                                    text: "s"
-                                    font.pixelSize: 18
-                                    color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
-                                }
+                                text: root.recipient.amount.unitLabel
+                                font.pixelSize: 18
+                                color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
                             }
                             Icon {
                                 id: flipIcon

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -325,14 +325,29 @@ PageStack {
                                 anchors.fill: parent
                                 onClicked: root.recipient.amount.flipUnit()
                             }
-                            CoreText {
+                            Loader {
                                 id: unitLabel
                                 objectName: "sendAmountUnitLabel"
                                 anchors.right: flipIcon.left
                                 anchors.verticalCenter: parent.verticalCenter
-                                text: root.recipient.amount.unitLabel
-                                font.pixelSize: 18
-                                color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                                sourceComponent: root.recipient.amount.unit === BitcoinAmount.SAT
+                                    ? satoshiIconComponent : btcTextComponent
+                            }
+                            Component {
+                                id: btcTextComponent
+                                CoreText {
+                                    text: root.recipient.amount.unitLabel
+                                    font.pixelSize: 18
+                                    color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                                }
+                            }
+                            Component {
+                                id: satoshiIconComponent
+                                CoreText {
+                                    text: "s"
+                                    font.pixelSize: 18
+                                    color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                                }
                             }
                             Icon {
                                 id: flipIcon

--- a/qml/pages/wallet/WalletBadge.qml
+++ b/qml/pages/wallet/WalletBadge.qml
@@ -22,6 +22,7 @@ Button {
     property bool showBalance: true
     property bool showIcon: true
     property string balance: "0.0 000 000"
+    property var balanceSatoshi: 0
     property bool loading: false
     property bool noWalletLoaded: false
     property bool noWalletsFound: false
@@ -143,7 +144,7 @@ Button {
                 CoreText {
                     id: balanceText
                     visible: root.showBalance
-                    text: (optionsModel.displayUnit === 1 ? "s" : "₿") + " " + root.balance
+                    text: root.balance + " " + (optionsModel.displayUnit === 1 ? (root.balanceSatoshi === 1 ? qsTr("sat") : qsTr("sats")) : "₿")
                     color: Theme.color.neutral7
                 }
             }

--- a/qml/pages/wallet/WalletBadge.qml
+++ b/qml/pages/wallet/WalletBadge.qml
@@ -143,7 +143,7 @@ Button {
                 CoreText {
                     id: balanceText
                     visible: root.showBalance
-                    text: "₿ " + root.balance
+                    text: (optionsModel.displayUnit === 1 ? "s" : "₿") + " " + root.balance
                     color: Theme.color.neutral7
                 }
             }

--- a/qml/walletqmlcontroller.cpp
+++ b/qml/walletqmlcontroller.cpp
@@ -282,8 +282,8 @@ void WalletQmlController::refreshExternalSignerStatus()
         } else if (signer_count > 1) {
             error = tr("More than one external signer was found. Connect only one device.");
         }
-    } catch (const std::runtime_error& e) {
-        error = QString::fromStdString(e.what());
+    } catch (const std::runtime_error&) {
+        error = tr("The signer command did not return valid output. Check that the path is correct.");
     }
 
     setExternalSignerStatus(path_configured, signer_count, signer_name, error);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(bitcoinqml_unit_tests
   test_walletqmlmodel.cpp
   test_bumptransactionmodel.cpp
   test_walletqmlcontroller.cpp
+  test_display_settings.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
 )
 

--- a/test/functional/qml_test_harness.py
+++ b/test/functional/qml_test_harness.py
@@ -87,11 +87,12 @@ class QmlTestHarness:
     instead of launching a new one.
     """
 
-    def __init__(self, socket_path=None, extra_args=None):
+    def __init__(self, socket_path=None, extra_args=None, reset_settings=True, datadir=None):
         self.external = socket_path is not None
         self.process = None
         self.driver = None
         self.extra_args = extra_args or []
+        self.reset_settings = reset_settings
 
         if self.external:
             self.socket_path = socket_path
@@ -99,9 +100,15 @@ class QmlTestHarness:
             self.datadir = None
         else:
             self.gui_binary = find_gui_binary()
-            self.tmpdir = tempfile.mkdtemp(prefix="qml_test_bridge_")
-            self.datadir = setup_datadir(self.tmpdir)
-            self.socket_path = os.path.join(self.tmpdir, "test_bridge.sock")
+            if datadir is not None:
+                # Reuse an existing datadir; don't create or delete a tmpdir.
+                self.tmpdir = None
+                self.datadir = datadir
+                self.socket_path = os.path.join(datadir, "test_bridge.sock")
+            else:
+                self.tmpdir = tempfile.mkdtemp(prefix="qml_test_bridge_")
+                self.datadir = setup_datadir(self.tmpdir)
+                self.socket_path = os.path.join(self.tmpdir, "test_bridge.sock")
 
     def start(self):
         """Launch bitcoin-core-app or attach to an existing instance."""
@@ -118,7 +125,7 @@ class QmlTestHarness:
             self.gui_binary,
             f"-datadir={self.datadir}",
             f"-test-automation={self.socket_path}",
-            "-resetguisettings",
+        ] + (["-resetguisettings"] if self.reset_settings else []) + [
             "-logtimemicros",
             "-debug",
             "-debugexclude=libevent",
@@ -138,8 +145,12 @@ class QmlTestHarness:
         self.driver = QmlDriver(self.socket_path, timeout=GUI_STARTUP_TIMEOUT)
         print("QmlDriver connected to test bridge.")
 
-    def stop(self):
-        """Shut down the GUI process (only if we launched it)."""
+    def stop(self, cleanup=True):
+        """Shut down the GUI process (only if we launched it).
+
+        If cleanup is False, the tmpdir and datadir are preserved on disk so
+        a second harness can reuse the same datadir for a restart-persistence test.
+        """
         if self.process and self.process.poll() is None:
             self.process.send_signal(signal.SIGTERM)
             try:
@@ -149,7 +160,7 @@ class QmlTestHarness:
                 self.process.wait()
         if self.driver:
             self.driver.close()
-        if self.tmpdir:
+        if cleanup and self.tmpdir:
             shutil.rmtree(self.tmpdir, ignore_errors=True)
             self.tmpdir = None
 

--- a/test/functional/qml_test_harness.py
+++ b/test/functional/qml_test_harness.py
@@ -87,10 +87,11 @@ class QmlTestHarness:
     instead of launching a new one.
     """
 
-    def __init__(self, socket_path=None):
+    def __init__(self, socket_path=None, extra_args=None):
         self.external = socket_path is not None
         self.process = None
         self.driver = None
+        self.extra_args = extra_args or []
 
         if self.external:
             self.socket_path = socket_path
@@ -123,7 +124,7 @@ class QmlTestHarness:
             "-debugexclude=libevent",
             "-debugexclude=leveldb",
             "-nolisten",
-        ]
+        ] + self.extra_args
 
         print(f"Starting GUI: {' '.join(args)}")
         self.process = subprocess.Popen(

--- a/test/functional/qml_test_settings_display.py
+++ b/test/functional/qml_test_settings_display.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""End-to-end tests for the Display settings page.
+
+Tests language selection, display unit switching (BTC / SAT), and the
+"Ask before opening links" toggle.
+
+These tests run post-onboarding and do not require a peer connection, but
+they do require the node to start up, so generous wait timeouts are used.
+
+This test requires:
+  - bitcoin-core-app built with -DENABLE_TEST_AUTOMATION=ON
+"""
+
+import sys
+import time
+
+from qml_test_harness import (
+    GUI_STARTUP_TIMEOUT,
+    QmlTestHarness,
+    complete_onboarding,
+    dump_qml_tree,
+    parse_args,
+)
+from qml_driver import QmlDriverError
+
+# The node must start up before post-onboarding pages are interactive.
+# Use a generous timeout for waits that follow onboarding completion.
+POST_ONBOARDING_TIMEOUT_MS = 30000
+
+
+# ── Navigation helpers ────────────────────────────────────────────────────────
+
+def navigate_to_display_settings(gui):
+    """From the NodeRunner main screen, navigate to the Display settings page."""
+    gui.click("nodeSettingsButton")
+    # Wait for the NodeSettings page to finish loading (gotoDisplay is one of
+    # its rows).
+    gui.wait_for_page("gotoDisplay", timeout_ms=5000)
+    gui.click("gotoDisplay")
+    # SettingsDisplay is identified by the presence of gotoDisplayUnit.
+    gui.wait_for_page("gotoDisplayUnit", timeout_ms=5000)
+    print("  Navigated to Display settings page")
+
+
+# ── Individual test cases ─────────────────────────────────────────────────────
+
+def test_display_unit_selection(gui):
+    """Select SAT on the Display unit page and verify it is reflected."""
+    print("\n── test_display_unit_selection ───────────────────────────────")
+
+    gui.click("gotoDisplayUnit")
+    gui.wait_for_page("settingsDisplayUnitPage", timeout_ms=5000)
+    print("  Navigated to SettingsDisplayUnit page")
+
+    # If SAT is selected (state persists across runs), switch to BTC first.
+    # We must navigate to a fresh page after the switch because clicking a
+    # checkable OptionButton breaks its declarative `checked:` binding.
+    if gui.get_property("displayUnitSAT", "checked"):
+        gui.click("displayUnitBTC")
+        gui.click("settingsDisplayUnitBack")
+        gui.wait_for_page("gotoDisplayUnit", timeout_ms=5000)
+        gui.click("gotoDisplayUnit")
+        gui.wait_for_page("settingsDisplayUnitPage", timeout_ms=5000)
+        print("  Switched to BTC starting state")
+
+    btc_checked = gui.get_property("displayUnitBTC", "checked")
+    sat_checked = gui.get_property("displayUnitSAT", "checked")
+    assert btc_checked, (
+        f"BTC should be checked at test start, got btc={btc_checked} sat={sat_checked}"
+    )
+    assert not sat_checked, (
+        f"SAT should not be checked at test start, got sat={sat_checked}"
+    )
+    print(f"  Starting state: BTC={btc_checked}, SAT={sat_checked}  PASSED")
+
+    # Select SAT.
+    gui.click("displayUnitSAT")
+    sat_after = gui.get_property("displayUnitSAT", "checked")
+    btc_after = gui.get_property("displayUnitBTC", "checked")
+    assert sat_after, f"SAT should be checked after clicking, got sat={sat_after}"
+    assert not btc_after, f"BTC should be unchecked after selecting SAT, got btc={btc_after}"
+    print(f"  After SAT selection: SAT={sat_after}, BTC={btc_after}  PASSED")
+
+    # Go back and reset to BTC for future runs.
+    gui.click("settingsDisplayUnitBack")
+    gui.wait_for_page("gotoDisplayUnit", timeout_ms=5000)
+
+    gui.click("gotoDisplayUnit")
+    gui.wait_for_page("settingsDisplayUnitPage", timeout_ms=5000)
+    gui.click("displayUnitBTC")
+    gui.click("settingsDisplayUnitBack")
+    gui.wait_for_page("gotoDisplayUnit", timeout_ms=5000)
+    print("  Reset display unit to BTC  PASSED")
+
+
+def test_language_selection(gui):
+    """Select Spanish and verify the summary and translated headers update."""
+    print("\n── test_language_selection ───────────────────────────────────")
+
+    gui.click("gotoLanguage")
+    gui.wait_for_page("settingsLanguagePage", timeout_ms=5000)
+    print("  Navigated to SettingsLanguage page")
+
+    # Filter the list to Spanish so the delegate is rendered by the ListView.
+    gui.set_text("languageSearch", "español")
+    gui.wait_for_page("language_es", timeout_ms=3000)
+    gui.click("language_es")
+    # Selecting a language navigates back to SettingsDisplay automatically.
+    gui.wait_for_page("gotoLanguage", timeout_ms=5000)
+    print("  Selected Spanish (es) and returned to Display settings")
+
+    # Verify the language summary description on the row has updated.
+    lang_summary = gui.get_property("gotoLanguage", "description")
+    assert "Español" in lang_summary, (
+        f"Language summary should contain 'Español' after selecting 'es', "
+        f"got: {lang_summary!r}"
+    )
+    assert "system default" not in lang_summary.lower(), (
+        f"Language summary should not show 'System default' after selecting 'es', "
+        f"got: {lang_summary!r}"
+    )
+    print(f"  Language summary updated to: {lang_summary!r}  PASSED")
+
+    # Verify translation propagated to other row headers on this page.
+    lang_header = gui.get_property("gotoLanguage", "header")
+    assert lang_header == "Idioma", (
+        f"'Language' row header should be 'Idioma' in Spanish, got: {lang_header!r}"
+    )
+    print(f"  Language row header translated: {lang_header!r}  PASSED")
+
+    unit_header = gui.get_property("gotoDisplayUnit", "header")
+    assert unit_header == "Unidad de visualización", (
+        f"'Display unit' row header should be translated in Spanish, got: {unit_header!r}"
+    )
+    print(f"  Display unit row header translated: {unit_header!r}  PASSED")
+
+    # Reset to System default (empty tag).
+    gui.click("gotoLanguage")
+    gui.wait_for_page("settingsLanguagePage", timeout_ms=5000)
+    gui.wait_for_page("language_", timeout_ms=3000)  # wait for delegate to render
+    gui.click("language_")  # objectName: "language_" + "" = "language_"
+    gui.wait_for_page("gotoLanguage", timeout_ms=5000)
+
+    default_summary = gui.get_property("gotoLanguage", "description")
+    assert "system default" in default_summary.lower(), (
+        f"Expected 'System default' summary after reset, got: {default_summary!r}"
+    )
+    print(f"  Reset to System default: {default_summary!r}  PASSED")
+
+    # Verify English headers are restored after reset.
+    lang_header_reset = gui.get_property("gotoLanguage", "header")
+    assert lang_header_reset == "Language", (
+        f"'Language' header should be restored to English after reset, got: {lang_header_reset!r}"
+    )
+    unit_header_reset = gui.get_property("gotoDisplayUnit", "header")
+    assert unit_header_reset == "Display unit", (
+        f"'Display unit' header should be restored to English after reset, got: {unit_header_reset!r}"
+    )
+    print(f"  Headers restored to English  PASSED")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def run_tests():
+    args = parse_args()
+    harness = QmlTestHarness(socket_path=args.socket_path, extra_args=["-disablewallet"])
+    try:
+        harness.start()
+        gui = harness.driver
+
+        # Complete onboarding to reach the main node screen.
+        complete_onboarding(gui)
+
+        # Wait for the NodeRunner main screen.
+        # Uses a generous timeout because the node starts up after onboarding.
+        gui.wait_for_page("nodeSettingsButton", timeout_ms=POST_ONBOARDING_TIMEOUT_MS)
+        print("Reached NodeRunner main screen")
+
+        navigate_to_display_settings(gui)
+
+        test_display_unit_selection(gui)
+        test_language_selection(gui)
+
+        print("\n" + "=" * 60)
+        print("All display settings tests PASSED")
+        print("=" * 60)
+
+    except Exception as e:
+        print(f"\nFAILED: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        if harness.driver:
+            dump_qml_tree(harness.driver)
+        sys.exit(1)
+    finally:
+        harness.stop()
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/functional/qml_test_settings_display.py
+++ b/test/functional/qml_test_settings_display.py
@@ -14,6 +14,7 @@ This test requires:
   - bitcoin-core-app built with -DENABLE_TEST_AUTOMATION=ON
 """
 
+import shutil
 import sys
 import time
 
@@ -162,6 +163,50 @@ def test_language_selection(gui):
     print(f"  Headers restored to English  PASSED")
 
 
+def test_settings_persistence(datadir):
+    """Restart the app without -resetguisettings and verify settings persisted.
+
+    Issue #512 requires: change unit/language → restart → verify persisted.
+    """
+    print("\n── test_settings_persistence ─────────────────────────────────")
+
+    harness2 = QmlTestHarness(
+        extra_args=["-disablewallet"],
+        reset_settings=False,
+        datadir=datadir,
+    )
+    try:
+        harness2.start()
+        gui2 = harness2.driver
+
+        # After a normal restart (no -resetguisettings) onboarding is skipped.
+        gui2.wait_for_page("nodeSettingsButton", timeout_ms=POST_ONBOARDING_TIMEOUT_MS)
+        print("  Reached NodeRunner main screen after restart")
+
+        navigate_to_display_settings(gui2)
+
+        # Verify SAT is still selected.
+        gui2.click("gotoDisplayUnit")
+        gui2.wait_for_page("settingsDisplayUnitPage", timeout_ms=5000)
+        sat_persisted = gui2.get_property("displayUnitSAT", "checked")
+        assert sat_persisted, (
+            f"SAT should still be selected after restart, got checked={sat_persisted}"
+        )
+        print("  Display unit (SAT) persisted across restart  PASSED")
+        gui2.click("settingsDisplayUnitBack")
+        gui2.wait_for_page("gotoDisplayUnit", timeout_ms=5000)
+
+        # Verify Spanish is still selected.
+        lang_summary = gui2.get_property("gotoLanguage", "description")
+        assert "Español" in lang_summary, (
+            f"Language should still be Spanish after restart, got: {lang_summary!r}"
+        )
+        print(f"  Language (Español) persisted across restart  PASSED")
+
+    finally:
+        harness2.stop()
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 def run_tests():
@@ -184,9 +229,23 @@ def run_tests():
         test_display_unit_selection(gui)
         test_language_selection(gui)
 
-        print("\n" + "=" * 60)
-        print("All display settings tests PASSED")
-        print("=" * 60)
+        # Set known state for persistence test: SAT + Spanish.
+        print("\n── Setting up state for persistence test ─────────────────────")
+        gui.click("gotoDisplayUnit")
+        gui.wait_for_page("settingsDisplayUnitPage", timeout_ms=5000)
+        gui.click("displayUnitSAT")
+        gui.click("settingsDisplayUnitBack")
+        gui.wait_for_page("gotoDisplayUnit", timeout_ms=5000)
+        gui.click("gotoLanguage")
+        gui.wait_for_page("settingsLanguagePage", timeout_ms=5000)
+        gui.set_text("languageSearch", "español")
+        gui.wait_for_page("language_es", timeout_ms=3000)
+        gui.click("language_es")
+        gui.wait_for_page("gotoLanguage", timeout_ms=5000)
+        print("  State set: SAT + Spanish")
+
+        datadir = harness.datadir
+        tmpdir = harness.tmpdir
 
     except Exception as e:
         print(f"\nFAILED: {e}", file=sys.stderr)
@@ -196,7 +255,24 @@ def run_tests():
             dump_qml_tree(harness.driver)
         sys.exit(1)
     finally:
-        harness.stop()
+        # Keep the datadir on disk so the second harness can reuse it.
+        harness.stop(cleanup=False)
+
+    # Phase 2: restart without -resetguisettings and verify persistence.
+    try:
+        test_settings_persistence(datadir)
+    except Exception as e:
+        print(f"\nFAILED: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+    finally:
+        if tmpdir:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    print("\n" + "=" * 60)
+    print("All display settings tests PASSED")
+    print("=" * 60)
 
 
 if __name__ == '__main__':

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -8,6 +8,7 @@
 #include <QQmlEngine>
 #include <QQmlContext>
 #include <QRegularExpression>
+#include <QStringList>
 #include <qqml.h>
 
 #include <algorithm>
@@ -759,6 +760,11 @@ class MockOptionsModel : public QObject
     Q_PROPERTY(int pruneSizeGB MEMBER m_prune_size_gb NOTIFY pruneSizeGBChanged)
     Q_PROPERTY(QString dataDir MEMBER m_data_dir NOTIFY dataDirChanged)
     Q_PROPERTY(QString getDefaultDataDirString READ getDefaultDataDirString CONSTANT)
+    Q_PROPERTY(int displayUnit READ displayUnit WRITE setDisplayUnit NOTIFY displayUnitChanged)
+    Q_PROPERTY(QString displayUnitLabel READ displayUnitLabel NOTIFY displayUnitChanged)
+    Q_PROPERTY(QString languageSummary READ languageSummary NOTIFY languageChanged)
+    Q_PROPERTY(QString language READ language WRITE setLanguage NOTIFY languageChanged)
+    Q_PROPERTY(QStringList availableLanguages READ availableLanguages CONSTANT)
 
 public:
     bool m_listen{true};
@@ -775,6 +781,25 @@ public:
     Q_INVOKABLE void setCustomDataDirArgs(const QString& dir) { m_data_dir = dir; }
     Q_INVOKABLE void onboard() {}
 
+    int displayUnit() const { return m_displayUnit; }
+    void setDisplayUnit(int u) {
+        if (u != m_displayUnit) { m_displayUnit = u; Q_EMIT displayUnitChanged(u); }
+    }
+    QString displayUnitLabel() const { return m_displayUnit == 1 ? "sat" : "BTC"; }
+    QString language() const { return m_language; }
+    void setLanguage(const QString& l) {
+        if (l != m_language) { m_language = l; Q_EMIT languageChanged(); }
+    }
+    QString languageSummary() const { return m_language.isEmpty() ? "System default" : m_language; }
+    QStringList availableLanguages() const { return {"", "de", "es", "fr"}; }
+    Q_INVOKABLE QString languageLabel(const QString& tag) const {
+        if (tag.isEmpty()) return "System default";
+        if (tag == "de") return "Deutsch — German";
+        if (tag == "es") return "Español — Spanish";
+        if (tag == "fr") return "Français — French";
+        return tag;
+    }
+
 Q_SIGNALS:
     void listenChanged();
     void natpmpChanged();
@@ -782,6 +807,12 @@ Q_SIGNALS:
     void pruneChanged();
     void pruneSizeGBChanged();
     void dataDirChanged();
+    void displayUnitChanged(int unit);
+    void languageChanged();
+
+private:
+    int m_displayUnit{0};
+    QString m_language;
 };
 
 class MockChainModel : public QObject

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -786,6 +786,10 @@ public:
         if (u != m_displayUnit) { m_displayUnit = u; Q_EMIT displayUnitChanged(u); }
     }
     QString displayUnitLabel() const { return m_displayUnit == 1 ? "sat" : "BTC"; }
+    Q_INVOKABLE QString displayUnitLabelForAmount(qint64 satoshi) const {
+        if (m_displayUnit != 1) return QString("₿");
+        return (qAbs(satoshi) == 1) ? QString("sat") : QString("sats");
+    }
     QString language() const { return m_language; }
     void setLanguage(const QString& l) {
         if (l != m_language) { m_language = l; Q_EMIT languageChanged(); }

--- a/test/qml/tst_displaysettings.qml
+++ b/test/qml/tst_displaysettings.qml
@@ -96,4 +96,62 @@ TestCase {
         btcBtn.clicked()
         compare(optionsModel.displayUnit, 0)
     }
+
+    // Mirrors the balance prefix expression in WalletBadge.qml.
+    Component {
+        id: balancePrefixComponent
+        Text {
+            property string balance: "1 000"
+            text: (optionsModel.displayUnit === 1 ? "s" : "₿") + " " + balance
+        }
+    }
+
+    function test_walletBadge_prefix_is_s_in_sat_mode() {
+        optionsModel.displayUnit = 1
+        const obj = createTemporaryObject(balancePrefixComponent, this)
+        verify(obj !== null)
+        compare(obj.text, "s 1 000")
+        optionsModel.displayUnit = 0
+    }
+
+    function test_walletBadge_prefix_is_btc_symbol_in_btc_mode() {
+        optionsModel.displayUnit = 0
+        const obj = createTemporaryObject(balancePrefixComponent, this)
+        verify(obj !== null)
+        compare(obj.text, "₿ 1 000")
+    }
+
+    // Mirrors the Loader + Component pattern in BitcoinAmountInputField.qml,
+    // Send.qml, and RequestPayment.qml.
+    Component {
+        id: unitLabelComponent
+        Item {
+            id: wrapper
+            property int unit: 0
+            Loader {
+                objectName: "unitLabelLoader"
+                sourceComponent: wrapper.unit === 1 ? satComponent : btcComponent
+            }
+            Component { id: btcComponent; Text { text: "₿" } }
+            Component { id: satComponent; Text { text: "s" } }
+        }
+    }
+
+    function test_unitLabel_shows_s_in_sat_mode() {
+        const obj = createTemporaryObject(unitLabelComponent, this)
+        obj.unit = 1
+        waitForRendering(obj)
+        const loader = findChild(obj, "unitLabelLoader")
+        verify(loader.item !== null)
+        compare(loader.item.text, "s")
+    }
+
+    function test_unitLabel_shows_btc_symbol_in_btc_mode() {
+        const obj = createTemporaryObject(unitLabelComponent, this)
+        obj.unit = 0
+        waitForRendering(obj)
+        const loader = findChild(obj, "unitLabelLoader")
+        verify(loader.item !== null)
+        compare(loader.item.text, "₿")
+    }
 }

--- a/test/qml/tst_displaysettings.qml
+++ b/test/qml/tst_displaysettings.qml
@@ -1,0 +1,99 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtTest 1.2
+import "../../qml/controls"
+
+TestCase {
+    name: "DisplaySettings"
+    when: windowShown
+    width: 600
+    height: 800
+
+    // Minimal component exercising the BTC/SAT OptionButton binding logic.
+    // Uses OptionButton directly (no NavButton / org.bitcoincore.qt dependency)
+    // to test the optionsModel.displayUnit binding in isolation.
+    // ButtonGroup is intentionally omitted: the declarative 'checked:' bindings
+    // already model mutual exclusion through optionsModel, and ButtonGroup's
+    // managed-checked behavior conflicts with declarative bindings in tests.
+    Component {
+        id: displayUnitButtons
+        Column {
+            OptionButton {
+                objectName: "displayUnitBTC"
+                text: "BTC"
+                checked: optionsModel.displayUnit === 0
+                onClicked: optionsModel.displayUnit = 0
+            }
+            OptionButton {
+                objectName: "displayUnitSAT"
+                text: "sat"
+                checked: optionsModel.displayUnit === 1
+                onClicked: optionsModel.displayUnit = 1
+            }
+        }
+    }
+
+    function test_displayUnit_BTC_button_checked_by_default() {
+        optionsModel.displayUnit = 0
+        const obj = createTemporaryObject(displayUnitButtons, this)
+        verify(obj !== null)
+
+        const btcBtn = findChild(obj, "displayUnitBTC")
+        verify(btcBtn !== null)
+        compare(btcBtn.checked, true)
+
+        const satBtn = findChild(obj, "displayUnitSAT")
+        verify(satBtn !== null)
+        compare(satBtn.checked, false)
+    }
+
+    function test_displayUnit_SAT_button_updates_on_model_change() {
+        optionsModel.displayUnit = 1
+        const obj = createTemporaryObject(displayUnitButtons, this)
+        verify(obj !== null)
+
+        const satBtn = findChild(obj, "displayUnitSAT")
+        verify(satBtn !== null)
+        compare(satBtn.checked, true)
+
+        const btcBtn = findChild(obj, "displayUnitBTC")
+        verify(btcBtn !== null)
+        compare(btcBtn.checked, false)
+
+        // Reset
+        optionsModel.displayUnit = 0
+    }
+
+    function test_displayUnit_clicking_SAT_updates_model() {
+        optionsModel.displayUnit = 0
+        const obj = createTemporaryObject(displayUnitButtons, this)
+        verify(obj !== null)
+
+        const satBtn = findChild(obj, "displayUnitSAT")
+        verify(satBtn !== null)
+
+        // Invoke the onClicked handler directly to simulate a user press.
+        satBtn.clicked()
+        compare(optionsModel.displayUnit, 1)
+
+        // Reset
+        optionsModel.displayUnit = 0
+    }
+
+    function test_displayUnit_clicking_BTC_after_SAT_resets_model() {
+        optionsModel.displayUnit = 1
+        const obj = createTemporaryObject(displayUnitButtons, this)
+        verify(obj !== null)
+
+        const btcBtn = findChild(obj, "displayUnitBTC")
+        verify(btcBtn !== null)
+        compare(btcBtn.checked, false)
+
+        btcBtn.clicked()
+        compare(optionsModel.displayUnit, 0)
+    }
+}

--- a/test/qml/tst_displaysettings.qml
+++ b/test/qml/tst_displaysettings.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Bitcoin Core developers
+// Copyright (c) 2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/qml/tst_displaysettings.qml
+++ b/test/qml/tst_displaysettings.qml
@@ -97,61 +97,60 @@ TestCase {
         compare(optionsModel.displayUnit, 0)
     }
 
-    // Mirrors the balance prefix expression in WalletBadge.qml.
+    // Mirrors the balance suffix expression in WalletBadge.qml.
+    // balanceSatoshi=1000 → plural "sats"; balanceSatoshi=1 → singular "sat".
     Component {
-        id: balancePrefixComponent
+        id: balanceSuffixComponent
         Text {
             property string balance: "1 000"
-            text: (optionsModel.displayUnit === 1 ? "s" : "₿") + " " + balance
+            property var balanceSatoshi: 1000
+            text: balance + " " + (optionsModel.displayUnit === 1 ? (balanceSatoshi === 1 ? "sat" : "sats") : "₿")
         }
     }
 
-    function test_walletBadge_prefix_is_s_in_sat_mode() {
+    function test_walletBadge_suffix_is_sats_in_sat_mode() {
         optionsModel.displayUnit = 1
-        const obj = createTemporaryObject(balancePrefixComponent, this)
+        const obj = createTemporaryObject(balanceSuffixComponent, this)
         verify(obj !== null)
-        compare(obj.text, "s 1 000")
+        compare(obj.text, "1 000 sats")
         optionsModel.displayUnit = 0
     }
 
-    function test_walletBadge_prefix_is_btc_symbol_in_btc_mode() {
-        optionsModel.displayUnit = 0
-        const obj = createTemporaryObject(balancePrefixComponent, this)
+    function test_walletBadge_suffix_is_sat_singular_in_sat_mode() {
+        optionsModel.displayUnit = 1
+        const obj = createTemporaryObject(balanceSuffixComponent, this)
         verify(obj !== null)
-        compare(obj.text, "₿ 1 000")
+        obj.balanceSatoshi = 1
+        compare(obj.text, "1 000 sat")
+        optionsModel.displayUnit = 0
     }
 
-    // Mirrors the Loader + Component pattern in BitcoinAmountInputField.qml,
-    // Send.qml, and RequestPayment.qml.
-    Component {
-        id: unitLabelComponent
-        Item {
-            id: wrapper
-            property int unit: 0
-            Loader {
-                objectName: "unitLabelLoader"
-                sourceComponent: wrapper.unit === 1 ? satComponent : btcComponent
-            }
-            Component { id: btcComponent; Text { text: "₿" } }
-            Component { id: satComponent; Text { text: "s" } }
-        }
+    function test_walletBadge_suffix_is_btc_symbol_in_btc_mode() {
+        optionsModel.displayUnit = 0
+        const obj = createTemporaryObject(balanceSuffixComponent, this)
+        verify(obj !== null)
+        compare(obj.text, "1 000 ₿")
     }
 
-    function test_unitLabel_shows_s_in_sat_mode() {
-        const obj = createTemporaryObject(unitLabelComponent, this)
-        obj.unit = 1
-        waitForRendering(obj)
-        const loader = findChild(obj, "unitLabelLoader")
-        verify(loader.item !== null)
-        compare(loader.item.text, "s")
+    // Tests displayUnitLabelForAmount pluralization logic.
+    function test_displayUnitLabelForAmount_singular_in_sat_mode() {
+        optionsModel.displayUnit = 1
+        compare(optionsModel.displayUnitLabelForAmount(1), "sat")
+        compare(optionsModel.displayUnitLabelForAmount(-1), "sat")
+        optionsModel.displayUnit = 0
     }
 
-    function test_unitLabel_shows_btc_symbol_in_btc_mode() {
-        const obj = createTemporaryObject(unitLabelComponent, this)
-        obj.unit = 0
-        waitForRendering(obj)
-        const loader = findChild(obj, "unitLabelLoader")
-        verify(loader.item !== null)
-        compare(loader.item.text, "₿")
+    function test_displayUnitLabelForAmount_plural_in_sat_mode() {
+        optionsModel.displayUnit = 1
+        compare(optionsModel.displayUnitLabelForAmount(0), "sats")
+        compare(optionsModel.displayUnitLabelForAmount(2), "sats")
+        compare(optionsModel.displayUnitLabelForAmount(1000), "sats")
+        optionsModel.displayUnit = 0
+    }
+
+    function test_displayUnitLabelForAmount_btc_symbol_in_btc_mode() {
+        optionsModel.displayUnit = 0
+        compare(optionsModel.displayUnitLabelForAmount(1), "₿")
+        compare(optionsModel.displayUnitLabelForAmount(1000), "₿")
     }
 }

--- a/test/test_display_settings.cpp
+++ b/test/test_display_settings.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+#include <QSettings>
+
+#include <qml/bitcoinunits.h>
+#include <qml/models/settings_keys.h>
+
+// Tests for display-settings persistence (language, display unit)
+// and the QmlBitcoinUnits SAT/BTC formatting used by Transaction::prettyAmount().
+// Persistence tests use SettingsKeys::* constants so that a key-name change in
+// the model will immediately break the corresponding test.
+class DisplaySettingsTests : public QObject {
+    Q_OBJECT
+
+private Q_SLOTS:
+    void init();
+    void cleanup();
+
+    void displayUnit_defaultIsBtc();
+    void displayUnit_persistsToQSettings();
+    void language_persistsToQSettings();
+    void qmlBitcoinUnits_satFormat_zero();
+    void qmlBitcoinUnits_satFormat_positive();
+    void qmlBitcoinUnits_satFormat_negative();
+    void qmlBitcoinUnits_btcFormat_roundtrip();
+
+private:
+    // Use a test-only settings group to avoid polluting real user settings.
+    static const inline QString TEST_GROUP = "DisplaySettingsTest";
+};
+
+void DisplaySettingsTests::init()
+{
+    QSettings settings;
+    settings.beginGroup(TEST_GROUP);
+    settings.remove("");  // clear all keys in group
+    settings.endGroup();
+}
+
+void DisplaySettingsTests::cleanup()
+{
+    QSettings settings;
+    settings.beginGroup(TEST_GROUP);
+    settings.remove("");
+    settings.endGroup();
+}
+
+void DisplaySettingsTests::displayUnit_defaultIsBtc()
+{
+    // Verify the default value using the same key the model reads.
+    QSettings settings;
+    settings.beginGroup(TEST_GROUP);
+    int unit = settings.value(SettingsKeys::DISPLAY_UNIT, 0).toInt();
+    settings.endGroup();
+    QCOMPARE(unit, 0);
+}
+
+void DisplaySettingsTests::displayUnit_persistsToQSettings()
+{
+    // Write using the model's key constant, read back in a fresh QSettings instance.
+    {
+        QSettings settings;
+        settings.beginGroup(TEST_GROUP);
+        settings.setValue(SettingsKeys::DISPLAY_UNIT, 1);
+        settings.endGroup();
+    }
+    {
+        QSettings settings;
+        settings.beginGroup(TEST_GROUP);
+        int unit = settings.value(SettingsKeys::DISPLAY_UNIT, 0).toInt();
+        settings.endGroup();
+        QCOMPARE(unit, 1);
+    }
+}
+
+void DisplaySettingsTests::language_persistsToQSettings()
+{
+    // Write using the model's key constant, read back in a fresh QSettings instance.
+    {
+        QSettings settings;
+        settings.beginGroup(TEST_GROUP);
+        settings.setValue(SettingsKeys::LANGUAGE, QStringLiteral("de"));
+        settings.endGroup();
+    }
+    {
+        QSettings settings;
+        settings.beginGroup(TEST_GROUP);
+        QString lang = settings.value(SettingsKeys::LANGUAGE, "").toString();
+        settings.endGroup();
+        QCOMPARE(lang, QStringLiteral("de"));
+    }
+}
+
+void DisplaySettingsTests::qmlBitcoinUnits_satFormat_zero()
+{
+    QCOMPARE(QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::SAT, 0),
+             QStringLiteral("0"));
+}
+
+void DisplaySettingsTests::qmlBitcoinUnits_satFormat_positive()
+{
+    // 1 BTC = 100,000,000 sat
+    QString result = QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::SAT, 100000000);
+    QVERIFY(!result.isEmpty());
+    // Strip thin-space separators (U+2009) before checking the digit content.
+    QString digits = result;
+    digits.remove(QChar(0x2009));
+    digits.remove(QLatin1Char(','));
+    QVERIFY(digits.contains(QStringLiteral("100000000")));
+}
+
+void DisplaySettingsTests::qmlBitcoinUnits_satFormat_negative()
+{
+    QString result = QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::SAT, -1, false);
+    QCOMPARE(result, QStringLiteral("-1"));
+}
+
+void DisplaySettingsTests::qmlBitcoinUnits_btcFormat_roundtrip()
+{
+    // 1 BTC = 100,000,000 sat; format() uses '.' separator (not locale-dependent).
+    QString result = QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, 100000000);
+    QCOMPARE(result, QStringLiteral("1.00000000"));
+}
+
+#ifdef BITCOINQML_NO_TEST_MAIN
+#include <test/qt_test_registry.h>
+BITCOINQML_REGISTER_QT_TEST(DisplaySettingsTests)
+#else
+QTEST_MAIN(DisplaySettingsTests)
+#endif
+#include "test_display_settings.moc"

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -428,6 +428,10 @@ void WalletQmlModelTests::prepareTransaction_reassignsAmountWhenFeeIncluded()
     QCOMPARE(model->currentTransaction()->amountAmount()->satoshi(), CAmount{49'800});
     QCOMPARE(model->currentTransaction()->feeAmount()->satoshi(), CAmount{200});
     QCOMPARE(model->currentTransaction()->totalAmount()->satoshi(), CAmount{50'000});
+    QCOMPARE(model->currentTransaction()->amount(), QString::fromUtf8("0.00049800 \xe2\x82\xbf"));
+    QCOMPARE(model->currentTransaction()->fee(), QString::fromUtf8("0.00000200 \xe2\x82\xbf"));
+    QCOMPARE(model->currentTransaction()->total(), QString::fromUtf8("0.00050000 \xe2\x82\xbf"));
+    QCOMPARE(model->currentTransaction()->getTotalTransactionAmount(), CAmount{50'000});
 }
 
 void WalletQmlModelTests::walletQmlModelTransaction_reassignAmounts_excludesChangeOutput()
@@ -453,6 +457,7 @@ void WalletQmlModelTests::walletQmlModelTransaction_reassignAmounts_excludesChan
     QCOMPARE(fee_changed_spy.count(), 1);
     QCOMPARE(total_changed_spy.count(), 1);
     QCOMPARE(transaction.totalAmount()->satoshi(), CAmount{50'200});
+    QCOMPARE(transaction.total(), QString::fromUtf8("0.00050200 \xe2\x82\xbf"));
 
     transaction.reassignAmounts(/*nChangePosRet=*/1);
 
@@ -461,6 +466,10 @@ void WalletQmlModelTests::walletQmlModelTransaction_reassignAmounts_excludesChan
     QCOMPARE(transaction.amountAmount()->satoshi(), CAmount{49'800});
     QCOMPARE(transaction.feeAmount()->satoshi(), CAmount{200});
     QCOMPARE(transaction.totalAmount()->satoshi(), CAmount{50'000});
+    QCOMPARE(transaction.amount(), QString::fromUtf8("0.00049800 \xe2\x82\xbf"));
+    QCOMPARE(transaction.fee(), QString::fromUtf8("0.00000200 \xe2\x82\xbf"));
+    QCOMPARE(transaction.total(), QString::fromUtf8("0.00050000 \xe2\x82\xbf"));
+    QCOMPARE(transaction.getTotalTransactionAmount(), CAmount{50'000});
 }
 
 void WalletQmlModelTests::scheduleFeeEstimates_usesSelectedCoinsInCoinControl()

--- a/test/test_walletqmlmodeltransaction.cpp
+++ b/test/test_walletqmlmodeltransaction.cpp
@@ -72,7 +72,7 @@ void WalletQmlModelTransactionTests::recipientRolesExposeFormattedAddressAndUnit
         QString("abcd 1234 efgh 5678"));
     QCOMPARE(
         recipients.data(index, SendRecipientsListModel::AmountUnitLabelRole).toString(),
-        QString("sat"));
+        QString("sats"));
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN


### PR DESCRIPTION
Added the option to change the display unit under display settings, can choose between BTC or sats. #512 
Added the option to change language under display settings, currently only English and Spanish are translated.
All instances of bitcoin values are now tagged so the change with display unit settings (s for sats).
All text now tagged so that it will change with language (with the exception of wallet names).
Added unit, qml and functional tests for display units and language.

<img width="660" height="894" alt="Screenshot from 2026-03-25 14-55-43" src="https://github.com/user-attachments/assets/8be85d35-34f5-4df0-863c-534257ae59a5" />

<img width="660" height="894" alt="Screenshot from 2026-03-25 14-56-50" src="https://github.com/user-attachments/assets/1c604042-3f16-4f13-bc0e-780b45c98416" />

<img width="660" height="894" alt="Screenshot from 2026-03-25 14-57-26" src="https://github.com/user-attachments/assets/edf3db5e-5354-4b2b-945f-1bed74d9f679" />