### PR TITLE
Fee selection

### DIFF
--- a/qml/components/BitcoinAddressInputField.qml
+++ b/qml/components/BitcoinAddressInputField.qml
@@ -15,8 +15,10 @@ ColumnLayout {
     property var address
     property string errorText: ""
     property string labelText: qsTr("Send to")
+    property string inputObjectName: ""
     property bool enabled: true
 
+    signal textChanged()
     signal editingFinished()
 
     Layout.fillWidth: true
@@ -40,6 +42,7 @@ ColumnLayout {
 
         TextArea {
             id: addressInput
+            objectName: root.inputObjectName
             anchors.left: label.right
             anchors.right: parent.right
             anchors.top: parent.top
@@ -64,6 +67,7 @@ ColumnLayout {
                 if (root.address) {
                     cursorPosition = root.address.setAddress(text, cursorPosition)
                 }
+                root.textChanged()
             }
 
             onEditingFinished: {

--- a/qml/components/FeeSelection.qml
+++ b/qml/components/FeeSelection.qml
@@ -14,6 +14,7 @@ ColumnLayout {
     objectName: "feeSelectionControl"
 
     property var walletModel: null
+    property bool includeFeeInAmount: false
     property int currentTarget: 2
     property bool customSelected: walletModel ? walletModel.customFeeEnabled : false
     property int selectedIndex: customSelected
@@ -36,6 +37,7 @@ ColumnLayout {
     readonly property int estimateColumnWidth: Math.ceil(estimateFontMetrics.advanceWidth("0.00000000 ₿"))
 
     signal feeChanged(int target)
+    signal includeFeeInAmountToggled(bool checked)
 
     spacing: 12
 
@@ -198,6 +200,7 @@ ColumnLayout {
                         maxWidth = Math.max(maxWidth, item.implicitWidth)
                     }
                 }
+                maxWidth = Math.max(maxWidth, includeFeeToggleItem.implicitWidth)
                 return Math.ceil(maxWidth)
             }
             width: feePopup.availableWidth
@@ -320,6 +323,59 @@ ColumnLayout {
                         }
                         feePopup.close()
                     }
+                }
+            }
+
+            Rectangle {
+                width: parent.width
+                height: 1
+                color: Theme.color.neutral4
+            }
+
+            ItemDelegate {
+                id: includeFeeToggleItem
+                objectName: "feeSelectionIncludeFeeToggle"
+                implicitWidth: includeFeeToggleContent.implicitWidth + leftPadding + rightPadding
+                width: feeList.width
+                height: 44
+                leftPadding: 12
+                rightPadding: 12
+                topPadding: 0
+                bottomPadding: 0
+
+                background: Item {
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: 6
+                        color: Theme.color.neutral2
+                        visible: includeFeeToggleItem.hovered
+                    }
+                }
+
+                contentItem: RowLayout {
+                    id: includeFeeToggleContent
+                    spacing: 12
+
+                    CoreText {
+                        Layout.fillWidth: true
+                        text: qsTr("Include fee in amount")
+                        font.pixelSize: 18
+                        color: Theme.color.neutral9
+                    }
+
+                    OptionSwitch {
+                        enabled: false
+                        checked: root.includeFeeInAmount
+                    }
+                }
+
+                HoverHandler {
+                    cursorShape: Qt.PointingHandCursor
+                }
+
+                onClicked: {
+                    root.includeFeeInAmountToggled(!root.includeFeeInAmount)
+                    feePopup.close()
                 }
             }
         }

