### PR TITLE
ci: drop unused qtqml-workerscript package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
             qml6-module-qtquick-templates \
             qml6-module-qtquick-window \
             qml6-module-qtqml \
-            qml6-module-qtqml-workerscript \
             libgl-dev \
             libqrencode-dev
 

--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -32,7 +32,7 @@ jobs:
             qt6-qpa-plugins \
             qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools \
             qt6-declarative-dev \
-            qml6-module-qtqml qml6-module-qtqml-models qml6-module-qtqml-workerscript qml6-module-qt-labs-settings \
+            qml6-module-qtqml qml6-module-qtqml-models qml6-module-qt-labs-settings \
             qml6-module-qtquick qml6-module-qtquick-window \
             qml6-module-qtquick-layouts qml6-module-qtquick-controls \
             qml6-module-qtquick-dialogs qml6-module-qtquick-templates


### PR DESCRIPTION
This removes qml6-module-qtqml-workerscript from CI dependency install lists.

I checked qt6 and found no WorkerScript / QtQml.WorkerScript usage in QML, tests, or CMake, so this package appears unused.

Related to #543 

