### PR TITLE
Desktop tray functionality and controls

### DIFF
--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -111,3 +111,4 @@ jobs:
           python3 test/functional/qml_test_wallet_migration.py
           python3 test/functional/qml_test_wallet_rbf.py
           python3 test/functional/qml_test_wallet_restore.py
+          python3 test/functional/qml_test_tray.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,6 @@ find_package(QRencode MODULE REQUIRED)
 
 option(ENABLE_TEST_AUTOMATION "Enable test automation bridge for QML UI testing" OFF)
 
-include(CMakeDependentOption)
-cmake_dependent_option(WITH_DBUS
-  "Enable DBus support for system tray icon on Linux."
-  ON "NOT CMAKE_SYSTEM_NAME MATCHES \"(Windows|Darwin|Android)\""
-  OFF
-)
-
 # Do not build any executable targets from bitcoin submodule
 set(BUILD_BENCH OFF)
 set(BUILD_BITCOIN_BIN OFF)
@@ -99,10 +92,6 @@ if(ENABLE_TEST_AUTOMATION)
   find_package(Qt6 REQUIRED COMPONENTS Network)
   target_compile_definitions(bitcoinqml PUBLIC ENABLE_TEST_AUTOMATION)
   target_link_libraries(bitcoinqml PUBLIC Qt6::Network)
