### PR TITLE
Add qtqml workerscript package to Debian deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ sudo apt install \
   qml6-module-qtquick-templates \
   qml6-module-qtquick-window \
   qml6-module-qtqml \
+  qml6-module-qtqml-workerscript \
   libgl-dev \
   libqrencode-dev
 ```


### PR DESCRIPTION
## Summary
- add `qml6-module-qtqml-workerscript` to the Debian-based install dependencies in the README

## Testing
- not run (README-only change)

Fixes #543 