--- a/qml/components/FeeSelection.qml
+++ b/qml/components/FeeSelection.qml
@@ -21,11 +21,48 @@ RowLayout {
     property int selectedTarget: feeModel.get(root.selectedIndex).target
     property string selectedEstimate: walletModel
         ? (walletModel.feeEstimateRevision, walletModel.estimatedFeeForTarget(selectedTarget))
-        : qsTr("—")
+        : ""
+    readonly property bool hasFeeEstimate: {
+        const feeEstimateRevision = walletModel ? walletModel.feeEstimateRevision : 0
+        if (!walletModel || feeEstimateRevision < 0) {
+            return false
+        }
+
+        for (let i = 0; i < feeModel.count; ++i) {
+            const option = feeModel.get(i)
+            if (walletModel.estimatedFeeForTarget(option.target).length > 0) {
+                return true
+            }
+        }
+
+        return false
+    }
+    readonly property int estimateColumnWidth: {
+        const feeEstimateRevision = walletModel ? walletModel.feeEstimateRevision : 0
+        if (!walletModel || feeEstimateRevision < 0) {
+            return 0
+        }
+
+        let maxWidth = 0
+        for (let i = 0; i < feeModel.count; ++i) {
+            const option = feeModel.get(i)
+            const estimate = walletModel.estimatedFeeForTarget(option.target)
+            if (estimate.length > 0) {
+                maxWidth = Math.max(maxWidth, estimateFontMetrics.advanceWidth(estimate))
+            }
+        }
+
+        return Math.ceil(maxWidth)
+    }
 
     signal feeChanged(int target)
 
     spacing: 16
+
+    FontMetrics {
+        id: estimateFontMetrics
+        font.pixelSize: 18
+    }
 
     CoreText {
         Layout.preferredWidth: 110
@@ -101,7 +138,7 @@ RowLayout {
         objectName: "feeSelectionPopup"
         modal: true
         dim: false
-        width: 360
+        width: root.hasFeeEstimate ? 360 : 280
         height: Math.min(feeModel.count * 44 + 12, 300)
         x: feePopup.parent.width - feePopup.width
         y: feePopup.parent.height + 6
@@ -153,11 +190,13 @@ RowLayout {
                     }
                 }
 
-                contentItem: RowLayout {
-                    spacing: 8
-
-                    RowLayout {
-                        Layout.fillWidth: true
+                contentItem: Item {
+                    Row {
+                        id: feeDetails
+                        anchors.left: parent.left
+                        anchors.right: estimateText.left
+                        anchors.rightMargin: 8
+                        anchors.verticalCenter: parent.verticalCenter
                         spacing: 4
 
                         CoreText {
@@ -174,19 +213,34 @@ RowLayout {
                     }
 
                     CoreText {
+                        id: estimateText
                         objectName: "feeSelectionOptionEstimate" + delegate.index
+                        anchors.right: selectionIconSlot.left
+                        anchors.rightMargin: 8
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: root.estimateColumnWidth
+                        horizontalAlignment: Text.AlignRight
                         text: root.walletModel
                             ? (root.walletModel.feeEstimateRevision, root.walletModel.estimatedFeeForTarget(target))
-                            : qsTr("—")
+                            : ""
                         font.pixelSize: 18
                         color: Theme.color.neutral7
                     }
 
-                    Icon {
-                        visible: delegate.index === root.selectedIndex
-                        source: "image://images/check"
-                        color: Theme.color.orange
-                        size: 20
+                    Item {
+                        id: selectionIconSlot
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 20
+                        height: 20
+
+                        Icon {
+                            anchors.centerIn: parent
+                            opacity: delegate.index === root.selectedIndex ? 1 : 0
+                            source: "image://images/check"
+                            color: Theme.color.orange
+                            size: 20
+                        }
                     }
                 }
 

--- a/qml/components/FeeSelection.qml
+++ b/qml/components/FeeSelection.qml
@@ -22,38 +22,10 @@ RowLayout {
     property string selectedEstimate: walletModel
         ? (walletModel.feeEstimateRevision, walletModel.estimatedFeeForTarget(selectedTarget))
         : ""
-    readonly property bool hasFeeEstimate: {
-        const feeEstimateRevision = walletModel ? walletModel.feeEstimateRevision : 0
-        if (!walletModel || feeEstimateRevision < 0) {
-            return false
-        }
-
-        for (let i = 0; i < feeModel.count; ++i) {
-            const option = feeModel.get(i)
-            if (walletModel.estimatedFeeForTarget(option.target).length > 0) {
-                return true
-            }
-        }
-
-        return false
-    }
-    readonly property int estimateColumnWidth: {
-        const feeEstimateRevision = walletModel ? walletModel.feeEstimateRevision : 0
-        if (!walletModel || feeEstimateRevision < 0) {
-            return 0
-        }
-
-        let maxWidth = 0
-        for (let i = 0; i < feeModel.count; ++i) {
-            const option = feeModel.get(i)
-            const estimate = walletModel.estimatedFeeForTarget(option.target)
-            if (estimate.length > 0) {
-                maxWidth = Math.max(maxWidth, estimateFontMetrics.advanceWidth(estimate))
-            }
-        }
-
-        return Math.ceil(maxWidth)
-    }
+    readonly property int optionSpacing: 8
+    readonly property int detailsSpacing: 4
+    readonly property int selectionColumnWidth: 20
+    readonly property int estimateColumnWidth: Math.ceil(estimateFontMetrics.advanceWidth("0.00000000 ₿"))
 
     signal feeChanged(int target)
 
@@ -61,7 +33,10 @@ RowLayout {
 
     FontMetrics {
         id: estimateFontMetrics
+        font.family: "Inter"
+        font.styleName: "Regular"
         font.pixelSize: 18
+        font.features: { "tnum": 1 }
     }
 
     CoreText {
@@ -77,6 +52,7 @@ RowLayout {
         Layout.fillWidth: true
         horizontalAlignment: Text.AlignLeft
         font.pixelSize: 18
+        font.features: { "tnum": 1 }
         color: Theme.color.neutral7
         text: root.selectedEstimate
     }
@@ -138,9 +114,9 @@ RowLayout {
         objectName: "feeSelectionPopup"
         modal: true
         dim: false
-        width: root.hasFeeEstimate ? 360 : 280
-        height: Math.min(feeModel.count * 44 + 12, 300)
-        x: feePopup.parent.width - feePopup.width
+        width: Math.ceil(Math.max(dropDownButton.implicitWidth + 24, feeList.maxItemImplicitWidth + leftPadding + rightPadding))
+        height: Math.min(feeList.implicitHeight + topPadding + bottomPadding, 300)
+        x: dropDownButton.x + dropDownButton.width - width
         y: feePopup.parent.height + 6
         padding: 6
 
@@ -150,107 +126,131 @@ RowLayout {
             border.color: Theme.color.neutral4
         }
 
-        contentItem: ListView {
+        contentItem: Column {
             id: feeList
             objectName: "feeSelectionList"
-            model: feeModel
-            interactive: false
+            readonly property int maxItemImplicitWidth: {
+                const feeEstimateRevision = root.walletModel ? root.walletModel.feeEstimateRevision : 0
+                return Math.ceil(Math.max(
+                    feeOptionsRepeater.itemAt(0) ? feeOptionsRepeater.itemAt(0).implicitWidth : 0,
+                    feeOptionsRepeater.itemAt(1) ? feeOptionsRepeater.itemAt(1).implicitWidth : 0,
+                    feeOptionsRepeater.itemAt(2) ? feeOptionsRepeater.itemAt(2).implicitWidth : 0))
+            }
             width: feePopup.availableWidth
-            height: contentHeight
+            spacing: 0
 
-            delegate: ItemDelegate {
-                id: delegate
-                objectName: "feeSelectionOption" + index
-                required property string feeLabel
-                required property string feeDuration
-                required property int index
-                required property int target
+            function itemAtIndex(index) {
+                return feeOptionsRepeater.itemAt(index)
+            }
 
-                width: ListView.view.width
-                height: 44
-                leftPadding: 12
-                rightPadding: 12
-                topPadding: 0
-                bottomPadding: 0
+            Repeater {
+                id: feeOptionsRepeater
+                model: feeModel
 
-                background: Item {
-                    Rectangle {
-                        anchors.fill: parent
-                        radius: 6
-                        color: Theme.color.neutral2
-                        visible: delegate.hovered
+                delegate: ItemDelegate {
+                    id: delegate
+                    objectName: "feeSelectionOption" + index
+                    required property string feeLabel
+                    required property string feeDuration
+                    required property int index
+                    required property int target
+
+                    implicitWidth: delegateContent.implicitWidth + leftPadding + rightPadding
+                    width: feeList.width
+                    height: 44
+                    leftPadding: 12
+                    rightPadding: 12
+                    topPadding: 0
+                    bottomPadding: 0
+
+                    background: Item {
+                        Rectangle {
+                            anchors.fill: parent
+                            radius: 6
+                            color: Theme.color.neutral2
+                            visible: delegate.hovered
+                        }
+
+                        Rectangle {
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.bottom: parent.bottom
+                            height: delegate.index === feeModel.count - 1 ? 0 : 1
+                            color: Theme.color.neutral4
+                        }
                     }
 
-                    Rectangle {
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        anchors.bottom: parent.bottom
-                        height: delegate.index === feeModel.count - 1 ? 0 : 1
-                        color: Theme.color.neutral4
-                    }
-                }
+                    contentItem: Item {
+                        id: delegateContent
+                        implicitWidth: selectionSlot.width
+                            + root.optionSpacing
+                            + feeDetails.implicitWidth
+                            + (estimateText.visible ? root.optionSpacing + root.estimateColumnWidth : 0)
+                        implicitHeight: Math.max(selectionSlot.height, feeDetails.implicitHeight, estimateText.implicitHeight)
 
-                contentItem: Item {
-                    Row {
-                        id: feeDetails
-                        anchors.left: parent.left
-                        anchors.right: estimateText.left
-                        anchors.rightMargin: 8
-                        anchors.verticalCenter: parent.verticalCenter
-                        spacing: 4
+                        Item {
+                            id: selectionSlot
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: root.selectionColumnWidth
+                            height: 20
 
-                        CoreText {
-                            text: feeLabel
-                            font.pixelSize: 18
-                            color: Theme.color.neutral9
+                            CoreText {
+                                anchors.centerIn: parent
+                                visible: delegate.index === root.selectedIndex
+                                text: "\u2713"
+                                font.pixelSize: 18
+                                color: Theme.color.orange
+                            }
+                        }
+
+                        Row {
+                            id: feeDetails
+                            anchors.left: selectionSlot.right
+                            anchors.leftMargin: root.optionSpacing
+                            anchors.right: estimateText.visible ? estimateText.left : parent.right
+                            anchors.rightMargin: estimateText.visible ? root.optionSpacing : 0
+                            anchors.verticalCenter: parent.verticalCenter
+                            spacing: root.detailsSpacing
+
+                            CoreText {
+                                text: feeLabel
+                                font.pixelSize: 18
+                                color: Theme.color.neutral9
+                            }
+
+                            CoreText {
+                                text: feeDuration
+                                font.pixelSize: 18
+                                color: Theme.color.neutral7
+                            }
                         }
 
                         CoreText {
-                            text: feeDuration
+                            id: estimateText
+                            objectName: "feeSelectionOptionEstimate" + delegate.index
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            visible: text.length > 0
+                            width: visible ? root.estimateColumnWidth : 0
+                            horizontalAlignment: Text.AlignRight
+                            text: root.walletModel
+                                ? (root.walletModel.feeEstimateRevision, root.walletModel.estimatedFeeForTarget(target))
+                                : ""
                             font.pixelSize: 18
+                            font.features: { "tnum": 1 }
                             color: Theme.color.neutral7
                         }
                     }
 
-                    CoreText {
-                        id: estimateText
-                        objectName: "feeSelectionOptionEstimate" + delegate.index
-                        anchors.right: selectionIconSlot.left
-                        anchors.rightMargin: 8
-                        anchors.verticalCenter: parent.verticalCenter
-                        width: root.estimateColumnWidth
-                        horizontalAlignment: Text.AlignRight
-                        text: root.walletModel
-                            ? (root.walletModel.feeEstimateRevision, root.walletModel.estimatedFeeForTarget(target))
-                            : ""
-                        font.pixelSize: 18
-                        color: Theme.color.neutral7
+                    HoverHandler {
+                        cursorShape: Qt.PointingHandCursor
                     }
 
-                    Item {
-                        id: selectionIconSlot
-                        anchors.right: parent.right
-                        anchors.verticalCenter: parent.verticalCenter
-                        width: 20
-                        height: 20
-
-                        Icon {
-                            anchors.centerIn: parent
-                            opacity: delegate.index === root.selectedIndex ? 1 : 0
-                            source: "image://images/check"
-                            color: Theme.color.orange
-                            size: 20
-                        }
+                    onClicked: {
+                        root.feeChanged(target)
+                        feePopup.close()
                     }
-                }
-
-                HoverHandler {
-                    cursorShape: Qt.PointingHandCursor
-                }
-
-                onClicked: {
-                    root.feeChanged(target)
-                    feePopup.close()
                 }
             }
         }

--- a/qml/components/FeeSelection.qml
+++ b/qml/components/FeeSelection.qml
@@ -34,6 +34,7 @@ ColumnLayout {
     readonly property int optionSpacing: 8
     readonly property int detailsSpacing: 4
     readonly property int selectionColumnWidth: 20
+    readonly property int customFeeRateMaximumLength: 12
     readonly property int estimateColumnWidth: Math.ceil(estimateFontMetrics.advanceWidth("0.00000000 ₿"))
 
     signal feeChanged(int target)
@@ -85,6 +86,7 @@ ColumnLayout {
             placeholderText: "0.000"
             selectByMouse: true
             text: root.walletModel ? root.walletModel.customFeeRate : ""
+            maximumLength: root.customFeeRateMaximumLength
             validator: RegularExpressionValidator {
                 regularExpression: /^(|[0-9]+(\.[0-9]{0,3})?)$/
             }

--- a/qml/components/FeeSelection.qml
+++ b/qml/components/FeeSelection.qml
@@ -9,19 +9,27 @@ import QtQuick.Layouts 1.15
 import "../controls"
 import "../components"
 
-RowLayout {
+ColumnLayout {
     id: root
     objectName: "feeSelectionControl"
 
     property var walletModel: null
     property int currentTarget: 2
-    property int selectedIndex: walletModel ? walletModel.feeTargetIndex(currentTarget) : 1
-    property string selectedLabel: feeModel.get(root.selectedIndex).feeLabel
-    property string selectedDuration: feeModel.get(root.selectedIndex).feeDuration
+    property bool customSelected: walletModel ? walletModel.customFeeEnabled : false
+    property int selectedIndex: customSelected
+        ? feeModel.count - 1
+        : (walletModel ? walletModel.feeTargetIndex(currentTarget) : 1)
+    property string selectedLabel: customSelected
+        ? qsTr("sats/vbyte")
+        : feeModel.get(root.selectedIndex).feeLabel
+    property string selectedDuration: customSelected
+        ? ""
+        : feeModel.get(root.selectedIndex).feeDuration
     property int selectedTarget: feeModel.get(root.selectedIndex).target
-    property string selectedEstimate: walletModel
-        ? (walletModel.feeEstimateRevision, walletModel.estimatedFeeForTarget(selectedTarget))
-        : ""
+    property string selectedEstimate: customSelected
+        ? ""
+        : (walletModel ? (walletModel.feeEstimateRevision, walletModel.estimatedFeeForTarget(selectedTarget)) : "")
+    property bool customFeeRateValid: walletModel ? walletModel.customFeeRateValid : false
     readonly property int optionSpacing: 8
     readonly property int detailsSpacing: 4
     readonly property int selectionColumnWidth: 20
@@ -29,7 +37,7 @@ RowLayout {
 
     signal feeChanged(int target)
 
-    spacing: 16
+    spacing: 12
 
     FontMetrics {
         id: estimateFontMetrics
@@ -39,73 +47,128 @@ RowLayout {
         font.features: { "tnum": 1 }
     }
 
-    CoreText {
-        Layout.preferredWidth: 110
-        horizontalAlignment: Text.AlignLeft
-        font.pixelSize: 18
-        text: qsTr("Fee")
-    }
-
-    CoreText {
-        id: estimateLabel
-        objectName: "feeSelectionEstimateLabel"
+    RowLayout {
         Layout.fillWidth: true
-        horizontalAlignment: Text.AlignLeft
-        font.pixelSize: 18
-        font.features: { "tnum": 1 }
-        color: Theme.color.neutral7
-        text: root.selectedEstimate
+        spacing: 16
+
+        CoreText {
+            Layout.preferredWidth: 110
+            horizontalAlignment: Text.AlignLeft
+            font.pixelSize: 18
+            text: root.customSelected ? qsTr("Fee Rate") : qsTr("Fee")
+        }
+
+        CoreText {
+            id: estimateLabel
+            objectName: "feeSelectionEstimateLabel"
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignLeft
+            font.pixelSize: 18
+            font.features: { "tnum": 1 }
+            color: Theme.color.neutral7
+            text: root.selectedEstimate
+            visible: !root.customSelected
+        }
+
+        TextField {
+            id: customFeeRateInput
+            objectName: "feeSelectionCustomRateInput"
+            Layout.fillWidth: true
+            visible: root.customSelected
+            leftPadding: 0
+            font.family: "Inter"
+            font.styleName: "Regular"
+            font.pixelSize: 18
+            color: Theme.color.neutral9
+            placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
+            background: Item {}
+            placeholderText: "0.000"
+            selectByMouse: true
+            text: root.walletModel ? root.walletModel.customFeeRate : ""
+            validator: RegularExpressionValidator {
+                regularExpression: /^(|[0-9]+(\.[0-9]{0,3})?)$/
+            }
+            onTextChanged: {
+                if (root.walletModel && root.walletModel.customFeeRate !== text) {
+                    root.walletModel.customFeeRate = text
+                }
+            }
+        }
+
+        Button {
+            id: dropDownButton
+            objectName: "feeSelectionDropdownButton"
+            hoverEnabled: true
+            leftPadding: 10
+            rightPadding: 8
+            topPadding: 4
+            bottomPadding: 4
+            implicitHeight: 32
+
+            HoverHandler {
+                cursorShape: Qt.PointingHandCursor
+            }
+
+            onPressed: feePopup.open()
+
+            contentItem: RowLayout {
+                spacing: 0
+
+                CoreText {
+                    text: root.selectedLabel
+                    font.pixelSize: 18
+                    color: dropDownButton.enabled ? Theme.color.neutral9 : Theme.color.neutral4
+                }
+
+                Item { width: 5 }
+
+                CoreText {
+                    text: root.selectedDuration
+                    font.pixelSize: 18
+                    color: dropDownButton.enabled ? Theme.color.neutral7 : Theme.color.neutral4
+                }
+
+                Icon {
+                    source: "image://images/caret-down-medium-filled"
+                    Layout.preferredWidth: 30
+                    size: 30
+                    color: dropDownButton.enabled ? Theme.color.orange : Theme.color.neutral4
+                }
+            }
+
+            background: Rectangle {
+                id: dropDownButtonBg
+                color: dropDownButton.hovered ? Theme.color.neutral2 : Theme.color.background
+                radius: 6
+
+                Behavior on color {
+                    ColorAnimation { duration: 150 }
+                }
+            }
+        }
     }
 
-    Button {
-        id: dropDownButton
-        objectName: "feeSelectionDropdownButton"
-        hoverEnabled: true
-        leftPadding: 10
-        rightPadding: 8
-        topPadding: 4
-        bottomPadding: 4
-        implicitHeight: 32
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 16
+        visible: root.customSelected
 
-        HoverHandler {
-            cursorShape: Qt.PointingHandCursor
+        CoreText {
+            Layout.preferredWidth: 110
+            horizontalAlignment: Text.AlignLeft
+            font.pixelSize: 18
+            text: qsTr("Fee")
         }
 
-        onPressed: feePopup.open()
-
-        contentItem: RowLayout {
-            spacing: 0
-
-            CoreText {
-                text: root.selectedLabel
-                font.pixelSize: 18
-                color: dropDownButton.enabled ? Theme.color.neutral9 : Theme.color.neutral4
-            }
-
-            Item { width: 5 }
-
-            CoreText {
-                text: root.selectedDuration
-                font.pixelSize: 18
-                color: dropDownButton.enabled ? Theme.color.neutral7 : Theme.color.neutral4
-            }
-
-            Icon {
-                source: "image://images/caret-down-medium-filled"
-                Layout.preferredWidth: 30
-                size: 30
-                color: dropDownButton.enabled ? Theme.color.orange : Theme.color.neutral4
-            }
-        }
-
-        background: Rectangle {
-            id: dropDownButtonBg
-            color: dropDownButton.hovered ? Theme.color.neutral2 : Theme.color.background
-            radius: 6
-
-            Behavior on color {
-                ColorAnimation { duration: 150 }
-            }
+        CoreText {
+            id: customEstimateLabel
+            objectName: "feeSelectionCustomEstimateLabel"
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignLeft
+            font.pixelSize: 18
+            font.features: { "tnum": 1 }
+            color: Theme.color.neutral7
+            text: root.walletModel ? (root.walletModel.feeEstimateRevision, root.walletModel.estimatedFee) : ""
         }
     }
 
@@ -117,7 +180,7 @@ RowLayout {
         width: Math.ceil(Math.max(dropDownButton.implicitWidth + 24, feeList.maxItemImplicitWidth + leftPadding + rightPadding))
         height: Math.min(feeList.implicitHeight + topPadding + bottomPadding, 300)
         x: dropDownButton.x + dropDownButton.width - width
-        y: feePopup.parent.height + 6
+        y: dropDownButton.height + 6
         padding: 6
 
         background: Rectangle {
@@ -131,10 +194,14 @@ RowLayout {
             objectName: "feeSelectionList"
             readonly property int maxItemImplicitWidth: {
                 const feeEstimateRevision = root.walletModel ? root.walletModel.feeEstimateRevision : 0
-                return Math.ceil(Math.max(
-                    feeOptionsRepeater.itemAt(0) ? feeOptionsRepeater.itemAt(0).implicitWidth : 0,
-                    feeOptionsRepeater.itemAt(1) ? feeOptionsRepeater.itemAt(1).implicitWidth : 0,
-                    feeOptionsRepeater.itemAt(2) ? feeOptionsRepeater.itemAt(2).implicitWidth : 0))
+                let maxWidth = 0
+                for (let i = 0; i < feeOptionsRepeater.count; ++i) {
+                    const item = feeOptionsRepeater.itemAt(i)
+                    if (item) {
+                        maxWidth = Math.max(maxWidth, item.implicitWidth)
+                    }
+                }
+                return Math.ceil(maxWidth)
             }
             width: feePopup.availableWidth
             spacing: 0
@@ -155,6 +222,7 @@ RowLayout {
                     required property int index
                     required property int target
 
+                    readonly property bool isCustomOption: target < 0
                     implicitWidth: delegateContent.implicitWidth + leftPadding + rightPadding
                     width: feeList.width
                     height: 44
@@ -231,12 +299,12 @@ RowLayout {
                             objectName: "feeSelectionOptionEstimate" + delegate.index
                             anchors.right: parent.right
                             anchors.verticalCenter: parent.verticalCenter
-                            visible: text.length > 0
+                            visible: !delegate.isCustomOption && text.length > 0
                             width: visible ? root.estimateColumnWidth : 0
                             horizontalAlignment: Text.AlignRight
-                            text: root.walletModel
-                                ? (root.walletModel.feeEstimateRevision, root.walletModel.estimatedFeeForTarget(target))
-                                : ""
+                            text: delegate.isCustomOption || !root.walletModel
+                                ? ""
+                                : (root.walletModel.feeEstimateRevision, root.walletModel.estimatedFeeForTarget(target))
                             font.pixelSize: 18
                             font.features: { "tnum": 1 }
                             color: Theme.color.neutral7
@@ -248,7 +316,12 @@ RowLayout {
                     }
 
                     onClicked: {
-                        root.feeChanged(target)
+                        if (root.walletModel) {
+                            root.walletModel.customFeeEnabled = delegate.isCustomOption
+                        }
+                        if (!delegate.isCustomOption) {
+                            root.feeChanged(target)
+                        }
                         feePopup.close()
                     }
                 }
@@ -261,5 +334,6 @@ RowLayout {
         ListElement { feeLabel: qsTr("High"); feeDuration: qsTr("(~10 mins)"); target: 1 }
         ListElement { feeLabel: qsTr("Default"); feeDuration: qsTr("(~20 mins)"); target: 2 }
         ListElement { feeLabel: qsTr("Low"); feeDuration: qsTr("(~60 mins)"); target: 6 }
+        ListElement { feeLabel: qsTr("Custom"); feeDuration: qsTr("sats/vbyte"); target: -1 }
     }
 }

--- a/qml/components/FeeSelection.qml
+++ b/qml/components/FeeSelection.qml
@@ -44,7 +44,6 @@ ColumnLayout {
         font.family: "Inter"
         font.styleName: "Regular"
         font.pixelSize: 18
-        font.features: { "tnum": 1 }
     }
 
     RowLayout {
@@ -64,7 +63,6 @@ ColumnLayout {
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignLeft
             font.pixelSize: 18
-            font.features: { "tnum": 1 }
             color: Theme.color.neutral7
             text: root.selectedEstimate
             visible: !root.customSelected
@@ -166,7 +164,6 @@ ColumnLayout {
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignLeft
             font.pixelSize: 18
-            font.features: { "tnum": 1 }
             color: Theme.color.neutral7
             text: root.walletModel ? (root.walletModel.feeEstimateRevision, root.walletModel.estimatedFee) : ""
         }
@@ -306,7 +303,6 @@ ColumnLayout {
                                 ? ""
                                 : (root.walletModel.feeEstimateRevision, root.walletModel.estimatedFeeForTarget(target))
                             font.pixelSize: 18
-                            font.features: { "tnum": 1 }
                             color: Theme.color.neutral7
                         }
                     }

--- a/qml/components/FeeSelection.qml
+++ b/qml/components/FeeSelection.qml
@@ -11,34 +11,48 @@ import "../components"
 
 RowLayout {
     id: root
+    objectName: "feeSelectionControl"
 
-    property int selectedIndex: 1
+    property var walletModel: null
+    property int currentTarget: 2
+    property int selectedIndex: walletModel ? walletModel.feeTargetIndex(currentTarget) : 1
     property string selectedLabel: feeModel.get(root.selectedIndex).feeLabel
     property string selectedDuration: feeModel.get(root.selectedIndex).feeDuration
+    property int selectedTarget: feeModel.get(root.selectedIndex).target
+    property string selectedEstimate: walletModel
+        ? (walletModel.feeEstimateRevision, walletModel.estimatedFeeForTarget(selectedTarget))
+        : qsTr("—")
 
     signal feeChanged(int target)
 
-    height: 40
+    spacing: 16
 
     CoreText {
-        Layout.fillWidth: true
+        Layout.preferredWidth: 110
         horizontalAlignment: Text.AlignLeft
         font.pixelSize: 18
         text: qsTr("Fee")
     }
 
+    CoreText {
+        id: estimateLabel
+        objectName: "feeSelectionEstimateLabel"
+        Layout.fillWidth: true
+        horizontalAlignment: Text.AlignLeft
+        font.pixelSize: 18
+        color: Theme.color.neutral7
+        text: root.selectedEstimate
+    }
+
     Button {
         id: dropDownButton
-        text: root.selectedLabel
-        font.pixelSize: 18
-
+        objectName: "feeSelectionDropdownButton"
         hoverEnabled: true
-
         leftPadding: 10
-        rightPadding: 4
-        topPadding: 2
-        bottomPadding: 2
-        height: 28
+        rightPadding: 8
+        topPadding: 4
+        bottomPadding: 4
+        implicitHeight: 32
 
         HoverHandler {
             cursorShape: Qt.PointingHandCursor
@@ -50,70 +64,48 @@ RowLayout {
             spacing: 0
 
             CoreText {
-                id: value
                 text: root.selectedLabel
                 font.pixelSize: 18
-
-                Behavior on color {
-                    ColorAnimation { duration: 150 }
-                }
+                color: dropDownButton.enabled ? Theme.color.neutral9 : Theme.color.neutral4
             }
 
             Item { width: 5 }
 
             CoreText {
-                id: duration
                 text: root.selectedDuration
                 font.pixelSize: 18
                 color: dropDownButton.enabled ? Theme.color.neutral7 : Theme.color.neutral4
-
-                Behavior on color {
-                    ColorAnimation { duration: 150 }
-                }
             }
 
             Icon {
-                id: caret
                 source: "image://images/caret-down-medium-filled"
                 Layout.preferredWidth: 30
                 size: 30
                 color: dropDownButton.enabled ? Theme.color.orange : Theme.color.neutral4
-
-                Behavior on color {
-                    ColorAnimation { duration: 150 }
-                }
             }
         }
 
         background: Rectangle {
             id: dropDownButtonBg
-            color: Theme.color.background
+            color: dropDownButton.hovered ? Theme.color.neutral2 : Theme.color.background
             radius: 6
+
             Behavior on color {
                 ColorAnimation { duration: 150 }
             }
         }
-
-        states: [
-            State {
-                name: "CHECKED"; when: dropDownButton.checked
-                PropertyChanges { target: icon; color: activeColor }
-            },
-            State {
-                name: "HOVER"; when: dropDownButton.hovered
-                PropertyChanges { target: dropDownButtonBg; color: Theme.color.neutral2 }
-            },
-            State {
-                name: "DISABLED"; when: !dropDownButton.enabled
-                PropertyChanges { target: dropDownButtonBg; color: Theme.color.background }
-            }
-        ]
     }
 
     Popup {
         id: feePopup
+        objectName: "feeSelectionPopup"
         modal: true
         dim: false
+        width: 360
+        height: Math.min(feeModel.count * 44 + 12, 300)
+        x: feePopup.parent.width - feePopup.width
+        y: feePopup.parent.height + 6
+        padding: 6
 
         background: Rectangle {
             color: Theme.color.background
@@ -121,32 +113,28 @@ RowLayout {
             border.color: Theme.color.neutral4
         }
 
-        width: 260
-        height: Math.min(feeModel.count * 36 + 10, 300)
-        x: feePopup.parent.width - feePopup.width
-        y: feePopup.parent.height + 2
-        padding: 5
-
         contentItem: ListView {
             id: feeList
+            objectName: "feeSelectionList"
             model: feeModel
             interactive: false
-            width: 260
+            width: feePopup.availableWidth
             height: contentHeight
+
             delegate: ItemDelegate {
                 id: delegate
+                objectName: "feeSelectionOption" + index
                 required property string feeLabel
                 required property string feeDuration
                 required property int index
                 required property int target
 
                 width: ListView.view.width
-                height: 36
-
-                leftPadding: 10
-                rightPadding: 4
-                topPadding: 2
-                bottomPadding: 2
+                height: 44
+                leftPadding: 12
+                rightPadding: 12
+                topPadding: 0
+                bottomPadding: 0
 
                 background: Item {
                     Rectangle {
@@ -155,22 +143,42 @@ RowLayout {
                         color: Theme.color.neutral2
                         visible: delegate.hovered
                     }
+
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: delegate.index === feeModel.count - 1 ? 0 : 1
+                        color: Theme.color.neutral4
+                    }
                 }
 
                 contentItem: RowLayout {
-                    spacing: 5
+                    spacing: 8
 
-                    CoreText {
-                        text: feeLabel
-                        horizontalAlignment: Text.AlignLeft
-                        font.pixelSize: 15
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 4
+
+                        CoreText {
+                            text: feeLabel
+                            font.pixelSize: 18
+                            color: Theme.color.neutral9
+                        }
+
+                        CoreText {
+                            text: feeDuration
+                            font.pixelSize: 18
+                            color: Theme.color.neutral7
+                        }
                     }
 
                     CoreText {
-                        text: feeDuration
-                        horizontalAlignment: Text.AlignLeft
-                        Layout.fillWidth: true
-                        font.pixelSize: 15
+                        objectName: "feeSelectionOptionEstimate" + delegate.index
+                        text: root.walletModel
+                            ? (root.walletModel.feeEstimateRevision, root.walletModel.estimatedFeeForTarget(target))
+                            : qsTr("—")
+                        font.pixelSize: 18
                         color: Theme.color.neutral7
                     }
 
@@ -187,9 +195,6 @@ RowLayout {
                 }
 
                 onClicked: {
-                    root.selectedIndex = delegate.index
-                    root.selectedLabel = feeLabel
-                    root.selectedDuration = feeDuration
                     root.feeChanged(target)
                     feePopup.close()
                 }
@@ -200,7 +205,7 @@ RowLayout {
     ListModel {
         id: feeModel
         ListElement { feeLabel: qsTr("High"); feeDuration: qsTr("(~10 mins)"); target: 1 }
-        ListElement { feeLabel: qsTr("Default"); feeDuration: qsTr("(~60 mins)"); target: 6 }
-        ListElement { feeLabel: qsTr("Low"); feeDuration: qsTr("(~24 hrs)"); target: 144 }
+        ListElement { feeLabel: qsTr("Default"); feeDuration: qsTr("(~20 mins)"); target: 2 }
+        ListElement { feeLabel: qsTr("Low"); feeDuration: qsTr("(~60 mins)"); target: 6 }
     }
 }

--- a/qml/controls/LabeledTextInput.qml
+++ b/qml/controls/LabeledTextInput.qml
@@ -17,6 +17,7 @@ Item {
     property alias maximumLength: input.maximumLength
     property alias cursorPosition: input.cursorPosition
     property alias inputActiveFocus: input.activeFocus
+    property alias inputObjectName: input.objectName
 
     signal iconClicked
     signal textEdited

--- a/qml/models/sendrecipient.cpp
+++ b/qml/models/sendrecipient.cpp
@@ -93,6 +93,14 @@ bool SendRecipient::subtractFeeFromAmount() const
     return m_subtractFeeFromAmount;
 }
 
+void SendRecipient::setSubtractFeeFromAmount(bool subtract)
+{
+    if (m_subtractFeeFromAmount != subtract) {
+        m_subtractFeeFromAmount = subtract;
+        Q_EMIT subtractFeeFromAmountChanged();
+    }
+}
+
 CAmount SendRecipient::cAmount() const
 {
     return m_amount->satoshi();
@@ -102,7 +110,7 @@ void SendRecipient::clear()
 {
     m_label = "";
     m_message = "";
-    m_subtractFeeFromAmount = false;
+    setSubtractFeeFromAmount(false);
     m_address->setAddress("", 0);
     m_amount->clear();
     Q_EMIT addressChanged();

--- a/qml/models/sendrecipient.h
+++ b/qml/models/sendrecipient.h
@@ -20,6 +20,7 @@ class SendRecipient : public QObject
     Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
     Q_PROPERTY(QString message READ message WRITE setMessage NOTIFY messageChanged)
     Q_PROPERTY(BitcoinAmount* amount READ amount CONSTANT)
+    Q_PROPERTY(bool subtractFeeFromAmount READ subtractFeeFromAmount WRITE setSubtractFeeFromAmount NOTIFY subtractFeeFromAmountChanged)
 
     Q_PROPERTY(QString addressError READ addressError NOTIFY addressErrorChanged)
     Q_PROPERTY(QString amountError READ amountError NOTIFY amountErrorChanged)
@@ -47,6 +48,7 @@ public:
     CAmount cAmount() const;
 
     bool subtractFeeFromAmount() const;
+    void setSubtractFeeFromAmount(bool subtract);
 
     bool isValid() const;
 
@@ -58,6 +60,7 @@ Q_SIGNALS:
     void amountErrorChanged();
     void labelChanged();
     void messageChanged();
+    void subtractFeeFromAmountChanged();
     void isValidChanged();
 
 private:

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -12,6 +12,7 @@
 #include <qml/models/sendrecipientslistmodel.h>
 #include <qml/models/walletqmlmodeltransaction.h>
 
+#include <chainparams.h>
 #include <consensus/amount.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
@@ -67,6 +68,18 @@ void ApplyPreviewChangeDestination(wallet::CCoinControl& coin_control, const QSt
     }
 }
 
+void ApplyRegtestStaticFeeOverride(wallet::CCoinControl& coin_control)
+{
+    if (Params().GetChainType() != ChainType::REGTEST) {
+        return;
+    }
+
+    // Regtest commonly runs without fee estimation, so use a fixed static fee
+    // rate instead of target-based estimation.
+    coin_control.m_confirm_target.reset();
+    coin_control.m_feerate = CFeeRate{wallet::DEFAULT_TRANSACTION_MINFEE};
+}
+
 std::optional<CAmount> TryPreviewFee(interfaces::Wallet& wallet,
                                      const std::vector<wallet::CRecipient>& recipients,
                                      const wallet::CCoinControl& coin_control)
@@ -91,9 +104,14 @@ std::optional<QString> EstimatePreviewFee(interfaces::Wallet& wallet,
     coin_control.m_feerate.reset();
     coin_control.m_confirm_target = target;
     ApplyPreviewChangeDestination(coin_control, preview_change_address);
+    ApplyRegtestStaticFeeOverride(coin_control);
 
     if (const auto fee = TryPreviewFee(wallet, recipients, coin_control)) {
         return FormatFeeEstimate(*fee);
+    }
+
+    if (Params().GetChainType() == ChainType::REGTEST) {
+        return std::nullopt;
     }
 
     const CAmount required_fee_per_k = wallet.getRequiredFee(FEE_RATE_BASIS_VBYTES);
@@ -549,10 +567,12 @@ bool WalletQmlModel::prepareTransaction()
         total += recipient.nAmount;
     }
 
-    m_coin_control.m_feerate.reset();
-    if (!m_coin_control.m_confirm_target.has_value()) {
-        m_coin_control.m_confirm_target = DEFAULT_STANDARD_FEE_TARGET;
+    wallet::CCoinControl coin_control{m_coin_control};
+    coin_control.m_feerate.reset();
+    if (!coin_control.m_confirm_target.has_value()) {
+        coin_control.m_confirm_target = DEFAULT_STANDARD_FEE_TARGET;
     }
+    ApplyRegtestStaticFeeOverride(coin_control);
 
     CAmount balance = m_wallet->getBalance();
     if (balance < total) {
@@ -561,12 +581,12 @@ bool WalletQmlModel::prepareTransaction()
 
     int nChangePosRet = -1;
     CAmount nFeeRequired = 0;
-    const auto& res = m_wallet->createTransaction(*vec_send, m_coin_control, true, nChangePosRet, nFeeRequired);
-    if (res) {
+    const auto& result = m_wallet->createTransaction(*vec_send, coin_control, true, nChangePosRet, nFeeRequired);
+    if (result) {
         if (m_current_transaction) {
             delete m_current_transaction;
         }
-        CTransactionRef newTx = *res;
+        const CTransactionRef& newTx = *result;
         m_current_transaction = new WalletQmlModelTransaction(m_send_recipients, this);
         m_current_transaction->setWtx(newTx);
         m_current_transaction->setTransactionFee(nFeeRequired);

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -17,6 +17,7 @@
 #include <key_io.h>
 #include <addresstype.h>
 #include <outputtype.h>
+#include <policy/feerate.h>
 #include <qml/bitcoinunits.h>
 #include <serialize.h>
 #include <streams.h>
@@ -33,13 +34,84 @@
 namespace {
 constexpr unsigned int DEFAULT_STANDARD_FEE_TARGET{2};
 constexpr int FEE_ESTIMATE_DEBOUNCE_MS{250};
+constexpr unsigned int FEE_RATE_BASIS_VBYTES{1000};
 constexpr std::array<unsigned int, 3> STANDARD_FEE_TARGETS{1, DEFAULT_STANDARD_FEE_TARGET, 6};
+
+int FallbackFeeMultiplier(const unsigned int target)
+{
+    for (size_t i = 0; i < STANDARD_FEE_TARGETS.size(); ++i) {
+        if (STANDARD_FEE_TARGETS[i] == target) {
+            return static_cast<int>(STANDARD_FEE_TARGETS.size() - i);
+        }
+    }
+
+    return 1;
+}
 
 QString FormatFeeEstimate(CAmount amount)
 {
     BitcoinAmount bitcoin_amount;
     bitcoin_amount.setSatoshi(amount);
     return bitcoin_amount.toDisplay() + QStringLiteral(" ") + bitcoin_amount.unitLabel();
+}
+
+void ApplyPreviewChangeDestination(wallet::CCoinControl& coin_control, const QString& preview_change_address)
+{
+    if (preview_change_address.isEmpty()) {
+        return;
+    }
+
+    const CTxDestination change_destination = DecodeDestination(preview_change_address.toStdString());
+    if (IsValidDestination(change_destination)) {
+        coin_control.destChange = change_destination;
+    }
+}
+
+std::optional<CAmount> TryPreviewFee(interfaces::Wallet& wallet,
+                                     const std::vector<wallet::CRecipient>& recipients,
+                                     const wallet::CCoinControl& coin_control)
+{
+    int change_position{-1};
+    CAmount fee{0};
+    const auto result = wallet.createTransaction(recipients, coin_control, /*sign=*/false, change_position, fee);
+    if (!result) {
+        return std::nullopt;
+    }
+
+    return fee;
+}
+
+std::optional<QString> EstimatePreviewFee(interfaces::Wallet& wallet,
+                                          const std::vector<wallet::CRecipient>& recipients,
+                                          const wallet::CCoinControl& base_coin_control,
+                                          const QString& preview_change_address,
+                                          const unsigned int target)
+{
+    wallet::CCoinControl coin_control{base_coin_control};
+    coin_control.m_feerate.reset();
+    coin_control.m_confirm_target = target;
+    ApplyPreviewChangeDestination(coin_control, preview_change_address);
+
+    if (const auto fee = TryPreviewFee(wallet, recipients, coin_control)) {
+        return FormatFeeEstimate(*fee);
+    }
+
+    const CAmount required_fee_per_k = wallet.getRequiredFee(FEE_RATE_BASIS_VBYTES);
+    if (required_fee_per_k <= 0) {
+        return std::nullopt;
+    }
+
+    wallet::CCoinControl fallback_coin_control{coin_control};
+    fallback_coin_control.m_confirm_target.reset();
+    // Keep fallback previews distinct across presets even when the backend can
+    // only provide a minimum required feerate.
+    fallback_coin_control.m_feerate = CFeeRate{required_fee_per_k * FallbackFeeMultiplier(target)};
+
+    if (const auto fee = TryPreviewFee(wallet, recipients, fallback_coin_control)) {
+        return FormatFeeEstimate(*fee);
+    }
+
+    return std::nullopt;
 }
 
 std::optional<std::vector<wallet::CRecipient>> BuildRecipients(const SendRecipientsListModel& recipients)
@@ -186,7 +258,7 @@ QString WalletQmlModel::estimatedFeeForTarget(const unsigned int target_blocks) 
         return estimate;
     }
 
-    return m_fee_estimate_pending ? QStringLiteral("…") : QStringLiteral("—");
+    return {};
 }
 
 int WalletQmlModel::feeTargetIndex(const unsigned int target_blocks) const
@@ -400,22 +472,12 @@ void WalletQmlModel::requestFeeEstimatesNow()
         QHash<unsigned int, QString> estimates;
 
         for (const unsigned int target : STANDARD_FEE_TARGETS) {
-            wallet::CCoinControl coin_control{base_coin_control};
-            coin_control.m_feerate.reset();
-            coin_control.m_confirm_target = target;
-
-            if (!preview_change_address.isEmpty()) {
-                const CTxDestination change_destination = DecodeDestination(preview_change_address.toStdString());
-                if (IsValidDestination(change_destination)) {
-                    coin_control.destChange = change_destination;
-                }
-            }
-
-            int change_position{-1};
-            CAmount fee{0};
-            const auto result = wallet->createTransaction(recipients, coin_control, /*sign=*/false, change_position, fee);
-            if (result) {
-                estimates.insert(target, FormatFeeEstimate(fee));
+            if (const auto estimate = EstimatePreviewFee(*wallet,
+                                                         recipients,
+                                                         base_coin_control,
+                                                         preview_change_address,
+                                                         target)) {
+                estimates.insert(target, *estimate);
             }
         }
 

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -28,6 +28,7 @@
 
 #include <QDateTime>
 #include <QMetaObject>
+#include <QRegularExpression>
 
 #include <array>
 #include <optional>
@@ -37,6 +38,7 @@ constexpr unsigned int DEFAULT_STANDARD_FEE_TARGET{2};
 constexpr int FEE_ESTIMATE_DEBOUNCE_MS{250};
 constexpr unsigned int FEE_RATE_BASIS_VBYTES{1000};
 constexpr std::array<unsigned int, 3> STANDARD_FEE_TARGETS{1, DEFAULT_STANDARD_FEE_TARGET, 6};
+const QRegularExpression CUSTOM_FEE_RATE_PATTERN{QStringLiteral(R"(^[0-9]+(?:\.[0-9]{0,3})?$)")};
 
 int FallbackFeeMultiplier(const unsigned int target)
 {
@@ -54,6 +56,40 @@ QString FormatFeeEstimate(CAmount amount)
     BitcoinAmount bitcoin_amount;
     bitcoin_amount.setSatoshi(amount);
     return bitcoin_amount.toDisplay() + QStringLiteral(" ") + bitcoin_amount.unitLabel();
+}
+
+std::optional<CAmount> ParseCustomFeeRatePerKvB(const QString& custom_fee_rate)
+{
+    const QString trimmed = custom_fee_rate.trimmed();
+    if (trimmed.isEmpty() || !CUSTOM_FEE_RATE_PATTERN.match(trimmed).hasMatch()) {
+        return std::nullopt;
+    }
+
+    const QStringList parts = trimmed.split('.');
+    bool whole_ok{false};
+    const CAmount whole_part{parts.at(0).toLongLong(&whole_ok)};
+    if (!whole_ok) {
+        return std::nullopt;
+    }
+
+    QString fractional_part = parts.size() == 2 ? parts.at(1) : QString{};
+    while (fractional_part.size() < 3) {
+        fractional_part += QLatin1Char{'0'};
+    }
+
+    bool fractional_ok{false};
+    const CAmount fractional_value{
+        fractional_part.isEmpty() ? 0 : fractional_part.toLongLong(&fractional_ok)};
+    if (!fractional_part.isEmpty() && !fractional_ok) {
+        return std::nullopt;
+    }
+
+    const CAmount fee_rate_per_kvb = (whole_part * FEE_RATE_BASIS_VBYTES) + fractional_value;
+    if (fee_rate_per_kvb <= 0) {
+        return std::nullopt;
+    }
+
+    return fee_rate_per_kvb;
 }
 
 void ApplyPreviewChangeDestination(wallet::CCoinControl& coin_control, const QString& preview_change_address)
@@ -126,6 +162,24 @@ std::optional<QString> EstimatePreviewFee(interfaces::Wallet& wallet,
     fallback_coin_control.m_feerate = CFeeRate{required_fee_per_k * FallbackFeeMultiplier(target)};
 
     if (const auto fee = TryPreviewFee(wallet, recipients, fallback_coin_control)) {
+        return FormatFeeEstimate(*fee);
+    }
+
+    return std::nullopt;
+}
+
+std::optional<QString> EstimateCustomPreviewFee(interfaces::Wallet& wallet,
+                                                const std::vector<wallet::CRecipient>& recipients,
+                                                const wallet::CCoinControl& base_coin_control,
+                                                const QString& preview_change_address,
+                                                const CAmount fee_rate_per_kvb)
+{
+    wallet::CCoinControl coin_control{base_coin_control};
+    coin_control.m_confirm_target.reset();
+    coin_control.m_feerate = CFeeRate{fee_rate_per_kvb};
+    ApplyPreviewChangeDestination(coin_control, preview_change_address);
+
+    if (const auto fee = TryPreviewFee(wallet, recipients, coin_control)) {
         return FormatFeeEstimate(*fee);
     }
 
@@ -266,7 +320,15 @@ CAmount WalletQmlModel::balanceSatoshi() const
 
 QString WalletQmlModel::estimatedFee() const
 {
+    if (m_custom_fee_enabled) {
+        return customFeeRateValid() ? m_custom_fee_estimate : QString{};
+    }
     return estimatedFeeForTarget(feeTargetBlocks());
+}
+
+bool WalletQmlModel::customFeeRateValid() const
+{
+    return ParseCustomFeeRatePerKvB(m_custom_fee_rate).has_value();
 }
 
 QString WalletQmlModel::estimatedFeeForTarget(const unsigned int target_blocks) const
@@ -477,6 +539,9 @@ void WalletQmlModel::requestFeeEstimatesNow()
     const quint64 request_id = ++m_fee_estimate_request_id;
     const QString preview_change_address = ensurePreviewChangeAddress();
     const wallet::CCoinControl base_coin_control{m_coin_control};
+    const bool custom_fee_enabled{m_custom_fee_enabled};
+    const std::optional<CAmount> custom_fee_rate_per_kvb{
+        ParseCustomFeeRatePerKvB(m_custom_fee_rate)};
     interfaces::Wallet* const wallet = m_wallet.get();
 
     if (!m_fee_estimate_pending) {
@@ -486,8 +551,9 @@ void WalletQmlModel::requestFeeEstimatesNow()
         Q_EMIT feeEstimateRevisionChanged();
     }
 
-    QTimer::singleShot(0, m_fee_estimation_worker, [this, request_id, recipients = *recipients, base_coin_control, preview_change_address, wallet]() {
+    QTimer::singleShot(0, m_fee_estimation_worker, [this, request_id, recipients = *recipients, base_coin_control, preview_change_address, custom_fee_enabled, custom_fee_rate_per_kvb, wallet]() {
         QHash<unsigned int, QString> estimates;
+        QString custom_estimate;
 
         for (const unsigned int target : STANDARD_FEE_TARGETS) {
             if (const auto estimate = EstimatePreviewFee(*wallet,
@@ -499,21 +565,39 @@ void WalletQmlModel::requestFeeEstimatesNow()
             }
         }
 
-        QMetaObject::invokeMethod(this, [this, estimates, request_id]() {
-            applyFeeEstimates(estimates, request_id);
+        if (custom_fee_enabled && custom_fee_rate_per_kvb.has_value()) {
+            if (const auto estimate = EstimateCustomPreviewFee(*wallet,
+                                                               recipients,
+                                                               base_coin_control,
+                                                               preview_change_address,
+                                                               *custom_fee_rate_per_kvb)) {
+                custom_estimate = *estimate;
+            }
+        }
+
+        QMetaObject::invokeMethod(this, [this, estimates, custom_estimate, request_id]() {
+            applyFeeEstimates(estimates, custom_estimate, request_id);
         }, Qt::QueuedConnection);
     });
 }
 
-void WalletQmlModel::applyFeeEstimates(const QHash<unsigned int, QString>& estimates, const quint64 request_id)
+void WalletQmlModel::applyFeeEstimates(const QHash<unsigned int, QString>& estimates,
+                                       const QString& custom_estimate,
+                                       const quint64 request_id)
 {
     if (request_id != m_fee_estimate_request_id) {
         return;
     }
 
     bool estimates_changed{m_fee_estimates != estimates};
+    bool custom_estimate_changed{m_custom_fee_estimate != custom_estimate};
     if (estimates_changed) {
         m_fee_estimates = estimates;
+    }
+    if (custom_estimate_changed) {
+        m_custom_fee_estimate = custom_estimate;
+    }
+    if (estimates_changed || custom_estimate_changed) {
         Q_EMIT estimatedFeeChanged();
     }
 
@@ -523,7 +607,7 @@ void WalletQmlModel::applyFeeEstimates(const QHash<unsigned int, QString>& estim
         Q_EMIT feeEstimatePendingChanged();
     }
 
-    if (estimates_changed || pending_changed) {
+    if (estimates_changed || custom_estimate_changed || pending_changed) {
         ++m_fee_estimate_revision;
         Q_EMIT feeEstimateRevisionChanged();
     }
@@ -534,8 +618,14 @@ void WalletQmlModel::clearFeeEstimates()
     ++m_fee_estimate_request_id;
 
     bool estimates_changed{!m_fee_estimates.isEmpty()};
+    bool custom_estimate_changed{!m_custom_fee_estimate.isEmpty()};
     if (estimates_changed) {
         m_fee_estimates.clear();
+    }
+    if (custom_estimate_changed) {
+        m_custom_fee_estimate.clear();
+    }
+    if (estimates_changed || custom_estimate_changed) {
         Q_EMIT estimatedFeeChanged();
     }
 
@@ -545,7 +635,7 @@ void WalletQmlModel::clearFeeEstimates()
         Q_EMIT feeEstimatePendingChanged();
     }
 
-    if (estimates_changed || pending_changed) {
+    if (estimates_changed || custom_estimate_changed || pending_changed) {
         ++m_fee_estimate_revision;
         Q_EMIT feeEstimateRevisionChanged();
     }
@@ -568,11 +658,20 @@ bool WalletQmlModel::prepareTransaction()
     }
 
     wallet::CCoinControl coin_control{m_coin_control};
-    coin_control.m_feerate.reset();
-    if (!coin_control.m_confirm_target.has_value()) {
-        coin_control.m_confirm_target = DEFAULT_STANDARD_FEE_TARGET;
+    if (m_custom_fee_enabled) {
+        const auto custom_fee_rate_per_kvb = ParseCustomFeeRatePerKvB(m_custom_fee_rate);
+        if (!custom_fee_rate_per_kvb.has_value()) {
+            return false;
+        }
+        coin_control.m_confirm_target.reset();
+        coin_control.m_feerate = CFeeRate{*custom_fee_rate_per_kvb};
+    } else {
+        coin_control.m_feerate.reset();
+        if (!coin_control.m_confirm_target.has_value()) {
+            coin_control.m_confirm_target = DEFAULT_STANDARD_FEE_TARGET;
+        }
+        ApplyRegtestStaticFeeOverride(coin_control);
     }
-    ApplyRegtestStaticFeeOverride(coin_control);
 
     CAmount balance = m_wallet->getBalance();
     if (balance < total) {
@@ -688,4 +787,34 @@ void WalletQmlModel::setFeeTargetBlocks(unsigned int target_blocks)
         Q_EMIT estimatedFeeChanged();
         scheduleFeeEstimates();
     }
+}
+
+void WalletQmlModel::setCustomFeeEnabled(const bool enabled)
+{
+    if (m_custom_fee_enabled != enabled) {
+        m_custom_fee_enabled = enabled;
+        Q_EMIT customFeeEnabledChanged();
+        Q_EMIT estimatedFeeChanged();
+        scheduleFeeEstimates();
+    }
+}
+
+void WalletQmlModel::setCustomFeeRate(const QString& fee_rate)
+{
+    const QString trimmed_fee_rate = fee_rate.trimmed();
+    const bool was_valid = customFeeRateValid();
+
+    if (m_custom_fee_rate == trimmed_fee_rate) {
+        return;
+    }
+
+    m_custom_fee_rate = trimmed_fee_rate;
+    m_custom_fee_estimate.clear();
+
+    Q_EMIT customFeeRateChanged();
+    if (was_valid != customFeeRateValid()) {
+        Q_EMIT customFeeRateValidChanged();
+    }
+    Q_EMIT estimatedFeeChanged();
+    scheduleFeeEstimates();
 }

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -653,8 +653,12 @@ bool WalletQmlModel::prepareTransaction()
     }
 
     CAmount total = 0;
+    bool subtract_fee_from_amount = false;
     for (const auto& recipient : *vec_send) {
         total += recipient.nAmount;
+        if (recipient.fSubtractFeeFromAmount) {
+            subtract_fee_from_amount = true;
+        }
     }
 
     wallet::CCoinControl coin_control{m_coin_control};
@@ -689,6 +693,9 @@ bool WalletQmlModel::prepareTransaction()
         m_current_transaction = new WalletQmlModelTransaction(m_send_recipients, this);
         m_current_transaction->setWtx(newTx);
         m_current_transaction->setTransactionFee(nFeeRequired);
+        if (subtract_fee_from_amount) {
+            m_current_transaction->reassignAmounts(nChangePosRet);
+        }
         Q_EMIT currentTransactionChanged();
         return true;
     } else {

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -5,6 +5,7 @@
 
 #include <qml/models/walletqmlmodel.h>
 
+#include <qml/bitcoinamount.h>
 #include <qml/models/activitylistmodel.h>
 #include <qml/models/paymentrequest.h>
 #include <qml/models/sendrecipient.h>
@@ -19,12 +20,53 @@
 #include <qml/bitcoinunits.h>
 #include <serialize.h>
 #include <streams.h>
+#include <util/threadnames.h>
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 
 #include <QDateTime>
+#include <QMetaObject>
+
+#include <array>
+#include <optional>
 
 namespace {
+constexpr unsigned int DEFAULT_STANDARD_FEE_TARGET{2};
+constexpr int FEE_ESTIMATE_DEBOUNCE_MS{250};
+constexpr std::array<unsigned int, 3> STANDARD_FEE_TARGETS{1, DEFAULT_STANDARD_FEE_TARGET, 6};
+
+QString FormatFeeEstimate(CAmount amount)
+{
+    BitcoinAmount bitcoin_amount;
+    bitcoin_amount.setSatoshi(amount);
+    return bitcoin_amount.toDisplay() + QStringLiteral(" ") + bitcoin_amount.unitLabel();
+}
+
+std::optional<std::vector<wallet::CRecipient>> BuildRecipients(const SendRecipientsListModel& recipients)
+{
+    std::vector<wallet::CRecipient> vec_send;
+    vec_send.reserve(recipients.recipients().size());
+
+    for (auto* recipient : recipients.recipients()) {
+        if (recipient == nullptr || !recipient->isValid()) {
+            return std::nullopt;
+        }
+
+        const CTxDestination destination = DecodeDestination(recipient->address()->address().toStdString());
+        if (!IsValidDestination(destination)) {
+            return std::nullopt;
+        }
+
+        vec_send.push_back({destination, recipient->cAmount(), recipient->subtractFeeFromAmount()});
+    }
+
+    if (vec_send.empty()) {
+        return std::nullopt;
+    }
+
+    return vec_send;
+}
+
 struct QmlReceiveRequestRecipient
 {
     static constexpr int CURRENT_VERSION{1};
@@ -68,6 +110,7 @@ WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObje
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
     m_current_payment_request = new PaymentRequest(this);
+    initializeFeeEstimator();
 }
 
 WalletQmlModel::WalletQmlModel(QObject* parent)
@@ -77,10 +120,19 @@ WalletQmlModel::WalletQmlModel(QObject* parent)
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
     m_current_payment_request = new PaymentRequest(this);
+    initializeFeeEstimator();
 }
 
 WalletQmlModel::~WalletQmlModel()
 {
+    if (m_fee_estimation_timer) {
+        m_fee_estimation_timer->stop();
+    }
+    if (m_fee_estimation_thread) {
+        m_fee_estimation_thread->quit();
+        m_fee_estimation_thread->wait();
+    }
+    delete m_fee_estimation_worker;
     delete m_activity_list_model;
     delete m_coins_list_model;
     delete m_send_recipients;
@@ -88,6 +140,22 @@ WalletQmlModel::~WalletQmlModel()
     if (m_current_transaction) {
         delete m_current_transaction;
     }
+}
+
+void WalletQmlModel::initializeFeeEstimator()
+{
+    m_fee_estimation_worker = new QObject;
+    m_fee_estimation_thread = new QThread(this);
+    m_fee_estimation_worker->moveToThread(m_fee_estimation_thread);
+    m_fee_estimation_thread->start();
+    QTimer::singleShot(0, m_fee_estimation_worker, []() {
+        util::ThreadRename("qml-fee-est");
+    });
+
+    m_fee_estimation_timer = new QTimer(this);
+    m_fee_estimation_timer->setSingleShot(true);
+    m_fee_estimation_timer->setInterval(FEE_ESTIMATE_DEBOUNCE_MS);
+    connect(m_fee_estimation_timer, &QTimer::timeout, this, &WalletQmlModel::requestFeeEstimatesNow);
 }
 
 QString WalletQmlModel::balance() const
@@ -104,6 +172,32 @@ CAmount WalletQmlModel::balanceSatoshi() const
         return 0;
     }
     return m_wallet->getBalance();
+}
+
+QString WalletQmlModel::estimatedFee() const
+{
+    return estimatedFeeForTarget(feeTargetBlocks());
+}
+
+QString WalletQmlModel::estimatedFeeForTarget(const unsigned int target_blocks) const
+{
+    const QString estimate = m_fee_estimates.value(target_blocks);
+    if (!estimate.isEmpty()) {
+        return estimate;
+    }
+
+    return m_fee_estimate_pending ? QStringLiteral("…") : QStringLiteral("—");
+}
+
+int WalletQmlModel::feeTargetIndex(const unsigned int target_blocks) const
+{
+    for (size_t i = 0; i < STANDARD_FEE_TARGETS.size(); ++i) {
+        if (STANDARD_FEE_TARGETS[i] == target_blocks) {
+            return static_cast<int>(i);
+        }
+    }
+
+    return 1;
 }
 
 QString WalletQmlModel::name() const
@@ -248,20 +342,154 @@ std::unique_ptr<interfaces::Handler> WalletQmlModel::handleTransactionChanged(Tr
     return m_wallet->handleTransactionChanged(fn);
 }
 
+void WalletQmlModel::scheduleFeeEstimates()
+{
+    if (m_fee_estimation_timer == nullptr) {
+        return;
+    }
+
+    if (!m_wallet || !m_send_recipients) {
+        clearFeeEstimates();
+        return;
+    }
+
+    m_fee_estimation_timer->start();
+}
+
+QString WalletQmlModel::ensurePreviewChangeAddress()
+{
+    if (!m_wallet || !m_preview_change_address.isEmpty()) {
+        return m_preview_change_address;
+    }
+
+    const auto destination = m_wallet->getNewDestination(m_wallet->getDefaultAddressType(), "qml-fee-preview");
+    if (!destination) {
+        return {};
+    }
+
+    m_preview_change_address = QString::fromStdString(EncodeDestination(destination.value()));
+    return m_preview_change_address;
+}
+
+void WalletQmlModel::requestFeeEstimatesNow()
+{
+    if (!m_wallet || !m_send_recipients) {
+        clearFeeEstimates();
+        return;
+    }
+
+    const auto recipients = BuildRecipients(*m_send_recipients);
+    if (!recipients.has_value()) {
+        clearFeeEstimates();
+        return;
+    }
+
+    const quint64 request_id = ++m_fee_estimate_request_id;
+    const QString preview_change_address = ensurePreviewChangeAddress();
+    const wallet::CCoinControl base_coin_control{m_coin_control};
+    interfaces::Wallet* const wallet = m_wallet.get();
+
+    if (!m_fee_estimate_pending) {
+        m_fee_estimate_pending = true;
+        Q_EMIT feeEstimatePendingChanged();
+        ++m_fee_estimate_revision;
+        Q_EMIT feeEstimateRevisionChanged();
+    }
+
+    QTimer::singleShot(0, m_fee_estimation_worker, [this, request_id, recipients = *recipients, base_coin_control, preview_change_address, wallet]() {
+        QHash<unsigned int, QString> estimates;
+
+        for (const unsigned int target : STANDARD_FEE_TARGETS) {
+            wallet::CCoinControl coin_control{base_coin_control};
+            coin_control.m_feerate.reset();
+            coin_control.m_confirm_target = target;
+
+            if (!preview_change_address.isEmpty()) {
+                const CTxDestination change_destination = DecodeDestination(preview_change_address.toStdString());
+                if (IsValidDestination(change_destination)) {
+                    coin_control.destChange = change_destination;
+                }
+            }
+
+            int change_position{-1};
+            CAmount fee{0};
+            const auto result = wallet->createTransaction(recipients, coin_control, /*sign=*/false, change_position, fee);
+            if (result) {
+                estimates.insert(target, FormatFeeEstimate(fee));
+            }
+        }
+
+        QMetaObject::invokeMethod(this, [this, estimates, request_id]() {
+            applyFeeEstimates(estimates, request_id);
+        }, Qt::QueuedConnection);
+    });
+}
+
+void WalletQmlModel::applyFeeEstimates(const QHash<unsigned int, QString>& estimates, const quint64 request_id)
+{
+    if (request_id != m_fee_estimate_request_id) {
+        return;
+    }
+
+    bool estimates_changed{m_fee_estimates != estimates};
+    if (estimates_changed) {
+        m_fee_estimates = estimates;
+        Q_EMIT estimatedFeeChanged();
+    }
+
+    bool pending_changed{m_fee_estimate_pending};
+    if (pending_changed) {
+        m_fee_estimate_pending = false;
+        Q_EMIT feeEstimatePendingChanged();
+    }
+
+    if (estimates_changed || pending_changed) {
+        ++m_fee_estimate_revision;
+        Q_EMIT feeEstimateRevisionChanged();
+    }
+}
+
+void WalletQmlModel::clearFeeEstimates()
+{
+    ++m_fee_estimate_request_id;
+
+    bool estimates_changed{!m_fee_estimates.isEmpty()};
+    if (estimates_changed) {
+        m_fee_estimates.clear();
+        Q_EMIT estimatedFeeChanged();
+    }
+
+    bool pending_changed{m_fee_estimate_pending};
+    if (pending_changed) {
+        m_fee_estimate_pending = false;
+        Q_EMIT feeEstimatePendingChanged();
+    }
+
+    if (estimates_changed || pending_changed) {
+        ++m_fee_estimate_revision;
+        Q_EMIT feeEstimateRevisionChanged();
+    }
+}
+
 bool WalletQmlModel::prepareTransaction()
 {
     if (!m_wallet || !m_send_recipients || m_send_recipients->recipients().empty()) {
         return false;
     }
 
-    std::vector<wallet::CRecipient> vecSend;
+    const auto vec_send = BuildRecipients(*m_send_recipients);
+    if (!vec_send.has_value()) {
+        return false;
+    }
+
     CAmount total = 0;
-    for (auto* recipient : m_send_recipients->recipients()) {
-        CTxDestination destination = DecodeDestination(recipient->address()->address().toStdString());
-        wallet::CRecipient c_recipient = {destination, recipient->cAmount(), recipient->subtractFeeFromAmount()};
-        m_coin_control.m_feerate = CFeeRate(1000);
-        vecSend.push_back(c_recipient);
-        total += recipient->cAmount();
+    for (const auto& recipient : *vec_send) {
+        total += recipient.nAmount;
+    }
+
+    m_coin_control.m_feerate.reset();
+    if (!m_coin_control.m_confirm_target.has_value()) {
+        m_coin_control.m_confirm_target = DEFAULT_STANDARD_FEE_TARGET;
     }
 
     CAmount balance = m_wallet->getBalance();
@@ -271,7 +499,7 @@ bool WalletQmlModel::prepareTransaction()
 
     int nChangePosRet = -1;
     CAmount nFeeRequired = 0;
-    const auto& res = m_wallet->createTransaction(vecSend, m_coin_control, true, nChangePosRet, nFeeRequired);
+    const auto& res = m_wallet->createTransaction(*vec_send, m_coin_control, true, nChangePosRet, nFeeRequired);
     if (res) {
         if (m_current_transaction) {
             delete m_current_transaction;
@@ -346,11 +574,13 @@ void WalletQmlModel::listLockedCoins(std::vector<COutPoint>& outputs)
 void WalletQmlModel::selectCoin(const COutPoint& output)
 {
     m_coin_control.Select(output);
+    scheduleFeeEstimates();
 }
 
 void WalletQmlModel::unselectCoin(const COutPoint& output)
 {
     m_coin_control.UnSelect(output);
+    scheduleFeeEstimates();
 }
 
 bool WalletQmlModel::isSelectedCoin(const COutPoint& output)
@@ -365,7 +595,7 @@ std::vector<COutPoint> WalletQmlModel::listSelectedCoins() const
 
 unsigned int WalletQmlModel::feeTargetBlocks() const
 {
-    return m_coin_control.m_confirm_target.value_or(wallet::DEFAULT_TX_CONFIRM_TARGET);
+    return m_coin_control.m_confirm_target.value_or(DEFAULT_STANDARD_FEE_TARGET);
 }
 
 void WalletQmlModel::setFeeTargetBlocks(unsigned int target_blocks)
@@ -373,5 +603,7 @@ void WalletQmlModel::setFeeTargetBlocks(unsigned int target_blocks)
     if (m_coin_control.m_confirm_target != target_blocks) {
         m_coin_control.m_confirm_target = target_blocks;
         Q_EMIT feeTargetBlocksChanged();
+        Q_EMIT estimatedFeeChanged();
+        scheduleFeeEstimates();
     }
 }

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -37,6 +37,9 @@ class WalletQmlModel : public QObject
     Q_PROPERTY(WalletQmlModelTransaction* currentTransaction READ currentTransaction NOTIFY currentTransactionChanged)
     Q_PROPERTY(unsigned int targetBlocks READ feeTargetBlocks WRITE setFeeTargetBlocks NOTIFY feeTargetBlocksChanged)
     Q_PROPERTY(QString estimatedFee READ estimatedFee NOTIFY estimatedFeeChanged)
+    Q_PROPERTY(bool customFeeEnabled READ customFeeEnabled WRITE setCustomFeeEnabled NOTIFY customFeeEnabledChanged)
+    Q_PROPERTY(QString customFeeRate READ customFeeRate WRITE setCustomFeeRate NOTIFY customFeeRateChanged)
+    Q_PROPERTY(bool customFeeRateValid READ customFeeRateValid NOTIFY customFeeRateValidChanged)
     Q_PROPERTY(bool feeEstimatePending READ feeEstimatePending NOTIFY feeEstimatePendingChanged)
     Q_PROPERTY(int feeEstimateRevision READ feeEstimateRevision NOTIFY feeEstimateRevisionChanged)
     Q_PROPERTY(bool isWalletLoaded READ isWalletLoaded NOTIFY walletIsLoadedChanged)
@@ -57,6 +60,9 @@ public:
     PaymentRequest* currentPaymentRequest() const { return m_current_payment_request; }
     WalletQmlModelTransaction* currentTransaction() const { return m_current_transaction; }
     QString estimatedFee() const;
+    bool customFeeEnabled() const { return m_custom_fee_enabled; }
+    QString customFeeRate() const { return m_custom_fee_rate; }
+    bool customFeeRateValid() const;
     bool feeEstimatePending() const { return m_fee_estimate_pending; }
     int feeEstimateRevision() const { return m_fee_estimate_revision; }
     Q_INVOKABLE bool prepareTransaction();
@@ -88,6 +94,8 @@ public:
     std::vector<COutPoint> listSelectedCoins() const;
     unsigned int feeTargetBlocks() const;
     void setFeeTargetBlocks(unsigned int target_blocks);
+    void setCustomFeeEnabled(bool enabled);
+    void setCustomFeeRate(const QString& fee_rate);
 
     bool isWalletLoaded() const { return m_is_wallet_loaded; }
     void setWalletLoaded(bool loaded);
@@ -98,6 +106,9 @@ Q_SIGNALS:
     void currentTransactionChanged();
     void feeTargetBlocksChanged();
     void estimatedFeeChanged();
+    void customFeeEnabledChanged();
+    void customFeeRateChanged();
+    void customFeeRateValidChanged();
     void feeEstimatePendingChanged();
     void feeEstimateRevisionChanged();
     void walletIsLoadedChanged();
@@ -105,7 +116,9 @@ Q_SIGNALS:
 private:
     void initializeFeeEstimator();
     void requestFeeEstimatesNow();
-    void applyFeeEstimates(const QHash<unsigned int, QString>& estimates, quint64 request_id);
+    void applyFeeEstimates(const QHash<unsigned int, QString>& estimates,
+                           const QString& custom_estimate,
+                           quint64 request_id);
     void clearFeeEstimates();
     QString ensurePreviewChangeAddress();
     unsigned int nextPaymentRequestId() const;
@@ -121,9 +134,12 @@ private:
     QThread* m_fee_estimation_thread{nullptr};
     QTimer* m_fee_estimation_timer{nullptr};
     QHash<unsigned int, QString> m_fee_estimates;
+    QString m_custom_fee_estimate;
+    QString m_custom_fee_rate;
     QString m_preview_change_address;
     quint64 m_fee_estimate_request_id{0};
     int m_fee_estimate_revision{0};
+    bool m_custom_fee_enabled{false};
     bool m_fee_estimate_pending{false};
     bool m_is_wallet_loaded{false};
 };

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -20,7 +20,10 @@
 #include <memory>
 #include <vector>
 
+#include <QHash>
 #include <QObject>
+#include <QThread>
+#include <QTimer>
 
 class WalletQmlModel : public QObject
 {
@@ -33,6 +36,9 @@ class WalletQmlModel : public QObject
     Q_PROPERTY(PaymentRequest* currentPaymentRequest READ currentPaymentRequest CONSTANT)
     Q_PROPERTY(WalletQmlModelTransaction* currentTransaction READ currentTransaction NOTIFY currentTransactionChanged)
     Q_PROPERTY(unsigned int targetBlocks READ feeTargetBlocks WRITE setFeeTargetBlocks NOTIFY feeTargetBlocksChanged)
+    Q_PROPERTY(QString estimatedFee READ estimatedFee NOTIFY estimatedFeeChanged)
+    Q_PROPERTY(bool feeEstimatePending READ feeEstimatePending NOTIFY feeEstimatePendingChanged)
+    Q_PROPERTY(int feeEstimateRevision READ feeEstimateRevision NOTIFY feeEstimateRevisionChanged)
     Q_PROPERTY(bool isWalletLoaded READ isWalletLoaded NOTIFY walletIsLoadedChanged)
 
 public:
@@ -50,9 +56,15 @@ public:
     SendRecipientsListModel* sendRecipientList() const { return m_send_recipients; }
     PaymentRequest* currentPaymentRequest() const { return m_current_payment_request; }
     WalletQmlModelTransaction* currentTransaction() const { return m_current_transaction; }
+    QString estimatedFee() const;
+    bool feeEstimatePending() const { return m_fee_estimate_pending; }
+    int feeEstimateRevision() const { return m_fee_estimate_revision; }
     Q_INVOKABLE bool prepareTransaction();
     Q_INVOKABLE void sendTransaction();
     Q_INVOKABLE QString newAddress(QString label);
+    Q_INVOKABLE QString estimatedFeeForTarget(unsigned int target_blocks) const;
+    Q_INVOKABLE int feeTargetIndex(unsigned int target_blocks) const;
+    Q_INVOKABLE void scheduleFeeEstimates();
 
     std::set<interfaces::WalletTx> getWalletTxs() const;
     interfaces::WalletTx getWalletTx(const uint256& hash) const;
@@ -85,9 +97,17 @@ Q_SIGNALS:
     void balanceChanged();
     void currentTransactionChanged();
     void feeTargetBlocksChanged();
+    void estimatedFeeChanged();
+    void feeEstimatePendingChanged();
+    void feeEstimateRevisionChanged();
     void walletIsLoadedChanged();
 
 private:
+    void initializeFeeEstimator();
+    void requestFeeEstimatesNow();
+    void applyFeeEstimates(const QHash<unsigned int, QString>& estimates, quint64 request_id);
+    void clearFeeEstimates();
+    QString ensurePreviewChangeAddress();
     unsigned int nextPaymentRequestId() const;
 
     std::unique_ptr<interfaces::Wallet> m_wallet;
@@ -97,6 +117,14 @@ private:
     PaymentRequest* m_current_payment_request{nullptr};
     WalletQmlModelTransaction* m_current_transaction{nullptr};
     wallet::CCoinControl m_coin_control;
+    QObject* m_fee_estimation_worker{nullptr};
+    QThread* m_fee_estimation_thread{nullptr};
+    QTimer* m_fee_estimation_timer{nullptr};
+    QHash<unsigned int, QString> m_fee_estimates;
+    QString m_preview_change_address;
+    quint64 m_fee_estimate_request_id{0};
+    int m_fee_estimate_revision{0};
+    bool m_fee_estimate_pending{false};
     bool m_is_wallet_loaded{false};
 };
 

--- a/qml/models/walletqmlmodeltransaction.cpp
+++ b/qml/models/walletqmlmodeltransaction.cpp
@@ -59,10 +59,34 @@ void WalletQmlModelTransaction::setTransactionFee(const CAmount& newFee)
     if (m_fee != newFee) {
         m_fee = newFee;
         Q_EMIT feeChanged();
+        Q_EMIT totalChanged();
     }
 }
 
 CAmount WalletQmlModelTransaction::getTotalTransactionAmount() const
 {
     return m_amount + m_fee;
+}
+
+void WalletQmlModelTransaction::reassignAmounts(int nChangePosRet)
+{
+    const CTransaction* wallet_transaction = m_wtx.get();
+    if (!wallet_transaction) {
+        return;
+    }
+
+    CAmount reassigned_amount = 0;
+    for (size_t recipient_index = 0; recipient_index < wallet_transaction->vout.size(); ++recipient_index) {
+        if (static_cast<int>(recipient_index) == nChangePosRet) {
+            continue;
+        }
+
+        reassigned_amount += wallet_transaction->vout[recipient_index].nValue;
+    }
+
+    if (m_amount != reassigned_amount) {
+        m_amount = reassigned_amount;
+        Q_EMIT amountChanged();
+        Q_EMIT totalChanged();
+    }
 }

--- a/qml/pages/wallet/DesktopWallets.qml
+++ b/qml/pages/wallet/DesktopWallets.qml
@@ -68,16 +68,19 @@ Page {
             visible: walletController.isWalletLoaded
             NavigationTab {
                 id: activityTabButton
+                objectName: "walletActivityTabButton"
                 text: qsTr("Activity")
                 property int index: 0
                 ButtonGroup.group: navigationTabs
             }
             NavigationTab {
+                objectName: "walletSendTabButton"
                 text: qsTr("Send")
                 property int index: 1
                 ButtonGroup.group: navigationTabs
             }
             NavigationTab {
+                objectName: "walletReceiveTabButton"
                 text: qsTr("Receive")
                 property int index: 2
                 ButtonGroup.group: navigationTabs

--- a/qml/pages/wallet/MultipleSendReview.qml
+++ b/qml/pages/wallet/MultipleSendReview.qml
@@ -12,6 +12,7 @@ import "../../components"
 
 Page {
     id: root
+    objectName: "walletMultipleSendReviewPage"
     background: null
 
     property WalletQmlModel wallet: walletController.selectedWallet
@@ -108,6 +109,7 @@ Page {
                     Layout.fillWidth: true
                 }
                 CoreText {
+                    objectName: "multipleSendReviewTotalValue"
                     text: root.transaction.total
                     font.pixelSize: 20
                     color: Theme.color.neutral9
@@ -130,6 +132,7 @@ Page {
                     Layout.fillWidth: true
                 }
                 CoreText {
+                    objectName: "multipleSendReviewFeeValue"
                     text: root.transaction.fee
                     font.pixelSize: 15
                 }
@@ -142,6 +145,7 @@ Page {
 
             ContinueButton {
                 id: confirmationButton
+                objectName: "multipleSendReviewSendButton"
                 Layout.fillWidth: true
                 Layout.topMargin: 30
                 text: qsTr("Send")

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -368,6 +368,7 @@ PageStack {
                 }
 
                 RowLayout {
+                    objectName: "sendFeeIncludedNote"
                     Layout.fillWidth: true
                     visible: root.recipient && root.recipient.subtractFeeFromAmount
 
@@ -378,6 +379,7 @@ PageStack {
                     }
 
                     CoreText {
+                        objectName: "sendFeeIncludedNoteText"
                         Layout.fillWidth: true
                         text: qsTr("Fees are included in the amount")
                         font.pixelSize: 15

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -350,10 +350,39 @@ PageStack {
                     id: feeSelection
                     Layout.fillWidth: true
                     walletModel: root.wallet
+                    includeFeeInAmount: root.recipient ? root.recipient.subtractFeeFromAmount : false
                     currentTarget: root.wallet ? root.wallet.targetBlocks : 2
 
                     onFeeChanged: function(target) {
                         root.wallet.targetBlocks = target
+                    }
+
+                    onIncludeFeeInAmountToggled: function(checked) {
+                        if (root.recipient && root.recipient.subtractFeeFromAmount !== checked) {
+                            root.recipient.subtractFeeFromAmount = checked
+                            if (root.wallet) {
+                                root.wallet.scheduleFeeEstimates()
+                            }
+                        }
+                    }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    visible: root.recipient && root.recipient.subtractFeeFromAmount
+
+                    Icon {
+                        source: "image://images/check"
+                        size: 18
+                        color: Theme.color.green
+                    }
+
+                    CoreText {
+                        Layout.fillWidth: true
+                        text: qsTr("Fees are included in the amount")
+                        font.pixelSize: 15
+                        color: Theme.color.neutral7
+                        horizontalAlignment: Text.AlignLeft
                     }
                 }
 

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -368,6 +368,7 @@ PageStack {
                     Layout.topMargin: 30
                     text: qsTr("Review")
                     enabled: root.recipient.isValid
+                        && (!root.wallet || !root.wallet.customFeeEnabled || root.wallet.customFeeRateValid)
                     onClicked: {
                         if (root.wallet.prepareTransaction()) {
                             root.transactionPrepared(settings.multipleRecipientsEnabled);

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 The Bitcoin Core developers
+// Copyright (c) 2024 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -13,6 +13,7 @@ import "../../components"
 
 PageStack {
     id: root
+    objectName: "walletSendPage"
     vertical: true
 
     property WalletQmlModel wallet: walletController.selectedWallet
@@ -28,12 +29,33 @@ PageStack {
     }
 
     Connections {
-        target: root.wallet.recipients
+        target: root.wallet ? root.wallet.recipients : null
         function onListCleared() {
             settings.multipleRecipientsEnabled = false
+            if (root.wallet) {
+                root.wallet.scheduleFeeEstimates()
+            }
+        }
+        function onCountChanged() {
+            if (root.wallet) {
+                root.wallet.scheduleFeeEstimates()
+            }
+        }
+        function onCurrentRecipientChanged() {
+            if (root.wallet) {
+                root.wallet.scheduleFeeEstimates()
+            }
         }
     }
 
+    Connections {
+        target: root.wallet ? root.wallet.coinsListModel : null
+        function onSelectedCoinsCountChanged() {
+            if (root.wallet) {
+                root.wallet.scheduleFeeEstimates()
+            }
+        }
+    }
 
     initialItem: Page {
         background: null
@@ -171,9 +193,12 @@ PageStack {
 
                 BitcoinAddressInputField {
                     Layout.fillWidth: true
+                    inputObjectName: "sendAddressInput"
                     enabled: walletController.initialized
                     address: root.recipient.address
                     errorText: root.recipient.addressError
+                    onTextChanged: if (root.wallet) root.wallet.scheduleFeeEstimates()
+                    onEditingFinished: if (root.wallet) root.wallet.scheduleFeeEstimates()
                 }
 
                 Separator {
@@ -198,6 +223,7 @@ PageStack {
 
                         TextField {
                             id: amountInput
+                            objectName: "sendAmountInput"
                             anchors.left: amountLabel.right
                             anchors.verticalCenter: parent.verticalCenter
                             leftPadding: 0
@@ -210,11 +236,25 @@ PageStack {
                             placeholderText: "0.00000000"
                             selectByMouse: true
                             text: root.recipient.amount.display
+                            onTextChanged: {
+                                root.recipient.amount.display = text
+                                if (root.wallet) {
+                                    root.wallet.scheduleFeeEstimates()
+                                }
+                            }
                             onTextEdited: root.recipient.amount.display = text
-                            onEditingFinished: root.recipient.amount.format()
+                            onEditingFinished: {
+                                root.recipient.amount.format()
+                                if (root.wallet) {
+                                    root.wallet.scheduleFeeEstimates()
+                                }
+                            }
                             onActiveFocusChanged: {
                                 if (!activeFocus) {
                                     root.recipient.amount.format()
+                                    if (root.wallet) {
+                                        root.wallet.scheduleFeeEstimates()
+                                    }
                                 }
                             }
                             validator: RegularExpressionValidator {
@@ -278,6 +318,7 @@ PageStack {
 
                 LabeledTextInput {
                     id: label
+                    inputObjectName: "sendNoteInput"
                     Layout.fillWidth: true
                     labelText: qsTr("Note to self")
                     placeholderText: qsTr("Enter ...")
@@ -308,14 +349,21 @@ PageStack {
                 FeeSelection {
                     id: feeSelection
                     Layout.fillWidth: true
+                    walletModel: root.wallet
+                    currentTarget: root.wallet ? root.wallet.targetBlocks : 2
 
-                    onFeeChanged: {
+                    onFeeChanged: function(target) {
                         root.wallet.targetBlocks = target
                     }
                 }
 
+                Separator {
+                    Layout.fillWidth: true
+                }
+
                 ContinueButton {
                     id: continueButton
+                    objectName: "sendContinueButton"
                     Layout.fillWidth: true
                     Layout.topMargin: 30
                     text: qsTr("Review")

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -83,7 +83,7 @@ PageStack {
 
             ColumnLayout {
                 id: columnLayout
-                width: 450
+                width: 520
                 anchors.horizontalCenter: parent.horizontalCenter
 
                 spacing: 10

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -18,8 +18,21 @@ PageStack {
 
     property WalletQmlModel wallet: walletController.selectedWallet
     property SendRecipient recipient: wallet.recipients.current
+    property string prepareTransactionErrorText: ""
 
     signal transactionPrepared(bool multipleRecipientsEnabled)
+
+    function clearPrepareTransactionError() {
+        if (prepareTransactionErrorText.length > 0) {
+            prepareTransactionErrorText = ""
+        }
+    }
+
+    function scheduleFeeEstimates() {
+        if (root.wallet) {
+            root.wallet.scheduleFeeEstimates()
+        }
+    }
 
     Connections {
         target: walletController
@@ -31,29 +44,37 @@ PageStack {
     Connections {
         target: root.wallet ? root.wallet.recipients : null
         function onListCleared() {
+            root.clearPrepareTransactionError()
             settings.multipleRecipientsEnabled = false
             if (root.wallet) {
                 root.wallet.scheduleFeeEstimates()
             }
         }
         function onCountChanged() {
-            if (root.wallet) {
-                root.wallet.scheduleFeeEstimates()
-            }
+            root.clearPrepareTransactionError()
+            root.scheduleFeeEstimates()
         }
         function onCurrentRecipientChanged() {
-            if (root.wallet) {
-                root.wallet.scheduleFeeEstimates()
-            }
+            root.clearPrepareTransactionError()
+            root.scheduleFeeEstimates()
         }
     }
 
     Connections {
         target: root.wallet ? root.wallet.coinsListModel : null
         function onSelectedCoinsCountChanged() {
-            if (root.wallet) {
-                root.wallet.scheduleFeeEstimates()
-            }
+            root.clearPrepareTransactionError()
+            root.scheduleFeeEstimates()
+        }
+    }
+
+    Connections {
+        target: root.wallet
+        function onCustomFeeEnabledChanged() {
+            root.clearPrepareTransactionError()
+        }
+        function onCustomFeeRateChanged() {
+            root.clearPrepareTransactionError()
         }
     }
 
@@ -197,8 +218,11 @@ PageStack {
                     enabled: walletController.initialized
                     address: root.recipient.address
                     errorText: root.recipient.addressError
-                    onTextChanged: if (root.wallet) root.wallet.scheduleFeeEstimates()
-                    onEditingFinished: if (root.wallet) root.wallet.scheduleFeeEstimates()
+                    onTextChanged: {
+                        root.clearPrepareTransactionError()
+                        root.scheduleFeeEstimates()
+                    }
+                    onEditingFinished: root.scheduleFeeEstimates()
                 }
 
                 Separator {
@@ -237,24 +261,19 @@ PageStack {
                             selectByMouse: true
                             text: root.recipient.amount.display
                             onTextChanged: {
+                                root.clearPrepareTransactionError()
                                 root.recipient.amount.display = text
-                                if (root.wallet) {
-                                    root.wallet.scheduleFeeEstimates()
-                                }
+                                root.scheduleFeeEstimates()
                             }
                             onTextEdited: root.recipient.amount.display = text
                             onEditingFinished: {
                                 root.recipient.amount.format()
-                                if (root.wallet) {
-                                    root.wallet.scheduleFeeEstimates()
-                                }
+                                root.scheduleFeeEstimates()
                             }
                             onActiveFocusChanged: {
                                 if (!activeFocus) {
                                     root.recipient.amount.format()
-                                    if (root.wallet) {
-                                        root.wallet.scheduleFeeEstimates()
-                                    }
+                                    root.scheduleFeeEstimates()
                                 }
                             }
                             validator: RegularExpressionValidator {
@@ -354,15 +373,17 @@ PageStack {
                     currentTarget: root.wallet ? root.wallet.targetBlocks : 2
 
                     onFeeChanged: function(target) {
-                        root.wallet.targetBlocks = target
+                        root.clearPrepareTransactionError()
+                        if (root.wallet) {
+                            root.wallet.targetBlocks = target
+                        }
                     }
 
                     onIncludeFeeInAmountToggled: function(checked) {
+                        root.clearPrepareTransactionError()
                         if (root.recipient && root.recipient.subtractFeeFromAmount !== checked) {
                             root.recipient.subtractFeeFromAmount = checked
-                            if (root.wallet) {
-                                root.wallet.scheduleFeeEstimates()
-                            }
+                            root.scheduleFeeEstimates()
                         }
                     }
                 }
@@ -381,7 +402,7 @@ PageStack {
                     CoreText {
                         objectName: "sendFeeIncludedNoteText"
                         Layout.fillWidth: true
-                        text: qsTr("Fees are included in the amount")
+                        text: qsTr("Fee is included in the amount")
                         font.pixelSize: 15
                         color: Theme.color.neutral7
                         horizontalAlignment: Text.AlignLeft
@@ -390,6 +411,27 @@ PageStack {
 
                 Separator {
                     Layout.fillWidth: true
+                }
+
+                RowLayout {
+                    objectName: "sendPrepareTransactionError"
+                    Layout.fillWidth: true
+                    visible: root.prepareTransactionErrorText.length > 0
+
+                    Icon {
+                        source: "image://images/alert-filled"
+                        size: 22
+                        color: Theme.color.red
+                    }
+
+                    CoreText {
+                        objectName: "sendPrepareTransactionErrorText"
+                        text: root.prepareTransactionErrorText
+                        font.pixelSize: 15
+                        color: Theme.color.red
+                        horizontalAlignment: Text.AlignLeft
+                        Layout.fillWidth: true
+                    }
                 }
 
                 ContinueButton {
@@ -401,8 +443,11 @@ PageStack {
                     enabled: root.recipient.isValid
                         && (!root.wallet || !root.wallet.customFeeEnabled || root.wallet.customFeeRateValid)
                     onClicked: {
+                        root.clearPrepareTransactionError()
                         if (root.wallet.prepareTransaction()) {
                             root.transactionPrepared(settings.multipleRecipientsEnabled);
+                        } else {
+                            root.prepareTransactionErrorText = qsTr("Amount plus fee exceeds available balance")
                         }
                     }
                 }

--- a/qml/pages/wallet/SendReview.qml
+++ b/qml/pages/wallet/SendReview.qml
@@ -12,6 +12,7 @@ import "../../components"
 
 Page {
     id: root
+    objectName: "walletSendReviewPage"
     background: null
 
     property WalletQmlModel wallet: walletController.selectedWallet
@@ -62,6 +63,7 @@ Page {
                     color: Theme.color.neutral7
                 }
                 CoreText {
+                    objectName: "sendReviewAddressValue"
                     text: root.transaction.address
                     font.pixelSize: 15
                     color: Theme.color.neutral9
@@ -76,6 +78,7 @@ Page {
                     color: Theme.color.neutral7
                 }
                 CoreText {
+                    objectName: "sendReviewNoteValue"
                     text: root.transaction.label
                     font.pixelSize: 15
                     color: Theme.color.neutral9
@@ -90,6 +93,7 @@ Page {
                     color: Theme.color.neutral7
                 }
                 CoreText {
+                    objectName: "sendReviewAmountValue"
                     text: root.transaction.amount
                     font.pixelSize: 15
                     color: Theme.color.neutral9
@@ -104,6 +108,7 @@ Page {
                     color: Theme.color.neutral7
                 }
                 CoreText {
+                    objectName: "sendReviewFeeValue"
                     text: root.transaction.fee
                     font.pixelSize: 15
                     color: Theme.color.neutral9
@@ -118,6 +123,7 @@ Page {
                     color: Theme.color.neutral7
                 }
                 CoreText {
+                    objectName: "sendReviewTotalValue"
                     text: root.transaction.total
                     font.pixelSize: 15
                     color: Theme.color.neutral9
@@ -125,7 +131,8 @@ Page {
             }
 
             ContinueButton {
-                id: confimationButton
+                id: confirmationButton
+                objectName: "sendReviewSendButton"
                 Layout.fillWidth: true
                 Layout.topMargin: 30
                 text: qsTr("Send")

--- a/qml/pages/wallet/SendReview.qml
+++ b/qml/pages/wallet/SendReview.qml
@@ -25,6 +25,7 @@ Page {
     header: NavigationBar2 {
         id: navbar
         leftItem: NavButton {
+            objectName: "sendReviewBackButton"
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
             onClicked: {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,7 +21,28 @@ add_executable(bitcoinqml_unit_tests
   test_qmlinitexecutor_api.cpp
   test_options_model.cpp
   test_banlistmodel.cpp
+  test_walletqmlmodel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinamount.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinunits.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/imageprovider.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/networkstyle.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/initexecutor.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/initexecutor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/wallet/coincontrol.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/activitylistmodel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/bitcoinaddress.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/coinslistmodel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/paymentrequest.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/sendrecipient.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/sendrecipientslistmodel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/transaction.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/walletqmlmodel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/walletqmlmodeltransaction.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerdetailsmodel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerlistmodel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerlistsortproxy.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/peerstatsutil.cpp
 )
 
 target_compile_definitions(bitcoinqml_unit_tests
@@ -35,6 +56,7 @@ target_include_directories(bitcoinqml_unit_tests
     ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src
     ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/univalue/include
     ${CMAKE_CURRENT_BINARY_DIR}/../bitcoin/src
+    ${PROJECT_BINARY_DIR}/bitcoin/src
 )
 
 target_link_libraries(bitcoinqml_unit_tests
@@ -54,6 +76,8 @@ add_test(NAME bitcoinqml_unit_tests COMMAND bitcoinqml_unit_tests -platform offs
 
 add_executable(bitcoinqml_qmltests
   qml/qml_tests_main.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/components/blockclockdial.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/controls/linegraph.cpp
 )
 
 target_compile_definitions(bitcoinqml_qmltests
@@ -69,6 +93,11 @@ target_link_libraries(bitcoinqml_qmltests
     Qt6::Qml
     Qt6::Quick
     Qt6::QuickTest
+)
+
+target_include_directories(bitcoinqml_qmltests
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
 add_test(NAME bitcoinqml_qmltests COMMAND bitcoinqml_qmltests -platform offscreen)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,27 +22,7 @@ add_executable(bitcoinqml_unit_tests
   test_options_model.cpp
   test_banlistmodel.cpp
   test_walletqmlmodel.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinamount.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/bitcoinunits.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/imageprovider.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/networkstyle.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/initexecutor.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/initexecutor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/wallet/coincontrol.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/activitylistmodel.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/bitcoinaddress.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/coinslistmodel.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/paymentrequest.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/sendrecipient.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/sendrecipientslistmodel.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/transaction.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/walletqmlmodel.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/walletqmlmodeltransaction.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerdetailsmodel.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerlistmodel.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/peerlistsortproxy.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/peerstatsutil.cpp
 )
 
 target_compile_definitions(bitcoinqml_unit_tests
@@ -56,7 +36,6 @@ target_include_directories(bitcoinqml_unit_tests
     ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src
     ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/univalue/include
     ${CMAKE_CURRENT_BINARY_DIR}/../bitcoin/src
-    ${PROJECT_BINARY_DIR}/bitcoin/src
 )
 
 target_link_libraries(bitcoinqml_unit_tests

--- a/test/functional/qml_test_send_receive.py
+++ b/test/functional/qml_test_send_receive.py
@@ -16,6 +16,10 @@ from qml_wallet_test_lib import WalletFlowHarness, rpc_call
 SEND_AMOUNT = "1.00000000"
 GUI_WALLET_NAME = "send_flow_wallet"
 RECEIVER_WALLET_NAME = "send_flow_receiver"
+DEFAULT_FEE_LABEL = "Default"
+DEFAULT_FEE_DURATION = "(~20 mins)"
+LOW_FEE_LABEL = "Low"
+LOW_FEE_DURATION = "(~60 mins)"
 LOW_FEE_OPTION_INDEX = 2
 LOW_FEE_TARGET_BLOCKS = 6
 
@@ -134,11 +138,22 @@ def run_test():
         gui.set_text("sendAmountInput", SEND_AMOUNT)
         gui.wait_for_property("sendContinueButton", "enabled", True, timeout_ms=20000)
 
+        gui.wait_for_property("feeSelectionControl", "selectedLabel", DEFAULT_FEE_LABEL, timeout_ms=5000)
+        gui.wait_for_property("feeSelectionControl", "selectedDuration", DEFAULT_FEE_DURATION, timeout_ms=5000)
+        gui.wait_for_property("feeSelectionControl", "selectedTarget", 2, timeout_ms=5000)
+
         gui.click("feeSelectionDropdownButton")
         gui.wait_for_property("feeSelectionPopup", "opened", True, timeout_ms=5000)
+        high_fee_option_estimate = wait_for_non_empty_text(gui, "feeSelectionOptionEstimate0")
+        default_fee_option_estimate = wait_for_non_empty_text(gui, "feeSelectionOptionEstimate1")
         low_fee_option_estimate = wait_for_non_empty_text(gui, f"feeSelectionOptionEstimate{LOW_FEE_OPTION_INDEX}")
+        assert high_fee_option_estimate, "Expected High option estimate to render in the dropdown"
+        assert default_fee_option_estimate, "Expected Default option estimate to render in the dropdown"
         gui.click(f"feeSelectionOption{LOW_FEE_OPTION_INDEX}")
         gui.wait_for_property("feeSelectionPopup", "opened", False, timeout_ms=5000)
+        gui.wait_for_property("feeSelectionControl", "selectedIndex", LOW_FEE_OPTION_INDEX, timeout_ms=5000)
+        gui.wait_for_property("feeSelectionControl", "selectedLabel", LOW_FEE_LABEL, timeout_ms=5000)
+        gui.wait_for_property("feeSelectionControl", "selectedDuration", LOW_FEE_DURATION, timeout_ms=5000)
         gui.wait_for_property("feeSelectionControl", "selectedTarget", LOW_FEE_TARGET_BLOCKS, timeout_ms=5000)
         gui.wait_for_property("feeSelectionEstimateLabel", "text", low_fee_option_estimate, timeout_ms=20000)
 

--- a/test/functional/qml_test_send_receive.py
+++ b/test/functional/qml_test_send_receive.py
@@ -4,7 +4,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """End-to-end GUI test for send preview fee parity."""
 
+import argparse
 from decimal import Decimal, InvalidOperation
+from datetime import datetime
+import os
 import re
 import sys
 import time
@@ -14,6 +17,7 @@ from qml_wallet_test_lib import WalletFlowHarness, rpc_call
 
 
 SEND_AMOUNT = "1.00000000"
+SEND_AMOUNT_SATS = 100000000
 GUI_WALLET_NAME = "send_flow_wallet"
 RECEIVER_WALLET_NAME = "send_flow_receiver"
 DEFAULT_FEE_LABEL = "Default"
@@ -22,6 +26,81 @@ LOW_FEE_LABEL = "Low"
 LOW_FEE_DURATION = "(~60 mins)"
 LOW_FEE_OPTION_INDEX = 2
 LOW_FEE_TARGET_BLOCKS = 6
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Send/receive GUI functional test",
+        add_help=True,
+    )
+    parser.add_argument(
+        "--save-screenshots",
+        action="store_true",
+        help="Save a PNG at each GUI checkpoint under test/artifacts/",
+    )
+    return parser.parse_args()
+
+
+def make_screenshot_root():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    artifacts_root = os.path.join(repo_root, "test", "artifacts")
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    screenshot_root = os.path.join(artifacts_root, f"qml_test_send_receive-{timestamp}")
+    os.makedirs(screenshot_root, exist_ok=True)
+    return screenshot_root
+
+
+class CheckpointRecorder:
+    def __init__(self, save_screenshots, screenshot_root):
+        self.save_screenshots = save_screenshots
+        self.screenshot_root = screenshot_root
+        self.index = 0
+
+    def _sanitize_label(self, label):
+        return re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-") or "checkpoint"
+
+    def checkpoint(self, label, gui=None):
+        self.index += 1
+        prefix = f"[qml_test_send_receive] checkpoint {self.index:02d}"
+        print(f"{prefix}: {label}")
+        if gui is None:
+            return
+
+        gui.settle()
+
+        if not self.save_screenshots:
+            return
+
+        filename = f"{self.index:02d}-{self._sanitize_label(label)}.png"
+        screenshot_path = os.path.join(self.screenshot_root, filename)
+        screenshot = gui.save_screenshot(screenshot_path)
+        print(
+            f"{prefix}: screenshot saved to {screenshot['path']} "
+            f"({screenshot['width']}x{screenshot['height']})"
+        )
+
+
+def assert_review_values(gui, *, expected_fee_sats, expected_amount_sats, expected_total_sats):
+    review_amount_text = gui.get_text("sendReviewAmountValue")
+    review_fee_text = gui.get_text("sendReviewFeeValue")
+    review_total_text = gui.get_text("sendReviewTotalValue")
+
+    review_amount_sats = sat_text_to_sats(review_amount_text)
+    review_fee_sats = sat_text_to_sats(review_fee_text)
+    review_total_sats = sat_text_to_sats(review_total_text)
+
+    assert review_fee_sats == expected_fee_sats, (
+        f"Preview fee {expected_fee_sats} sats did not match review fee "
+        f"{review_fee_text!r} ({review_fee_sats} sats)"
+    )
+    assert review_amount_sats == expected_amount_sats, (
+        f"Expected review amount {expected_amount_sats} sats, got "
+        f"{review_amount_text!r} ({review_amount_sats} sats)"
+    )
+    assert review_total_sats == expected_total_sats, (
+        f"Expected review total {expected_total_sats} sats, got "
+        f"{review_total_text!r} ({review_total_sats} sats)"
+    )
 
 
 def wait_until(predicate, *, timeout=20, interval=0.1, description="condition"):
@@ -97,10 +176,12 @@ def wait_for_single_mempool_tx(port):
     return txids[0]
 
 
-def run_test():
+def run_test(*, save_screenshots=False, screenshot_root=None):
     harness = WalletFlowHarness("qml_test_send_receive", port_offset=60)
+    checkpoints = CheckpointRecorder(save_screenshots, screenshot_root)
     gui = None
     try:
+        checkpoints.checkpoint("starting source node")
         harness.start_source_node()
         rpc_call(harness.source_rpc_port, "createwallet", {"wallet_name": RECEIVER_WALLET_NAME})
         receiver_address = rpc_call(
@@ -108,16 +189,19 @@ def run_test():
             "getnewaddress",
             wallet=RECEIVER_WALLET_NAME,
         )
+        checkpoints.checkpoint("receiver wallet prepared")
 
         harness.start_gui()
         gui = harness.driver
         gui.wait_for_property("walletBadge", "loading", False, timeout_ms=20000)
         gui.wait_for_property("walletBadge", "visible", True, timeout_ms=10000)
         assert gui.get_property("walletBadge", "noWalletLoaded") is True, "Expected no wallet at startup"
+        checkpoints.checkpoint("gui launched", gui)
 
         rpc_call(harness.gui_rpc_port, "createwallet", {"wallet_name": GUI_WALLET_NAME})
         gui.wait_for_property("walletBadge", "text", GUI_WALLET_NAME, timeout_ms=20000)
         gui.wait_for_property("walletBadge", "noWalletLoaded", False, timeout_ms=10000)
+        checkpoints.checkpoint("gui wallet created", gui)
 
         mining_address = rpc_call(
             harness.gui_rpc_port,
@@ -130,13 +214,16 @@ def run_test():
             GUI_WALLET_NAME,
             minimum_balance=Decimal("50"),
         )
+        checkpoints.checkpoint("gui wallet funded", gui)
 
         gui.click("walletSendTabButton")
         gui.wait_for_page("walletSendPage", timeout_ms=10000)
+        checkpoints.checkpoint("send page opened", gui)
 
         gui.set_text("sendAddressInput", receiver_address)
         gui.set_text("sendAmountInput", SEND_AMOUNT)
         gui.wait_for_property("sendContinueButton", "enabled", True, timeout_ms=20000)
+        checkpoints.checkpoint("send form populated", gui)
 
         gui.wait_for_property("feeSelectionControl", "selectedLabel", DEFAULT_FEE_LABEL, timeout_ms=5000)
         gui.wait_for_property("feeSelectionControl", "selectedDuration", DEFAULT_FEE_DURATION, timeout_ms=5000)
@@ -144,6 +231,7 @@ def run_test():
 
         gui.click("feeSelectionDropdownButton")
         gui.wait_for_property("feeSelectionPopup", "opened", True, timeout_ms=5000)
+        checkpoints.checkpoint("fee dropdown opened", gui)
         high_fee_option_estimate = wait_for_non_empty_text(gui, "feeSelectionOptionEstimate0")
         default_fee_option_estimate = wait_for_non_empty_text(gui, "feeSelectionOptionEstimate1")
         low_fee_option_estimate = wait_for_non_empty_text(gui, f"feeSelectionOptionEstimate{LOW_FEE_OPTION_INDEX}")
@@ -156,21 +244,61 @@ def run_test():
         gui.wait_for_property("feeSelectionControl", "selectedDuration", LOW_FEE_DURATION, timeout_ms=5000)
         gui.wait_for_property("feeSelectionControl", "selectedTarget", LOW_FEE_TARGET_BLOCKS, timeout_ms=5000)
         gui.wait_for_property("feeSelectionEstimateLabel", "text", low_fee_option_estimate, timeout_ms=20000)
+        checkpoints.checkpoint("low fee option selected", gui)
 
         estimated_fee_text = gui.get_text("feeSelectionEstimateLabel")
         estimated_fee_sats = btc_text_to_sats(estimated_fee_text)
         assert estimated_fee_sats > 0, f"Expected a positive estimated fee, got {estimated_fee_text!r}"
 
+        gui.wait_for_property("feeSelectionControl", "includeFeeInAmount", False, timeout_ms=5000)
         gui.click("sendContinueButton")
         gui.wait_for_page("walletSendReviewPage", timeout_ms=10000)
-        review_fee_text = gui.get_text("sendReviewFeeValue")
-        review_fee_sats = sat_text_to_sats(review_fee_text)
-        assert review_fee_sats == estimated_fee_sats, (
-            f"Preview estimate {estimated_fee_text!r} ({estimated_fee_sats} sats) "
-            f"did not match review fee {review_fee_text!r} ({review_fee_sats} sats)"
+        checkpoints.checkpoint("review page with include-fee off", gui)
+        assert_review_values(
+            gui,
+            expected_fee_sats=estimated_fee_sats,
+            expected_amount_sats=SEND_AMOUNT_SATS,
+            expected_total_sats=SEND_AMOUNT_SATS + estimated_fee_sats,
+        )
+
+        gui.click("sendReviewBackButton")
+        gui.wait_for_page("walletSendPage", timeout_ms=10000)
+        gui.wait_for_property("sendContinueButton", "enabled", True, timeout_ms=10000)
+        checkpoints.checkpoint("returned to send page", gui)
+
+        gui.click("feeSelectionDropdownButton")
+        gui.wait_for_property("feeSelectionPopup", "opened", True, timeout_ms=5000)
+        checkpoints.checkpoint("fee dropdown reopened", gui)
+        gui.click("feeSelectionIncludeFeeToggle")
+        gui.wait_for_property("feeSelectionPopup", "opened", False, timeout_ms=5000)
+        gui.wait_for_property("feeSelectionControl", "includeFeeInAmount", True, timeout_ms=5000)
+        checkpoints.checkpoint("include fee in amount enabled", gui)
+
+        gui.click("feeSelectionDropdownButton")
+        gui.wait_for_property("feeSelectionPopup", "opened", True, timeout_ms=5000)
+        checkpoints.checkpoint("fee dropdown with include fee enabled", gui)
+        gui.click("sendAmountInput")
+        gui.wait_for_property("feeSelectionPopup", "opened", False, timeout_ms=5000)
+
+        estimated_fee_with_subtract_text = gui.get_text("feeSelectionEstimateLabel")
+        estimated_fee_with_subtract_sats = btc_text_to_sats(estimated_fee_with_subtract_text)
+        assert estimated_fee_with_subtract_sats > 0, (
+            f"Expected a positive estimated fee with subtract-fee enabled, got "
+            f"{estimated_fee_with_subtract_text!r}"
+        )
+
+        gui.click("sendContinueButton")
+        gui.wait_for_page("walletSendReviewPage", timeout_ms=10000)
+        checkpoints.checkpoint("review page with include-fee on", gui)
+        assert_review_values(
+            gui,
+            expected_fee_sats=estimated_fee_with_subtract_sats,
+            expected_amount_sats=SEND_AMOUNT_SATS - estimated_fee_with_subtract_sats,
+            expected_total_sats=SEND_AMOUNT_SATS,
         )
 
         gui.click("sendReviewSendButton")
+        checkpoints.checkpoint("transaction submitted from review", gui)
 
         txid = wait_for_single_mempool_tx(harness.gui_rpc_port)
         tx_details = rpc_call(harness.gui_rpc_port, "gettransaction", [txid], wallet=GUI_WALLET_NAME)
@@ -179,19 +307,26 @@ def run_test():
                 abs(Decimal(str(tx_details["fee"]))) * Decimal("100000000")
             ).to_integral_value()
         )
-        assert rpc_fee_sats == estimated_fee_sats, (
-            f"Broadcast fee {rpc_fee_sats} sats did not match preview estimate {estimated_fee_sats} sats"
+        assert rpc_fee_sats == estimated_fee_with_subtract_sats, (
+            f"Broadcast fee {rpc_fee_sats} sats did not match preview estimate "
+            f"{estimated_fee_with_subtract_sats} sats"
         )
+        checkpoints.checkpoint("broadcast fee verified", gui)
 
         print(
-            "Send flow passed: selected low fee target, preview estimate matched "
-            "review fee, and broadcast fee matched preview."
+            "Send flow passed: preview totals were correct with include-fee off and on, "
+            "and the broadcast fee matched the subtract-fee preview."
         )
         return 0
     except Exception as err:  # noqa: BLE001 - preserve failure context for functional test output
         print(f"\\nFAILED: {err}", file=sys.stderr)
         import traceback
         traceback.print_exc()
+        if gui is not None:
+            try:
+                checkpoints.checkpoint("failure state", gui)
+            except Exception as screenshot_err:  # noqa: BLE001 - preserve original failure context
+                print(f"[qml_test_send_receive] failed to save failure screenshot: {screenshot_err}", file=sys.stderr)
         gui_output = harness.process_output(harness.gui_process)
         if gui_output:
             print("\\n--- GUI process output ---", file=sys.stderr)
@@ -204,4 +339,9 @@ def run_test():
 
 
 if __name__ == "__main__":
-    sys.exit(run_test())
+    args = parse_args()
+    screenshot_root = None
+    if args.save_screenshots:
+        screenshot_root = make_screenshot_root()
+        print(f"Checkpoint screenshots will be saved under: {screenshot_root}")
+    sys.exit(run_test(save_screenshots=args.save_screenshots, screenshot_root=screenshot_root))

--- a/test/functional/qml_test_send_receive.py
+++ b/test/functional/qml_test_send_receive.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""End-to-end GUI test for send preview fee parity."""
+
+from decimal import Decimal, InvalidOperation
+import re
+import sys
+import time
+
+from qml_test_harness import dump_qml_tree
+from qml_wallet_test_lib import WalletFlowHarness, rpc_call
+
+
+SEND_AMOUNT = "1.00000000"
+GUI_WALLET_NAME = "send_flow_wallet"
+RECEIVER_WALLET_NAME = "send_flow_receiver"
+LOW_FEE_OPTION_INDEX = 2
+LOW_FEE_TARGET_BLOCKS = 6
+
+
+def wait_until(predicate, *, timeout=20, interval=0.1, description="condition"):
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            if predicate():
+                return
+        except Exception as err:  # noqa: BLE001 - retry helper preserves latest error context
+            last_error = err
+        time.sleep(interval)
+    if last_error is not None:
+        raise AssertionError(f"Timed out waiting for {description}: {last_error}") from last_error
+    raise AssertionError(f"Timed out waiting for {description}")
+
+
+def wait_for_non_empty_text(gui, object_name, *, timeout=20):
+    value = ""
+
+    def has_text():
+        nonlocal value
+        value = gui.get_text(object_name).strip()
+        return bool(value)
+
+    wait_until(has_text, timeout=timeout, description=f"{object_name} text")
+    return value
+
+
+def btc_text_to_sats(text):
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)", text.replace(",", ""))
+    if match is None:
+        raise AssertionError(f"Could not parse BTC amount from {text!r}")
+    try:
+        return int((Decimal(match.group(1)) * Decimal("100000000")).to_integral_value())
+    except InvalidOperation as err:
+        raise AssertionError(f"Invalid BTC amount {text!r}") from err
+
+
+def sat_text_to_sats(text):
+    match = re.search(r"(-?[0-9]+)", text.replace(",", ""))
+    if match is None:
+        raise AssertionError(f"Could not parse satoshi amount from {text!r}")
+    return int(match.group(1))
+
+
+def wait_for_wallet_balance(port, wallet_name, *, minimum_balance):
+    balance = Decimal("0")
+
+    def has_balance():
+        nonlocal balance
+        balance = Decimal(str(rpc_call(port, "getbalance", wallet=wallet_name)))
+        return balance >= minimum_balance
+
+    wait_until(
+        has_balance,
+        timeout=30,
+        interval=0.25,
+        description=f"{wallet_name} balance >= {minimum_balance}",
+    )
+    return balance
+
+
+def wait_for_single_mempool_tx(port):
+    txids = []
+
+    def has_tx():
+        nonlocal txids
+        txids = rpc_call(port, "getrawmempool")
+        return len(txids) == 1
+
+    wait_until(has_tx, timeout=20, interval=0.25, description="single mempool transaction")
+    return txids[0]
+
+
+def run_test():
+    harness = WalletFlowHarness("qml_test_send_receive", port_offset=60)
+    gui = None
+    try:
+        harness.start_source_node()
+        rpc_call(harness.source_rpc_port, "createwallet", {"wallet_name": RECEIVER_WALLET_NAME})
+        receiver_address = rpc_call(
+            harness.source_rpc_port,
+            "getnewaddress",
+            wallet=RECEIVER_WALLET_NAME,
+        )
+
+        harness.start_gui()
+        gui = harness.driver
+        gui.wait_for_property("walletBadge", "loading", False, timeout_ms=20000)
+        gui.wait_for_property("walletBadge", "visible", True, timeout_ms=10000)
+        assert gui.get_property("walletBadge", "noWalletLoaded") is True, "Expected no wallet at startup"
+
+        rpc_call(harness.gui_rpc_port, "createwallet", {"wallet_name": GUI_WALLET_NAME})
+        gui.wait_for_property("walletBadge", "text", GUI_WALLET_NAME, timeout_ms=20000)
+        gui.wait_for_property("walletBadge", "noWalletLoaded", False, timeout_ms=10000)
+
+        mining_address = rpc_call(
+            harness.gui_rpc_port,
+            "getnewaddress",
+            wallet=GUI_WALLET_NAME,
+        )
+        rpc_call(harness.gui_rpc_port, "generatetoaddress", [101, mining_address])
+        wait_for_wallet_balance(
+            harness.gui_rpc_port,
+            GUI_WALLET_NAME,
+            minimum_balance=Decimal("50"),
+        )
+
+        gui.click("walletSendTabButton")
+        gui.wait_for_page("walletSendPage", timeout_ms=10000)
+
+        gui.set_text("sendAddressInput", receiver_address)
+        gui.set_text("sendAmountInput", SEND_AMOUNT)
+        gui.wait_for_property("sendContinueButton", "enabled", True, timeout_ms=20000)
+
+        gui.click("feeSelectionDropdownButton")
+        gui.wait_for_property("feeSelectionPopup", "opened", True, timeout_ms=5000)
+        low_fee_option_estimate = wait_for_non_empty_text(gui, f"feeSelectionOptionEstimate{LOW_FEE_OPTION_INDEX}")
+        gui.click(f"feeSelectionOption{LOW_FEE_OPTION_INDEX}")
+        gui.wait_for_property("feeSelectionPopup", "opened", False, timeout_ms=5000)
+        gui.wait_for_property("feeSelectionControl", "selectedTarget", LOW_FEE_TARGET_BLOCKS, timeout_ms=5000)
+        gui.wait_for_property("feeSelectionEstimateLabel", "text", low_fee_option_estimate, timeout_ms=20000)
+
+        estimated_fee_text = gui.get_text("feeSelectionEstimateLabel")
+        estimated_fee_sats = btc_text_to_sats(estimated_fee_text)
+        assert estimated_fee_sats > 0, f"Expected a positive estimated fee, got {estimated_fee_text!r}"
+
+        gui.click("sendContinueButton")
+        gui.wait_for_page("walletSendReviewPage", timeout_ms=10000)
+        review_fee_text = gui.get_text("sendReviewFeeValue")
+        review_fee_sats = sat_text_to_sats(review_fee_text)
+        assert review_fee_sats == estimated_fee_sats, (
+            f"Preview estimate {estimated_fee_text!r} ({estimated_fee_sats} sats) "
+            f"did not match review fee {review_fee_text!r} ({review_fee_sats} sats)"
+        )
+
+        gui.click("sendReviewSendButton")
+
+        txid = wait_for_single_mempool_tx(harness.gui_rpc_port)
+        tx_details = rpc_call(harness.gui_rpc_port, "gettransaction", [txid], wallet=GUI_WALLET_NAME)
+        rpc_fee_sats = int(
+            (
+                abs(Decimal(str(tx_details["fee"]))) * Decimal("100000000")
+            ).to_integral_value()
+        )
+        assert rpc_fee_sats == estimated_fee_sats, (
+            f"Broadcast fee {rpc_fee_sats} sats did not match preview estimate {estimated_fee_sats} sats"
+        )
+
+        print(
+            "Send flow passed: selected low fee target, preview estimate matched "
+            "review fee, and broadcast fee matched preview."
+        )
+        return 0
+    except Exception as err:  # noqa: BLE001 - preserve failure context for functional test output
+        print(f"\\nFAILED: {err}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        gui_output = harness.process_output(harness.gui_process)
+        if gui_output:
+            print("\\n--- GUI process output ---", file=sys.stderr)
+            print(gui_output, file=sys.stderr)
+        if gui is not None:
+            dump_qml_tree(gui)
+        return 1
+    finally:
+        harness.stop()
+
+
+if __name__ == "__main__":
+    sys.exit(run_test())

--- a/test/mocks/mockwallet.h
+++ b/test/mocks/mockwallet.h
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_TEST_MOCKS_MOCKWALLET_H
+#define BITCOIN_QML_TEST_MOCKS_MOCKWALLET_H
+
+#ifdef Assert
+#pragma push_macro("Assert")
+#undef Assert
+#define BITCOIN_QML_RESTORE_ASSERT_MACRO
+#endif
+
+#include <gmock/gmock.h>
+
+#ifdef BITCOIN_QML_RESTORE_ASSERT_MACRO
+#pragma pop_macro("Assert")
+#undef BITCOIN_QML_RESTORE_ASSERT_MACRO
+#endif
+
+#include <interfaces/wallet.h>
+#include <outputtype.h>
+#include <wallet/coincontrol.h>
+#include <wallet/types.h>
+#include <wallet/wallet.h>
+
+#include <functional>
+
+class StubWallet : public interfaces::Wallet
+{
+public:
+    bool encryptWallet(const SecureString&) override { return false; }
+    bool isCrypted() override { return false; }
+    bool lock() override { return false; }
+    bool unlock(const SecureString&) override { return false; }
+    bool isLocked() override { return false; }
+    bool changeWalletPassphrase(const SecureString&, const SecureString&) override { return false; }
+    void abortRescan() override {}
+    bool backupWallet(const std::string&) override { return false; }
+    std::string getWalletName() override { return {}; }
+    util::Result<CTxDestination> getNewDestination(const OutputType, const std::string&) override { return util::Error{Untranslated("not implemented")}; }
+    bool getPubKey(const CScript&, const CKeyID&, CPubKey&) override { return false; }
+    SigningResult signMessage(const std::string&, const PKHash&, std::string&) override { return SigningResult::PRIVATE_KEY_NOT_AVAILABLE; }
+    bool isSpendable(const CTxDestination&) override { return false; }
+    bool setAddressBook(const CTxDestination&, const std::string&, const std::optional<wallet::AddressPurpose>&) override { return false; }
+    bool delAddressBook(const CTxDestination&) override { return false; }
+    bool getAddress(const CTxDestination&, std::string*, wallet::isminetype*, wallet::AddressPurpose*) override { return false; }
+    std::vector<interfaces::WalletAddress> getAddresses() override { return {}; }
+    std::vector<std::string> getAddressReceiveRequests() override { return {}; }
+    bool setAddressReceiveRequest(const CTxDestination&, const std::string&, const std::string&) override { return false; }
+    util::Result<void> displayAddress(const CTxDestination&) override { return {}; }
+    bool lockCoin(const COutPoint&, const bool) override { return false; }
+    bool unlockCoin(const COutPoint&) override { return false; }
+    bool isLockedCoin(const COutPoint&) override { return false; }
+    void listLockedCoins(std::vector<COutPoint>&) override {}
+    util::Result<CTransactionRef> createTransaction(const std::vector<wallet::CRecipient>&, const wallet::CCoinControl&, bool, int&, CAmount&) override { return util::Error{Untranslated("not implemented")}; }
+    void commitTransaction(CTransactionRef, interfaces::WalletValueMap, interfaces::WalletOrderForm) override {}
+    bool transactionCanBeAbandoned(const Txid&) override { return false; }
+    bool abandonTransaction(const Txid&) override { return false; }
+    bool transactionCanBeBumped(const Txid&) override { return false; }
+    bool createBumpTransaction(const Txid&, const wallet::CCoinControl&, std::vector<bilingual_str>&, CAmount&, CAmount&, CMutableTransaction&) override { return false; }
+    bool signBumpTransaction(CMutableTransaction&) override { return false; }
+    bool commitBumpTransaction(const Txid&, CMutableTransaction&&, std::vector<bilingual_str>&, Txid&) override { return false; }
+    CTransactionRef getTx(const Txid&) override { return {}; }
+    interfaces::WalletTx getWalletTx(const Txid&) override { return {}; }
+    std::set<interfaces::WalletTx> getWalletTxs() override { return {}; }
+    bool tryGetTxStatus(const Txid&, interfaces::WalletTxStatus&, int&, int64_t&) override { return false; }
+    interfaces::WalletTx getWalletTxDetails(const Txid&, interfaces::WalletTxStatus&, interfaces::WalletOrderForm&, bool&, int&) override { return {}; }
+    std::optional<common::PSBTError> fillPSBT(std::optional<int>, bool, bool, size_t*, PartiallySignedTransaction&, bool&) override { return std::nullopt; }
+    interfaces::WalletBalances getBalances() override { return {}; }
+    bool tryGetBalances(interfaces::WalletBalances&, uint256&) override { return false; }
+    CAmount getBalance() override { return 0; }
+    CAmount getAvailableBalance(const wallet::CCoinControl&) override { return 0; }
+    wallet::isminetype txinIsMine(const CTxIn&) override { return wallet::ISMINE_NO; }
+    wallet::isminetype txoutIsMine(const CTxOut&) override { return wallet::ISMINE_NO; }
+    CAmount getDebit(const CTxIn&, wallet::isminefilter) override { return 0; }
+    CAmount getCredit(const CTxOut&, wallet::isminefilter) override { return 0; }
+    CoinsList listCoins() override { return {}; }
+    std::vector<interfaces::WalletTxOut> getCoins(const std::vector<COutPoint>&) override { return {}; }
+    CAmount getRequiredFee(unsigned int) override { return 0; }
+    CAmount getMinimumFee(unsigned int, const wallet::CCoinControl&, int*, FeeReason*) override { return 0; }
+    unsigned int getConfirmTarget() override { return 0; }
+    bool hdEnabled() override { return false; }
+    bool canGetAddresses() override { return false; }
+    bool privateKeysDisabled() override { return false; }
+    bool taprootEnabled() override { return false; }
+    bool hasExternalSigner() override { return false; }
+    OutputType getDefaultAddressType() override { return OutputType::BECH32; }
+    CAmount getDefaultMaxTxFee() override { return 0; }
+    void remove() override {}
+    std::unique_ptr<interfaces::Handler> handleUnload(UnloadFn) override { return {}; }
+    std::unique_ptr<interfaces::Handler> handleShowProgress(ShowProgressFn) override { return {}; }
+    std::unique_ptr<interfaces::Handler> handleStatusChanged(StatusChangedFn) override { return {}; }
+    std::unique_ptr<interfaces::Handler> handleAddressBookChanged(AddressBookChangedFn) override { return {}; }
+    std::unique_ptr<interfaces::Handler> handleTransactionChanged(TransactionChangedFn) override { return {}; }
+    std::unique_ptr<interfaces::Handler> handleCanGetAddressesChanged(CanGetAddressesChangedFn) override { return {}; }
+};
+
+class MockWallet : public StubWallet
+{
+public:
+    std::function<util::Result<CTransactionRef>(const std::vector<wallet::CRecipient>&, const wallet::CCoinControl&, bool, int&, CAmount&)> createTransactionHandler;
+
+    util::Result<CTxDestination> getNewDestination(const OutputType type, const std::string& label) override
+    {
+        return getNewDestinationValue(type, label);
+    }
+
+    util::Result<CTransactionRef> createTransaction(const std::vector<wallet::CRecipient>& recipients,
+        const wallet::CCoinControl& coin_control,
+        bool sign,
+        int& change_pos,
+        CAmount& fee) override
+    {
+        if (createTransactionHandler) {
+            return createTransactionHandler(recipients, coin_control, sign, change_pos, fee);
+        }
+        return util::Error{Untranslated("no createTransactionHandler installed")};
+    }
+
+    MOCK_METHOD(CTxDestination, getNewDestinationValue, (OutputType, const std::string&));
+    MOCK_METHOD((std::set<interfaces::WalletTx>), getWalletTxs, (), (override));
+    MOCK_METHOD(CAmount, getBalance, (), (override));
+    MOCK_METHOD(CoinsList, listCoins, (), (override));
+    MOCK_METHOD(OutputType, getDefaultAddressType, (), (override));
+    MOCK_METHOD((std::unique_ptr<interfaces::Handler>), handleTransactionChanged, (TransactionChangedFn), (override));
+};
+
+#endif // BITCOIN_QML_TEST_MOCKS_MOCKWALLET_H

--- a/test/mocks/mockwallet.h
+++ b/test/mocks/mockwallet.h
@@ -121,6 +121,7 @@ public:
     MOCK_METHOD(CTxDestination, getNewDestinationValue, (OutputType, const std::string&));
     MOCK_METHOD((std::set<interfaces::WalletTx>), getWalletTxs, (), (override));
     MOCK_METHOD(CAmount, getBalance, (), (override));
+    MOCK_METHOD(CAmount, getRequiredFee, (unsigned int), (override));
     MOCK_METHOD(CoinsList, listCoins, (), (override));
     MOCK_METHOD(OutputType, getDefaultAddressType, (), (override));
     MOCK_METHOD((std::unique_ptr<interfaces::Handler>), handleTransactionChanged, (TransactionChangedFn), (override));

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -230,6 +230,7 @@ class MockSendRecipient : public QObject
     Q_PROPERTY(QObject* amount READ amount CONSTANT)
     Q_PROPERTY(QString amountError MEMBER m_amount_error NOTIFY amountErrorChanged)
     Q_PROPERTY(QString label MEMBER m_label NOTIFY labelChanged)
+    Q_PROPERTY(bool subtractFeeFromAmount READ subtractFeeFromAmount WRITE setSubtractFeeFromAmount NOTIFY subtractFeeFromAmountChanged)
     Q_PROPERTY(bool isValid MEMBER m_is_valid NOTIFY isValidChanged)
 
 public:
@@ -238,15 +239,24 @@ public:
     MockBitcoinAmount m_amount{};
     QString m_amount_error;
     QString m_label;
+    bool m_subtract_fee_from_amount{false};
     bool m_is_valid{true};
 
     QObject* amount() { return &m_amount; }
+    bool subtractFeeFromAmount() const { return m_subtract_fee_from_amount; }
+    void setSubtractFeeFromAmount(bool value)
+    {
+        if (m_subtract_fee_from_amount == value) return;
+        m_subtract_fee_from_amount = value;
+        Q_EMIT subtractFeeFromAmountChanged();
+    }
 
 Q_SIGNALS:
     void addressChanged();
     void addressErrorChanged();
     void amountErrorChanged();
     void labelChanged();
+    void subtractFeeFromAmountChanged();
     void isValidChanged();
 };
 
@@ -287,6 +297,7 @@ public:
     {
         m_current = recipient;
         Q_EMIT currentChanged();
+        Q_EMIT currentRecipientChanged();
     }
 
     void setCurrentIndex(int index)
@@ -370,6 +381,7 @@ public:
 
 Q_SIGNALS:
     void currentChanged();
+    void currentRecipientChanged();
     void currentIndexChanged();
     void countChanged();
     void listCleared();

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -4,7 +4,938 @@
 
 #include <QtQuickTest/quicktest.h>
 
+#include <QAbstractListModel>
 #include <QQmlEngine>
+#include <QQmlContext>
+#include <QRegularExpression>
+#include <qqml.h>
+
+#include <algorithm>
+#include <vector>
+
+#include <qml/components/blockclockdial.h>
+#include <qml/controls/linegraph.h>
+
+class MockAppMode : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool isDesktop READ isDesktop WRITE setIsDesktop NOTIFY isDesktopChanged)
+    Q_PROPERTY(bool walletEnabled READ walletEnabled WRITE setWalletEnabled NOTIFY walletEnabledChanged)
+    Q_PROPERTY(QString state READ state WRITE setState NOTIFY stateChanged)
+
+public:
+    bool isDesktop() const { return m_is_desktop; }
+    bool walletEnabled() const { return m_wallet_enabled; }
+    QString state() const { return m_state; }
+
+public Q_SLOTS:
+    void setIsDesktop(const bool value)
+    {
+        if (m_is_desktop == value) return;
+        m_is_desktop = value;
+        Q_EMIT isDesktopChanged();
+    }
+    void setWalletEnabled(const bool value)
+    {
+        if (m_wallet_enabled == value) return;
+        m_wallet_enabled = value;
+        Q_EMIT walletEnabledChanged();
+    }
+    void setState(const QString& value)
+    {
+        if (m_state == value) return;
+        m_state = value;
+        Q_EMIT stateChanged();
+    }
+
+Q_SIGNALS:
+    void isDesktopChanged();
+    void walletEnabledChanged();
+    void stateChanged();
+
+private:
+    bool m_is_desktop{true};
+    bool m_wallet_enabled{true};
+    QString m_state{QStringLiteral("desktop")};
+};
+
+class MockPeerDetailsModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int nodeId MEMBER m_node_id CONSTANT)
+    Q_PROPERTY(QString address MEMBER m_address CONSTANT)
+    Q_PROPERTY(QString addressLocal MEMBER m_address_local CONSTANT)
+    Q_PROPERTY(QString type MEMBER m_type CONSTANT)
+    Q_PROPERTY(QString permission MEMBER m_permission CONSTANT)
+    Q_PROPERTY(QString version MEMBER m_version CONSTANT)
+    Q_PROPERTY(QString userAgent MEMBER m_user_agent CONSTANT)
+    Q_PROPERTY(QString services MEMBER m_services CONSTANT)
+    Q_PROPERTY(bool transactionRelay MEMBER m_transaction_relay CONSTANT)
+    Q_PROPERTY(bool addressRelay MEMBER m_address_relay CONSTANT)
+    Q_PROPERTY(QString mappedAS MEMBER m_mapped_as CONSTANT)
+    Q_PROPERTY(QString startingHeight MEMBER m_starting_height CONSTANT)
+    Q_PROPERTY(QString syncedHeaders MEMBER m_synced_headers CONSTANT)
+    Q_PROPERTY(QString syncedBlocks MEMBER m_synced_blocks CONSTANT)
+    Q_PROPERTY(QString direction MEMBER m_direction CONSTANT)
+    Q_PROPERTY(QString connectionDuration MEMBER m_connection_duration CONSTANT)
+    Q_PROPERTY(QString lastSend MEMBER m_last_send CONSTANT)
+    Q_PROPERTY(QString lastReceived MEMBER m_last_received CONSTANT)
+    Q_PROPERTY(QString bytesSent MEMBER m_bytes_sent CONSTANT)
+    Q_PROPERTY(QString bytesReceived MEMBER m_bytes_received CONSTANT)
+    Q_PROPERTY(QString pingTime MEMBER m_ping_time CONSTANT)
+    Q_PROPERTY(QString pingWait MEMBER m_ping_wait CONSTANT)
+    Q_PROPERTY(QString pingMin MEMBER m_ping_min CONSTANT)
+    Q_PROPERTY(QString timeOffset MEMBER m_time_offset CONSTANT)
+
+public:
+    int m_node_id{7};
+    QString m_address{QStringLiteral("127.0.0.1:8333")};
+    QString m_address_local{QStringLiteral("127.0.0.1:18444")};
+    QString m_type{QStringLiteral("Outbound Full Relay")};
+    QString m_permission{QStringLiteral("N/A")};
+    QString m_version{QStringLiteral("70016")};
+    QString m_user_agent{QStringLiteral("/Satoshi:test/")};
+    QString m_services{QStringLiteral("NETWORK|WITNESS")};
+    bool m_transaction_relay{true};
+    bool m_address_relay{false};
+    QString m_mapped_as{QStringLiteral("N/A")};
+    QString m_starting_height{QStringLiteral("100")};
+    QString m_synced_headers{QStringLiteral("200")};
+    QString m_synced_blocks{QStringLiteral("150")};
+    QString m_direction{QStringLiteral("Inbound")};
+    QString m_connection_duration{QStringLiteral("5 min")};
+    QString m_last_send{QStringLiteral("2 s")};
+    QString m_last_received{QStringLiteral("3 s")};
+    QString m_bytes_sent{QStringLiteral("1.0 MiB")};
+    QString m_bytes_received{QStringLiteral("2.0 MiB")};
+    QString m_ping_time{QStringLiteral("10 ms")};
+    QString m_ping_wait{QStringLiteral("N/A")};
+    QString m_ping_min{QStringLiteral("7 ms")};
+    QString m_time_offset{QStringLiteral("0 s")};
+
+    Q_INVOKABLE void triggerDisconnected() { Q_EMIT disconnected(); }
+
+Q_SIGNALS:
+    void disconnected();
+};
+
+class MockBitcoinAmount : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString display MEMBER m_display NOTIFY displayChanged)
+    Q_PROPERTY(Unit unit MEMBER m_unit NOTIFY unitChanged)
+    Q_PROPERTY(QString unitLabel READ unitLabel NOTIFY unitChanged)
+
+public:
+    enum Unit {
+        BTC,
+        SAT
+    };
+    Q_ENUM(Unit)
+
+    QString m_display{QStringLiteral("0.00000000")};
+    Unit m_unit{BTC};
+
+    QString unitLabel() const { return m_unit == BTC ? QStringLiteral("BTC") : QStringLiteral("sat"); }
+    Q_INVOKABLE void format() {}
+    Q_INVOKABLE void flipUnit()
+    {
+        m_unit = (m_unit == BTC) ? SAT : BTC;
+        Q_EMIT unitChanged();
+    }
+
+Q_SIGNALS:
+    void displayChanged();
+    void unitChanged();
+};
+
+class MockBitcoinAddress : public QObject
+{
+    Q_OBJECT
+};
+
+class MockPaymentRequest : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString id MEMBER m_id NOTIFY idChanged)
+    Q_PROPERTY(QObject* amount READ amount CONSTANT)
+    Q_PROPERTY(QString amountError MEMBER m_amount_error NOTIFY amountErrorChanged)
+    Q_PROPERTY(QString label MEMBER m_label NOTIFY labelChanged)
+    Q_PROPERTY(QString message MEMBER m_message NOTIFY messageChanged)
+    Q_PROPERTY(QString address MEMBER m_address NOTIFY addressChanged)
+    Q_PROPERTY(QString addressFormatted READ addressFormatted NOTIFY addressChanged)
+
+public:
+    QString m_id;
+    QString m_amount_error;
+    QString m_label;
+    QString m_message;
+    QString m_address;
+    MockBitcoinAmount m_amount{};
+
+    QObject* amount() { return &m_amount; }
+    QString addressFormatted() const { return m_address; }
+    Q_INVOKABLE void clear()
+    {
+        m_id.clear();
+        m_amount_error.clear();
+        m_label.clear();
+        m_message.clear();
+        m_address.clear();
+        m_amount.m_display = QStringLiteral("0.00000000");
+        m_amount.m_unit = MockBitcoinAmount::BTC;
+        Q_EMIT idChanged();
+        Q_EMIT amountErrorChanged();
+        Q_EMIT labelChanged();
+        Q_EMIT messageChanged();
+        Q_EMIT addressChanged();
+    }
+
+Q_SIGNALS:
+    void idChanged();
+    void amountErrorChanged();
+    void labelChanged();
+    void messageChanged();
+    void addressChanged();
+};
+
+class MockTransaction : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum Status {
+        Unconfirmed = 0,
+        Confirming = 1,
+        Confirmed = 2
+    };
+    Q_ENUM(Status)
+
+    enum Type {
+        Other = 0,
+        RecvWithAddress = 1,
+        RecvFromOther = 2,
+        SendToAddress = 3,
+        SendToOther = 4,
+        Generated = 5
+    };
+    Q_ENUM(Type)
+};
+
+class MockSendRecipient : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString address MEMBER m_address NOTIFY addressChanged)
+    Q_PROPERTY(QString addressError MEMBER m_address_error NOTIFY addressErrorChanged)
+    Q_PROPERTY(QObject* amount READ amount CONSTANT)
+    Q_PROPERTY(QString amountError MEMBER m_amount_error NOTIFY amountErrorChanged)
+    Q_PROPERTY(QString label MEMBER m_label NOTIFY labelChanged)
+    Q_PROPERTY(bool isValid MEMBER m_is_valid NOTIFY isValidChanged)
+
+public:
+    QString m_address{QStringLiteral("bcrt1qsendtoaddress")};
+    QString m_address_error;
+    MockBitcoinAmount m_amount{};
+    QString m_amount_error;
+    QString m_label;
+    bool m_is_valid{true};
+
+    QObject* amount() { return &m_amount; }
+
+Q_SIGNALS:
+    void addressChanged();
+    void addressErrorChanged();
+    void amountErrorChanged();
+    void labelChanged();
+    void isValidChanged();
+};
+
+class MockRecipientsModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QObject* current READ current NOTIFY currentChanged)
+    Q_PROPERTY(int currentIndex READ currentIndex WRITE setCurrentIndex NOTIFY currentIndexChanged)
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+
+public:
+    enum Roles {
+        AddressRole = Qt::UserRole + 1,
+        LabelRole,
+        AmountRole
+    };
+
+    struct RecipientRow {
+        QString address;
+        QString label;
+        QString amount;
+    };
+
+    MockRecipientsModel()
+    {
+        m_rows.push_back({
+            QStringLiteral("bcrt1qsendtoaddress"),
+            QStringLiteral("recipient-1"),
+            QStringLiteral("0.01000000 BTC"),
+        });
+    }
+
+    QObject* current() const { return m_current; }
+    int currentIndex() const { return m_current_index; } // 1-based, matches QML expectations.
+    int count() const { return static_cast<int>(m_rows.size()); }
+
+    void setCurrent(QObject* recipient)
+    {
+        m_current = recipient;
+        Q_EMIT currentChanged();
+    }
+
+    void setCurrentIndex(int index)
+    {
+        const int bounded = std::clamp(index, 1, std::max(1, count()));
+        if (m_current_index == bounded) return;
+        m_current_index = bounded;
+        Q_EMIT currentIndexChanged();
+    }
+
+    int rowCount(const QModelIndex& parent = QModelIndex{}) const override
+    {
+        Q_UNUSED(parent);
+        return count();
+    }
+
+    QVariant data(const QModelIndex& index, int role) const override
+    {
+        if (!index.isValid() || index.row() < 0 || index.row() >= count()) return {};
+        const RecipientRow& row = m_rows.at(index.row());
+        switch (role) {
+        case AddressRole: return row.address;
+        case LabelRole: return row.label;
+        case AmountRole: return row.amount;
+        default: return {};
+        }
+    }
+
+    QHash<int, QByteArray> roleNames() const override
+    {
+        return {
+            {AddressRole, "address"},
+            {LabelRole, "label"},
+            {AmountRole, "amount"},
+        };
+    }
+
+    Q_INVOKABLE void clearToFront()
+    {
+        beginResetModel();
+        while (m_rows.size() > 1) {
+            m_rows.pop_back();
+        }
+        endResetModel();
+        m_current_index = 1;
+        Q_EMIT countChanged();
+        Q_EMIT currentIndexChanged();
+        Q_EMIT listCleared();
+    }
+
+    Q_INVOKABLE void add()
+    {
+        const int row = count();
+        beginInsertRows(QModelIndex{}, row, row);
+        const int next = row + 1;
+        m_rows.push_back({
+            QStringLiteral("bcrt1qrecipient%1").arg(next),
+            QStringLiteral("recipient-%1").arg(next),
+            QStringLiteral("0.00%1 BTC").arg(next),
+        });
+        endInsertRows();
+        m_current_index = count();
+        Q_EMIT countChanged();
+        Q_EMIT currentIndexChanged();
+    }
+
+    Q_INVOKABLE void prev() { setCurrentIndex(m_current_index - 1); }
+    Q_INVOKABLE void next() { setCurrentIndex(m_current_index + 1); }
+
+    Q_INVOKABLE void remove()
+    {
+        if (count() <= 1) return;
+        const int row = count() - 1;
+        beginRemoveRows(QModelIndex{}, row, row);
+        m_rows.pop_back();
+        endRemoveRows();
+        if (m_current_index > count()) m_current_index = count();
+        Q_EMIT countChanged();
+        Q_EMIT currentIndexChanged();
+    }
+
+Q_SIGNALS:
+    void currentChanged();
+    void currentIndexChanged();
+    void countChanged();
+    void listCleared();
+
+private:
+    QObject* m_current{nullptr};
+    int m_current_index{1};
+    std::vector<RecipientRow> m_rows{};
+};
+
+class MockCoinsListModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(int selectedCoinsCount READ selectedCoinsCount NOTIFY selectedCoinsCountChanged)
+    Q_PROPERTY(int coinCount READ coinCount NOTIFY coinCountChanged)
+    Q_PROPERTY(QString totalSelected READ totalSelected NOTIFY totalSelectedChanged)
+    Q_PROPERTY(bool overRequiredAmount READ overRequiredAmount NOTIFY overRequiredAmountChanged)
+    Q_PROPERTY(QString changeAmount READ changeAmount NOTIFY changeAmountChanged)
+
+public:
+    enum Roles {
+        AddressRole = Qt::UserRole + 1,
+        AmountRole,
+        LabelRole,
+        LockedRole,
+        SelectedRole
+    };
+
+    struct CoinRow {
+        QString address;
+        QString amount;
+        QString label;
+        bool locked;
+        bool selected;
+    };
+
+    MockCoinsListModel()
+    {
+        m_rows = {
+            {QStringLiteral("bcrt1qcoin1"), QStringLiteral("0.00100000 BTC"), QStringLiteral("utxo-1"), false, false},
+            {QStringLiteral("bcrt1qcoin2"), QStringLiteral("0.00200000 BTC"), QStringLiteral("utxo-2"), false, false},
+            {QStringLiteral("bcrt1qcoin3"), QStringLiteral("0.00300000 BTC"), QStringLiteral(""), true, false},
+        };
+    }
+
+    int rowCount(const QModelIndex& parent = QModelIndex{}) const override
+    {
+        Q_UNUSED(parent);
+        return static_cast<int>(m_rows.size());
+    }
+
+    QVariant data(const QModelIndex& index, int role) const override
+    {
+        if (!index.isValid() || index.row() < 0 || index.row() >= rowCount()) return {};
+        const CoinRow& row = m_rows.at(index.row());
+        switch (role) {
+        case AddressRole: return row.address;
+        case AmountRole: return row.amount;
+        case LabelRole: return row.label;
+        case LockedRole: return row.locked;
+        case SelectedRole: return row.selected;
+        default: return {};
+        }
+    }
+
+    QHash<int, QByteArray> roleNames() const override
+    {
+        return {
+            {AddressRole, "address"},
+            {AmountRole, "amount"},
+            {LabelRole, "label"},
+            {LockedRole, "locked"},
+            {SelectedRole, "selected"},
+        };
+    }
+
+    int selectedCoinsCount() const
+    {
+        return std::count_if(m_rows.begin(), m_rows.end(), [](const CoinRow& row) { return row.selected; });
+    }
+
+    int coinCount() const { return rowCount(); }
+
+    QString totalSelected() const
+    {
+        return QStringLiteral("%1 selected").arg(selectedCoinsCount());
+    }
+
+    bool overRequiredAmount() const { return selectedCoinsCount() > 1; }
+
+    QString changeAmount() const
+    {
+        return overRequiredAmount() ? QStringLiteral("0.00050000 BTC") : QStringLiteral("0.00000000 BTC");
+    }
+
+    Q_INVOKABLE void toggleCoinSelection(int index)
+    {
+        if (index < 0 || index >= rowCount()) return;
+        CoinRow& row = m_rows[static_cast<size_t>(index)];
+        if (row.locked) return;
+        row.selected = !row.selected;
+        const QModelIndex model_index = createIndex(index, 0);
+        Q_EMIT dataChanged(model_index, model_index, {SelectedRole});
+        emitAggregateSignals();
+    }
+
+    Q_INVOKABLE void update() {}
+
+Q_SIGNALS:
+    void selectedCoinsCountChanged();
+    void coinCountChanged();
+    void totalSelectedChanged();
+    void overRequiredAmountChanged();
+    void changeAmountChanged();
+
+private:
+    void emitAggregateSignals()
+    {
+        Q_EMIT selectedCoinsCountChanged();
+        Q_EMIT totalSelectedChanged();
+        Q_EMIT overRequiredAmountChanged();
+        Q_EMIT changeAmountChanged();
+    }
+
+    std::vector<CoinRow> m_rows{};
+};
+
+class MockWalletQmlModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString name MEMBER m_name NOTIFY nameChanged)
+    Q_PROPERTY(QString balance MEMBER m_balance NOTIFY balanceChanged)
+    Q_PROPERTY(QObject* activityListModel READ activityListModel CONSTANT)
+    Q_PROPERTY(QObject* recipients READ recipients CONSTANT)
+    Q_PROPERTY(QObject* coinsListModel READ coinsListModel CONSTANT)
+    Q_PROPERTY(QObject* currentTransaction READ currentTransaction CONSTANT)
+    Q_PROPERTY(QObject* currentPaymentRequest READ currentPaymentRequest CONSTANT)
+    Q_PROPERTY(int targetBlocks READ targetBlocks WRITE setTargetBlocks NOTIFY targetBlocksChanged)
+    Q_PROPERTY(bool feeEstimatePending MEMBER m_fee_estimate_pending NOTIFY feeEstimatePendingChanged)
+    Q_PROPERTY(int feeEstimateRevision MEMBER m_fee_estimate_revision NOTIFY feeEstimateRevisionChanged)
+    Q_PROPERTY(bool prepareTransactionResult MEMBER m_prepare_transaction_result NOTIFY prepareTransactionResultChanged)
+    Q_PROPERTY(int prepareTransactionCalls READ prepareTransactionCalls NOTIFY prepareTransactionCallsChanged)
+    Q_PROPERTY(int scheduleFeeEstimatesCalls READ scheduleFeeEstimatesCalls NOTIFY scheduleFeeEstimatesCallsChanged)
+    Q_PROPERTY(int sendTransactionCalls READ sendTransactionCalls NOTIFY sendTransactionCallsChanged)
+
+public:
+    QString m_name{QStringLiteral("testwallet")};
+    QString m_balance{QStringLiteral("1.00000000 BTC")};
+    QObject* m_activity_list_model{nullptr};
+    QObject* m_recipients{nullptr};
+    QObject* m_coins_list_model{nullptr};
+    QObject* m_current_transaction{nullptr};
+    QObject* m_current_payment_request{nullptr};
+    int m_target_blocks{2};
+    bool m_prepare_transaction_result{true};
+
+    QObject* activityListModel() const { return m_activity_list_model; }
+    QObject* recipients() const { return m_recipients; }
+    QObject* coinsListModel() const { return m_coins_list_model; }
+    QObject* currentTransaction() const { return m_current_transaction; }
+    QObject* currentPaymentRequest() const { return m_current_payment_request; }
+    int targetBlocks() const { return m_target_blocks; }
+    int prepareTransactionCalls() const { return m_prepare_transaction_calls; }
+    int scheduleFeeEstimatesCalls() const { return m_schedule_fee_estimates_calls; }
+    int sendTransactionCalls() const { return m_send_transaction_calls; }
+    Q_INVOKABLE QString estimatedFeeForTarget(const int target) const
+    {
+        const QString estimate = m_fee_estimates.value(target);
+        if (!estimate.isEmpty()) {
+            return estimate;
+        }
+
+        return m_fee_estimate_pending ? QStringLiteral("…") : QStringLiteral("—");
+    }
+    Q_INVOKABLE int feeTargetIndex(const int target) const
+    {
+        switch (target) {
+        case 1: return 0;
+        case 6: return 2;
+        case 2:
+        default:
+            return 1;
+        }
+    }
+    void setActivityListModel(QObject* model) { m_activity_list_model = model; }
+    void setRecipients(QObject* model) { m_recipients = model; }
+    void setCoinsListModel(QObject* model) { m_coins_list_model = model; }
+    void setCurrentTransaction(QObject* transaction) { m_current_transaction = transaction; }
+    void setCurrentPaymentRequest(QObject* request) { m_current_payment_request = request; }
+    void setTargetBlocks(const int value)
+    {
+        if (m_target_blocks == value) return;
+        m_target_blocks = value;
+        ++m_fee_estimate_revision;
+        Q_EMIT targetBlocksChanged();
+        Q_EMIT feeEstimateRevisionChanged();
+        scheduleFeeEstimates();
+    }
+    Q_INVOKABLE bool prepareTransaction()
+    {
+        ++m_prepare_transaction_calls;
+        Q_EMIT prepareTransactionCallsChanged();
+        return m_prepare_transaction_result;
+    }
+    Q_INVOKABLE void scheduleFeeEstimates()
+    {
+        ++m_schedule_fee_estimates_calls;
+        Q_EMIT scheduleFeeEstimatesCallsChanged();
+    }
+    Q_INVOKABLE void sendTransaction()
+    {
+        ++m_send_transaction_calls;
+        Q_EMIT sendTransactionCallsChanged();
+    }
+    Q_INVOKABLE void commitPaymentRequest()
+    {
+        auto* request = qobject_cast<MockPaymentRequest*>(m_current_payment_request);
+        if (!request) return;
+        request->m_id = QStringLiteral("1");
+        request->m_address = QStringLiteral("bcrt1qrequestaddress0000000000000000000000");
+        Q_EMIT request->idChanged();
+        Q_EMIT request->addressChanged();
+    }
+
+Q_SIGNALS:
+    void nameChanged();
+    void balanceChanged();
+    void targetBlocksChanged();
+    void feeEstimatePendingChanged();
+    void feeEstimateRevisionChanged();
+    void prepareTransactionResultChanged();
+    void prepareTransactionCallsChanged();
+    void scheduleFeeEstimatesCallsChanged();
+    void sendTransactionCallsChanged();
+
+private:
+    QHash<int, QString> m_fee_estimates{{1, QStringLiteral("0.00000750 ₿")}, {2, QStringLiteral("0.00000500 ₿")}, {6, QStringLiteral("0.00000250 ₿")}};
+    bool m_fee_estimate_pending{false};
+    int m_fee_estimate_revision{1};
+    int m_prepare_transaction_calls{0};
+    int m_schedule_fee_estimates_calls{0};
+    int m_send_transaction_calls{0};
+};
+
+class MockWalletQmlModelTransaction : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString address MEMBER m_address CONSTANT)
+    Q_PROPERTY(QString label MEMBER m_label CONSTANT)
+    Q_PROPERTY(QString amount MEMBER m_amount CONSTANT)
+    Q_PROPERTY(QString fee MEMBER m_fee CONSTANT)
+    Q_PROPERTY(QString total MEMBER m_total CONSTANT)
+
+public:
+    QString m_address{QStringLiteral("bcrt1qexampleaddress")};
+    QString m_label{QStringLiteral("example-label")};
+    QString m_amount{QStringLiteral("0.01000000 BTC")};
+    QString m_fee{QStringLiteral("0.00001000 BTC")};
+    QString m_total{QStringLiteral("0.01001000 BTC")};
+};
+
+class MockWalletController : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool initialized MEMBER m_initialized NOTIFY initializedChanged)
+    Q_PROPERTY(bool isWalletLoaded MEMBER m_is_wallet_loaded NOTIFY isWalletLoadedChanged)
+    Q_PROPERTY(bool noWalletsFound MEMBER m_no_wallets_found NOTIFY noWalletsFoundChanged)
+    Q_PROPERTY(QString lastSelectedWalletName READ lastSelectedWalletName NOTIFY lastSelectedWalletNameChanged)
+    Q_PROPERTY(QObject* selectedWallet READ selectedWallet NOTIFY selectedWalletChanged)
+
+public:
+    bool m_initialized{true};
+    bool m_is_wallet_loaded{true};
+    bool m_no_wallets_found{false};
+    QObject* m_selected_wallet{nullptr};
+    QString m_last_selected_wallet_name;
+
+    QObject* selectedWallet() const { return m_selected_wallet; }
+    QString lastSelectedWalletName() const { return m_last_selected_wallet_name; }
+    void setSelectedWalletObject(QObject* wallet)
+    {
+        if (m_selected_wallet == wallet) return;
+        m_selected_wallet = wallet;
+        Q_EMIT selectedWalletChanged();
+    }
+    Q_INVOKABLE void setSelectedWallet(const QString& name)
+    {
+        if (m_last_selected_wallet_name == name) return;
+        m_last_selected_wallet_name = name;
+        Q_EMIT lastSelectedWalletNameChanged();
+        Q_EMIT selectedWalletChanged();
+    }
+
+Q_SIGNALS:
+    void initializedChanged();
+    void isWalletLoadedChanged();
+    void noWalletsFoundChanged();
+    void lastSelectedWalletNameChanged();
+    void selectedWalletChanged();
+};
+
+class MockOptionsModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool listen MEMBER m_listen NOTIFY listenChanged)
+    Q_PROPERTY(bool natpmp MEMBER m_natpmp NOTIFY natpmpChanged)
+    Q_PROPERTY(bool server MEMBER m_server NOTIFY serverChanged)
+    Q_PROPERTY(bool prune MEMBER m_prune NOTIFY pruneChanged)
+    Q_PROPERTY(int pruneSizeGB MEMBER m_prune_size_gb NOTIFY pruneSizeGBChanged)
+    Q_PROPERTY(QString dataDir MEMBER m_data_dir NOTIFY dataDirChanged)
+    Q_PROPERTY(QString getDefaultDataDirString READ getDefaultDataDirString CONSTANT)
+
+public:
+    bool m_listen{true};
+    bool m_natpmp{false};
+    bool m_server{false};
+    bool m_prune{true};
+    int m_prune_size_gb{2};
+    QString m_data_dir{QStringLiteral("/tmp/bitcoin-default")};
+    QString m_custom_data_dir{QStringLiteral("/tmp/bitcoin-custom")};
+
+    QString getDefaultDataDirString() const { return QStringLiteral("/tmp/bitcoin-default"); }
+    Q_INVOKABLE QString getCustomDataDirString() const { return m_custom_data_dir; }
+    Q_INVOKABLE void setCustomDataDirString(const QString& dir) { m_custom_data_dir = dir; }
+    Q_INVOKABLE void setCustomDataDirArgs(const QString& dir) { m_data_dir = dir; }
+    Q_INVOKABLE void onboard() {}
+
+Q_SIGNALS:
+    void listenChanged();
+    void natpmpChanged();
+    void serverChanged();
+    void pruneChanged();
+    void pruneSizeGBChanged();
+    void dataDirChanged();
+};
+
+class MockChainModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int assumedChainstateSize MEMBER m_assumed_chainstate_size CONSTANT)
+    Q_PROPERTY(int assumedBlockchainSize MEMBER m_assumed_blockchain_size CONSTANT)
+    Q_PROPERTY(QVariantList timeRatioList MEMBER m_time_ratio_list CONSTANT)
+
+public:
+    int m_assumed_chainstate_size{12};
+    int m_assumed_blockchain_size{610};
+    QVariantList m_time_ratio_list{0.1, 0.2, 0.4, 0.8};
+};
+
+class MockNodeModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool pause MEMBER m_pause NOTIFY pauseChanged)
+    Q_PROPERTY(int numOutboundPeers MEMBER m_num_outbound_peers NOTIFY numOutboundPeersChanged)
+    Q_PROPERTY(int maxNumOutboundPeers MEMBER m_max_num_outbound_peers NOTIFY maxNumOutboundPeersChanged)
+    Q_PROPERTY(double verificationProgress MEMBER m_verification_progress NOTIFY verificationProgressChanged)
+    Q_PROPERTY(int remainingSyncTime MEMBER m_remaining_sync_time NOTIFY remainingSyncTimeChanged)
+    Q_PROPERTY(bool faulted MEMBER m_faulted NOTIFY faultedChanged)
+    Q_PROPERTY(int blockTipHeight MEMBER m_block_tip_height NOTIFY blockTipHeightChanged)
+
+public:
+    bool m_pause{false};
+    int m_num_outbound_peers{0};
+    int m_max_num_outbound_peers{8};
+    double m_verification_progress{0.0};
+    int m_remaining_sync_time{0};
+    bool m_faulted{false};
+    int m_block_tip_height{0};
+
+    Q_INVOKABLE void startNodeInitializionThread() {}
+    Q_INVOKABLE void requestShutdown() { Q_EMIT requestedShutdown(); }
+    Q_INVOKABLE QString defaultProxyAddress() const { return QStringLiteral("127.0.0.1:9050"); }
+    Q_INVOKABLE bool validateProxyAddress(const QString& value) const
+    {
+        // Minimal test stub to emulate host:port and [ipv6]:port acceptance.
+        static const QRegularExpression pattern{
+            QStringLiteral(R"(^(\[[0-9A-Fa-f:.]+\]|[0-9]{1,3}(\.[0-9]{1,3}){3}):([0-9]{1,5})$)")
+        };
+        return pattern.match(value).hasMatch();
+    }
+
+Q_SIGNALS:
+    void requestedShutdown();
+    void pauseChanged();
+    void numOutboundPeersChanged();
+    void maxNumOutboundPeersChanged();
+    void verificationProgressChanged();
+    void remainingSyncTimeChanged();
+    void faultedChanged();
+    void blockTipHeightChanged();
+};
+
+class MockPeerTableModel : public QObject
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE void startAutoRefresh() {}
+    Q_INVOKABLE void stopAutoRefresh() {}
+};
+
+class MockNetworkTrafficTower : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(quint64 totalBytesReceived MEMBER m_total_bytes_received NOTIFY totalBytesReceivedChanged)
+    Q_PROPERTY(quint64 totalBytesSent MEMBER m_total_bytes_sent NOTIFY totalBytesSentChanged)
+    Q_PROPERTY(double maxReceivedRateBps MEMBER m_max_received_rate_bps NOTIFY maxReceivedRateBpsChanged)
+    Q_PROPERTY(double maxSentRateBps MEMBER m_max_sent_rate_bps NOTIFY maxSentRateBpsChanged)
+    Q_PROPERTY(QVariantList receivedRateList MEMBER m_received_rate_list NOTIFY receivedRateListChanged)
+    Q_PROPERTY(QVariantList sentRateList MEMBER m_sent_rate_list NOTIFY sentRateListChanged)
+    Q_PROPERTY(int lastFilterWindowSize MEMBER m_last_filter_window_size NOTIFY lastFilterWindowSizeChanged)
+
+public:
+    quint64 m_total_bytes_received{1'000};
+    quint64 m_total_bytes_sent{2'000};
+    double m_max_received_rate_bps{100.0};
+    double m_max_sent_rate_bps{200.0};
+    QVariantList m_received_rate_list{10.0, 20.0, 30.0};
+    QVariantList m_sent_rate_list{15.0, 25.0, 35.0};
+    int m_last_filter_window_size{30};
+
+    Q_INVOKABLE void updateFilterWindowSize(const int window_size)
+    {
+        m_last_filter_window_size = window_size;
+        Q_EMIT lastFilterWindowSizeChanged();
+    }
+
+Q_SIGNALS:
+    void totalBytesReceivedChanged();
+    void totalBytesSentChanged();
+    void maxReceivedRateBpsChanged();
+    void maxSentRateBpsChanged();
+    void receivedRateListChanged();
+    void sentRateListChanged();
+    void lastFilterWindowSizeChanged();
+};
+
+class MockPeerListModelProxy : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QString sortBy READ sortBy WRITE setSortBy NOTIFY sortByChanged)
+
+public:
+    QString sortBy() const { return m_sort_by; }
+    void setSortBy(const QString& value)
+    {
+        if (m_sort_by == value) return;
+        m_sort_by = value;
+        Q_EMIT sortByChanged(m_sort_by);
+    }
+
+    int rowCount(const QModelIndex& parent = QModelIndex{}) const override
+    {
+        Q_UNUSED(parent);
+        return 0;
+    }
+
+    QVariant data(const QModelIndex& index, int role) const override
+    {
+        Q_UNUSED(index);
+        Q_UNUSED(role);
+        return {};
+    }
+
+Q_SIGNALS:
+    void sortByChanged(const QString& roleName);
+    void dataChanged(int startIndex, int endIndex);
+
+private:
+    QString m_sort_by{QStringLiteral("nodeId")};
+};
+
+class MockWalletListModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    enum Roles {
+        NameRole = Qt::UserRole + 1
+    };
+
+    int rowCount(const QModelIndex& parent = QModelIndex{}) const override
+    {
+        Q_UNUSED(parent);
+        return m_wallet_names.size();
+    }
+
+    QVariant data(const QModelIndex& index, int role) const override
+    {
+        if (!index.isValid() || index.row() < 0 || index.row() >= m_wallet_names.size()) return {};
+        if (role == NameRole) return m_wallet_names.at(index.row());
+        return {};
+    }
+
+    QHash<int, QByteArray> roleNames() const override
+    {
+        return {{NameRole, "name"}};
+    }
+
+    Q_INVOKABLE void listWalletDir() {}
+
+private:
+    QStringList m_wallet_names{QStringLiteral("testwallet"), QStringLiteral("secondarywallet")};
+};
+
+class MockActivityListModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    enum Roles {
+        AddressRole = Qt::UserRole + 1,
+        AmountRole,
+        DateRole,
+        DepthRole,
+        LabelRole,
+        StatusRole,
+        TypeRole
+    };
+
+    int rowCount(const QModelIndex& parent = QModelIndex{}) const override
+    {
+        Q_UNUSED(parent);
+        return 2;
+    }
+
+    QVariant data(const QModelIndex& index, int role) const override
+    {
+        if (!index.isValid() || index.row() < 0 || index.row() >= rowCount()) return {};
+        if (index.row() == 0) {
+            switch (role) {
+            case AddressRole: return QStringLiteral("bcrt1qreceiveaddress");
+            case AmountRole: return QStringLiteral("+0.01000000 BTC");
+            case DateRole: return QStringLiteral("2026-01-01 00:00");
+            case DepthRole: return 3;
+            case LabelRole: return QStringLiteral("salary");
+            case StatusRole: return MockTransaction::Confirmed;
+            case TypeRole: return MockTransaction::RecvWithAddress;
+            default: return {};
+            }
+        }
+        switch (role) {
+        case AddressRole: return QStringLiteral("bcrt1qsendaddress");
+        case AmountRole: return QStringLiteral("-0.00100000 BTC");
+        case DateRole: return QStringLiteral("2026-01-02 00:00");
+        case DepthRole: return 1;
+        case LabelRole: return QStringLiteral("coffee");
+        case StatusRole: return MockTransaction::Confirming;
+        case TypeRole: return MockTransaction::SendToAddress;
+        default: return {};
+        }
+    }
+
+    QHash<int, QByteArray> roleNames() const override
+    {
+        return {
+            {AddressRole, "address"},
+            {AmountRole, "amount"},
+            {DateRole, "date"},
+            {DepthRole, "depth"},
+            {LabelRole, "label"},
+            {StatusRole, "status"},
+            {TypeRole, "type"},
+        };
+    }
+};
 
 class QmlTestsSetup : public QObject
 {
@@ -14,6 +945,69 @@ public Q_SLOTS:
     void qmlEngineAvailable(QQmlEngine* engine)
     {
         engine->addImportPath(QStringLiteral(BITCOINQML_QML_TEST_MOCKS_DIR));
+        static MockAppMode app_mode;
+        static MockOptionsModel options_model;
+        static MockChainModel chain_model;
+        static MockNodeModel node_model;
+        static MockPeerTableModel peer_table_model;
+        static MockNetworkTrafficTower network_traffic_tower;
+        static MockPeerListModelProxy peer_list_model_proxy;
+        static MockPeerDetailsModel peer_details_model;
+        static MockWalletQmlModelTransaction wallet_transaction;
+        static MockPaymentRequest payment_request;
+        static MockSendRecipient send_recipient;
+        static MockRecipientsModel recipients_model;
+        static MockCoinsListModel coins_list_model;
+        static MockWalletQmlModel wallet_model;
+        static MockWalletController wallet_controller;
+        static MockWalletListModel wallet_list_model;
+        static MockActivityListModel activity_list_model;
+        recipients_model.setCurrent(&send_recipient);
+        wallet_model.setActivityListModel(&activity_list_model);
+        wallet_model.setRecipients(&recipients_model);
+        wallet_model.setCoinsListModel(&coins_list_model);
+        wallet_model.setCurrentTransaction(&wallet_transaction);
+        wallet_model.setCurrentPaymentRequest(&payment_request);
+        wallet_controller.setSelectedWalletObject(&wallet_model);
+        qmlRegisterSingletonInstance<MockAppMode>("org.bitcoincore.qt", 1, 0, "AppMode", &app_mode);
+        qmlRegisterUncreatableType<MockPeerDetailsModel>(
+            "org.bitcoincore.qt",
+            1,
+            0,
+            "PeerDetailsModel",
+            "Test stub type"
+        );
+        qmlRegisterType<MockBitcoinAmount>("org.bitcoincore.qt", 1, 0, "BitcoinAmount");
+        qmlRegisterType<MockBitcoinAddress>("org.bitcoincore.qt", 1, 0, "BitcoinAddress");
+        qmlRegisterType<MockPaymentRequest>("org.bitcoincore.qt", 1, 0, "PaymentRequest");
+        qmlRegisterUncreatableType<MockTransaction>("org.bitcoincore.qt", 1, 0, "Transaction", "Test stub type");
+        qmlRegisterUncreatableType<MockSendRecipient>("org.bitcoincore.qt", 1, 0, "SendRecipient", "Test stub type");
+        qmlRegisterUncreatableType<MockWalletQmlModel>("org.bitcoincore.qt", 1, 0, "WalletQmlModel", "Test stub type");
+        qmlRegisterUncreatableType<MockWalletQmlModelTransaction>(
+            "org.bitcoincore.qt",
+            1,
+            0,
+            "WalletQmlModelTransaction",
+            "Test stub type"
+        );
+        qmlRegisterType<BlockClockDial>("org.bitcoincore.qt", 1, 0, "BlockClockDial");
+        qmlRegisterType<LineGraph>("org.bitcoincore.qt", 1, 0, "LineGraph");
+        engine->rootContext()->setContextProperty(QStringLiteral("needOnboarding"), true);
+        engine->rootContext()->setContextProperty(QStringLiteral("optionsModel"), &options_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("chainModel"), &chain_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("nodeModel"), &node_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("peerTableModel"), &peer_table_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("networkTrafficTower"), &network_traffic_tower);
+        engine->rootContext()->setContextProperty(QStringLiteral("peerListModelProxy"), &peer_list_model_proxy);
+        engine->rootContext()->setContextProperty(QStringLiteral("testPeerDetailsModel"), &peer_details_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("walletController"), &wallet_controller);
+        engine->rootContext()->setContextProperty(QStringLiteral("walletListModel"), &wallet_list_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("testWalletModel"), &wallet_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("testWalletTransaction"), &wallet_transaction);
+        engine->rootContext()->setContextProperty(QStringLiteral("testPaymentRequest"), &payment_request);
+        engine->rootContext()->setContextProperty(QStringLiteral("testSendRecipient"), &send_recipient);
+        engine->rootContext()->setContextProperty(QStringLiteral("testRecipientsModel"), &recipients_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("testCoinsListModel"), &coins_list_model);
         engine->addImportPath(QStringLiteral(BITCOINQML_QML_SOURCE_DIR));
     }
 };

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -508,6 +508,10 @@ class MockWalletQmlModel : public QObject
     Q_PROPERTY(QObject* currentTransaction READ currentTransaction CONSTANT)
     Q_PROPERTY(QObject* currentPaymentRequest READ currentPaymentRequest CONSTANT)
     Q_PROPERTY(int targetBlocks READ targetBlocks WRITE setTargetBlocks NOTIFY targetBlocksChanged)
+    Q_PROPERTY(QString estimatedFee READ estimatedFee NOTIFY feeEstimateRevisionChanged)
+    Q_PROPERTY(bool customFeeEnabled READ customFeeEnabled WRITE setCustomFeeEnabled NOTIFY customFeeEnabledChanged)
+    Q_PROPERTY(QString customFeeRate READ customFeeRate WRITE setCustomFeeRate NOTIFY customFeeRateChanged)
+    Q_PROPERTY(bool customFeeRateValid READ customFeeRateValid NOTIFY customFeeRateValidChanged)
     Q_PROPERTY(bool feeEstimatePending MEMBER m_fee_estimate_pending NOTIFY feeEstimatePendingChanged)
     Q_PROPERTY(int feeEstimateRevision MEMBER m_fee_estimate_revision NOTIFY feeEstimateRevisionChanged)
     Q_PROPERTY(bool prepareTransactionResult MEMBER m_prepare_transaction_result NOTIFY prepareTransactionResultChanged)
@@ -532,6 +536,19 @@ public:
     QObject* currentTransaction() const { return m_current_transaction; }
     QObject* currentPaymentRequest() const { return m_current_payment_request; }
     int targetBlocks() const { return m_target_blocks; }
+    QString estimatedFee() const
+    {
+        return m_custom_fee_enabled ? m_custom_fee_estimate : estimatedFeeForTarget(m_target_blocks);
+    }
+    bool customFeeEnabled() const { return m_custom_fee_enabled; }
+    QString customFeeRate() const { return m_custom_fee_rate; }
+    bool customFeeRateValid() const
+    {
+        static const QRegularExpression pattern{
+            QStringLiteral(R"(^[0-9]+(?:\.[0-9]{0,3})?$)")
+        };
+        return pattern.match(m_custom_fee_rate).hasMatch() && m_custom_fee_rate != QStringLiteral("0");
+    }
     int prepareTransactionCalls() const { return m_prepare_transaction_calls; }
     int scheduleFeeEstimatesCalls() const { return m_schedule_fee_estimates_calls; }
     int sendTransactionCalls() const { return m_send_transaction_calls; }
@@ -565,6 +582,29 @@ public:
         m_target_blocks = value;
         ++m_fee_estimate_revision;
         Q_EMIT targetBlocksChanged();
+        Q_EMIT feeEstimateRevisionChanged();
+        scheduleFeeEstimates();
+    }
+    void setCustomFeeEnabled(const bool value)
+    {
+        if (m_custom_fee_enabled == value) return;
+        m_custom_fee_enabled = value;
+        ++m_fee_estimate_revision;
+        Q_EMIT customFeeEnabledChanged();
+        Q_EMIT feeEstimateRevisionChanged();
+        scheduleFeeEstimates();
+    }
+    void setCustomFeeRate(const QString& value)
+    {
+        const bool was_valid = customFeeRateValid();
+        if (m_custom_fee_rate == value) return;
+        m_custom_fee_rate = value;
+        m_custom_fee_estimate = customFeeRateValid() ? QStringLiteral("0.00000400 ₿") : QString{};
+        ++m_fee_estimate_revision;
+        Q_EMIT customFeeRateChanged();
+        if (was_valid != customFeeRateValid()) {
+            Q_EMIT customFeeRateValidChanged();
+        }
         Q_EMIT feeEstimateRevisionChanged();
         scheduleFeeEstimates();
     }
@@ -614,6 +654,9 @@ Q_SIGNALS:
     void nameChanged();
     void balanceChanged();
     void targetBlocksChanged();
+    void customFeeEnabledChanged();
+    void customFeeRateChanged();
+    void customFeeRateValidChanged();
     void feeEstimatePendingChanged();
     void feeEstimateRevisionChanged();
     void prepareTransactionResultChanged();
@@ -623,6 +666,9 @@ Q_SIGNALS:
 
 private:
     QHash<int, QString> m_fee_estimates{{1, QStringLiteral("0.00000750 ₿")}, {2, QStringLiteral("0.00000500 ₿")}, {6, QStringLiteral("0.00000250 ₿")}};
+    bool m_custom_fee_enabled{false};
+    QString m_custom_fee_rate;
+    QString m_custom_fee_estimate;
     bool m_fee_estimate_pending{false};
     int m_fee_estimate_revision{1};
     int m_prepare_transaction_calls{0};

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -542,7 +542,7 @@ public:
             return estimate;
         }
 
-        return m_fee_estimate_pending ? QStringLiteral("…") : QStringLiteral("—");
+        return {};
     }
     Q_INVOKABLE int feeTargetIndex(const int target) const
     {
@@ -578,6 +578,22 @@ public:
     {
         ++m_schedule_fee_estimates_calls;
         Q_EMIT scheduleFeeEstimatesCallsChanged();
+    }
+    Q_INVOKABLE void setFeeEstimate(const int target, const QString& estimate)
+    {
+        if (estimate.isEmpty()) {
+            m_fee_estimates.remove(target);
+        } else {
+            m_fee_estimates.insert(target, estimate);
+        }
+        ++m_fee_estimate_revision;
+        Q_EMIT feeEstimateRevisionChanged();
+    }
+    Q_INVOKABLE void clearFeeEstimates()
+    {
+        m_fee_estimates.clear();
+        ++m_fee_estimate_revision;
+        Q_EMIT feeEstimateRevisionChanged();
     }
     Q_INVOKABLE void sendTransaction()
     {

--- a/test/qml/tst_feeselection.qml
+++ b/test/qml/tst_feeselection.qml
@@ -33,6 +33,8 @@ TestCase {
         testWalletModel.setFeeEstimate(1, "0.00000750 ₿")
         testWalletModel.setFeeEstimate(2, "0.00000500 ₿")
         testWalletModel.setFeeEstimate(6, "0.00000250 ₿")
+        testWalletModel.customFeeEnabled = false
+        testWalletModel.customFeeRate = ""
         testWalletModel.targetBlocks = 2
     }
 
@@ -42,6 +44,8 @@ TestCase {
 
         compare(control.objectName, "feeSelectionControl")
         verify(findChild(control, "feeSelectionEstimateLabel") !== null)
+        verify(findChild(control, "feeSelectionCustomRateInput") !== null)
+        verify(findChild(control, "feeSelectionCustomEstimateLabel") !== null)
         verify(findChild(control, "feeSelectionDropdownButton") !== null)
         verify(findChild(control, "feeSelectionPopup") !== null)
         verify(findChild(control, "feeSelectionList") !== null)
@@ -101,7 +105,7 @@ TestCase {
         compare(popup.visible, false)
     }
 
-    function test_feeSelection_popup_width_matches_estimate_availability() {
+    function test_feeSelection_popup_width_handles_estimate_availability() {
         const control = createTemporaryObject(feeSelectionComponent, this)
         verify(control !== null)
 
@@ -118,24 +122,20 @@ TestCase {
         })
 
         const initialWidth = popup.width
-        testWalletModel.setFeeEstimate(2, "0.12345678 ₿")
-        tryVerify(function() {
-            return popup.width > initialWidth
-        })
-
-        const widthWithEstimates = popup.width
+        verify(initialWidth > 0)
 
         testWalletModel.clearFeeEstimates()
         tryVerify(function() {
-            return popup.width < widthWithEstimates
+            return popup.width > 0
         })
 
         const widthWithoutEstimates = popup.width
+        verify(widthWithoutEstimates > 0)
 
-        testWalletModel.setFeeEstimate(2, "0.12345678 ₿")
+        testWalletModel.setFeeEstimate(2, "12345.12345678 ₿")
 
         tryVerify(function() {
-            return popup.width > widthWithoutEstimates
+            return popup.width >= widthWithoutEstimates
         })
     }
 
@@ -187,5 +187,80 @@ TestCase {
         compare(control.selectedLabel, "High")
         compare(control.selectedDuration, "(~10 mins)")
         compare(control.selectedEstimate, "0.00000750 ₿")
+    }
+
+    function test_feeSelection_custom_option_switches_to_fee_rate_mode() {
+        const control = createTemporaryObject(feeSelectionComponent, this)
+        verify(control !== null)
+
+        const popup = findChild(control, "feeSelectionPopup")
+        const list = findChild(control, "feeSelectionList")
+        const presetEstimateLabel = findChild(control, "feeSelectionEstimateLabel")
+        const customFeeRateInput = findChild(control, "feeSelectionCustomRateInput")
+        const customEstimateLabel = findChild(control, "feeSelectionCustomEstimateLabel")
+        verify(popup !== null)
+        verify(list !== null)
+        verify(presetEstimateLabel !== null)
+        verify(customFeeRateInput !== null)
+        verify(customEstimateLabel !== null)
+
+        popup.open()
+        tryVerify(function() {
+            return list.itemAtIndex(3) !== null
+        })
+
+        const customOption = list.itemAtIndex(3)
+        verify(customOption !== null)
+
+        const customOptionEstimate = findChild(customOption, "feeSelectionOptionEstimate3")
+        verify(customOptionEstimate !== null)
+        compare(customOptionEstimate.text, "")
+
+        customOption.clicked()
+
+        compare(control.selectedIndex, 3)
+        compare(control.selectedLabel, "sats/vbyte")
+        compare(control.selectedDuration, "")
+        compare(testWalletModel.customFeeEnabled, true)
+        tryCompare(presetEstimateLabel, "visible", false)
+        compare(customEstimateLabel.text, "")
+    }
+
+    function test_feeSelection_custom_rate_updates_fee_estimate_and_presets_restore_layout() {
+        const control = createTemporaryObject(feeSelectionComponent, this)
+        verify(control !== null)
+
+        const popup = findChild(control, "feeSelectionPopup")
+        const list = findChild(control, "feeSelectionList")
+        const presetEstimateLabel = findChild(control, "feeSelectionEstimateLabel")
+        const customFeeRateInput = findChild(control, "feeSelectionCustomRateInput")
+        const customEstimateLabel = findChild(control, "feeSelectionCustomEstimateLabel")
+        verify(popup !== null)
+        verify(list !== null)
+        verify(presetEstimateLabel !== null)
+        verify(customFeeRateInput !== null)
+        verify(customEstimateLabel !== null)
+
+        popup.open()
+        tryVerify(function() {
+            return list.itemAtIndex(3) !== null
+        })
+        list.itemAtIndex(3).clicked()
+
+        customFeeRateInput.text = "2"
+        compare(testWalletModel.customFeeRate, "2")
+        compare(testWalletModel.customFeeRateValid, true)
+        tryCompare(customEstimateLabel, "text", "0.00000400 ₿")
+
+        popup.open()
+        tryVerify(function() {
+            return list.itemAtIndex(2) !== null
+        })
+        list.itemAtIndex(2).clicked()
+
+        compare(testWalletModel.customFeeEnabled, false)
+        compare(control.selectedIndex, 2)
+        compare(control.selectedLabel, "Low")
+        compare(control.selectedEstimate, "0.00000250 ₿")
     }
 }

--- a/test/qml/tst_feeselection.qml
+++ b/test/qml/tst_feeselection.qml
@@ -28,6 +28,10 @@ TestCase {
         id: feeChangedSpy
     }
 
+    SignalSpy {
+        id: includeFeeInAmountToggledSpy
+    }
+
     function init() {
         testWalletModel.clearFeeEstimates()
         testWalletModel.setFeeEstimate(1, "0.00000750 ₿")
@@ -36,6 +40,8 @@ TestCase {
         testWalletModel.customFeeEnabled = false
         testWalletModel.customFeeRate = ""
         testWalletModel.targetBlocks = 2
+        includeFeeInAmountToggledSpy.target = null
+        includeFeeInAmountToggledSpy.signalName = ""
     }
 
     function test_feeSelection_has_stable_selectors() {
@@ -49,6 +55,7 @@ TestCase {
         verify(findChild(control, "feeSelectionDropdownButton") !== null)
         verify(findChild(control, "feeSelectionPopup") !== null)
         verify(findChild(control, "feeSelectionList") !== null)
+        verify(findChild(control, "feeSelectionIncludeFeeToggle") !== null)
     }
 
     function test_feeSelection_matches_standard_fee_spec_labels_and_estimate() {
@@ -262,5 +269,32 @@ TestCase {
         compare(control.selectedIndex, 2)
         compare(control.selectedLabel, "Low")
         compare(control.selectedEstimate, "0.00000250 ₿")
+    }
+
+    function test_feeSelection_include_fee_toggle_tracks_state_and_emits() {
+        const control = createTemporaryObject(feeSelectionComponent, this, {
+            "includeFeeInAmount": false
+        })
+        verify(control !== null)
+
+        const popup = findChild(control, "feeSelectionPopup")
+        const list = findChild(control, "feeSelectionList")
+        const toggle = findChild(control, "feeSelectionIncludeFeeToggle")
+        verify(popup !== null)
+        verify(list !== null)
+        verify(toggle !== null)
+
+        includeFeeInAmountToggledSpy.target = control
+        includeFeeInAmountToggledSpy.signalName = "includeFeeInAmountToggled"
+        includeFeeInAmountToggledSpy.clear()
+
+        popup.open()
+        tryCompare(popup, "opened", true)
+
+        toggle.clicked()
+
+        compare(includeFeeInAmountToggledSpy.count, 1)
+        compare(includeFeeInAmountToggledSpy.signalArguments[0][0], true)
+        compare(popup.visible, false)
     }
 }

--- a/test/qml/tst_feeselection.qml
+++ b/test/qml/tst_feeselection.qml
@@ -106,15 +106,36 @@ TestCase {
         verify(control !== null)
 
         const popup = findChild(control, "feeSelectionPopup")
+        const list = findChild(control, "feeSelectionList")
         verify(popup !== null)
+        verify(list !== null)
+
+        popup.open()
+        tryVerify(function() {
+            return list.itemAtIndex(0) !== null
+                && list.itemAtIndex(1) !== null
+                && list.itemAtIndex(2) !== null
+        })
+
+        const initialWidth = popup.width
+        testWalletModel.setFeeEstimate(2, "0.12345678 ₿")
+        tryVerify(function() {
+            return popup.width > initialWidth
+        })
+
+        const widthWithEstimates = popup.width
 
         testWalletModel.clearFeeEstimates()
-        compare(popup.width, 280)
+        tryVerify(function() {
+            return popup.width < widthWithEstimates
+        })
 
-        testWalletModel.setFeeEstimate(2, "0.00000500 ₿")
+        const widthWithoutEstimates = popup.width
+
+        testWalletModel.setFeeEstimate(2, "0.12345678 ₿")
 
         tryVerify(function() {
-            return popup.width === 360
+            return popup.width > widthWithoutEstimates
         })
     }
 
@@ -145,6 +166,9 @@ TestCase {
 
         compare(highFeeEstimate.x + highFeeEstimate.width, defaultFeeEstimate.x + defaultFeeEstimate.width)
         compare(defaultFeeEstimate.x + defaultFeeEstimate.width, lowFeeEstimate.x + lowFeeEstimate.width)
+        verify(highFeeEstimate.width >= highFeeEstimate.contentWidth)
+        verify(defaultFeeEstimate.width >= defaultFeeEstimate.contentWidth)
+        verify(lowFeeEstimate.width >= lowFeeEstimate.contentWidth)
     }
 
     function test_feeSelection_current_target_syncs_selected_preset() {

--- a/test/qml/tst_feeselection.qml
+++ b/test/qml/tst_feeselection.qml
@@ -28,6 +28,14 @@ TestCase {
         id: feeChangedSpy
     }
 
+    function init() {
+        testWalletModel.clearFeeEstimates()
+        testWalletModel.setFeeEstimate(1, "0.00000750 ₿")
+        testWalletModel.setFeeEstimate(2, "0.00000500 ₿")
+        testWalletModel.setFeeEstimate(6, "0.00000250 ₿")
+        testWalletModel.targetBlocks = 2
+    }
+
     function test_feeSelection_has_stable_selectors() {
         const control = createTemporaryObject(feeSelectionComponent, this)
         verify(control !== null)
@@ -91,6 +99,52 @@ TestCase {
         compare(feeChangedSpy.count, 1)
         compare(feeChangedSpy.signalArguments[0][0], 6)
         compare(popup.visible, false)
+    }
+
+    function test_feeSelection_popup_width_matches_estimate_availability() {
+        const control = createTemporaryObject(feeSelectionComponent, this)
+        verify(control !== null)
+
+        const popup = findChild(control, "feeSelectionPopup")
+        verify(popup !== null)
+
+        testWalletModel.clearFeeEstimates()
+        compare(popup.width, 280)
+
+        testWalletModel.setFeeEstimate(2, "0.00000500 ₿")
+
+        tryVerify(function() {
+            return popup.width === 360
+        })
+    }
+
+    function test_feeSelection_popup_estimates_stay_aligned_when_selection_changes() {
+        testWalletModel.targetBlocks = 2
+
+        const control = createTemporaryObject(feeSelectionComponent, this)
+        verify(control !== null)
+
+        const popup = findChild(control, "feeSelectionPopup")
+        const list = findChild(control, "feeSelectionList")
+        verify(popup !== null)
+        verify(list !== null)
+
+        popup.open()
+        tryVerify(function() {
+            return list.itemAtIndex(0) !== null
+                && list.itemAtIndex(1) !== null
+                && list.itemAtIndex(2) !== null
+        })
+
+        const highFeeEstimate = findChild(list.itemAtIndex(0), "feeSelectionOptionEstimate0")
+        const defaultFeeEstimate = findChild(list.itemAtIndex(1), "feeSelectionOptionEstimate1")
+        const lowFeeEstimate = findChild(list.itemAtIndex(2), "feeSelectionOptionEstimate2")
+        verify(highFeeEstimate !== null)
+        verify(defaultFeeEstimate !== null)
+        verify(lowFeeEstimate !== null)
+
+        compare(highFeeEstimate.x + highFeeEstimate.width, defaultFeeEstimate.x + defaultFeeEstimate.width)
+        compare(defaultFeeEstimate.x + defaultFeeEstimate.width, lowFeeEstimate.x + lowFeeEstimate.width)
     }
 
     function test_feeSelection_current_target_syncs_selected_preset() {

--- a/test/qml/tst_feeselection.qml
+++ b/test/qml/tst_feeselection.qml
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/components"
+
+TestCase {
+    name: "FeeSelection"
+    when: windowShown
+    width: 900
+    height: 700
+
+    Component {
+        id: feeSelectionComponent
+
+        FeeSelection {
+            walletModel: testWalletModel
+            currentTarget: testWalletModel.targetBlocks
+            onFeeChanged: function(target) {
+                testWalletModel.targetBlocks = target
+            }
+        }
+    }
+
+    SignalSpy {
+        id: feeChangedSpy
+    }
+
+    function test_feeSelection_has_stable_selectors() {
+        const control = createTemporaryObject(feeSelectionComponent, this)
+        verify(control !== null)
+
+        compare(control.objectName, "feeSelectionControl")
+        verify(findChild(control, "feeSelectionEstimateLabel") !== null)
+        verify(findChild(control, "feeSelectionDropdownButton") !== null)
+        verify(findChild(control, "feeSelectionPopup") !== null)
+        verify(findChild(control, "feeSelectionList") !== null)
+    }
+
+    function test_feeSelection_matches_standard_fee_spec_labels_and_estimate() {
+        testWalletModel.targetBlocks = 2
+
+        const control = createTemporaryObject(feeSelectionComponent, this)
+        verify(control !== null)
+
+        compare(control.selectedIndex, 1)
+        compare(control.selectedLabel, "Default")
+        compare(control.selectedDuration, "(~20 mins)")
+        compare(control.selectedEstimate, "0.00000500 ₿")
+
+        const estimateLabel = findChild(control, "feeSelectionEstimateLabel")
+        verify(estimateLabel !== null)
+        compare(estimateLabel.text, "0.00000500 ₿")
+    }
+
+    function test_feeSelection_selecting_option_updates_state_and_emits() {
+        testWalletModel.targetBlocks = 2
+
+        const control = createTemporaryObject(feeSelectionComponent, this)
+        verify(control !== null)
+
+        const popup = findChild(control, "feeSelectionPopup")
+        const list = findChild(control, "feeSelectionList")
+        verify(popup !== null)
+        verify(list !== null)
+
+        feeChangedSpy.target = control
+        feeChangedSpy.signalName = "feeChanged"
+        feeChangedSpy.clear()
+
+        popup.open()
+        tryVerify(function() {
+            return list.itemAtIndex(2) !== null
+        })
+
+        const lowFeeOption = list.itemAtIndex(2)
+        verify(lowFeeOption !== null)
+
+        const lowFeeEstimate = findChild(lowFeeOption, "feeSelectionOptionEstimate2")
+        verify(lowFeeEstimate !== null)
+        compare(lowFeeEstimate.text, "0.00000250 ₿")
+
+        lowFeeOption.clicked()
+
+        compare(control.selectedIndex, 2)
+        compare(control.selectedLabel, "Low")
+        compare(control.selectedDuration, "(~60 mins)")
+        compare(control.selectedEstimate, "0.00000250 ₿")
+        compare(feeChangedSpy.count, 1)
+        compare(feeChangedSpy.signalArguments[0][0], 6)
+        compare(popup.visible, false)
+    }
+
+    function test_feeSelection_current_target_syncs_selected_preset() {
+        testWalletModel.targetBlocks = 6
+
+        const control = createTemporaryObject(feeSelectionComponent, this)
+        verify(control !== null)
+
+        compare(control.selectedIndex, 2)
+        compare(control.selectedLabel, "Low")
+        compare(control.selectedDuration, "(~60 mins)")
+        compare(control.selectedEstimate, "0.00000250 ₿")
+
+        testWalletModel.targetBlocks = 1
+        compare(control.selectedIndex, 0)
+        compare(control.selectedLabel, "High")
+        compare(control.selectedDuration, "(~10 mins)")
+        compare(control.selectedEstimate, "0.00000750 ₿")
+    }
+}

--- a/test/qml/tst_feeselection.qml
+++ b/test/qml/tst_feeselection.qml
@@ -56,6 +56,9 @@ TestCase {
         verify(findChild(control, "feeSelectionPopup") !== null)
         verify(findChild(control, "feeSelectionList") !== null)
         verify(findChild(control, "feeSelectionIncludeFeeToggle") !== null)
+
+        const customFeeRateInput = findChild(control, "feeSelectionCustomRateInput")
+        compare(customFeeRateInput.maximumLength, control.customFeeRateMaximumLength)
     }
 
     function test_feeSelection_matches_standard_fee_spec_labels_and_estimate() {
@@ -258,6 +261,10 @@ TestCase {
         compare(testWalletModel.customFeeRate, "2")
         compare(testWalletModel.customFeeRateValid, true)
         tryCompare(customEstimateLabel, "text", "0.00000400 ₿")
+
+        customFeeRateInput.text = "12345678901234567890"
+        compare(customFeeRateInput.text.length, control.customFeeRateMaximumLength)
+        compare(testWalletModel.customFeeRate, customFeeRateInput.text)
 
         popup.open()
         tryVerify(function() {

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -22,6 +22,14 @@ TestCase {
         id: transactionPreparedSpy
     }
 
+    function init() {
+        testWalletModel.customFeeEnabled = false
+        testWalletModel.customFeeRate = ""
+        testWalletModel.targetBlocks = 2
+        testWalletModel.prepareTransactionResult = true
+        testSendRecipient.isValid = true
+    }
+
     function test_send_has_stable_selectors() {
         const page = createTemporaryObject(sendComponent, this)
         verify(page !== null)
@@ -31,6 +39,8 @@ TestCase {
         verify(findChild(page, "sendAmountInput") !== null)
         verify(findChild(page, "sendNoteInput") !== null)
         verify(findChild(page, "feeSelectionEstimateLabel") !== null)
+        verify(findChild(page, "feeSelectionCustomRateInput") !== null)
+        verify(findChild(page, "feeSelectionCustomEstimateLabel") !== null)
         verify(findChild(page, "sendContinueButton") !== null)
     }
 
@@ -118,5 +128,61 @@ TestCase {
         const estimateLabel = findChild(page, "feeSelectionEstimateLabel")
         verify(estimateLabel !== null)
         compare(estimateLabel.text, "0.00000500 ₿")
+    }
+
+    function test_send_custom_fee_selection_updates_wallet_mode() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const popup = findChild(page, "feeSelectionPopup")
+        const list = findChild(page, "feeSelectionList")
+        const customInput = findChild(page, "feeSelectionCustomRateInput")
+        verify(popup !== null)
+        verify(list !== null)
+        verify(customInput !== null)
+
+        popup.open()
+        tryVerify(function() {
+            return list.itemAtIndex(3) !== null
+        })
+        list.itemAtIndex(3).clicked()
+
+        compare(testWalletModel.customFeeEnabled, true)
+
+        popup.open()
+        tryVerify(function() {
+            return list.itemAtIndex(0) !== null
+        })
+        list.itemAtIndex(0).clicked()
+
+        compare(testWalletModel.customFeeEnabled, false)
+        compare(testWalletModel.targetBlocks, 1)
+    }
+
+    function test_send_continue_button_requires_valid_custom_fee() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const popup = findChild(page, "feeSelectionPopup")
+        const list = findChild(page, "feeSelectionList")
+        const continueButton = findChild(page, "sendContinueButton")
+        const customInput = findChild(page, "feeSelectionCustomRateInput")
+        verify(popup !== null)
+        verify(list !== null)
+        verify(continueButton !== null)
+        verify(customInput !== null)
+
+        testSendRecipient.isValid = true
+
+        popup.open()
+        tryVerify(function() {
+            return list.itemAtIndex(3) !== null
+        })
+        list.itemAtIndex(3).clicked()
+
+        compare(continueButton.enabled, false)
+
+        customInput.text = "2"
+        tryCompare(continueButton, "enabled", true)
     }
 }

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -45,6 +45,8 @@ TestCase {
         verify(findChild(page, "feeSelectionIncludeFeeToggle") !== null)
         verify(findChild(page, "sendFeeIncludedNote") !== null)
         verify(findChild(page, "sendFeeIncludedNoteText") !== null)
+        verify(findChild(page, "sendPrepareTransactionError") !== null)
+        verify(findChild(page, "sendPrepareTransactionErrorText") !== null)
         verify(findChild(page, "sendContinueButton") !== null)
     }
 
@@ -67,7 +69,11 @@ TestCase {
         verify(page !== null)
 
         const continueButton = findChild(page, "sendContinueButton")
+        const prepareError = findChild(page, "sendPrepareTransactionError")
+        const prepareErrorText = findChild(page, "sendPrepareTransactionErrorText")
         verify(continueButton !== null)
+        verify(prepareError !== null)
+        verify(prepareErrorText !== null)
 
         testSendRecipient.isValid = true
         transactionPreparedSpy.target = page
@@ -75,17 +81,23 @@ TestCase {
         transactionPreparedSpy.clear()
 
         const callsBefore = testWalletModel.prepareTransactionCalls
+        compare(page.prepareTransactionErrorText, "")
+        compare(prepareErrorText.text, "")
 
         testWalletModel.prepareTransactionResult = false
         continueButton.clicked()
         compare(testWalletModel.prepareTransactionCalls, callsBefore + 1)
         compare(transactionPreparedSpy.count, 0)
+        compare(page.prepareTransactionErrorText, "Amount plus fee exceeds available balance")
+        compare(prepareErrorText.text, "Amount plus fee exceeds available balance")
 
         testWalletModel.prepareTransactionResult = true
         continueButton.clicked()
         compare(testWalletModel.prepareTransactionCalls, callsBefore + 2)
         compare(transactionPreparedSpy.count, 1)
         compare(transactionPreparedSpy.signalArguments[0][0], false)
+        compare(page.prepareTransactionErrorText, "")
+        compare(prepareErrorText.text, "")
     }
 
     function test_send_fee_selection_updates_wallet_target_blocks() {
@@ -200,7 +212,7 @@ TestCase {
         verify(includedFeeNoteText !== null)
 
         compare(includedFeeNote.visible, false)
-        compare(includedFeeNoteText.text, "Fees are included in the amount")
+        compare(includedFeeNoteText.text, "Fee is included in the amount")
     }
 
     function test_send_include_fee_toggle_updates_recipient_and_schedules_fee_estimate() {

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/pages/wallet"
+
+TestCase {
+    name: "Send"
+    when: windowShown
+    width: 900
+    height: 700
+
+    Component {
+        id: sendComponent
+
+        Send {}
+    }
+
+    SignalSpy {
+        id: transactionPreparedSpy
+    }
+
+    function test_send_has_stable_selectors() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        compare(page.objectName, "walletSendPage")
+        verify(findChild(page, "sendAddressInput") !== null)
+        verify(findChild(page, "sendAmountInput") !== null)
+        verify(findChild(page, "sendNoteInput") !== null)
+        verify(findChild(page, "feeSelectionEstimateLabel") !== null)
+        verify(findChild(page, "sendContinueButton") !== null)
+    }
+
+    function test_send_continue_button_tracks_recipient_validity() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const continueButton = findChild(page, "sendContinueButton")
+        verify(continueButton !== null)
+
+        testSendRecipient.isValid = false
+        tryCompare(continueButton, "enabled", false)
+
+        testSendRecipient.isValid = true
+        tryCompare(continueButton, "enabled", true)
+    }
+
+    function test_send_prepare_transaction_success_and_failure_paths() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const continueButton = findChild(page, "sendContinueButton")
+        verify(continueButton !== null)
+
+        testSendRecipient.isValid = true
+        transactionPreparedSpy.target = page
+        transactionPreparedSpy.signalName = "transactionPrepared"
+        transactionPreparedSpy.clear()
+
+        const callsBefore = testWalletModel.prepareTransactionCalls
+
+        testWalletModel.prepareTransactionResult = false
+        continueButton.clicked()
+        compare(testWalletModel.prepareTransactionCalls, callsBefore + 1)
+        compare(transactionPreparedSpy.count, 0)
+
+        testWalletModel.prepareTransactionResult = true
+        continueButton.clicked()
+        compare(testWalletModel.prepareTransactionCalls, callsBefore + 2)
+        compare(transactionPreparedSpy.count, 1)
+        compare(transactionPreparedSpy.signalArguments[0][0], false)
+    }
+
+    function test_send_fee_selection_updates_wallet_target_blocks() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        testWalletModel.targetBlocks = 2
+        const popup = findChild(page, "feeSelectionPopup")
+        const list = findChild(page, "feeSelectionList")
+        verify(popup !== null)
+        verify(list !== null)
+
+        popup.open()
+        tryVerify(function() {
+            return list.itemAtIndex(0) !== null
+        })
+
+        const highFeeOption = list.itemAtIndex(0)
+        verify(highFeeOption !== null)
+        highFeeOption.clicked()
+
+        compare(testWalletModel.targetBlocks, 1)
+    }
+
+    function test_send_amount_changes_schedule_live_fee_estimation() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const amountInput = findChild(page, "sendAmountInput")
+        verify(amountInput !== null)
+
+        const callsBefore = testWalletModel.scheduleFeeEstimatesCalls
+        amountInput.text = "0.01000000"
+
+        tryCompare(testWalletModel, "scheduleFeeEstimatesCalls", callsBefore + 1)
+    }
+
+    function test_send_shows_selected_estimated_fee() {
+        testWalletModel.targetBlocks = 2
+
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const estimateLabel = findChild(page, "feeSelectionEstimateLabel")
+        verify(estimateLabel !== null)
+        compare(estimateLabel.text, "0.00000500 ₿")
+    }
+}

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -27,6 +27,7 @@ TestCase {
         testWalletModel.customFeeRate = ""
         testWalletModel.targetBlocks = 2
         testWalletModel.prepareTransactionResult = true
+        testSendRecipient.subtractFeeFromAmount = false
         testSendRecipient.isValid = true
     }
 
@@ -41,6 +42,9 @@ TestCase {
         verify(findChild(page, "feeSelectionEstimateLabel") !== null)
         verify(findChild(page, "feeSelectionCustomRateInput") !== null)
         verify(findChild(page, "feeSelectionCustomEstimateLabel") !== null)
+        verify(findChild(page, "feeSelectionIncludeFeeToggle") !== null)
+        verify(findChild(page, "sendFeeIncludedNote") !== null)
+        verify(findChild(page, "sendFeeIncludedNoteText") !== null)
         verify(findChild(page, "sendContinueButton") !== null)
     }
 
@@ -184,5 +188,41 @@ TestCase {
 
         customInput.text = "2"
         tryCompare(continueButton, "enabled", true)
+    }
+
+    function test_send_include_fee_note_tracks_recipient_state() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const includedFeeNote = findChild(page, "sendFeeIncludedNote")
+        const includedFeeNoteText = findChild(page, "sendFeeIncludedNoteText")
+        verify(includedFeeNote !== null)
+        verify(includedFeeNoteText !== null)
+
+        compare(includedFeeNote.visible, false)
+        compare(includedFeeNoteText.text, "Fees are included in the amount")
+    }
+
+    function test_send_include_fee_toggle_updates_recipient_and_schedules_fee_estimate() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const popup = findChild(page, "feeSelectionPopup")
+        const toggle = findChild(page, "feeSelectionIncludeFeeToggle")
+        const note = findChild(page, "sendFeeIncludedNote")
+        verify(popup !== null)
+        verify(toggle !== null)
+        verify(note !== null)
+
+        const callsBefore = testWalletModel.scheduleFeeEstimatesCalls
+
+        popup.open()
+        tryCompare(popup, "opened", true)
+
+        toggle.clicked()
+
+        compare(testSendRecipient.subtractFeeFromAmount, true)
+        tryCompare(testWalletModel, "scheduleFeeEstimatesCalls", callsBefore + 1)
+        compare(popup.visible, false)
     }
 }

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -18,6 +18,7 @@ int RunNetworkStyleTests(int argc, char* argv[]);
 int RunQmlInitExecutorApiTests(int argc, char* argv[]);
 int RunOptionsModelTests(int argc, char* argv[]);
 int RunBanListModelTests(int argc, char* argv[]);
+int RunWalletQmlModelTests(int argc, char* argv[]);
 
 int main(int argc, char* argv[])
 {
@@ -35,6 +36,7 @@ int main(int argc, char* argv[])
     status |= RunQmlInitExecutorApiTests(argc, argv);
     status |= RunOptionsModelTests(argc, argv);
     status |= RunBanListModelTests(argc, argv);
+    status |= RunWalletQmlModelTests(argc, argv);
 
     return status;
 }

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -8,11 +8,13 @@
 #include <qml/models/sendrecipient.h>
 #include <qml/models/sendrecipientslistmodel.h>
 #include <qml/models/walletqmlmodel.h>
+#include <qml/models/walletqmlmodeltransaction.h>
 
 #include <chainparams.h>
 #include <key_io.h>
 #include <primitives/transaction.h>
 
+#include <QSignalSpy>
 #include <QSemaphore>
 
 #include <algorithm>
@@ -68,13 +70,16 @@ std::unique_ptr<WalletQmlModel> MakeWalletModel(NiceMock<MockWallet>*& wallet_ou
     return std::make_unique<WalletQmlModel>(std::move(wallet));
 }
 
-void SetValidRecipient(WalletQmlModel& model, const QString& address = VALID_MAINNET_ADDRESS)
+void SetValidRecipient(WalletQmlModel& model,
+                       const QString& address = VALID_MAINNET_ADDRESS,
+                       const bool subtract_fee_from_amount = false)
 {
     auto* recipient = model.sendRecipientList()->currentRecipient();
     QVERIFY(recipient != nullptr);
 
     recipient->address()->setAddress(address, 0);
     recipient->amount()->setSatoshi(50'000);
+    recipient->setSubtractFeeFromAmount(subtract_fee_from_amount);
 
     QVERIFY2(recipient->isValid(), "Recipient must be valid before scheduling fee estimates");
 }
@@ -94,6 +99,8 @@ private Q_SLOTS:
     void scheduleFeeEstimates_usesCustomFeeRateWhenEnabled();
     void prepareTransaction_usesStaticRegtestFeeOverride();
     void prepareTransaction_usesCustomFeeRateWithoutRegtestOverride();
+    void prepareTransaction_reassignsAmountWhenFeeIncluded();
+    void walletQmlModelTransaction_reassignAmounts_excludesChangeOutput();
     void scheduleFeeEstimates_usesSelectedCoinsInCoinControl();
     void scheduleFeeEstimates_debouncesRapidRestarts();
 };
@@ -385,6 +392,76 @@ void WalletQmlModelTests::prepareTransaction_usesCustomFeeRateWithoutRegtestOver
     QCOMPARE(requested_targets.at(0), 0U);
     QCOMPARE(requested_fee_rates.size(), 1U);
     QCOMPARE(requested_fee_rates.at(0), CAmount{2000});
+}
+
+void WalletQmlModelTests::prepareTransaction_reassignsAmountWhenFeeIncluded()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model, VALID_MAINNET_ADDRESS, /*subtract_fee_from_amount=*/true);
+
+    bool saw_subtract_fee_from_amount{false};
+    bool saw_wrong_recipient_count{false};
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>& recipients,
+                                           const wallet::CCoinControl&,
+                                           bool,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        if (recipients.size() != 1U) {
+            saw_wrong_recipient_count = true;
+            return util::Error{Untranslated("unexpected recipient count")};
+        }
+        saw_subtract_fee_from_amount = recipients.at(0).fSubtractFeeFromAmount;
+        change_pos = -1;
+        fee = 200;
+
+        CMutableTransaction tx;
+        tx.vout.emplace_back(/*nValue=*/49'800, CScript{});
+        return util::Result<CTransactionRef>{MakeTransactionRef(std::move(tx))};
+    };
+
+    QVERIFY(model->prepareTransaction());
+    QVERIFY(!saw_wrong_recipient_count);
+    QVERIFY(saw_subtract_fee_from_amount);
+    QVERIFY(model->currentTransaction() != nullptr);
+    QCOMPARE(model->currentTransaction()->amount(), QStringLiteral("49800"));
+    QCOMPARE(model->currentTransaction()->fee(), QStringLiteral("200"));
+    QCOMPARE(model->currentTransaction()->total(), QStringLiteral("50000"));
+    QCOMPARE(model->currentTransaction()->getTotalTransactionAmount(), CAmount{50'000});
+}
+
+void WalletQmlModelTests::walletQmlModelTransaction_reassignAmounts_excludesChangeOutput()
+{
+    SendRecipientsListModel recipients;
+    auto* recipient = recipients.currentRecipient();
+    QVERIFY(recipient != nullptr);
+
+    recipient->address()->setAddress(VALID_MAINNET_ADDRESS, 0);
+    recipient->amount()->setSatoshi(50'000);
+
+    WalletQmlModelTransaction transaction{&recipients};
+    QSignalSpy amount_changed_spy{&transaction, &WalletQmlModelTransaction::amountChanged};
+    QSignalSpy total_changed_spy{&transaction, &WalletQmlModelTransaction::totalChanged};
+    QSignalSpy fee_changed_spy{&transaction, &WalletQmlModelTransaction::feeChanged};
+
+    CMutableTransaction tx;
+    tx.vout.emplace_back(/*nValue=*/49'800, CScript{});
+    tx.vout.emplace_back(/*nValue=*/1'000, CScript{}); // change
+    transaction.setWtx(MakeTransactionRef(std::move(tx)));
+
+    transaction.setTransactionFee(200);
+    QCOMPARE(fee_changed_spy.count(), 1);
+    QCOMPARE(total_changed_spy.count(), 1);
+    QCOMPARE(transaction.total(), QStringLiteral("50200"));
+
+    transaction.reassignAmounts(/*nChangePosRet=*/1);
+
+    QCOMPARE(amount_changed_spy.count(), 1);
+    QCOMPARE(total_changed_spy.count(), 2);
+    QCOMPARE(transaction.amount(), QStringLiteral("49800"));
+    QCOMPARE(transaction.fee(), QStringLiteral("200"));
+    QCOMPARE(transaction.total(), QStringLiteral("50000"));
+    QCOMPARE(transaction.getTotalTransactionAmount(), CAmount{50'000});
 }
 
 void WalletQmlModelTests::scheduleFeeEstimates_usesSelectedCoinsInCoinControl()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -15,6 +15,7 @@
 
 #include <QSemaphore>
 
+#include <algorithm>
 #include <atomic>
 #include <memory>
 #include <vector>
@@ -90,7 +91,9 @@ private Q_SLOTS:
     void scheduleFeeEstimates_populatesFormattedEstimates();
     void scheduleFeeEstimates_fallsBackWhenNetworkFeeEstimatesUnavailable();
     void scheduleFeeEstimates_usesStaticRegtestFeeOverride();
+    void scheduleFeeEstimates_usesCustomFeeRateWhenEnabled();
     void prepareTransaction_usesStaticRegtestFeeOverride();
+    void prepareTransaction_usesCustomFeeRateWithoutRegtestOverride();
     void scheduleFeeEstimates_usesSelectedCoinsInCoinControl();
     void scheduleFeeEstimates_debouncesRapidRestarts();
 };
@@ -268,6 +271,44 @@ void WalletQmlModelTests::scheduleFeeEstimates_usesStaticRegtestFeeOverride()
     QCOMPARE(requested_fee_rates.at(2), CAmount{wallet::DEFAULT_TRANSACTION_MINFEE});
 }
 
+void WalletQmlModelTests::scheduleFeeEstimates_usesCustomFeeRateWhenEnabled()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model);
+
+    std::vector<unsigned int> requested_targets;
+    std::vector<CAmount> requested_fee_rates;
+
+    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        requested_targets.push_back(coin_control.m_confirm_target.value_or(0));
+        requested_fee_rates.push_back(coin_control.m_feerate.has_value() ? coin_control.m_feerate->GetFeePerK() : 0);
+        change_pos = -1;
+        fee = coin_control.m_feerate.has_value()
+            ? coin_control.m_feerate->GetFee(250)
+            : coin_control.m_confirm_target.value_or(0) * 100;
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    model->setCustomFeeEnabled(true);
+    model->setCustomFeeRate(QStringLiteral("2"));
+    model->scheduleFeeEstimates();
+
+    QTRY_COMPARE_WITH_TIMEOUT(model->estimatedFee(), QStringLiteral("0.00000500 ₿"), FEE_ESTIMATE_TIMEOUT_MS);
+    QCOMPARE(requested_targets.size(), 4U);
+    QCOMPARE(requested_fee_rates.size(), 4U);
+    QVERIFY(std::find(requested_fee_rates.begin(), requested_fee_rates.end(), CAmount{2000}) != requested_fee_rates.end());
+    QVERIFY(std::find(requested_targets.begin(), requested_targets.end(), 1U) != requested_targets.end());
+    QVERIFY(std::find(requested_targets.begin(), requested_targets.end(), 2U) != requested_targets.end());
+    QVERIFY(std::find(requested_targets.begin(), requested_targets.end(), 6U) != requested_targets.end());
+    QVERIFY(std::find(requested_targets.begin(), requested_targets.end(), 0U) != requested_targets.end());
+}
+
 void WalletQmlModelTests::prepareTransaction_usesStaticRegtestFeeOverride()
 {
     ChainSelectionGuard chain_guard{ChainType::REGTEST};
@@ -304,6 +345,46 @@ void WalletQmlModelTests::prepareTransaction_usesStaticRegtestFeeOverride()
     QCOMPARE(requested_targets.at(0), 0U);
     QCOMPARE(requested_fee_rates.size(), 1U);
     QCOMPARE(requested_fee_rates.at(0), CAmount{wallet::DEFAULT_TRANSACTION_MINFEE});
+}
+
+void WalletQmlModelTests::prepareTransaction_usesCustomFeeRateWithoutRegtestOverride()
+{
+    ChainSelectionGuard chain_guard{ChainType::REGTEST};
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model, VALID_REGTEST_ADDRESS);
+
+    std::vector<unsigned int> requested_targets;
+    std::vector<CAmount> requested_fee_rates;
+
+    EXPECT_CALL(*wallet, getRequiredFee(1000)).Times(0);
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        requested_targets.push_back(coin_control.m_confirm_target.value_or(0));
+        requested_fee_rates.push_back(coin_control.m_feerate.has_value() ? coin_control.m_feerate->GetFeePerK() : 0);
+        change_pos = -1;
+
+        if (!coin_control.m_feerate.has_value()) {
+            return util::Error{Untranslated("missing custom fee override")};
+        }
+
+        fee = coin_control.m_feerate->GetFee(250);
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    model->setCustomFeeEnabled(true);
+    model->setCustomFeeRate(QStringLiteral("2"));
+
+    QVERIFY(model->prepareTransaction());
+    QVERIFY(model->currentTransaction() != nullptr);
+    QCOMPARE(model->currentTransaction()->getTransactionFee(), CAmount{500});
+    QCOMPARE(requested_targets.size(), 1U);
+    QCOMPARE(requested_targets.at(0), 0U);
+    QCOMPARE(requested_fee_rates.size(), 1U);
+    QCOMPARE(requested_fee_rates.at(0), CAmount{2000});
 }
 
 void WalletQmlModelTests::scheduleFeeEstimates_usesSelectedCoinsInCoinControl()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -27,6 +27,25 @@ using ::testing::AtLeast;
 
 constexpr auto FEE_ESTIMATE_TIMEOUT_MS{3'000};
 const auto VALID_MAINNET_ADDRESS = QStringLiteral("1BoatSLRHtKNngkdXEeobR76b53LETtpyT");
+const auto VALID_REGTEST_ADDRESS = QStringLiteral("bcrt1qdavt4j2sd7dlhqsavtnfxvzppw6k7qy97tmnu9");
+
+class ChainSelectionGuard
+{
+public:
+    explicit ChainSelectionGuard(const ChainType chain_type)
+        : m_previous_chain_type{Params().GetChainType()}
+    {
+        SelectParams(chain_type);
+    }
+
+    ~ChainSelectionGuard()
+    {
+        SelectParams(m_previous_chain_type);
+    }
+
+private:
+    ChainType m_previous_chain_type;
+};
 
 std::unique_ptr<WalletQmlModel> MakeWalletModel(NiceMock<MockWallet>*& wallet_out)
 {
@@ -48,12 +67,12 @@ std::unique_ptr<WalletQmlModel> MakeWalletModel(NiceMock<MockWallet>*& wallet_ou
     return std::make_unique<WalletQmlModel>(std::move(wallet));
 }
 
-void SetValidRecipient(WalletQmlModel& model)
+void SetValidRecipient(WalletQmlModel& model, const QString& address = VALID_MAINNET_ADDRESS)
 {
     auto* recipient = model.sendRecipientList()->currentRecipient();
     QVERIFY(recipient != nullptr);
 
-    recipient->address()->setAddress(VALID_MAINNET_ADDRESS, 0);
+    recipient->address()->setAddress(address, 0);
     recipient->amount()->setSatoshi(50'000);
 
     QVERIFY2(recipient->isValid(), "Recipient must be valid before scheduling fee estimates");
@@ -70,6 +89,8 @@ private Q_SLOTS:
     void estimatedFeeForTarget_returnsEmptyWhenUnavailable();
     void scheduleFeeEstimates_populatesFormattedEstimates();
     void scheduleFeeEstimates_fallsBackWhenNetworkFeeEstimatesUnavailable();
+    void scheduleFeeEstimates_usesStaticRegtestFeeOverride();
+    void prepareTransaction_usesStaticRegtestFeeOverride();
     void scheduleFeeEstimates_usesSelectedCoinsInCoinControl();
     void scheduleFeeEstimates_debouncesRapidRestarts();
 };
@@ -199,6 +220,90 @@ void WalletQmlModelTests::scheduleFeeEstimates_fallsBackWhenNetworkFeeEstimatesU
     QCOMPARE(fallback_fee_rates.at(0), CAmount{3000});
     QCOMPARE(fallback_fee_rates.at(1), CAmount{2000});
     QCOMPARE(fallback_fee_rates.at(2), CAmount{1000});
+}
+
+void WalletQmlModelTests::scheduleFeeEstimates_usesStaticRegtestFeeOverride()
+{
+    ChainSelectionGuard chain_guard{ChainType::REGTEST};
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model, VALID_REGTEST_ADDRESS);
+
+    bool saw_sign_true{false};
+    std::vector<unsigned int> requested_targets;
+    std::vector<CAmount> requested_fee_rates;
+
+    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    EXPECT_CALL(*wallet, getRequiredFee(1000)).Times(0);
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool sign,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        if (sign) saw_sign_true = true;
+        requested_targets.push_back(coin_control.m_confirm_target.value_or(0));
+        requested_fee_rates.push_back(coin_control.m_feerate.has_value() ? coin_control.m_feerate->GetFeePerK() : 0);
+        change_pos = -1;
+
+        if (!coin_control.m_feerate.has_value()) return util::Error{Untranslated("missing regtest fee override")};
+
+        fee = coin_control.m_feerate->GetFee(250);
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    model->scheduleFeeEstimates();
+
+    QTRY_COMPARE_WITH_TIMEOUT(model->estimatedFeeForTarget(2), QStringLiteral("0.00000250 ₿"), FEE_ESTIMATE_TIMEOUT_MS);
+    QVERIFY(!saw_sign_true);
+    QCOMPARE(model->estimatedFeeForTarget(1), QStringLiteral("0.00000250 ₿"));
+    QCOMPARE(model->estimatedFeeForTarget(2), QStringLiteral("0.00000250 ₿"));
+    QCOMPARE(model->estimatedFeeForTarget(6), QStringLiteral("0.00000250 ₿"));
+    QCOMPARE(requested_targets.size(), 3U);
+    QCOMPARE(requested_targets.at(0), 0U);
+    QCOMPARE(requested_targets.at(1), 0U);
+    QCOMPARE(requested_targets.at(2), 0U);
+    QCOMPARE(requested_fee_rates.size(), 3U);
+    QCOMPARE(requested_fee_rates.at(0), CAmount{wallet::DEFAULT_TRANSACTION_MINFEE});
+    QCOMPARE(requested_fee_rates.at(1), CAmount{wallet::DEFAULT_TRANSACTION_MINFEE});
+    QCOMPARE(requested_fee_rates.at(2), CAmount{wallet::DEFAULT_TRANSACTION_MINFEE});
+}
+
+void WalletQmlModelTests::prepareTransaction_usesStaticRegtestFeeOverride()
+{
+    ChainSelectionGuard chain_guard{ChainType::REGTEST};
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model, VALID_REGTEST_ADDRESS);
+
+    bool saw_sign_false{false};
+    std::vector<unsigned int> requested_targets;
+    std::vector<CAmount> requested_fee_rates;
+
+    EXPECT_CALL(*wallet, getRequiredFee(1000)).Times(0);
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool sign,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        if (!sign) saw_sign_false = true;
+        requested_targets.push_back(coin_control.m_confirm_target.value_or(0));
+        requested_fee_rates.push_back(coin_control.m_feerate.has_value() ? coin_control.m_feerate->GetFeePerK() : 0);
+        change_pos = -1;
+
+        if (!coin_control.m_feerate.has_value()) return util::Error{Untranslated("missing regtest fee override")};
+
+        fee = coin_control.m_feerate->GetFee(250);
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    QVERIFY(model->prepareTransaction());
+    QVERIFY(!saw_sign_false);
+    QVERIFY(model->currentTransaction() != nullptr);
+    QCOMPARE(model->currentTransaction()->getTransactionFee(), CAmount{250});
+    QCOMPARE(requested_targets.size(), 1U);
+    QCOMPARE(requested_targets.at(0), 0U);
+    QCOMPARE(requested_fee_rates.size(), 1U);
+    QCOMPARE(requested_fee_rates.at(0), CAmount{wallet::DEFAULT_TRANSACTION_MINFEE});
 }
 
 void WalletQmlModelTests::scheduleFeeEstimates_usesSelectedCoinsInCoinControl()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -23,6 +23,7 @@ namespace {
 using ::testing::Invoke;
 using ::testing::NiceMock;
 using ::testing::Return;
+using ::testing::AtLeast;
 
 constexpr auto FEE_ESTIMATE_TIMEOUT_MS{3'000};
 const auto VALID_MAINNET_ADDRESS = QStringLiteral("1BoatSLRHtKNngkdXEeobR76b53LETtpyT");
@@ -35,6 +36,7 @@ std::unique_ptr<WalletQmlModel> MakeWalletModel(NiceMock<MockWallet>*& wallet_ou
     ON_CALL(*wallet_out, getWalletTxs()).WillByDefault(Return(std::set<interfaces::WalletTx>{}));
     ON_CALL(*wallet_out, listCoins()).WillByDefault(Return(interfaces::Wallet::CoinsList{}));
     ON_CALL(*wallet_out, getBalance()).WillByDefault(Return(10 * COIN));
+    ON_CALL(*wallet_out, getRequiredFee(testing::_)).WillByDefault(Return(1000));
     ON_CALL(*wallet_out, getDefaultAddressType()).WillByDefault(Return(OutputType::BECH32));
     ON_CALL(*wallet_out, handleTransactionChanged(testing::_)).WillByDefault(Invoke([](interfaces::Wallet::TransactionChangedFn) {
         return std::unique_ptr<interfaces::Handler>{};
@@ -65,8 +67,9 @@ class WalletQmlModelTests : public QObject
 private Q_SLOTS:
     void initTestCase();
     void feeTargetIndex_mapsStandardTargets();
-    void estimatedFeeForTarget_returnsDashWhenUnavailable();
+    void estimatedFeeForTarget_returnsEmptyWhenUnavailable();
     void scheduleFeeEstimates_populatesFormattedEstimates();
+    void scheduleFeeEstimates_fallsBackWhenNetworkFeeEstimatesUnavailable();
     void scheduleFeeEstimates_usesSelectedCoinsInCoinControl();
     void scheduleFeeEstimates_debouncesRapidRestarts();
 };
@@ -86,13 +89,13 @@ void WalletQmlModelTests::feeTargetIndex_mapsStandardTargets()
     QCOMPARE(model.feeTargetIndex(42), 1);
 }
 
-void WalletQmlModelTests::estimatedFeeForTarget_returnsDashWhenUnavailable()
+void WalletQmlModelTests::estimatedFeeForTarget_returnsEmptyWhenUnavailable()
 {
     WalletQmlModel model;
 
-    QCOMPARE(model.estimatedFeeForTarget(1), QStringLiteral("—"));
-    QCOMPARE(model.estimatedFeeForTarget(2), QStringLiteral("—"));
-    QCOMPARE(model.estimatedFee(), QStringLiteral("—"));
+    QCOMPARE(model.estimatedFeeForTarget(1), QString());
+    QCOMPARE(model.estimatedFeeForTarget(2), QString());
+    QCOMPARE(model.estimatedFee(), QString());
 }
 
 void WalletQmlModelTests::scheduleFeeEstimates_populatesFormattedEstimates()
@@ -135,7 +138,7 @@ void WalletQmlModelTests::scheduleFeeEstimates_populatesFormattedEstimates()
 
     QTRY_VERIFY_WITH_TIMEOUT(first_call_started.load(), FEE_ESTIMATE_TIMEOUT_MS);
     QTRY_VERIFY_WITH_TIMEOUT(model->feeEstimatePending(), FEE_ESTIMATE_TIMEOUT_MS);
-    QCOMPARE(model->estimatedFeeForTarget(2), QStringLiteral("…"));
+    QCOMPARE(model->estimatedFeeForTarget(2), QString());
 
     release_first_call.release();
 
@@ -152,6 +155,50 @@ void WalletQmlModelTests::scheduleFeeEstimates_populatesFormattedEstimates()
     QCOMPARE(model->estimatedFeeForTarget(2), QStringLiteral("0.00000200 ₿"));
     QCOMPARE(model->estimatedFeeForTarget(6), QStringLiteral("0.00000600 ₿"));
     QCOMPARE(model->estimatedFee(), QStringLiteral("0.00000200 ₿"));
+}
+
+void WalletQmlModelTests::scheduleFeeEstimates_fallsBackWhenNetworkFeeEstimatesUnavailable()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model);
+
+    std::atomic<bool> saw_fallback_feerate{false};
+    std::vector<CAmount> fallback_fee_rates;
+
+    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    EXPECT_CALL(*wallet, getRequiredFee(1000)).Times(AtLeast(3)).WillRepeatedly(Return(1000));
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        change_pos = -1;
+
+        if (!coin_control.m_feerate.has_value()) {
+            return util::Error{Untranslated("fee estimation unavailable")};
+        }
+
+        saw_fallback_feerate = true;
+        fallback_fee_rates.push_back(coin_control.m_feerate->GetFeePerK());
+        fee = coin_control.m_feerate->GetFee(250);
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    model->scheduleFeeEstimates();
+
+    QTRY_COMPARE_WITH_TIMEOUT(model->estimatedFeeForTarget(2), QStringLiteral("0.00000500 ₿"), FEE_ESTIMATE_TIMEOUT_MS);
+    QTRY_VERIFY_WITH_TIMEOUT(!model->feeEstimatePending(), FEE_ESTIMATE_TIMEOUT_MS);
+    QVERIFY(saw_fallback_feerate.load());
+    QVERIFY(!fallback_fee_rates.empty());
+    QCOMPARE(model->estimatedFeeForTarget(1), QStringLiteral("0.00000750 ₿"));
+    QCOMPARE(model->estimatedFeeForTarget(2), QStringLiteral("0.00000500 ₿"));
+    QCOMPARE(model->estimatedFeeForTarget(6), QStringLiteral("0.00000250 ₿"));
+    QCOMPARE(model->estimatedFee(), QStringLiteral("0.00000500 ₿"));
+    QCOMPARE(fallback_fee_rates.size(), 3U);
+    QCOMPARE(fallback_fee_rates.at(0), CAmount{3000});
+    QCOMPARE(fallback_fee_rates.at(1), CAmount{2000});
+    QCOMPARE(fallback_fee_rates.at(2), CAmount{1000});
 }
 
 void WalletQmlModelTests::scheduleFeeEstimates_usesSelectedCoinsInCoinControl()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <test/mocks/mockwallet.h>
+#include <qml/models/sendrecipient.h>
+#include <qml/models/sendrecipientslistmodel.h>
+#include <qml/models/walletqmlmodel.h>
+
+#include <chainparams.h>
+#include <key_io.h>
+#include <primitives/transaction.h>
+
+#include <QSemaphore>
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+namespace {
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+constexpr auto FEE_ESTIMATE_TIMEOUT_MS{3'000};
+const auto VALID_MAINNET_ADDRESS = QStringLiteral("1BoatSLRHtKNngkdXEeobR76b53LETtpyT");
+
+std::unique_ptr<WalletQmlModel> MakeWalletModel(NiceMock<MockWallet>*& wallet_out)
+{
+    auto wallet = std::make_unique<NiceMock<MockWallet>>();
+    wallet_out = wallet.get();
+
+    ON_CALL(*wallet_out, getWalletTxs()).WillByDefault(Return(std::set<interfaces::WalletTx>{}));
+    ON_CALL(*wallet_out, listCoins()).WillByDefault(Return(interfaces::Wallet::CoinsList{}));
+    ON_CALL(*wallet_out, getBalance()).WillByDefault(Return(10 * COIN));
+    ON_CALL(*wallet_out, getDefaultAddressType()).WillByDefault(Return(OutputType::BECH32));
+    ON_CALL(*wallet_out, handleTransactionChanged(testing::_)).WillByDefault(Invoke([](interfaces::Wallet::TransactionChangedFn) {
+        return std::unique_ptr<interfaces::Handler>{};
+    }));
+    ON_CALL(*wallet_out, getNewDestinationValue(testing::_, testing::_)).WillByDefault(Invoke([](OutputType, const std::string&) {
+        return DecodeDestination(VALID_MAINNET_ADDRESS.toStdString());
+    }));
+
+    return std::make_unique<WalletQmlModel>(std::move(wallet));
+}
+
+void SetValidRecipient(WalletQmlModel& model)
+{
+    auto* recipient = model.sendRecipientList()->currentRecipient();
+    QVERIFY(recipient != nullptr);
+
+    recipient->address()->setAddress(VALID_MAINNET_ADDRESS, 0);
+    recipient->amount()->setSatoshi(50'000);
+
+    QVERIFY2(recipient->isValid(), "Recipient must be valid before scheduling fee estimates");
+}
+} // namespace
+
+class WalletQmlModelTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase();
+    void feeTargetIndex_mapsStandardTargets();
+    void estimatedFeeForTarget_returnsDashWhenUnavailable();
+    void scheduleFeeEstimates_populatesFormattedEstimates();
+    void scheduleFeeEstimates_usesSelectedCoinsInCoinControl();
+    void scheduleFeeEstimates_debouncesRapidRestarts();
+};
+
+void WalletQmlModelTests::initTestCase()
+{
+    SelectParams(ChainType::MAIN);
+}
+
+void WalletQmlModelTests::feeTargetIndex_mapsStandardTargets()
+{
+    WalletQmlModel model;
+
+    QCOMPARE(model.feeTargetIndex(1), 0);
+    QCOMPARE(model.feeTargetIndex(2), 1);
+    QCOMPARE(model.feeTargetIndex(6), 2);
+    QCOMPARE(model.feeTargetIndex(42), 1);
+}
+
+void WalletQmlModelTests::estimatedFeeForTarget_returnsDashWhenUnavailable()
+{
+    WalletQmlModel model;
+
+    QCOMPARE(model.estimatedFeeForTarget(1), QStringLiteral("—"));
+    QCOMPARE(model.estimatedFeeForTarget(2), QStringLiteral("—"));
+    QCOMPARE(model.estimatedFee(), QStringLiteral("—"));
+}
+
+void WalletQmlModelTests::scheduleFeeEstimates_populatesFormattedEstimates()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model);
+
+    QSemaphore release_first_call;
+    std::atomic<bool> first_call_started{false};
+    std::atomic<bool> first_call_blocked{false};
+    std::atomic<bool> saw_sign_true{false};
+    std::atomic<bool> saw_wrong_recipient_count{false};
+    std::atomic<bool> saw_selected_inputs{false};
+    std::atomic<bool> saw_nonempty_feerate{false};
+    std::vector<unsigned int> requested_targets;
+
+    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>& recipients,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool sign,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        if (sign) saw_sign_true = true;
+        if (recipients.size() != 1U) saw_wrong_recipient_count = true;
+        if (coin_control.HasSelected() || !coin_control.ListSelected().empty()) saw_selected_inputs = true;
+        if (coin_control.m_feerate.has_value()) saw_nonempty_feerate = true;
+
+        requested_targets.push_back(coin_control.m_confirm_target.value_or(0));
+        change_pos = -1;
+        fee = coin_control.m_confirm_target.value_or(0) * 100;
+        if (!first_call_blocked.exchange(true)) {
+            first_call_started = true;
+            release_first_call.acquire();
+        }
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    model->scheduleFeeEstimates();
+
+    QTRY_VERIFY_WITH_TIMEOUT(first_call_started.load(), FEE_ESTIMATE_TIMEOUT_MS);
+    QTRY_VERIFY_WITH_TIMEOUT(model->feeEstimatePending(), FEE_ESTIMATE_TIMEOUT_MS);
+    QCOMPARE(model->estimatedFeeForTarget(2), QStringLiteral("…"));
+
+    release_first_call.release();
+
+    QTRY_VERIFY_WITH_TIMEOUT(requested_targets.size() == 3, FEE_ESTIMATE_TIMEOUT_MS);
+    QVERIFY(!saw_sign_true.load());
+    QVERIFY(!saw_wrong_recipient_count.load());
+    QVERIFY(!saw_selected_inputs.load());
+    QVERIFY(!saw_nonempty_feerate.load());
+    QCOMPARE(requested_targets.at(0), 1U);
+    QCOMPARE(requested_targets.at(1), 2U);
+    QCOMPARE(requested_targets.at(2), 6U);
+    QTRY_VERIFY_WITH_TIMEOUT(!model->feeEstimatePending(), FEE_ESTIMATE_TIMEOUT_MS);
+    QCOMPARE(model->estimatedFeeForTarget(1), QStringLiteral("0.00000100 ₿"));
+    QCOMPARE(model->estimatedFeeForTarget(2), QStringLiteral("0.00000200 ₿"));
+    QCOMPARE(model->estimatedFeeForTarget(6), QStringLiteral("0.00000600 ₿"));
+    QCOMPARE(model->estimatedFee(), QStringLiteral("0.00000200 ₿"));
+}
+
+void WalletQmlModelTests::scheduleFeeEstimates_usesSelectedCoinsInCoinControl()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model);
+
+    const COutPoint selected_outpoint{Txid{}, 5};
+    std::atomic<int> create_transaction_calls{0};
+    std::atomic<bool> saw_sign_true{false};
+    std::atomic<bool> saw_missing_selection{false};
+    std::atomic<int> selected_count{-1};
+    std::vector<unsigned int> selected_targets;
+
+    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool sign,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        if (sign) saw_sign_true = true;
+        if (!coin_control.HasSelected() || !coin_control.IsSelected(selected_outpoint)) saw_missing_selection = true;
+        const auto selected = coin_control.ListSelected();
+        selected_count = static_cast<int>(selected.size());
+        if (selected.size() != 1U || selected.front() != selected_outpoint) saw_missing_selection = true;
+
+        selected_targets.push_back(coin_control.m_confirm_target.value_or(0));
+        ++create_transaction_calls;
+        change_pos = -1;
+        fee = coin_control.m_confirm_target.value_or(0) * 200;
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    model->selectCoin(selected_outpoint);
+
+    QTRY_COMPARE_WITH_TIMEOUT(create_transaction_calls.load(), 3, FEE_ESTIMATE_TIMEOUT_MS);
+    QVERIFY(!saw_sign_true.load());
+    QVERIFY(!saw_missing_selection.load());
+    QCOMPARE(selected_count.load(), 1);
+    QCOMPARE(selected_targets.size(), 3U);
+    QCOMPARE(selected_targets.at(0), 1U);
+    QCOMPARE(selected_targets.at(1), 2U);
+    QCOMPARE(selected_targets.at(2), 6U);
+}
+
+void WalletQmlModelTests::scheduleFeeEstimates_debouncesRapidRestarts()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model);
+
+    std::atomic<int> create_transaction_calls{0};
+
+    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    std::atomic<bool> saw_sign_true{false};
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool sign,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        if (sign) saw_sign_true = true;
+        ++create_transaction_calls;
+        change_pos = -1;
+        fee = coin_control.m_confirm_target.value_or(0) * 250;
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    model->scheduleFeeEstimates();
+    model->scheduleFeeEstimates();
+    model->scheduleFeeEstimates();
+
+    QTRY_COMPARE_WITH_TIMEOUT(create_transaction_calls.load(), 3, FEE_ESTIMATE_TIMEOUT_MS);
+    QVERIFY(!saw_sign_true.load());
+    QTRY_VERIFY_WITH_TIMEOUT(!model->feeEstimatePending(), FEE_ESTIMATE_TIMEOUT_MS);
+    QCOMPARE(model->estimatedFeeForTarget(1), QStringLiteral("0.00000250 ₿"));
+    QCOMPARE(model->estimatedFeeForTarget(2), QStringLiteral("0.00000500 ₿"));
+    QCOMPARE(model->estimatedFeeForTarget(6), QStringLiteral("0.00001500 ₿"));
+}
+
+int RunWalletQmlModelTests(int argc, char* argv[])
+{
+    WalletQmlModelTests tests;
+    return QTest::qExec(&tests, argc, argv);
+}
+
+#ifndef BITCOINQML_NO_TEST_MAIN
+QTEST_MAIN(WalletQmlModelTests)
+#endif
+#include "test_walletqmlmodel.moc"


### PR DESCRIPTION
<img width="639" height="693" alt="image" src="https://github.com/user-attachments/assets/4c9653a5-574a-4147-8dc9-e76b77aadb7f" />
<img width="639" height="693" alt="image" src="https://github.com/user-attachments/assets/29cfe88c-8cd9-437d-89ff-d1cc00ecd488" />
<img width="639" height="693" alt="image" src="https://github.com/user-attachments/assets/3c310061-f444-47cd-8ff2-e2e8f2d9b976" />

Wires up fee selection in the Send page. Overrides are in place for Regtest where CoinControl fee estimations aren't supported.