-endif()
-if(WITH_DBUS)
-  find_package(Qt6 REQUIRED COMPONENTS DBus)
-  target_link_libraries(bitcoinqml PUBLIC Qt6::DBus)
 endif()
 target_include_directories(bitcoinqml
   PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,13 @@ find_package(QRencode MODULE REQUIRED)
 
 option(ENABLE_TEST_AUTOMATION "Enable test automation bridge for QML UI testing" OFF)
 
+include(CMakeDependentOption)
+cmake_dependent_option(WITH_DBUS
+  "Enable DBus support for system tray icon on Linux."
+  ON "NOT CMAKE_SYSTEM_NAME MATCHES \"(Windows|Darwin|Android)\""
+  OFF
+)
+
 # Do not build any executable targets from bitcoin submodule
 set(BUILD_BENCH OFF)
 set(BUILD_BITCOIN_BIN OFF)
@@ -92,6 +99,10 @@ if(ENABLE_TEST_AUTOMATION)
   find_package(Qt6 REQUIRED COMPONENTS Network)
   target_compile_definitions(bitcoinqml PUBLIC ENABLE_TEST_AUTOMATION)
   target_link_libraries(bitcoinqml PUBLIC Qt6::Network)
+endif()
+if(WITH_DBUS)
+  find_package(Qt6 REQUIRED COMPONENTS DBus)
+  target_link_libraries(bitcoinqml PUBLIC Qt6::DBus)
 endif()
 target_include_directories(bitcoinqml
   PRIVATE

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -66,9 +66,8 @@
 #include <QDebug>
 #include <QFontDatabase>
 #include <QSettings>
-#include <QIcon>
-#include <QPixmap>
 #include <QApplication>
+#include <QPixmap>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QQuickWindow>
@@ -342,6 +341,7 @@ int QmlGuiMain(int argc, char* argv[])
 
     DesktopWindowBehaviorModel desktop_window_behavior_model;
     DesktopTrayIconController desktop_tray_icon_controller;
+    AppMode app_mode = SetupAppMode();
 
     qGuiApp->setQuitOnLastWindowClosed(false);
     QObject::connect(qGuiApp, &QGuiApplication::lastWindowClosed, [&] {
@@ -431,18 +431,13 @@ int QmlGuiMain(int argc, char* argv[])
         engine.retranslate();
     });
 
-    AppMode app_mode = SetupAppMode();
     BuildInfo build_info;
     Clipboard clipboard;
 
-    // Desktop tray icon: set base pixmap and initial dark mode from persisted setting.
-    // The QML Binding in main.qml keeps isDark in sync with Theme.dark at runtime.
     desktop_tray_icon_controller.setBasePixmap(QPixmap(":/icons/bitcoin-circle"));
     desktop_tray_icon_controller.setIsDark(QSettings().value("dark", true).toBool());
     desktop_tray_icon_controller.setVisible(
         app_mode.isDesktop() && desktop_window_behavior_model.showTrayIcon());
-    // If the system tray is unavailable after all show() retries, reflect that
-    // in the model so the UI does not show the setting as enabled.
     QObject::connect(&desktop_tray_icon_controller, &DesktopTrayIconController::supportedChanged,
         [&desktop_window_behavior_model](bool supported) {
             if (!supported) desktop_window_behavior_model.setShowTrayIcon(false);

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -37,6 +37,8 @@
 #include <qml/models/debuglogmodel.h>
 #include <qml/models/networktraffictower.h>
 #include <qml/models/nodemodel.h>
+#include <qml/models/desktoptrayiconcontroller.h>
+#include <qml/models/desktopwindowbehaviormodel.h>
 #include <qml/models/options_model.h>
 #include <qml/models/paymentrequest.h>
 #include <qml/models/peerdetailsmodel.h>
@@ -63,7 +65,10 @@
 
 #include <QDebug>
 #include <QFontDatabase>
-#include <QGuiApplication>
+#include <QSettings>
+#include <QIcon>
+#include <QPixmap>
+#include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QQuickWindow>
@@ -208,7 +213,7 @@ int QmlGuiMain(int argc, char* argv[])
     qRegisterMetaType<interfaces::BlockAndHeaderTipInfo>("interfaces::BlockAndHeaderTipInfo");
 
     QGuiApplication::styleHints()->setTabFocusBehavior(Qt::TabFocusAllControls);
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
 
     std::unique_ptr<interfaces::Init> init = interfaces::MakeGuiInit(argc, argv);
     auto handler_message_box = ::uiInterface.ThreadSafeMessageBox_connect(InitErrorMessageBox);
@@ -322,13 +327,26 @@ int QmlGuiMain(int argc, char* argv[])
     ChainModel chain_model{*chain};
     chain_model.setCurrentNetworkName(QString::fromStdString(gArgs.GetChainTypeString()));
     setupChainQSettings(&app, chain_model.currentNetworkName());
+    // Settings reset must happen before model instantiation so the models
+    // read clean defaults from QSettings.
+    if (gArgs.IsArgSet("-resetguisettings")) {
+        QSettings settings;
+        settings.remove(QStringLiteral("fHideTrayIcon"));
+        settings.remove(QStringLiteral("fMinimizeToTray"));
+        settings.remove(QStringLiteral("fMinimizeOnClose"));
+    }
 
     QObject::connect(&node_model, &NodeModel::setTimeRatioList, &chain_model, &ChainModel::setTimeRatioList);
     QObject::connect(&node_model, &NodeModel::setTimeRatioListInitial, &chain_model, &ChainModel::setTimeRatioListInitial);
 
 
+    DesktopWindowBehaviorModel desktop_window_behavior_model;
+    DesktopTrayIconController desktop_tray_icon_controller;
+
     qGuiApp->setQuitOnLastWindowClosed(false);
     QObject::connect(qGuiApp, &QGuiApplication::lastWindowClosed, [&] {
+        // When the tray icon is visible the node keeps running in the background.
+        if (desktop_tray_icon_controller.visible()) return;
 #ifdef ENABLE_WALLET
         wallet_controller.unloadWallets();
 #endif
@@ -416,6 +434,21 @@ int QmlGuiMain(int argc, char* argv[])
     AppMode app_mode = SetupAppMode();
     BuildInfo build_info;
     Clipboard clipboard;
+
+    // Desktop tray icon: set base pixmap and initial dark mode from persisted setting.
+    // The QML Binding in main.qml keeps isDark in sync with Theme.dark at runtime.
+    desktop_tray_icon_controller.setBasePixmap(QPixmap(":/icons/bitcoin-circle"));
+    desktop_tray_icon_controller.setIsDark(QSettings().value("dark", true).toBool());
+    desktop_tray_icon_controller.setVisible(
+        app_mode.isDesktop() && desktop_window_behavior_model.showTrayIcon());
+    // If the system tray is unavailable after all show() retries, reflect that
+    // in the model so the UI does not show the setting as enabled.
+    QObject::connect(&desktop_tray_icon_controller, &DesktopTrayIconController::supportedChanged,
+        [&desktop_window_behavior_model](bool supported) {
+            if (!supported) desktop_window_behavior_model.setShowTrayIcon(false);
+        });
+    engine.rootContext()->setContextProperty("desktopWindowBehaviorModel", &desktop_window_behavior_model);
+    engine.rootContext()->setContextProperty("desktopTrayIconController", &desktop_tray_icon_controller);
 
     qmlRegisterSingletonInstance<AppMode>("org.bitcoincore.qt", 1, 0, "AppMode", &app_mode);
     qmlRegisterSingletonInstance<BuildInfo>("org.bitcoincore.qt", 1, 0, "BuildInfo", &build_info);

--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -94,6 +94,7 @@
         <file>pages/settings/SettingsAbout.qml</file>
         <file>pages/settings/SettingsDisplayUnit.qml</file>
         <file>pages/settings/SettingsLanguage.qml</file>
+        <file>pages/settings/SettingsWindowBehavior.qml</file>
         <file>pages/settings/SettingsBlockClockDisplayMode.qml</file>
         <file>pages/settings/SettingsConnection.qml</file>
         <file>pages/settings/SettingsDebugLog.qml</file>

--- a/qml/controls/Setting.qml
+++ b/qml/controls/Setting.qml
@@ -36,16 +36,16 @@ AbstractButton {
                 target: root
                 enabled: true
                 stateColor: root.filledStateColor
-                stateDescriptionColor: Theme.color.neutral8
+                stateDescriptionColor: root.descriptionColor
             }
         },
         State {
             name: "HOVER"
-            PropertyChanges { target: root; stateColor: root.hoverStateColor; stateDescriptionColor: Theme.color.neutral8 }
+            PropertyChanges { target: root; stateColor: root.hoverStateColor; stateDescriptionColor: root.descriptionColor }
         },
         State {
             name: "ACTIVE"
-            PropertyChanges { target: root; stateColor: root.activeStateColor; stateDescriptionColor: Theme.color.neutral8 }
+            PropertyChanges { target: root; stateColor: root.activeStateColor; stateDescriptionColor: root.descriptionColor }
         },
         State {
             name: "DISABLED"
@@ -105,7 +105,6 @@ AbstractButton {
             descriptionColor: root.stateDescriptionColor
             description: root.description
             descriptionSize: root.descriptionSize
-            descriptionColor: root.descriptionColor
             descriptionMargin: 0
             subtext: root.showErrorText ? root.errorText : ""
             subtextColor: Theme.color.blue

--- a/qml/controls/Setting.qml
+++ b/qml/controls/Setting.qml
@@ -23,8 +23,11 @@ AbstractButton {
     property color hoverStateColor: Theme.color.orangeLight1
     property color activeStateColor: Theme.color.orange
     property color disabledStateColor: Theme.color.neutral4
+    property color stateDescriptionColor
+    property bool disabled: false
     hoverEnabled: AppMode.isDesktop
     state: "FILLED"
+    onDisabledChanged: state = disabled ? "DISABLED" : "FILLED"
 
     states: [
         State {
@@ -33,15 +36,16 @@ AbstractButton {
                 target: root
                 enabled: true
                 stateColor: root.filledStateColor
+                stateDescriptionColor: Theme.color.neutral8
             }
         },
         State {
             name: "HOVER"
-            PropertyChanges { target: root; stateColor: root.hoverStateColor }
+            PropertyChanges { target: root; stateColor: root.hoverStateColor; stateDescriptionColor: Theme.color.neutral8 }
         },
         State {
             name: "ACTIVE"
-            PropertyChanges { target: root; stateColor: root.activeStateColor }
+            PropertyChanges { target: root; stateColor: root.activeStateColor; stateDescriptionColor: Theme.color.neutral8 }
         },
         State {
             name: "DISABLED"
@@ -49,6 +53,7 @@ AbstractButton {
                 target: root
                 enabled: false
                 stateColor: root.disabledStateColor
+                stateDescriptionColor: Theme.dark ? Theme.color.neutral4 : Theme.color.neutral6
             }
         }
     ]
@@ -74,14 +79,16 @@ AbstractButton {
             if (root.state !== "DISABLED") root.state = "FILLED"
         }
         onPressed: {
-            root.state = "ACTIVE"
+            if (!root.disabled) root.state = "ACTIVE"
         }
         onReleased: {
-            if (mouseArea.containsMouse) {
-                root.state = "HOVER"
-                root.clicked()
-            } else {
-                root.state = "FILLED"
+            if (!root.disabled) {
+                if (mouseArea.containsMouse) {
+                    root.state = "HOVER"
+                    root.clicked()
+                } else {
+                    root.state = "FILLED"
+                }
             }
         }
     }
@@ -95,6 +102,7 @@ AbstractButton {
             header: root.header
             headerSize: 18
             headerColor: root.stateColor
+            descriptionColor: root.stateDescriptionColor
             description: root.description
             descriptionSize: root.descriptionSize
             descriptionColor: root.descriptionColor

--- a/qml/models/desktoptrayiconcontroller.cpp
+++ b/qml/models/desktoptrayiconcontroller.cpp
@@ -1,0 +1,256 @@
+// Copyright (c) 2021-2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/desktoptrayiconcontroller.h>
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QIcon>
+#include <QImage>
+#include <QMenu>
+#include <QStandardPaths>
+#include <QStringList>
+#include <QTextStream>
+#include <QTimer>
+
+DesktopTrayIconController::DesktopTrayIconController(QObject* parent)
+    : QObject(parent)
+    , m_tray_icon(new QSystemTrayIcon(this))
+{
+    // Tooltip is required by the StatusNotifierItem/AppIndicator protocol —
+    // some GNOME AppIndicator versions silently drop icons with no title set.
+    m_tray_icon->setToolTip(QStringLiteral("Bitcoin Core"));
+
+    // Fix 5: Register a native QMenu before any show() call.
+    // Some AppIndicator/SNI hosts (Ubuntu Unity era and gnome-shell-extension-
+    // appindicator) take direct ownership of all click interactions when a menu
+    // is registered, bypassing QSystemTrayIcon::activated entirely. The menu
+    // must therefore contain real actions so users can restore and quit the app.
+    auto* nativeMenu = new QMenu();
+    auto* showAction = nativeMenu->addAction(tr("Show"));
+    connect(showAction, &QAction::triggered, this, [this] { Q_EMIT restoreRequested(); });
+    nativeMenu->addSeparator();
+    auto* quitAction = nativeMenu->addAction(tr("Quit"));
+    connect(quitAction, &QAction::triggered, this, [this] { Q_EMIT quitRequested(); });
+    m_tray_icon->setContextMenu(nativeMenu);
+
+    connect(m_tray_icon, &QSystemTrayIcon::activated, this,
+        [this](QSystemTrayIcon::ActivationReason reason) {
+            if (reason == QSystemTrayIcon::Trigger ||
+                    reason == QSystemTrayIcon::DoubleClick) {
+                Q_EMIT restoreRequested();
+            } else if (reason == QSystemTrayIcon::Context) {
+                Q_EMIT contextMenuRequested();
+            }
+        });
+}
+
+bool DesktopTrayIconController::supported() const
+{
+    return QSystemTrayIcon::isSystemTrayAvailable();
+}
+
+bool DesktopTrayIconController::visible() const
+{
+    return m_visible;
+}
+
+void DesktopTrayIconController::setVisible(bool visible)
+{
+    if (visible) {
+        // Idempotent: already showing, or a show attempt is already in flight.
+        if (m_visible || m_show_requested) return;
+
+        m_show_requested = true;
+        m_show_attempts = 0;
+
+        // Fix 3: Defer show() to the first event-loop iteration so the D-Bus
+        // connection is ready on SNI systems. Do NOT set m_visible or emit
+        // visibleChanged(true) yet — only do so after show() is confirmed.
+        QTimer::singleShot(0, this, [this] { attemptShow(); });
+    } else {
+        // Cancel any in-flight show attempt.
+        m_show_requested = false;
+        if (!m_visible) return;
+        m_visible = false;
+        m_tray_icon->hide();
+        Q_EMIT visibleChanged(false);
+    }
+}
+
+void DesktopTrayIconController::attemptShow()
+{
+    // Fix 3+4: Abort if setVisible(false) cancelled the request.
+    if (!m_show_requested) return;
+
+    m_tray_icon->show();
+
+    if (m_tray_icon->isVisible()) {
+        m_show_requested = false;
+        m_visible = true;
+        qInfo() << "[tray] System tray icon registered and visible";
+        Q_EMIT visibleChanged(true);
+        Q_EMIT supportedChanged(true);
+        return;
+    }
+
+    // Fix 4: Retry with increasing delay to handle slow SNI host init.
+    ++m_show_attempts;
+    if (m_show_attempts < kMaxShowAttempts) {
+        const int delay_ms = 100 * m_show_attempts; // 100, 200, 300, 400 ms
+        QTimer::singleShot(delay_ms, this, [this] { attemptShow(); });
+        return;
+    }
+
+    // All retries exhausted.
+    m_show_requested = false;
+    Q_EMIT supportedChanged(false);
+}
+
+QString DesktopTrayIconController::iconName() const
+{
+    return m_tray_icon->icon().name();
+}
+
+void DesktopTrayIconController::setIcon(const QIcon& icon)
+{
+#if defined(Q_OS_LINUX)
+    // gnome-shell-extension-appindicator looks up icons by IconName in the default
+    // GTK icon theme. It appends '-panel' to try a monochrome panel variant first.
+    // We install both variants to the standard XDG user icon directory
+    // (~/.local/share/icons/hicolor/48x48/apps/) so GTK finds them without
+    // requiring a custom IconThemePath — which the extension often ignores.
+    // This block is Linux-only: on macOS/Windows GenericDataLocation resolves to
+    // different paths and AppIndicator does not exist.
+    const QPixmap pixmap = icon.pixmap(48, 48);
+    if (!pixmap.isNull()) {
+        const QString data_dir =
+            QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+        const QString apps_dir =
+            data_dir + QStringLiteral("/icons/hicolor/48x48/apps");
+        if (QDir().mkpath(apps_dir)) {
+            const bool ok =
+                pixmap.save(apps_dir + QStringLiteral("/bitcoin-core.png")) &&
+                pixmap.save(apps_dir + QStringLiteral("/bitcoin-core-panel.png"));
+            if (ok) {
+                const QString theme_path =
+                    data_dir + QStringLiteral("/icons/hicolor/index.theme");
+
+                // Fix 1: Ensure 48x48/apps appears in BOTH the Directories= line
+                // AND has its own stanza. Qt's QIconLoader and GTK both use the
+                // Directories= value as the authoritative list of subdirs to scan;
+                // a stanza without a Directories= entry is silently ignored.
+                bool has_48x48_apps = false;
+                QString existing_content;
+                if (QFile::exists(theme_path)) {
+                    QFile rf(theme_path);
+                    if (rf.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                        existing_content = QTextStream(&rf).readAll();
+                        has_48x48_apps =
+                            existing_content.contains(QStringLiteral("48x48/apps"));
+                    }
+                }
+
+                if (!has_48x48_apps) {
+                    const QString dirs_key = QStringLiteral("Directories=");
+                    const int dirs_pos = existing_content.indexOf(dirs_key);
+                    if (dirs_pos >= 0) {
+                        // Existing index.theme has a Directories= line but it
+                        // doesn't include 48x48/apps. Append the directory to that
+                        // line, then add the required stanza.
+                        const int eol = existing_content.indexOf(
+                            QLatin1Char('\n'), dirs_pos);
+                        const int insert_at =
+                            (eol >= 0) ? eol : existing_content.size();
+                        existing_content.insert(
+                            insert_at, QStringLiteral(",48x48/apps"));
+                        existing_content +=
+                            QStringLiteral("\n[48x48/apps]\n"
+                                           "Size=48\n"
+                                           "Context=Applications\n"
+                                           "Type=Fixed\n");
+                        QFile wf(theme_path);
+                        if (wf.open(QIODevice::WriteOnly |
+                                    QIODevice::Truncate |
+                                    QIODevice::Text)) {
+                            QTextStream(&wf) << existing_content;
+                        } else {
+                            qWarning() << "[tray] Failed to update index.theme:" << wf.errorString();
+                        }
+                    } else {
+                        // No Directories= line (malformed or new file): write a
+                        // fresh minimal hicolor theme from scratch.
+                        QFile wf(theme_path);
+                        if (wf.open(QIODevice::WriteOnly |
+                                    QIODevice::Truncate |
+                                    QIODevice::Text)) {
+                            QTextStream s(&wf);
+                            s << "[Icon Theme]\n"
+                              << "Name=hicolor\n"
+                              << "Comment=Fallback Theme\n"
+                              << "Directories=48x48/apps\n\n"
+                              << "[48x48/apps]\n"
+                              << "Size=48\n"
+                              << "Context=Applications\n"
+                              << "Type=Fixed\n";
+                        } else {
+                            qWarning() << "[tray] Failed to write index.theme:" << wf.errorString();
+                        }
+                    }
+                }
+
+                // Use the icon directly via IconPixmap (StatusNotifierItem spec)
+                // rather than QIcon::fromTheme(). GNOME AppIndicator forces
+                // all named/themed icons to monochrome, which strips colour.
+                // Passing the QIcon directly uses the IconPixmap D-Bus property
+                // and preserves the full-colour pixmap.
+                m_tray_icon->setIcon(icon);
+                return;
+            }
+        }
+    }
+#endif // Q_OS_LINUX
+    m_tray_icon->setIcon(icon);
+}
+
+void DesktopTrayIconController::setBasePixmap(const QPixmap& pixmap)
+{
+    m_base_pixmap = pixmap;
+    updateIcon();
+}
+
+bool DesktopTrayIconController::isDark() const
+{
+    return m_is_dark;
+}
+
+void DesktopTrayIconController::setIsDark(bool dark)
+{
+    if (m_is_dark == dark) return;
+    m_is_dark = dark;
+    updateIcon();
+    Q_EMIT isDarkChanged(m_is_dark);
+}
+
+void DesktopTrayIconController::updateIcon()
+{
+    if (m_base_pixmap.isNull()) return;
+    QIcon icon;
+#if defined(Q_OS_MACOS)
+    // macOS NSStatusBar handles tray icon theming automatically via template
+    // images; manual inversion is not needed and could double-invert.
+    icon = QIcon(m_base_pixmap);
+    icon.setIsMask(true);
+#else
+    if (m_is_dark) {
+        QImage img = m_base_pixmap.toImage();
+        img.invertPixels(QImage::InvertRgb);
+        icon = QIcon(QPixmap::fromImage(img));
+    } else {
+        icon = QIcon(m_base_pixmap);
+    }
+#endif
+    setIcon(icon);
+}

--- a/qml/models/desktoptrayiconcontroller.cpp
+++ b/qml/models/desktoptrayiconcontroller.cpp
@@ -4,37 +4,22 @@
 
 #include <qml/models/desktoptrayiconcontroller.h>
 
-#include <QDebug>
-#include <QDir>
-#include <QFile>
-#include <QIcon>
 #include <QImage>
 #include <QMenu>
-#include <QStandardPaths>
-#include <QStringList>
-#include <QTextStream>
-#include <QTimer>
 
 DesktopTrayIconController::DesktopTrayIconController(QObject* parent)
     : QObject(parent)
     , m_tray_icon(new QSystemTrayIcon(this))
 {
-    // Tooltip is required by the StatusNotifierItem/AppIndicator protocol —
-    // some GNOME AppIndicator versions silently drop icons with no title set.
     m_tray_icon->setToolTip(QStringLiteral("Bitcoin Core"));
 
-    // Fix 5: Register a native QMenu before any show() call.
-    // Some AppIndicator/SNI hosts (Ubuntu Unity era and gnome-shell-extension-
-    // appindicator) take direct ownership of all click interactions when a menu
-    // is registered, bypassing QSystemTrayIcon::activated entirely. The menu
-    // must therefore contain real actions so users can restore and quit the app.
-    auto* nativeMenu = new QMenu();
-    auto* showAction = nativeMenu->addAction(tr("Show"));
+    auto* menu = new QMenu();
+    auto* showAction = menu->addAction(tr("Show"));
     connect(showAction, &QAction::triggered, this, [this] { Q_EMIT restoreRequested(); });
-    nativeMenu->addSeparator();
-    auto* quitAction = nativeMenu->addAction(tr("Quit"));
+    menu->addSeparator();
+    auto* quitAction = menu->addAction(tr("Quit"));
     connect(quitAction, &QAction::triggered, this, [this] { Q_EMIT quitRequested(); });
-    m_tray_icon->setContextMenu(nativeMenu);
+    m_tray_icon->setContextMenu(menu);
 
     connect(m_tray_icon, &QSystemTrayIcon::activated, this,
         [this](QSystemTrayIcon::ActivationReason reason) {
@@ -54,171 +39,23 @@ bool DesktopTrayIconController::supported() const
 
 bool DesktopTrayIconController::visible() const
 {
-    return m_visible;
+    return m_tray_icon->isVisible();
 }
 
 void DesktopTrayIconController::setVisible(bool visible)
 {
+    if (visible == m_tray_icon->isVisible()) return;
+
     if (visible) {
-        // Idempotent: already showing, or a show attempt is already in flight.
-        if (m_visible || m_show_requested) return;
-
-        m_show_requested = true;
-        m_show_attempts = 0;
-
-        // Fix 3: Defer show() to the first event-loop iteration so the D-Bus
-        // connection is ready on SNI systems. Do NOT set m_visible or emit
-        // visibleChanged(true) yet — only do so after show() is confirmed.
-        QTimer::singleShot(0, this, [this] { attemptShow(); });
-    } else {
-        // Cancel any in-flight show attempt.
-        m_show_requested = false;
-        if (!m_visible) return;
-        m_visible = false;
-        m_tray_icon->hide();
-        Q_EMIT visibleChanged(false);
-    }
-}
-
-void DesktopTrayIconController::attemptShow()
-{
-    // Fix 3+4: Abort if setVisible(false) cancelled the request.
-    if (!m_show_requested) return;
-
-    m_tray_icon->show();
-
-    if (m_tray_icon->isVisible()) {
-        m_show_requested = false;
-        m_visible = true;
-        qInfo() << "[tray] System tray icon registered and visible";
-        Q_EMIT visibleChanged(true);
-        Q_EMIT supportedChanged(true);
-        return;
-    }
-
-    // Fix 4: Retry with increasing delay to handle slow SNI host init.
-    ++m_show_attempts;
-    if (m_show_attempts < kMaxShowAttempts) {
-        const int delay_ms = 100 * m_show_attempts; // 100, 200, 300, 400 ms
-        QTimer::singleShot(delay_ms, this, [this] { attemptShow(); });
-        return;
-    }
-
-    // All retries exhausted.
-    m_show_requested = false;
-    Q_EMIT supportedChanged(false);
-}
-
-QString DesktopTrayIconController::iconName() const
-{
-    return m_tray_icon->icon().name();
-}
-
-void DesktopTrayIconController::setIcon(const QIcon& icon)
-{
-#if defined(Q_OS_LINUX)
-    // gnome-shell-extension-appindicator looks up icons by IconName in the default
-    // GTK icon theme. It appends '-panel' to try a monochrome panel variant first.
-    // We install both variants to the standard XDG user icon directory
-    // (~/.local/share/icons/hicolor/48x48/apps/) so GTK finds them without
-    // requiring a custom IconThemePath — which the extension often ignores.
-    // This block is Linux-only: on macOS/Windows GenericDataLocation resolves to
-    // different paths and AppIndicator does not exist.
-    const QPixmap pixmap = icon.pixmap(48, 48);
-    if (!pixmap.isNull()) {
-        const QString data_dir =
-            QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
-        const QString apps_dir =
-            data_dir + QStringLiteral("/icons/hicolor/48x48/apps");
-        if (QDir().mkpath(apps_dir)) {
-            const bool ok =
-                pixmap.save(apps_dir + QStringLiteral("/bitcoin-core.png")) &&
-                pixmap.save(apps_dir + QStringLiteral("/bitcoin-core-panel.png"));
-            if (ok) {
-                const QString theme_path =
-                    data_dir + QStringLiteral("/icons/hicolor/index.theme");
-
-                // Fix 1: Ensure 48x48/apps appears in BOTH the Directories= line
-                // AND has its own stanza. Qt's QIconLoader and GTK both use the
-                // Directories= value as the authoritative list of subdirs to scan;
-                // a stanza without a Directories= entry is silently ignored.
-                bool has_48x48_apps = false;
-                QString existing_content;
-                if (QFile::exists(theme_path)) {
-                    QFile rf(theme_path);
-                    if (rf.open(QIODevice::ReadOnly | QIODevice::Text)) {
-                        existing_content = QTextStream(&rf).readAll();
-                        has_48x48_apps =
-                            existing_content.contains(QStringLiteral("48x48/apps"));
-                    }
-                }
-
-                if (!has_48x48_apps) {
-                    const QString dirs_key = QStringLiteral("Directories=");
-                    const int dirs_pos = existing_content.indexOf(dirs_key);
-                    if (dirs_pos >= 0) {
-                        // Existing index.theme has a Directories= line but it
-                        // doesn't include 48x48/apps. Append the directory to that
-                        // line, then add the required stanza.
-                        const int eol = existing_content.indexOf(
-                            QLatin1Char('\n'), dirs_pos);
-                        const int insert_at =
-                            (eol >= 0) ? eol : existing_content.size();
-                        existing_content.insert(
-                            insert_at, QStringLiteral(",48x48/apps"));
-                        existing_content +=
-                            QStringLiteral("\n[48x48/apps]\n"
-                                           "Size=48\n"
-                                           "Context=Applications\n"
-                                           "Type=Fixed\n");
-                        QFile wf(theme_path);
-                        if (wf.open(QIODevice::WriteOnly |
-                                    QIODevice::Truncate |
-                                    QIODevice::Text)) {
-                            QTextStream(&wf) << existing_content;
-                        } else {
-                            qWarning() << "[tray] Failed to update index.theme:" << wf.errorString();
-                        }
-                    } else {
-                        // No Directories= line (malformed or new file): write a
-                        // fresh minimal hicolor theme from scratch.
-                        QFile wf(theme_path);
-                        if (wf.open(QIODevice::WriteOnly |
-                                    QIODevice::Truncate |
-                                    QIODevice::Text)) {
-                            QTextStream s(&wf);
-                            s << "[Icon Theme]\n"
-                              << "Name=hicolor\n"
-                              << "Comment=Fallback Theme\n"
-                              << "Directories=48x48/apps\n\n"
-                              << "[48x48/apps]\n"
-                              << "Size=48\n"
-                              << "Context=Applications\n"
-                              << "Type=Fixed\n";
-                        } else {
-                            qWarning() << "[tray] Failed to write index.theme:" << wf.errorString();
-                        }
-                    }
-                }
-
-                // Use the icon directly via IconPixmap (StatusNotifierItem spec)
-                // rather than QIcon::fromTheme(). GNOME AppIndicator forces
-                // all named/themed icons to monochrome, which strips colour.
-                // Passing the QIcon directly uses the IconPixmap D-Bus property
-                // and preserves the full-colour pixmap.
-                m_tray_icon->setIcon(icon);
-                return;
-            }
+        m_tray_icon->show();
+        if (!m_tray_icon->isVisible()) {
+            Q_EMIT supportedChanged(false);
+            return;
         }
+    } else {
+        m_tray_icon->hide();
     }
-#endif // Q_OS_LINUX
-    m_tray_icon->setIcon(icon);
-}
-
-void DesktopTrayIconController::setBasePixmap(const QPixmap& pixmap)
-{
-    m_base_pixmap = pixmap;
-    updateIcon();
+    Q_EMIT visibleChanged(m_tray_icon->isVisible());
 }
 
 bool DesktopTrayIconController::isDark() const
@@ -234,13 +71,17 @@ void DesktopTrayIconController::setIsDark(bool dark)
     Q_EMIT isDarkChanged(m_is_dark);
 }
 
+void DesktopTrayIconController::setBasePixmap(const QPixmap& pixmap)
+{
+    m_base_pixmap = pixmap;
+    updateIcon();
+}
+
 void DesktopTrayIconController::updateIcon()
 {
     if (m_base_pixmap.isNull()) return;
     QIcon icon;
 #if defined(Q_OS_MACOS)
-    // macOS NSStatusBar handles tray icon theming automatically via template
-    // images; manual inversion is not needed and could double-invert.
     icon = QIcon(m_base_pixmap);
     icon.setIsMask(true);
 #else
@@ -252,5 +93,5 @@ void DesktopTrayIconController::updateIcon()
         icon = QIcon(m_base_pixmap);
     }
 #endif
-    setIcon(icon);
+    m_tray_icon->setIcon(icon);
 }

--- a/qml/models/desktoptrayiconcontroller.h
+++ b/qml/models/desktoptrayiconcontroller.h
@@ -23,9 +23,7 @@ public:
     bool supported() const;
     bool visible() const;
     void setVisible(bool visible);
-    void setIcon(const QIcon& icon);
     void setBasePixmap(const QPixmap& pixmap);
-    QString iconName() const;
     bool isDark() const;
     void setIsDark(bool dark);
 
@@ -38,16 +36,9 @@ Q_SIGNALS:
     void isDarkChanged(bool dark);
 
 private:
-    void attemptShow();
     void updateIcon();
 
     QSystemTrayIcon* m_tray_icon{nullptr};
-    bool m_visible{false};
-    // True while a deferred show() is in flight; cleared on success, failure,
-    // or when setVisible(false) cancels the attempt.
-    bool m_show_requested{false};
-    int m_show_attempts{0};
-    static constexpr int kMaxShowAttempts{5};
     bool m_is_dark{true};
     QPixmap m_base_pixmap;
 };

--- a/qml/models/desktoptrayiconcontroller.h
+++ b/qml/models/desktoptrayiconcontroller.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2021-2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_DESKTOPTRAYICONCONTROLLER_H
+#define BITCOIN_QML_MODELS_DESKTOPTRAYICONCONTROLLER_H
+
+#include <QObject>
+#include <QPixmap>
+#include <QString>
+#include <QSystemTrayIcon>
+
+class DesktopTrayIconController : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool supported READ supported NOTIFY supportedChanged)
+    Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
+    Q_PROPERTY(bool isDark READ isDark WRITE setIsDark NOTIFY isDarkChanged)
+
+public:
+    explicit DesktopTrayIconController(QObject* parent = nullptr);
+
+    bool supported() const;
+    bool visible() const;
+    void setVisible(bool visible);
+    void setIcon(const QIcon& icon);
+    void setBasePixmap(const QPixmap& pixmap);
+    QString iconName() const;
+    bool isDark() const;
+    void setIsDark(bool dark);
+
+Q_SIGNALS:
+    void visibleChanged(bool visible);
+    void supportedChanged(bool supported);
+    void restoreRequested();
+    void contextMenuRequested();
+    void quitRequested();
+    void isDarkChanged(bool dark);
+
+private:
+    void attemptShow();
+    void updateIcon();
+
+    QSystemTrayIcon* m_tray_icon{nullptr};
+    bool m_visible{false};
+    // True while a deferred show() is in flight; cleared on success, failure,
+    // or when setVisible(false) cancels the attempt.
+    bool m_show_requested{false};
+    int m_show_attempts{0};
+    static constexpr int kMaxShowAttempts{5};
+    bool m_is_dark{true};
+    QPixmap m_base_pixmap;
+};
+
+#endif // BITCOIN_QML_MODELS_DESKTOPTRAYICONCONTROLLER_H

--- a/qml/models/desktopwindowbehaviormodel.cpp
+++ b/qml/models/desktopwindowbehaviormodel.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2021-2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/desktopwindowbehaviormodel.h>
+
+#include <QSettings>
+
+void DesktopWindowBehaviorModel::loadFromSettings()
+{
+    QSettings settings;
+    // fHideTrayIcon stores the inverse of showTrayIcon (default: show = true → hide = false)
+    m_show_tray_icon = !settings.value(KEY_HIDE_TRAY_ICON, false).toBool();
+    m_minimize_to_tray = settings.value(KEY_MINIMIZE_TO_TRAY, false).toBool();
+    m_minimize_on_close = settings.value(KEY_MINIMIZE_ON_CLOSE, false).toBool();
+
+    if (!m_desktop_platform) {
+        m_show_tray_icon = false;
+        m_minimize_to_tray = false;
+        m_minimize_on_close = false;
+    }
+}
+
+DesktopWindowBehaviorModel::DesktopWindowBehaviorModel(QObject* parent)
+    : QObject(parent)
+{
+#ifdef Q_OS_ANDROID
+    m_desktop_platform = false;
+#else
+    m_desktop_platform = true;
+#endif
+    loadFromSettings();
+}
+
+DesktopWindowBehaviorModel::DesktopWindowBehaviorModel(bool desktop_platform, QObject* parent)
+    : QObject(parent)
+    , m_desktop_platform(desktop_platform)
+{
+    loadFromSettings();
+}
+
+bool DesktopWindowBehaviorModel::desktopPlatform() const
+{
+    return m_desktop_platform;
+}
+
+bool DesktopWindowBehaviorModel::showTrayIcon() const
+{
+    return m_show_tray_icon;
+}
+
+void DesktopWindowBehaviorModel::setShowTrayIcon(bool show)
+{
+    if (m_show_tray_icon == show) return;
+
+    m_show_tray_icon = show;
+    QSettings settings;
+    settings.setValue(KEY_HIDE_TRAY_ICON, !show);
+
+    // Cascade: cannot minimize to tray or on close without a tray icon
+    if (!show && m_minimize_to_tray) {
+        setMinimizeToTray(false);
+    }
+    if (!show && m_minimize_on_close) {
+        setMinimizeOnClose(false);
+    }
+
+    Q_EMIT showTrayIconChanged(m_show_tray_icon);
+}
+
+bool DesktopWindowBehaviorModel::minimizeToTray() const
+{
+    return m_minimize_to_tray;
+}
+
+void DesktopWindowBehaviorModel::setMinimizeToTray(bool minimize)
+{
+    // No-op when tray icon is disabled
+    if (!m_show_tray_icon && minimize) return;
+    if (m_minimize_to_tray == minimize) return;
+
+    m_minimize_to_tray = minimize;
+    QSettings settings;
+    settings.setValue(KEY_MINIMIZE_TO_TRAY, minimize);
+    Q_EMIT minimizeToTrayChanged(m_minimize_to_tray);
+}
+
+bool DesktopWindowBehaviorModel::minimizeOnClose() const
+{
+    return m_minimize_on_close;
+}
+
+void DesktopWindowBehaviorModel::setMinimizeOnClose(bool minimize)
+{
+    if (!m_show_tray_icon && minimize) return;
+    if (m_minimize_on_close == minimize) return;
+
+    m_minimize_on_close = minimize;
+    QSettings settings;
+    settings.setValue(KEY_MINIMIZE_ON_CLOSE, minimize);
+    Q_EMIT minimizeOnCloseChanged(m_minimize_on_close);
+}
+
+bool DesktopWindowBehaviorModel::shouldHideToTrayOnMinimize() const
+{
+    return m_desktop_platform && m_show_tray_icon && m_minimize_to_tray;
+}
+
+bool DesktopWindowBehaviorModel::shouldMinimizeWindowOnClose() const
+{
+    return m_desktop_platform && m_minimize_on_close;
+}

--- a/qml/models/desktopwindowbehaviormodel.h
+++ b/qml/models/desktopwindowbehaviormodel.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2021-2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_DESKTOPWINDOWBEHAVIORMODEL_H
+#define BITCOIN_QML_MODELS_DESKTOPWINDOWBEHAVIORMODEL_H
+
+#include <QObject>
+
+class DesktopWindowBehaviorModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool desktopPlatform READ desktopPlatform CONSTANT)
+    Q_PROPERTY(bool showTrayIcon READ showTrayIcon WRITE setShowTrayIcon NOTIFY showTrayIconChanged)
+    Q_PROPERTY(bool minimizeToTray READ minimizeToTray WRITE setMinimizeToTray NOTIFY minimizeToTrayChanged)
+    Q_PROPERTY(bool minimizeOnClose READ minimizeOnClose WRITE setMinimizeOnClose NOTIFY minimizeOnCloseChanged)
+
+public:
+    explicit DesktopWindowBehaviorModel(QObject* parent = nullptr);
+
+    // Constructor for unit-testing: allows injecting the platform flag without
+    // relying on QGuiApplication::platformName().
+    explicit DesktopWindowBehaviorModel(bool desktop_platform, QObject* parent = nullptr);
+
+    bool desktopPlatform() const;
+
+    bool showTrayIcon() const;
+    void setShowTrayIcon(bool show);
+
+    bool minimizeToTray() const;
+    void setMinimizeToTray(bool minimize);
+
+    bool minimizeOnClose() const;
+    void setMinimizeOnClose(bool minimize);
+
+    Q_INVOKABLE bool shouldHideToTrayOnMinimize() const;
+    Q_INVOKABLE bool shouldMinimizeWindowOnClose() const;
+
+Q_SIGNALS:
+    void showTrayIconChanged(bool show);
+    void minimizeToTrayChanged(bool minimize);
+    void minimizeOnCloseChanged(bool minimize);
+
+private:
+    // QSettings keys (kept compatible with legacy Bitcoin Qt GUI)
+    static constexpr const char* KEY_HIDE_TRAY_ICON{"fHideTrayIcon"};
+    static constexpr const char* KEY_MINIMIZE_TO_TRAY{"fMinimizeToTray"};
+    static constexpr const char* KEY_MINIMIZE_ON_CLOSE{"fMinimizeOnClose"};
+
+    void loadFromSettings();
+
+    bool m_desktop_platform{false};
+    bool m_show_tray_icon{true};
+    bool m_minimize_to_tray{false};
+    bool m_minimize_on_close{false};
+};
+
+#endif // BITCOIN_QML_MODELS_DESKTOPWINDOWBEHAVIORMODEL_H

--- a/qml/pages/main.qml
+++ b/qml/pages/main.qml
@@ -32,6 +32,83 @@ ApplicationWindow {
         ColorAnimation { duration: 150 }
     }
 
+    // Tracks the previous visibility state to distinguish a user-initiated minimize
+    // (Windowed → Minimized) from a WM restore transition (Hidden → Minimized).
+    // The latter occurs when showNormal() calls setVisible(true) before
+    // setWindowState(NoState); without this guard the onVisibilityChanged handler
+    // would immediately re-hide the window, making tray-icon restore a no-op.
+    property int m_prevVisibility: Window.AutomaticVisibility
+
+    onClosing: (close) => {
+        close.accepted = false
+        if (desktopWindowBehaviorModel.shouldMinimizeWindowOnClose()) {
+            hide()
+        } else {
+            nodeModel.requestShutdown()
+        }
+    }
+
+    onVisibilityChanged: function(visibility) {
+        const prev = m_prevVisibility
+        m_prevVisibility = visibility
+        if (visibility === Window.Minimized &&
+                prev !== Window.Hidden &&
+                desktopWindowBehaviorModel.shouldHideToTrayOnMinimize()) {
+            hide()
+        }
+    }
+
+    Connections {
+        target: desktopWindowBehaviorModel
+        function onShowTrayIconChanged(show) {
+            desktopTrayIconController.visible = AppMode.isDesktop && show
+        }
+    }
+
+    // Keeps the tray icon in sync with the app theme on Linux/Windows.
+    // On macOS, updateIcon() uses setIsMask(true) so isDark has no effect.
+    Binding {
+        target: desktopTrayIconController
+        property: "isDark"
+        value: Theme.dark
+    }
+
+    Connections {
+        target: desktopTrayIconController
+        function onRestoreRequested() {
+            appWindow.showNormal()
+            appWindow.raise()
+            appWindow.requestActivate()
+        }
+        function onQuitRequested() {
+            nodeModel.requestShutdown()
+        }
+        function onContextMenuRequested() {
+            trayContextMenu.popup()
+        }
+    }
+
+    Menu {
+        id: trayContextMenu
+        MenuItem {
+            text: appWindow.visibility !== Window.Hidden ? qsTr("&Hide") : qsTr("S&how")
+            onTriggered: {
+                if (appWindow.visibility !== Window.Hidden) {
+                    appWindow.hide()
+                } else {
+                    appWindow.showNormal()
+                    appWindow.raise()
+                    appWindow.requestActivate()
+                }
+            }
+        }
+        MenuSeparator {}
+        MenuItem {
+            text: qsTr("&Quit")
+            onTriggered: nodeModel.requestShutdown()
+        }
+    }
+
     PageStack {
         id: main
         objectName: "mainPageStack"

--- a/qml/pages/node/NodeSettings.qml
+++ b/qml/pages/node/NodeSettings.qml
@@ -218,6 +218,23 @@ PageStack {
                         root.push(about_page)
                     }
                 }
+                Separator {
+                    Layout.fillWidth: true
+                    visible: AppMode.isDesktop
+                }
+                Setting {
+                    id: gotoWindowBehavior
+                    objectName: "settingsWindowBehavior"
+                    visible: AppMode.isDesktop
+                    Layout.fillWidth: true
+                    header: qsTr("Window Behavior")
+                    actionItem: CaretRightIcon {
+                        color: gotoWindowBehavior.stateColor
+                    }
+                    onClicked: {
+                        root.push(window_behavior_page)
+                    }
+                }
                 Item {
                     Layout.fillHeight: true
                 }
@@ -339,6 +356,12 @@ PageStack {
         WalletPasswordSettings {
             onBack: root.pop()
             onSaved: root.pop()
+        }
+    }
+    Component {
+        id: window_behavior_page
+        SettingsWindowBehavior {
+            onBack: root.pop()
         }
     }
 }

--- a/qml/pages/settings/SettingsWindowBehavior.qml
+++ b/qml/pages/settings/SettingsWindowBehavior.qml
@@ -1,0 +1,98 @@
+// Copyright (c) 2021-2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../../controls"
+import "../../components"
+
+Item {
+    id: root
+    objectName: "windowBehaviorPage"
+    signal back
+
+    property var windowBehaviorModel: desktopWindowBehaviorModel
+
+    Page {
+        anchors.fill: parent
+        background: null
+        implicitWidth: 450
+        leftPadding: 20
+        rightPadding: 20
+        topPadding: 30
+
+        header: NavigationBar2 {
+            leftItem: NavButton {
+                objectName: "windowBehaviorBack"
+                iconSource: "image://images/caret-left"
+                text: qsTr("Back")
+                onClicked: root.back()
+            }
+            centerItem: Header {
+                headerBold: true
+                headerSize: 18
+                header: qsTr("Window behavior")
+            }
+        }
+
+        ColumnLayout {
+            spacing: 4
+            width: Math.min(parent.width, 450)
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            Setting {
+                id: showTrayIconSetting
+                Layout.fillWidth: true
+                header: qsTr("Show tray icon")
+                description: qsTr("Keep the app available in the system tray")
+                disabled: !windowBehaviorModel.desktopPlatform
+                actionItem: OptionSwitch {
+                    objectName: "showTrayIconSwitch"
+                    checked: windowBehaviorModel.showTrayIcon
+                    onToggled: windowBehaviorModel.showTrayIcon = checked
+                }
+                onClicked: windowBehaviorModel.showTrayIcon = !windowBehaviorModel.showTrayIcon
+            }
+
+            Separator { Layout.fillWidth: true }
+
+            Setting {
+                id: minimizeToTraySetting
+                Layout.fillWidth: true
+                header: qsTr("Minimize to tray")
+                description: qsTr("Hide window to tray when minimized")
+                disabled: !windowBehaviorModel.desktopPlatform ||
+                          !windowBehaviorModel.showTrayIcon
+                actionItem: OptionSwitch {
+                    objectName: "minimizeToTraySwitch"
+                    checked: windowBehaviorModel.minimizeToTray
+                    enabled: windowBehaviorModel.desktopPlatform &&
+                             windowBehaviorModel.showTrayIcon
+                    onToggled: windowBehaviorModel.minimizeToTray = checked
+                }
+                onClicked: windowBehaviorModel.minimizeToTray = !windowBehaviorModel.minimizeToTray
+            }
+
+            Separator { Layout.fillWidth: true }
+
+            Setting {
+                id: minimizeOnCloseSetting
+                Layout.fillWidth: true
+                header: qsTr("Minimize on close")
+                description: qsTr("Keep node running when the window is closed")
+                disabled: !windowBehaviorModel.desktopPlatform ||
+                          !windowBehaviorModel.showTrayIcon
+                actionItem: OptionSwitch {
+                    objectName: "minimizeOnCloseSwitch"
+                    checked: windowBehaviorModel.minimizeOnClose
+                    enabled: windowBehaviorModel.desktopPlatform &&
+                             windowBehaviorModel.showTrayIcon
+                    onToggled: windowBehaviorModel.minimizeOnClose = checked
+                }
+                onClicked: windowBehaviorModel.minimizeOnClose = !windowBehaviorModel.minimizeOnClose
+            }
+        }
+    }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 # Tests for the QML/Qt6 app
 
-find_package(Qt 6.2 MODULE REQUIRED COMPONENTS Core Gui Test Qml Quick QuickTest)
+find_package(Qt 6.2 MODULE REQUIRED COMPONENTS Core Gui Test Qml Quick QuickTest Widgets)
 find_package(GTest REQUIRED)
 
 if(NOT TARGET GTest::gmock)
@@ -14,6 +14,8 @@ add_executable(bitcoinqml_unit_tests
   gmocktestfixture.h
   test_bitcoinaddress.cpp
   test_bitcoinamount.cpp
+  test_desktoptrayiconcontroller.cpp
+  test_desktopwindowbehaviormodel.cpp
   test_peerlistmodel.cpp
   test_peerstatsutil.cpp
   test_walletqmlmodel.cpp
@@ -58,6 +60,7 @@ target_link_libraries(bitcoinqml_unit_tests
     Qt6::Gui
     Qt6::Quick
     Qt6::Test
+    Qt6::Widgets
 )
 
 add_test(NAME bitcoinqml_unit_tests COMMAND bitcoinqml_unit_tests -platform offscreen)

--- a/test/functional/qml_test_tray.py
+++ b/test/functional/qml_test_tray.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021-2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""End-to-end tests for Window Behavior settings (tray icon, minimize behavior).
+
+Navigates to Settings → Window Behavior and verifies that the page is
+reachable, the correct controls are present, and toggle state is reflected
+in the UI.
+
+Note: desktopPlatform is a compile-time flag (#ifdef __ANDROID__), so it is
+true on Linux CI regardless of the QPA platform.  However,
+QSystemTrayIcon::isSystemTrayAvailable() returns false with the offscreen
+QPA backend, so the tray icon will not visually register.  The switches are
+ENABLED (desktopPlatform=true) but the tray won't appear.  This test
+therefore focuses on navigation and default-state correctness; the
+toggle state-machine is covered by test_desktopwindowbehaviormodel.cpp
+(C++ unit tests).  Full interactive testing (minimize, close, tray reopen,
+shutdown) requires a headed desktop session.
+
+This test requires:
+  - bitcoin-core-app built with -DENABLE_TEST_AUTOMATION=ON
+"""
+
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+from qml_test_harness import (
+    GUI_STARTUP_TIMEOUT,
+    find_gui_binary,
+    setup_datadir,
+    complete_onboarding,
+    dump_qml_tree,
+    parse_args,
+)
+from qml_driver import QmlDriver, QmlDriverError
+
+
+def navigate_to_window_behavior(gui):
+    """Open Settings then navigate to the Window Behavior page."""
+    gui.click("nodeSettingsButton")
+    # Wait for the settings list with the Window Behavior entry.
+    gui.wait_for_page("settingsWindowBehavior", timeout_ms=5000)
+    gui.click("settingsWindowBehavior")
+    gui.wait_for_page("windowBehaviorPage", timeout_ms=5000)
+
+
+def run_tests():
+    args = parse_args()
+
+    # Support attaching to an already-running instance.
+    if args.socket_path:
+        gui = QmlDriver(args.socket_path, timeout=GUI_STARTUP_TIMEOUT)
+        process = None
+        tmpdir = None
+    else:
+        gui_binary = find_gui_binary()
+        tmpdir = tempfile.mkdtemp(prefix="qml_test_tray_")
+        datadir = setup_datadir(tmpdir)
+        socket_path = os.path.join(tmpdir, "test_bridge.sock")
+
+        env = dict(os.environ)
+        env["QT_QPA_PLATFORM"] = "offscreen"
+
+        gui_args = [
+            gui_binary,
+            f"-datadir={datadir}",
+            f"-test-automation={socket_path}",
+            "-disablewallet",
+            "-resetguisettings",
+            "-logtimemicros",
+            "-debug",
+            "-debugexclude=libevent",
+            "-debugexclude=leveldb",
+            "-nolisten",
+        ]
+        print(f"Starting GUI: {' '.join(gui_args)}")
+        process = subprocess.Popen(
+            gui_args,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        gui = QmlDriver(socket_path, timeout=GUI_STARTUP_TIMEOUT)
+        print("QmlDriver connected to test bridge.")
+
+    try:
+        # ── Complete onboarding ───────────────────────────────────────────────
+        print("Completing onboarding ...")
+        complete_onboarding(gui)
+
+        # After onboarding (wallet disabled) the app transitions to NodeRunner.
+        # The gear button objectName "nodeSettingsButton" appears immediately,
+        # before full node initialization completes.
+        gui.wait_for_page("nodeSettingsButton", timeout_ms=15000)
+        print("Reached post-onboarding (NodeRunner) screen.")
+
+        # ── Test 1: Navigation to Window Behavior page ────────────────────────
+        print("Test 1: Navigate to Settings → Window Behavior ...")
+        navigate_to_window_behavior(gui)
+        current = gui.get_current_page()
+        assert "windowBehaviorPage" in current, (
+            f"Expected windowBehaviorPage, got: {current}"
+        )
+        print(f"  -> current page: {current}  ✓")
+
+        # ── Test 2: Required controls are present ─────────────────────────────
+        print("Test 2: Verify expected controls exist on the page ...")
+        required_controls = [
+            "windowBehaviorBack",
+            "showTrayIconSwitch",
+            "minimizeToTraySwitch",
+            "minimizeOnCloseSwitch",
+        ]
+        all_objects = gui.list_objects()
+        object_names = {o["objectName"] for o in all_objects}
+        for name in required_controls:
+            assert name in object_names, (
+                f"Expected control '{name}' not found in QML tree"
+            )
+            print(f"  -> {name}  ✓")
+
+        # ── Test 3: Default switch states ─────────────────────────────────────
+        # showTrayIcon defaults to true; the others default to false.
+        print("Test 3: Verify default switch states ...")
+        expected_defaults = {
+            "showTrayIconSwitch":    True,   # show tray icon is on by default
+            "minimizeToTraySwitch":  False,  # minimize-to-tray is off by default
+            "minimizeOnCloseSwitch": False,  # minimize-on-close is off by default
+        }
+        for switch_name, expected in expected_defaults.items():
+            checked = gui.get_property(switch_name, "checked")
+            # normalize to bool
+            if isinstance(checked, str):
+                checked = checked.lower() == "true"
+            assert checked == expected, (
+                f"{switch_name} expected checked={expected}, got: {checked}"
+            )
+            print(f"  -> {switch_name}.checked == {str(expected).lower()}  ✓")
+
+        # ── Tests 4–5: showTrayIcon toggle round-trip ─────────────────────────
+        # Run the toggle tests while only one windowBehaviorPage instance is in
+        # the StackView (before the back/re-open cycle), so objectName lookups
+        # are unambiguous.
+        #
+        # Note: The cascade state-machine (showTrayIcon off → minimizeToTray
+        # disabled) is already covered by the C++ unit tests in
+        # test_desktopwindowbehaviormodel.cpp. Here we only verify that the
+        # toggle round-trip works correctly via the UI on the offscreen backend.
+        print("Test 4: showTrayIconSwitch toggles off and the model reflects the change ...")
+        gui.click("showTrayIconSwitch")
+        gui.wait_for_property("showTrayIconSwitch", "checked", False, timeout_ms=2000)
+        print("  -> showTrayIconSwitch clicked off  ✓")
+
+        print("Test 5: showTrayIconSwitch toggles back on ...")
+        gui.click("showTrayIconSwitch")
+        gui.wait_for_property("showTrayIconSwitch", "checked", True, timeout_ms=2000)
+        print("  -> showTrayIconSwitch restored to on  ✓")
+
+        # ── Test 6: Back navigation ───────────────────────────────────────────
+        print("Test 6: Back button returns to settings list ...")
+        gui.click("windowBehaviorBack")
+        gui.wait_for_page("settingsWindowBehavior", timeout_ms=5000)
+        current = gui.get_current_page()
+        print(f"  -> current page after back: {current}  ✓")
+
+        # ── Test 7: Re-open page (round-trip) ─────────────────────────────────
+        print("Test 7: Re-open Window Behavior page (round-trip) ...")
+        gui.click("settingsWindowBehavior")
+        gui.wait_for_page("windowBehaviorPage", timeout_ms=5000)
+        current = gui.get_current_page()
+        assert "windowBehaviorPage" in current, (
+            f"Could not re-open windowBehaviorPage, got: {current}"
+        )
+        print(f"  -> current page: {current}  ✓")
+
+        print("\n" + "=" * 50)
+        print("All tests PASSED")
+        print("=" * 50)
+
+    except Exception as e:
+        print(f"\nFAILED: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        if gui is not None:
+            dump_qml_tree(gui)
+        sys.exit(1)
+    finally:
+        gui.close()
+        if process and process.poll() is None:
+            process.send_signal(signal.SIGTERM)
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+        if tmpdir:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/qml/tst_settingswindowbehavior.qml
+++ b/test/qml/tst_settingswindowbehavior.qml
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+
+TestCase {
+    name: "SettingsWindowBehavior"
+
+    // ── Test 1: showTrayIconSwitch enabled iff desktopPlatform ───────────────
+    function test_showTrayIcon_enabled_on_desktop() {
+        const m = Qt.createQmlObject(
+            'import QtQuick 2.15; QtObject {' +
+            '  property bool desktopPlatform: true;' +
+            '  property bool enabled: desktopPlatform }', this)
+        compare(m.enabled, true)
+    }
+
+    function test_showTrayIcon_disabled_on_non_desktop() {
+        const m = Qt.createQmlObject(
+            'import QtQuick 2.15; QtObject {' +
+            '  property bool desktopPlatform: false;' +
+            '  property bool enabled: desktopPlatform }', this)
+        compare(m.enabled, false)
+    }
+
+    // ── Test 2: minimizeToTraySwitch requires desktopPlatform && showTrayIcon ─
+    function test_minimizeToTray_enabled_when_desktop_and_tray_visible() {
+        const m = Qt.createQmlObject(
+            'import QtQuick 2.15; QtObject {' +
+            '  property bool desktopPlatform: true;' +
+            '  property bool showTrayIcon: true;' +
+            '  property bool enabled: desktopPlatform && showTrayIcon }', this)
+        compare(m.enabled, true)
+    }
+
+    function test_minimizeToTray_disabled_when_trayIcon_hidden() {
+        const m = Qt.createQmlObject(
+            'import QtQuick 2.15; QtObject {' +
+            '  property bool desktopPlatform: true;' +
+            '  property bool showTrayIcon: false;' +
+            '  property bool enabled: desktopPlatform && showTrayIcon }', this)
+        compare(m.enabled, false)
+    }
+
+    function test_minimizeToTray_disabled_on_non_desktop() {
+        const m = Qt.createQmlObject(
+            'import QtQuick 2.15; QtObject {' +
+            '  property bool desktopPlatform: false;' +
+            '  property bool showTrayIcon: true;' +
+            '  property bool enabled: desktopPlatform && showTrayIcon }', this)
+        compare(m.enabled, false)
+    }
+
+    // ── Test 3: minimizeOnCloseSwitch enabled iff desktopPlatform ────────────
+    function test_minimizeOnClose_enabled_on_desktop() {
+        const m = Qt.createQmlObject(
+            'import QtQuick 2.15; QtObject {' +
+            '  property bool desktopPlatform: true;' +
+            '  property bool enabled: desktopPlatform }', this)
+        compare(m.enabled, true)
+    }
+
+    function test_minimizeOnClose_disabled_on_non_desktop() {
+        const m = Qt.createQmlObject(
+            'import QtQuick 2.15; QtObject {' +
+            '  property bool desktopPlatform: false;' +
+            '  property bool enabled: desktopPlatform }', this)
+        compare(m.enabled, false)
+    }
+}

--- a/test/test_desktoptrayiconcontroller.cpp
+++ b/test/test_desktoptrayiconcontroller.cpp
@@ -2,263 +2,60 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <QtTest/QtTest>
-
 #include <qml/models/desktoptrayiconcontroller.h>
 
-#include <QDir>
-#include <QFile>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <QSignalSpy>
-#include <QTemporaryDir>
-#include <QTextStream>
-
-class DesktopTrayIconControllerTests : public QObject
-{
-    Q_OBJECT
-
-private Q_SLOTS:
-    // setVisible() signal timing
-    void setVisibleFalse_isImmediate();
-    void setVisibleTrue_deferredUntilShowConfirms();
-    void cancelPendingShow_preventsTrueEmission();
-
-#if defined(Q_OS_LINUX)
-    // index.theme and icon-name correctness (Linux-only; AppIndicator path)
-    void indexTheme_createsValidFileWhenMissing();
-    void indexTheme_updatesDirectoriesLineInExistingFile();
-    void indexTheme_preservesExistingDirectoriesEntries();
-    void setIcon_setsNamedIcon();
-#endif
-};
-
-// ── setVisible() signal timing ────────────────────────────────────────────────
-
-void DesktopTrayIconControllerTests::setVisibleFalse_isImmediate()
-{
-    DesktopTrayIconController ctrl;
-    QSignalSpy spy(&ctrl, &DesktopTrayIconController::visibleChanged);
-
-    ctrl.setVisible(false);
-
-    // Calling setVisible(false) on a fresh controller (already false) is a no-op.
-    QCOMPARE(ctrl.visible(), false);
-    QCOMPARE(spy.count(), 0);
-}
-
-void DesktopTrayIconControllerTests::setVisibleTrue_deferredUntilShowConfirms()
-{
-    DesktopTrayIconController ctrl;
-    QSignalSpy spy(&ctrl, &DesktopTrayIconController::visibleChanged);
-
-    ctrl.setVisible(true);
-
-    // Immediately after setVisible(true), visible() must still be false — the
-    // show() has been deferred to the first event-loop iteration (Fix 3).
-    QCOMPARE(ctrl.visible(), false);
-
-    // Let the deferred show() run. On the offscreen platform,
-    // QSystemTrayIcon::isVisible() returns false, so we expect visibleChanged
-    // to eventually be emitted (either true on a real DE, or false after retries
-    // exhaust on offscreen). We just verify the signal IS eventually emitted.
-    QTRY_VERIFY_WITH_TIMEOUT(spy.count() >= 1, 1500);
-}
-
-void DesktopTrayIconControllerTests::cancelPendingShow_preventsTrueEmission()
-{
-    DesktopTrayIconController ctrl;
-    QSignalSpy spy(&ctrl, &DesktopTrayIconController::visibleChanged);
-
-    // Queue a deferred show, then immediately cancel it before the event loop runs.
-    ctrl.setVisible(true);
-    ctrl.setVisible(false);
-
-    QCOMPARE(ctrl.visible(), false);
-
-    // visibleChanged(false) was emitted by the cancelling setVisible(false) call
-    // only if visible was true. Since it wasn't, the count is 0 here.
-    // The key property: process the event loop and confirm no stale true emission.
-    QTest::qWait(50);
-    for (int i = 0; i < spy.count(); ++i) {
-        const bool emitted_value = spy.at(i).at(0).toBool();
-        QVERIFY2(!emitted_value,
-                 "visibleChanged(true) must not be emitted after cancellation");
-    }
-    QCOMPARE(ctrl.visible(), false);
-}
-
-// ── index.theme and icon-name correctness (Linux-only) ───────────────────────
-
-#if defined(Q_OS_LINUX)
-
-// Helper: redirect GenericDataLocation to a temp dir for the duration of a test.
-// QStandardPaths on Linux honours $XDG_DATA_HOME; Qt does not cache the result.
-struct XdgDataHomeOverride {
-    QByteArray old_val;
-    bool was_set;
-
-    explicit XdgDataHomeOverride(const QString& path)
-    {
-        old_val = qgetenv("XDG_DATA_HOME");
-        was_set = !old_val.isNull();
-        qputenv("XDG_DATA_HOME", path.toLocal8Bit());
-    }
-    ~XdgDataHomeOverride()
-    {
-        if (was_set) {
-            qputenv("XDG_DATA_HOME", old_val);
-        } else {
-            qunsetenv("XDG_DATA_HOME");
-        }
-    }
-};
-
-void DesktopTrayIconControllerTests::indexTheme_createsValidFileWhenMissing()
-{
-    QTemporaryDir tmp;
-    QVERIFY(tmp.isValid());
-    XdgDataHomeOverride env_guard(tmp.path());
-
-    DesktopTrayIconController ctrl;
-    QPixmap pixmap(48, 48);
-    pixmap.fill(Qt::red);
-    ctrl.setIcon(QIcon(pixmap));
-
-    const QString theme_path =
-        tmp.path() + QStringLiteral("/icons/hicolor/index.theme");
-    QVERIFY2(QFile::exists(theme_path),
-             "index.theme must be created when missing");
-
-    QFile f(theme_path);
-    QVERIFY(f.open(QIODevice::ReadOnly | QIODevice::Text));
-    const QString content = QTextStream(&f).readAll();
-
-    QVERIFY2(content.contains(QStringLiteral("Directories=")),
-             "index.theme must contain a Directories= line");
-    QVERIFY2(content.contains(QStringLiteral("48x48/apps")),
-             "index.theme Directories= must include 48x48/apps");
-    QVERIFY2(content.contains(QStringLiteral("[48x48/apps]")),
-             "index.theme must contain a [48x48/apps] stanza");
-}
-
-void DesktopTrayIconControllerTests::indexTheme_updatesDirectoriesLineInExistingFile()
-{
-    QTemporaryDir tmp;
-    QVERIFY(tmp.isValid());
-    XdgDataHomeOverride env_guard(tmp.path());
-
-    // Pre-create an index.theme that has Directories= but NOT 48x48/apps.
-    const QString icons_dir = tmp.path() + QStringLiteral("/icons/hicolor");
-    QVERIFY(QDir().mkpath(icons_dir));
-    const QString theme_path = icons_dir + QStringLiteral("/index.theme");
-    {
-        QFile f(theme_path);
-        QVERIFY(f.open(QIODevice::WriteOnly | QIODevice::Text));
-        QTextStream(&f) << "[Icon Theme]\nName=hicolor\nDirectories=32x32/apps\n\n"
-                        << "[32x32/apps]\nSize=32\nContext=Applications\nType=Fixed\n";
-    }
-
-    DesktopTrayIconController ctrl;
-    QPixmap pixmap(48, 48);
-    pixmap.fill(Qt::blue);
-    ctrl.setIcon(QIcon(pixmap));
-
-    QFile f(theme_path);
-    QVERIFY(f.open(QIODevice::ReadOnly | QIODevice::Text));
-    const QString content = QTextStream(&f).readAll();
-
-    QVERIFY2(content.contains(QStringLiteral("48x48/apps")),
-             "After setIcon(), 48x48/apps must appear in index.theme");
-    QVERIFY2(content.contains(QStringLiteral("[48x48/apps]")),
-             "A [48x48/apps] stanza must be appended");
-
-    // Find the Directories= line and verify 48x48/apps is on it.
-    bool dirs_line_has_48 = false;
-    for (const QString& line : content.split(QLatin1Char('\n'))) {
-        if (line.startsWith(QStringLiteral("Directories="))) {
-            dirs_line_has_48 = line.contains(QStringLiteral("48x48/apps"));
-            break;
-        }
-    }
-    QVERIFY2(dirs_line_has_48,
-             "The Directories= line itself must list 48x48/apps");
-}
-
-void DesktopTrayIconControllerTests::indexTheme_preservesExistingDirectoriesEntries()
-{
-    QTemporaryDir tmp;
-    QVERIFY(tmp.isValid());
-    XdgDataHomeOverride env_guard(tmp.path());
-
-    const QString icons_dir = tmp.path() + QStringLiteral("/icons/hicolor");
-    QVERIFY(QDir().mkpath(icons_dir));
-    const QString theme_path = icons_dir + QStringLiteral("/index.theme");
-    {
-        QFile f(theme_path);
-        QVERIFY(f.open(QIODevice::WriteOnly | QIODevice::Text));
-        QTextStream(&f) << "[Icon Theme]\nName=hicolor\nDirectories=32x32/apps,22x22/apps\n\n"
-                        << "[32x32/apps]\nSize=32\nContext=Applications\nType=Fixed\n"
-                        << "[22x22/apps]\nSize=22\nContext=Applications\nType=Fixed\n";
-    }
-
-    DesktopTrayIconController ctrl;
-    QPixmap pixmap(48, 48);
-    pixmap.fill(Qt::green);
-    ctrl.setIcon(QIcon(pixmap));
-
-    QFile f(theme_path);
-    QVERIFY(f.open(QIODevice::ReadOnly | QIODevice::Text));
-    const QString content = QTextStream(&f).readAll();
-
-    // Existing entries must be preserved.
-    bool dirs_has_all = false;
-    for (const QString& line : content.split(QLatin1Char('\n'))) {
-        if (line.startsWith(QStringLiteral("Directories="))) {
-            dirs_has_all = line.contains(QStringLiteral("32x32/apps"))
-                        && line.contains(QStringLiteral("22x22/apps"))
-                        && line.contains(QStringLiteral("48x48/apps"));
-            break;
-        }
-    }
-    QVERIFY2(dirs_has_all,
-             "Directories= must retain existing entries and add 48x48/apps");
-}
-
-void DesktopTrayIconControllerTests::setIcon_setsNamedIcon()
-{
-    QTemporaryDir tmp;
-    QVERIFY(tmp.isValid());
-    XdgDataHomeOverride env_guard(tmp.path());
-
-    DesktopTrayIconController ctrl;
-    QPixmap pixmap(48, 48);
-    pixmap.fill(Qt::cyan);
-    ctrl.setIcon(QIcon(pixmap));
-
-    // Both the main icon and its '-panel' monochrome variant (used by AppIndicator
-    // for panel theming) must be written to the expected XDG location.
-    const QString apps_dir =
-        tmp.path() + QStringLiteral("/icons/hicolor/48x48/apps");
-    QVERIFY2(QFile::exists(apps_dir + QStringLiteral("/bitcoin-core.png")),
-             "bitcoin-core.png must be written to ~/.local/share/icons/hicolor/48x48/apps/");
-    QVERIFY2(QFile::exists(apps_dir + QStringLiteral("/bitcoin-core-panel.png")),
-             "bitcoin-core-panel.png must be written to ~/.local/share/icons/hicolor/48x48/apps/");
-
-    // Verify the written PNGs are non-empty valid images.
-    QPixmap loaded;
-    QVERIFY2(loaded.load(apps_dir + QStringLiteral("/bitcoin-core.png")),
-             "Written bitcoin-core.png must be a valid PNG");
-    QVERIFY(!loaded.isNull());
-}
-
-#endif // Q_OS_LINUX
-
-int RunDesktopTrayIconControllerTests(int argc, char* argv[])
-{
-    DesktopTrayIconControllerTests tests;
-    return QTest::qExec(&tests, argc, argv);
-}
 
 #ifndef BITCOINQML_NO_TEST_MAIN
-QTEST_MAIN(DesktopTrayIconControllerTests)
+int main(int argc, char* argv[])
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+#else
+int RunDesktopTrayIconControllerTests(int argc, char* argv[])
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
 #endif
-#include "test_desktoptrayiconcontroller.moc"
+
+TEST(DesktopTrayIconControllerTest, initiallyNotVisible)
+{
+    DesktopTrayIconController controller;
+    EXPECT_FALSE(controller.visible());
+}
+
+TEST(DesktopTrayIconControllerTest, setVisibleFalseWhenAlreadyHidden_noSignal)
+{
+    DesktopTrayIconController controller;
+    QSignalSpy spy(&controller, &DesktopTrayIconController::visibleChanged);
+    controller.setVisible(false);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST(DesktopTrayIconControllerTest, isDarkDefaultTrue)
+{
+    DesktopTrayIconController controller;
+    EXPECT_TRUE(controller.isDark());
+}
+
+TEST(DesktopTrayIconControllerTest, setIsDarkSameValue_noSignal)
+{
+    DesktopTrayIconController controller;
+    QSignalSpy spy(&controller, &DesktopTrayIconController::isDarkChanged);
+    controller.setIsDark(true); // same as default
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST(DesktopTrayIconControllerTest, setIsDarkChanged_emitsSignal)
+{
+    DesktopTrayIconController controller;
+    QSignalSpy spy(&controller, &DesktopTrayIconController::isDarkChanged);
+    controller.setIsDark(false);
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toBool(), false);
+}

--- a/test/test_desktoptrayiconcontroller.cpp
+++ b/test/test_desktoptrayiconcontroller.cpp
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <qml/models/desktoptrayiconcontroller.h>
+
+#include <QDir>
+#include <QFile>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QTextStream>
+
+class DesktopTrayIconControllerTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    // setVisible() signal timing
+    void setVisibleFalse_isImmediate();
+    void setVisibleTrue_deferredUntilShowConfirms();
+    void cancelPendingShow_preventsTrueEmission();
+
+#if defined(Q_OS_LINUX)
+    // index.theme and icon-name correctness (Linux-only; AppIndicator path)
+    void indexTheme_createsValidFileWhenMissing();
+    void indexTheme_updatesDirectoriesLineInExistingFile();
+    void indexTheme_preservesExistingDirectoriesEntries();
+    void setIcon_setsNamedIcon();
+#endif
+};
+
+// ── setVisible() signal timing ────────────────────────────────────────────────
+
+void DesktopTrayIconControllerTests::setVisibleFalse_isImmediate()
+{
+    DesktopTrayIconController ctrl;
+    QSignalSpy spy(&ctrl, &DesktopTrayIconController::visibleChanged);
+
+    ctrl.setVisible(false);
+
+    // Calling setVisible(false) on a fresh controller (already false) is a no-op.
+    QCOMPARE(ctrl.visible(), false);
+    QCOMPARE(spy.count(), 0);
+}
+
+void DesktopTrayIconControllerTests::setVisibleTrue_deferredUntilShowConfirms()
+{
+    DesktopTrayIconController ctrl;
+    QSignalSpy spy(&ctrl, &DesktopTrayIconController::visibleChanged);
+
+    ctrl.setVisible(true);
+
+    // Immediately after setVisible(true), visible() must still be false — the
+    // show() has been deferred to the first event-loop iteration (Fix 3).
+    QCOMPARE(ctrl.visible(), false);
+
+    // Let the deferred show() run. On the offscreen platform,
+    // QSystemTrayIcon::isVisible() returns false, so we expect visibleChanged
+    // to eventually be emitted (either true on a real DE, or false after retries
+    // exhaust on offscreen). We just verify the signal IS eventually emitted.
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() >= 1, 1500);
+}
+
+void DesktopTrayIconControllerTests::cancelPendingShow_preventsTrueEmission()
+{
+    DesktopTrayIconController ctrl;
+    QSignalSpy spy(&ctrl, &DesktopTrayIconController::visibleChanged);
+
+    // Queue a deferred show, then immediately cancel it before the event loop runs.
+    ctrl.setVisible(true);
+    ctrl.setVisible(false);
+
+    QCOMPARE(ctrl.visible(), false);
+
+    // visibleChanged(false) was emitted by the cancelling setVisible(false) call
+    // only if visible was true. Since it wasn't, the count is 0 here.
+    // The key property: process the event loop and confirm no stale true emission.
+    QTest::qWait(50);
+    for (int i = 0; i < spy.count(); ++i) {
+        const bool emitted_value = spy.at(i).at(0).toBool();
+        QVERIFY2(!emitted_value,
+                 "visibleChanged(true) must not be emitted after cancellation");
+    }
+    QCOMPARE(ctrl.visible(), false);
+}
+
+// ── index.theme and icon-name correctness (Linux-only) ───────────────────────
+
+#if defined(Q_OS_LINUX)
+
+// Helper: redirect GenericDataLocation to a temp dir for the duration of a test.
+// QStandardPaths on Linux honours $XDG_DATA_HOME; Qt does not cache the result.
+struct XdgDataHomeOverride {
+    QByteArray old_val;
+    bool was_set;
+
+    explicit XdgDataHomeOverride(const QString& path)
+    {
+        old_val = qgetenv("XDG_DATA_HOME");
+        was_set = !old_val.isNull();
+        qputenv("XDG_DATA_HOME", path.toLocal8Bit());
+    }
+    ~XdgDataHomeOverride()
+    {
+        if (was_set) {
+            qputenv("XDG_DATA_HOME", old_val);
+        } else {
+            qunsetenv("XDG_DATA_HOME");
+        }
+    }
+};
+
+void DesktopTrayIconControllerTests::indexTheme_createsValidFileWhenMissing()
+{
+    QTemporaryDir tmp;
+    QVERIFY(tmp.isValid());
+    XdgDataHomeOverride env_guard(tmp.path());
+
+    DesktopTrayIconController ctrl;
+    QPixmap pixmap(48, 48);
+    pixmap.fill(Qt::red);
+    ctrl.setIcon(QIcon(pixmap));
+
+    const QString theme_path =
+        tmp.path() + QStringLiteral("/icons/hicolor/index.theme");
+    QVERIFY2(QFile::exists(theme_path),
+             "index.theme must be created when missing");
+
+    QFile f(theme_path);
+    QVERIFY(f.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString content = QTextStream(&f).readAll();
+
+    QVERIFY2(content.contains(QStringLiteral("Directories=")),
+             "index.theme must contain a Directories= line");
+    QVERIFY2(content.contains(QStringLiteral("48x48/apps")),
+             "index.theme Directories= must include 48x48/apps");
+    QVERIFY2(content.contains(QStringLiteral("[48x48/apps]")),
+             "index.theme must contain a [48x48/apps] stanza");
+}
+
+void DesktopTrayIconControllerTests::indexTheme_updatesDirectoriesLineInExistingFile()
+{
+    QTemporaryDir tmp;
+    QVERIFY(tmp.isValid());
+    XdgDataHomeOverride env_guard(tmp.path());
+
+    // Pre-create an index.theme that has Directories= but NOT 48x48/apps.
+    const QString icons_dir = tmp.path() + QStringLiteral("/icons/hicolor");
+    QVERIFY(QDir().mkpath(icons_dir));
+    const QString theme_path = icons_dir + QStringLiteral("/index.theme");
+    {
+        QFile f(theme_path);
+        QVERIFY(f.open(QIODevice::WriteOnly | QIODevice::Text));
+        QTextStream(&f) << "[Icon Theme]\nName=hicolor\nDirectories=32x32/apps\n\n"
+                        << "[32x32/apps]\nSize=32\nContext=Applications\nType=Fixed\n";
+    }
+
+    DesktopTrayIconController ctrl;
+    QPixmap pixmap(48, 48);
+    pixmap.fill(Qt::blue);
+    ctrl.setIcon(QIcon(pixmap));
+
+    QFile f(theme_path);
+    QVERIFY(f.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString content = QTextStream(&f).readAll();
+
+    QVERIFY2(content.contains(QStringLiteral("48x48/apps")),
+             "After setIcon(), 48x48/apps must appear in index.theme");
+    QVERIFY2(content.contains(QStringLiteral("[48x48/apps]")),
+             "A [48x48/apps] stanza must be appended");
+
+    // Find the Directories= line and verify 48x48/apps is on it.
+    bool dirs_line_has_48 = false;
+    for (const QString& line : content.split(QLatin1Char('\n'))) {
+        if (line.startsWith(QStringLiteral("Directories="))) {
+            dirs_line_has_48 = line.contains(QStringLiteral("48x48/apps"));
+            break;
+        }
+    }
+    QVERIFY2(dirs_line_has_48,
+             "The Directories= line itself must list 48x48/apps");
+}
+
+void DesktopTrayIconControllerTests::indexTheme_preservesExistingDirectoriesEntries()
+{
+    QTemporaryDir tmp;
+    QVERIFY(tmp.isValid());
+    XdgDataHomeOverride env_guard(tmp.path());
+
+    const QString icons_dir = tmp.path() + QStringLiteral("/icons/hicolor");
+    QVERIFY(QDir().mkpath(icons_dir));
+    const QString theme_path = icons_dir + QStringLiteral("/index.theme");
+    {
+        QFile f(theme_path);
+        QVERIFY(f.open(QIODevice::WriteOnly | QIODevice::Text));
+        QTextStream(&f) << "[Icon Theme]\nName=hicolor\nDirectories=32x32/apps,22x22/apps\n\n"
+                        << "[32x32/apps]\nSize=32\nContext=Applications\nType=Fixed\n"
+                        << "[22x22/apps]\nSize=22\nContext=Applications\nType=Fixed\n";
+    }
+
+    DesktopTrayIconController ctrl;
+    QPixmap pixmap(48, 48);
+    pixmap.fill(Qt::green);
+    ctrl.setIcon(QIcon(pixmap));
+
+    QFile f(theme_path);
+    QVERIFY(f.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString content = QTextStream(&f).readAll();
+
+    // Existing entries must be preserved.
+    bool dirs_has_all = false;
+    for (const QString& line : content.split(QLatin1Char('\n'))) {
+        if (line.startsWith(QStringLiteral("Directories="))) {
+            dirs_has_all = line.contains(QStringLiteral("32x32/apps"))
+                        && line.contains(QStringLiteral("22x22/apps"))
+                        && line.contains(QStringLiteral("48x48/apps"));
+            break;
+        }
+    }
+    QVERIFY2(dirs_has_all,
+             "Directories= must retain existing entries and add 48x48/apps");
+}
+
+void DesktopTrayIconControllerTests::setIcon_setsNamedIcon()
+{
+    QTemporaryDir tmp;
+    QVERIFY(tmp.isValid());
+    XdgDataHomeOverride env_guard(tmp.path());
+
+    DesktopTrayIconController ctrl;
+    QPixmap pixmap(48, 48);
+    pixmap.fill(Qt::cyan);
+    ctrl.setIcon(QIcon(pixmap));
+
+    // Both the main icon and its '-panel' monochrome variant (used by AppIndicator
+    // for panel theming) must be written to the expected XDG location.
+    const QString apps_dir =
+        tmp.path() + QStringLiteral("/icons/hicolor/48x48/apps");
+    QVERIFY2(QFile::exists(apps_dir + QStringLiteral("/bitcoin-core.png")),
+             "bitcoin-core.png must be written to ~/.local/share/icons/hicolor/48x48/apps/");
+    QVERIFY2(QFile::exists(apps_dir + QStringLiteral("/bitcoin-core-panel.png")),
+             "bitcoin-core-panel.png must be written to ~/.local/share/icons/hicolor/48x48/apps/");
+
+    // Verify the written PNGs are non-empty valid images.
+    QPixmap loaded;
+    QVERIFY2(loaded.load(apps_dir + QStringLiteral("/bitcoin-core.png")),
+             "Written bitcoin-core.png must be a valid PNG");
+    QVERIFY(!loaded.isNull());
+}
+
+#endif // Q_OS_LINUX
+
+int RunDesktopTrayIconControllerTests(int argc, char* argv[])
+{
+    DesktopTrayIconControllerTests tests;
+    return QTest::qExec(&tests, argc, argv);
+}
+
+#ifndef BITCOINQML_NO_TEST_MAIN
+QTEST_MAIN(DesktopTrayIconControllerTests)
+#endif
+#include "test_desktoptrayiconcontroller.moc"

--- a/test/test_desktopwindowbehaviormodel.cpp
+++ b/test/test_desktopwindowbehaviormodel.cpp
@@ -1,0 +1,209 @@
+// Copyright (c) 2021-2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <qml/models/desktopwindowbehaviormodel.h>
+
+class DesktopWindowBehaviorModelTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void init();
+    void cleanup();
+
+    // Platform guard
+    void nonDesktopPlatform_allSettingsFalse();
+
+    // Defaults on desktop
+    void desktopPlatform_showTrayIconDefaultsTrue();
+    void desktopPlatform_minimizeToTrayDefaultsFalse();
+    void desktopPlatform_minimizeOnCloseDefaultsFalse();
+
+    // Cascade logic
+    void setShowTrayIconFalse_cascadesToMinimizeToTrayFalse();
+    void setShowTrayIconFalse_cascadesToMinimizeOnCloseFalse();
+    void setMinimizeToTray_noopWhenTrayIconDisabled();
+
+    // Composite helpers
+    void shouldHideToTrayOnMinimize_allConditionsRequired();
+    void shouldMinimizeWindowOnClose_requiresDesktopAndMinimizeOnClose();
+
+    // QSettings persistence
+    void settings_persistAcrossInstances();
+
+private:
+    // Use a unique org/app name so tests don't pollute the user's real settings.
+    void setTestAppName();
+    void clearTestSettings();
+};
+
+void DesktopWindowBehaviorModelTests::setTestAppName()
+{
+    QCoreApplication::setOrganizationName("BitcoinCoreAppTest");
+    QCoreApplication::setApplicationName("DesktopWindowBehaviorModelTests");
+}
+
+void DesktopWindowBehaviorModelTests::clearTestSettings()
+{
+    QSettings settings;
+    settings.remove("fHideTrayIcon");
+    settings.remove("fMinimizeToTray");
+    settings.remove("fMinimizeOnClose");
+    settings.sync();
+}
+
+void DesktopWindowBehaviorModelTests::init()
+{
+    setTestAppName();
+    clearTestSettings();
+}
+
+void DesktopWindowBehaviorModelTests::cleanup()
+{
+    clearTestSettings();
+}
+
+void DesktopWindowBehaviorModelTests::nonDesktopPlatform_allSettingsFalse()
+{
+    DesktopWindowBehaviorModel model(/*desktop_platform=*/false);
+    QCOMPARE(model.desktopPlatform(), false);
+    QCOMPARE(model.showTrayIcon(), false);
+    QCOMPARE(model.minimizeToTray(), false);
+    QCOMPARE(model.minimizeOnClose(), false);
+}
+
+void DesktopWindowBehaviorModelTests::desktopPlatform_showTrayIconDefaultsTrue()
+{
+    DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+    QCOMPARE(model.desktopPlatform(), true);
+    QCOMPARE(model.showTrayIcon(), true);
+}
+
+void DesktopWindowBehaviorModelTests::desktopPlatform_minimizeToTrayDefaultsFalse()
+{
+    DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+    QCOMPARE(model.minimizeToTray(), false);
+}
+
+void DesktopWindowBehaviorModelTests::desktopPlatform_minimizeOnCloseDefaultsFalse()
+{
+    DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+    QCOMPARE(model.minimizeOnClose(), false);
+}
+
+void DesktopWindowBehaviorModelTests::setShowTrayIconFalse_cascadesToMinimizeToTrayFalse()
+{
+    DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+
+    // Enable minimize-to-tray first
+    model.setMinimizeToTray(true);
+    QCOMPARE(model.minimizeToTray(), true);
+
+    // Now disable the tray icon — minimizeToTray must cascade to false
+    QSignalSpy spyMinimize(&model, &DesktopWindowBehaviorModel::minimizeToTrayChanged);
+    model.setShowTrayIcon(false);
+    QCOMPARE(model.showTrayIcon(), false);
+    QCOMPARE(model.minimizeToTray(), false);
+    QVERIFY(spyMinimize.count() >= 1);
+}
+
+void DesktopWindowBehaviorModelTests::setShowTrayIconFalse_cascadesToMinimizeOnCloseFalse()
+{
+    DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+
+    // Enable minimize-on-close first (requires showTrayIcon=true default)
+    model.setMinimizeOnClose(true);
+    QCOMPARE(model.minimizeOnClose(), true);
+
+    // Disable the tray icon — minimizeOnClose must cascade to false
+    QSignalSpy spy(&model, &DesktopWindowBehaviorModel::minimizeOnCloseChanged);
+    model.setShowTrayIcon(false);
+    QCOMPARE(model.showTrayIcon(), false);
+    QCOMPARE(model.minimizeOnClose(), false);
+    QVERIFY(spy.count() >= 1);
+}
+
+void DesktopWindowBehaviorModelTests::setMinimizeToTray_noopWhenTrayIconDisabled()
+{
+    DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+    model.setShowTrayIcon(false);
+    QCOMPARE(model.showTrayIcon(), false);
+
+    // Trying to enable minimizeToTray without a tray icon must be a no-op
+    model.setMinimizeToTray(true);
+    QCOMPARE(model.minimizeToTray(), false);
+}
+
+void DesktopWindowBehaviorModelTests::shouldHideToTrayOnMinimize_allConditionsRequired()
+{
+    DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+
+    // desktopPlatform=true, showTrayIcon=true (default), minimizeToTray=false → false
+    QCOMPARE(model.shouldHideToTrayOnMinimize(), false);
+
+    // Enable all conditions
+    model.setMinimizeToTray(true);
+    QCOMPARE(model.shouldHideToTrayOnMinimize(), true);
+
+    // Disable tray icon → false again (cascade also disables minimizeToTray)
+    model.setShowTrayIcon(false);
+    QCOMPARE(model.shouldHideToTrayOnMinimize(), false);
+}
+
+void DesktopWindowBehaviorModelTests::shouldMinimizeWindowOnClose_requiresDesktopAndMinimizeOnClose()
+{
+    // Non-desktop: always false regardless of minimizeOnClose value
+    {
+        DesktopWindowBehaviorModel model(/*desktop_platform=*/false);
+        QCOMPARE(model.shouldMinimizeWindowOnClose(), false);
+    }
+
+    // Desktop, minimizeOnClose=false (default)
+    {
+        DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+        QCOMPARE(model.shouldMinimizeWindowOnClose(), false);
+
+        model.setMinimizeOnClose(true);
+        QCOMPARE(model.shouldMinimizeWindowOnClose(), true);
+    }
+}
+
+void DesktopWindowBehaviorModelTests::settings_persistAcrossInstances()
+{
+    // minimizeOnClose persists when tray icon stays enabled
+    {
+        DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+        model.setMinimizeOnClose(true);
+    }
+    {
+        DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+        QCOMPARE(model.minimizeOnClose(), true);
+        QCOMPARE(model.showTrayIcon(), true);
+    }
+
+    // Disabling tray icon cascades minimizeOnClose=false and persists that
+    {
+        DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+        QCOMPARE(model.minimizeOnClose(), true);
+        model.setShowTrayIcon(false); // cascade: minimizeOnClose → false
+    }
+    {
+        DesktopWindowBehaviorModel model(/*desktop_platform=*/true);
+        QCOMPARE(model.minimizeOnClose(), false);
+        QCOMPARE(model.showTrayIcon(), false);
+    }
+}
+
+int RunDesktopWindowBehaviorModelTests(int argc, char* argv[])
+{
+    DesktopWindowBehaviorModelTests tests;
+    return QTest::qExec(&tests, argc, argv);
+}
+
+#ifndef BITCOINQML_NO_TEST_MAIN
+QTEST_MAIN(DesktopWindowBehaviorModelTests)
+#endif
+#include "test_desktopwindowbehaviormodel.moc"

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <QGuiApplication>
+#include <QApplication>
 
 #include <chainparams.h>
 #include <test/gmocktestfixture.h>
@@ -15,7 +15,7 @@ int main(int argc, char* argv[])
 {
     testing::InitGoogleMock(&argc, argv);
     testing::UnitTest::GetInstance()->listeners().Append(new QtestGmockListener());
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
     SelectParams(ChainType::REGTEST);
 
     int status = 0;


### PR DESCRIPTION
Added window behavior as a new option in settings. #513
Added window behavior page, allows the user to configure if the tray is visible, behavior on minimization and behavior on closing.
Tray icon matches dark and light mode in the app.
Tray icon gives option to show or quit when clicked on.
Added unit, qml and functional tests.
 
<img width="1915" height="1007" alt="Screenshot from 2026-03-25 15-35-28" src="https://github.com/user-attachments/assets/52a1dd12-7e80-4d03-ab89-c3e60be38df8" />

<img width="1915" height="1007" alt="Screenshot from 2026-03-25 15-35-39" src="https://github.com/user-attachments/assets/659264eb-71d4-48b3-b4b1-2ca35ef4099c" />
