### PR TITLE
QtTest now see GMock Failures

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 add_executable(bitcoinqml_unit_tests
   test_unit_tests_main.cpp
+  gmocktestfixture.h
   test_bitcoinamount.cpp
   test_peerlistmodel.cpp
   test_peerstatsutil.cpp

--- a/test/gmocktestfixture.h
+++ b/test/gmocktestfixture.h
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_TEST_GMOCKTESTFIXTURE_H
+#define BITCOIN_QML_TEST_GMOCKTESTFIXTURE_H
+
+#include <QObject>
+#include <QtTest/QtTest>
+
+#ifdef Assert
+#pragma push_macro("Assert")
+#undef Assert
+#define BITCOIN_QML_RESTORE_ASSERT_MACRO
+#endif
+
+#include <gmock/gmock.h>
+
+#ifdef BITCOIN_QML_RESTORE_ASSERT_MACRO
+#pragma pop_macro("Assert")
+#undef BITCOIN_QML_RESTORE_ASSERT_MACRO
+#endif
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+class GmockFailureLog
+{
+public:
+    void add(std::string msg)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_failures.push_back(std::move(msg));
+    }
+
+    std::vector<std::string> drain()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        std::vector<std::string> out;
+        out.swap(m_failures);
+        return out;
+    }
+
+private:
+    std::mutex m_mutex;
+    std::vector<std::string> m_failures;
+};
+
+inline GmockFailureLog& gmockFailureLog()
+{
+    static GmockFailureLog log;
+    return log;
+}
+
+class QtestGmockListener : public testing::EmptyTestEventListener
+{
+public:
+    void OnTestPartResult(const testing::TestPartResult& result) override
+    {
+        if (result.failed()) {
+            std::string msg;
+            if (result.file_name()) {
+                msg += result.file_name();
+                msg += ":";
+                msg += std::to_string(result.line_number());
+                msg += "\n";
+            }
+            msg += result.message();
+            gmockFailureLog().add(std::move(msg));
+        }
+    }
+};
+
+class GmockTestFixture : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void init()
+    {
+        gmockFailureLog().drain();
+    }
+
+    void cleanup()
+    {
+        auto failures = gmockFailureLog().drain();
+        if (!failures.empty()) {
+            std::string combined{"GMock failure(s):\n"};
+            for (const auto& f : failures) {
+                combined += f;
+                combined += "\n";
+            }
+            QFAIL(combined.c_str());
+        }
+    }
+};
+
+#endif // BITCOIN_QML_TEST_GMOCKTESTFIXTURE_H

--- a/test/test_options_model.cpp
+++ b/test/test_options_model.cpp
@@ -59,6 +59,7 @@ void OptionsModelTests::proxyDisabledRemovesKey()
 
     model.setProxyEnabled(false);
     QVERIFY(!model.proxyEnabled());
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void OptionsModelTests::torDisabledRemovesKey()
@@ -81,6 +82,7 @@ void OptionsModelTests::torDisabledRemovesKey()
 
     model.setTorEnabled(false);
     QVERIFY(!model.torEnabled());
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void OptionsModelTests::proxyEnabledWritesAddress()
@@ -109,6 +111,7 @@ void OptionsModelTests::proxyEnabledWritesAddress()
 
     model.setProxyEnabled(true);
     QVERIFY(model.proxyEnabled());
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void OptionsModelTests::onboardWritesProxy()
@@ -127,6 +130,7 @@ void OptionsModelTests::onboardWritesProxy()
     model.setProxyEnabled(true);
     model.setProxyAddress("10.0.0.1:9050");
 
+    EXPECT_CALL(node, updateRwSetting(_, _)).Times(::testing::AnyNumber());
     // onboard() must write the proxy address to disk.
     EXPECT_CALL(node, updateRwSetting(std::string{"proxy"},
         Truly([](const common::SettingsValue& v) {
@@ -134,6 +138,7 @@ void OptionsModelTests::onboardWritesProxy()
         })));
 
     model.onboard();
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void OptionsModelTests::proxyDirtySetWhenOnboarded()

--- a/test/test_options_model.cpp
+++ b/test/test_options_model.cpp
@@ -4,6 +4,7 @@
 
 #include <QtTest/QtTest>
 
+#include <test/gmocktestfixture.h>
 #include <test/mocks/mocknode.h>
 #include <qml/models/options_model.h>
 #include <net_processing.h>
@@ -14,7 +15,7 @@
 const TranslateFn G_TRANSLATION_FUN{nullptr};
 #endif
 
-class OptionsModelTests : public QObject
+class OptionsModelTests : public GmockTestFixture
 {
     Q_OBJECT
 
@@ -59,7 +60,6 @@ void OptionsModelTests::proxyDisabledRemovesKey()
 
     model.setProxyEnabled(false);
     QVERIFY(!model.proxyEnabled());
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void OptionsModelTests::torDisabledRemovesKey()
@@ -82,7 +82,6 @@ void OptionsModelTests::torDisabledRemovesKey()
 
     model.setTorEnabled(false);
     QVERIFY(!model.torEnabled());
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void OptionsModelTests::proxyEnabledWritesAddress()
@@ -111,7 +110,6 @@ void OptionsModelTests::proxyEnabledWritesAddress()
 
     model.setProxyEnabled(true);
     QVERIFY(model.proxyEnabled());
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void OptionsModelTests::onboardWritesProxy()
@@ -138,7 +136,6 @@ void OptionsModelTests::onboardWritesProxy()
         })));
 
     model.onboard();
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void OptionsModelTests::proxyDirtySetWhenOnboarded()

--- a/test/test_peerlistmodel.cpp
+++ b/test/test_peerlistmodel.cpp
@@ -4,6 +4,7 @@
 
 #include <QtTest/QtTest>
 
+#include <test/gmocktestfixture.h>
 #include <test/mocks/mocknode.h>
 #include <qml/models/peerlistsortproxy.h>
 #include <qml/models/peerlistmodel.h>
@@ -43,7 +44,7 @@ constexpr auto AUTO_REFRESH_TRIGGER_TIMEOUT{2'000};
 constexpr auto AUTO_REFRESH_STOP_WAIT{450};
 } // namespace
 
-class PeerListModelTests : public QObject
+class PeerListModelTests : public GmockTestFixture
 {
     Q_OBJECT
 
@@ -100,7 +101,6 @@ void PeerListModelTests::mapsRoleData()
     QCOMPARE(model.flags(QModelIndex{}), Qt::NoItemFlags);
     QVERIFY(model.flags(index).testFlag(Qt::ItemIsSelectable));
     QVERIFY(model.flags(index).testFlag(Qt::ItemIsEnabled));
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void PeerListModelTests::refreshUpdatesRows()
@@ -143,7 +143,6 @@ void PeerListModelTests::refreshUpdatesRows()
     QCOMPARE(model.rowCount(), 2);
     QCOMPARE(model.data(model.index(0, 0), PeerListModel::NetNodeId).toLongLong(), 2LL);
     QCOMPARE(model.data(model.index(1, 0), PeerListModel::NetNodeId).toLongLong(), 3LL);
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void PeerListModelTests::refreshHandlesGetNodesStatsFailure()
@@ -169,7 +168,6 @@ void PeerListModelTests::refreshHandlesGetNodesStatsFailure()
     model.refresh();
     QCOMPARE(model.rowCount(), 1);
     QCOMPARE(model.data(model.index(0, 0), PeerListModel::NetNodeId).toLongLong(), 1LL);
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void PeerListModelTests::startStopAutoRefresh()
@@ -202,7 +200,6 @@ void PeerListModelTests::startStopAutoRefresh()
     const int calls_after_stop = get_nodes_stats_calls;
     QTest::qWait(AUTO_REFRESH_STOP_WAIT);
     QCOMPARE(get_nodes_stats_calls, calls_after_stop);
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void PeerListModelTests::sortProxySortsByRoles()
@@ -292,7 +289,6 @@ void PeerListModelTests::sortProxySortsByRoles()
     assert_sort("sent", [](const CNodeStats& left, const CNodeStats& right) { return left.nSendBytes < right.nSendBytes; });
     assert_sort("received", [](const CNodeStats& left, const CNodeStats& right) { return left.nRecvBytes < right.nRecvBytes; });
     assert_sort("subversion", [](const CNodeStats& left, const CNodeStats& right) { return left.cleanSubVer.compare(right.cleanSubVer) < 0; });
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 int RunPeerListModelTests(int argc, char* argv[])

--- a/test/test_peerlistmodel.cpp
+++ b/test/test_peerlistmodel.cpp
@@ -100,6 +100,7 @@ void PeerListModelTests::mapsRoleData()
     QCOMPARE(model.flags(QModelIndex{}), Qt::NoItemFlags);
     QVERIFY(model.flags(index).testFlag(Qt::ItemIsSelectable));
     QVERIFY(model.flags(index).testFlag(Qt::ItemIsEnabled));
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void PeerListModelTests::refreshUpdatesRows()
@@ -142,6 +143,7 @@ void PeerListModelTests::refreshUpdatesRows()
     QCOMPARE(model.rowCount(), 2);
     QCOMPARE(model.data(model.index(0, 0), PeerListModel::NetNodeId).toLongLong(), 2LL);
     QCOMPARE(model.data(model.index(1, 0), PeerListModel::NetNodeId).toLongLong(), 3LL);
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void PeerListModelTests::refreshHandlesGetNodesStatsFailure()
@@ -167,6 +169,7 @@ void PeerListModelTests::refreshHandlesGetNodesStatsFailure()
     model.refresh();
     QCOMPARE(model.rowCount(), 1);
     QCOMPARE(model.data(model.index(0, 0), PeerListModel::NetNodeId).toLongLong(), 1LL);
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void PeerListModelTests::startStopAutoRefresh()
@@ -199,6 +202,7 @@ void PeerListModelTests::startStopAutoRefresh()
     const int calls_after_stop = get_nodes_stats_calls;
     QTest::qWait(AUTO_REFRESH_STOP_WAIT);
     QCOMPARE(get_nodes_stats_calls, calls_after_stop);
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void PeerListModelTests::sortProxySortsByRoles()
@@ -288,6 +292,7 @@ void PeerListModelTests::sortProxySortsByRoles()
     assert_sort("sent", [](const CNodeStats& left, const CNodeStats& right) { return left.nSendBytes < right.nSendBytes; });
     assert_sort("received", [](const CNodeStats& left, const CNodeStats& right) { return left.nRecvBytes < right.nRecvBytes; });
     assert_sort("subversion", [](const CNodeStats& left, const CNodeStats& right) { return left.cleanSubVer.compare(right.cleanSubVer) < 0; });
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 int RunPeerListModelTests(int argc, char* argv[])

--- a/test/test_qmlinitexecutor_api.cpp
+++ b/test/test_qmlinitexecutor_api.cpp
@@ -4,6 +4,7 @@
 
 #include <QtTest/QtTest>
 
+#include <test/gmocktestfixture.h>
 #include <net_processing.h>
 #include <test/mocks/mocknode.h>
 #include <qml/initexecutor.h>
@@ -18,7 +19,7 @@ namespace {
 constexpr auto SIGNAL_TIMEOUT{5'000};
 }
 
-class QmlInitExecutorApiTests : public QObject
+class QmlInitExecutorApiTests : public GmockTestFixture
 {
     Q_OBJECT
 
@@ -74,7 +75,6 @@ void QmlInitExecutorApiTests::initializeEmitsResultAndRunsOffMainThread()
     QCOMPARE(tip_info.header_height, 105);
     QCOMPARE(tip_info.header_time, 1'700'000'099LL);
     QCOMPARE(tip_info.verification_progress, 0.75);
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void QmlInitExecutorApiTests::initializeEmitsRunawayExceptionOnFailure()
@@ -101,7 +101,6 @@ void QmlInitExecutorApiTests::initializeEmitsRunawayExceptionOnFailure()
     QCOMPARE(runaway_spy.count(), 1);
     QCOMPARE(initialize_spy.count(), 0);
     QCOMPARE(runaway_spy.takeFirst().at(0).toString(), QString{"Translated init failure"});
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void QmlInitExecutorApiTests::shutdownEmitsResultAndRunsOffMainThread()
@@ -126,7 +125,6 @@ void QmlInitExecutorApiTests::shutdownEmitsResultAndRunsOffMainThread()
     QCOMPARE(shutdown_spy.count(), 1);
     QCOMPARE(runaway_spy.count(), 0);
     QVERIFY(ran_off_main_thread);
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void QmlInitExecutorApiTests::shutdownEmitsRunawayExceptionOnFailure()
@@ -152,7 +150,6 @@ void QmlInitExecutorApiTests::shutdownEmitsRunawayExceptionOnFailure()
     QCOMPARE(runaway_spy.count(), 1);
     QCOMPARE(shutdown_spy.count(), 0);
     QCOMPARE(runaway_spy.takeFirst().at(0).toString(), QString{"Translated shutdown failure"});
-    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 int RunQmlInitExecutorApiTests(int argc, char* argv[])

--- a/test/test_qmlinitexecutor_api.cpp
+++ b/test/test_qmlinitexecutor_api.cpp
@@ -74,6 +74,7 @@ void QmlInitExecutorApiTests::initializeEmitsResultAndRunsOffMainThread()
     QCOMPARE(tip_info.header_height, 105);
     QCOMPARE(tip_info.header_time, 1'700'000'099LL);
     QCOMPARE(tip_info.verification_progress, 0.75);
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void QmlInitExecutorApiTests::initializeEmitsRunawayExceptionOnFailure()
@@ -100,6 +101,7 @@ void QmlInitExecutorApiTests::initializeEmitsRunawayExceptionOnFailure()
     QCOMPARE(runaway_spy.count(), 1);
     QCOMPARE(initialize_spy.count(), 0);
     QCOMPARE(runaway_spy.takeFirst().at(0).toString(), QString{"Translated init failure"});
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void QmlInitExecutorApiTests::shutdownEmitsResultAndRunsOffMainThread()
@@ -124,6 +126,7 @@ void QmlInitExecutorApiTests::shutdownEmitsResultAndRunsOffMainThread()
     QCOMPARE(shutdown_spy.count(), 1);
     QCOMPARE(runaway_spy.count(), 0);
     QVERIFY(ran_off_main_thread);
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 void QmlInitExecutorApiTests::shutdownEmitsRunawayExceptionOnFailure()
@@ -149,6 +152,7 @@ void QmlInitExecutorApiTests::shutdownEmitsRunawayExceptionOnFailure()
     QCOMPARE(runaway_spy.count(), 1);
     QCOMPARE(shutdown_spy.count(), 0);
     QCOMPARE(runaway_spy.takeFirst().at(0).toString(), QString{"Translated shutdown failure"});
+    QVERIFY(testing::Mock::VerifyAndClearExpectations(&node));
 }
 
 int RunQmlInitExecutorApiTests(int argc, char* argv[])

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -4,6 +4,19 @@
 
 #include <QGuiApplication>
 
+#ifdef Assert
+#pragma push_macro("Assert")
+#undef Assert
+#define BITCOIN_QML_RESTORE_ASSERT_MACRO
+#endif
+
+#include <gmock/gmock.h>
+
+#ifdef BITCOIN_QML_RESTORE_ASSERT_MACRO
+#pragma pop_macro("Assert")
+#undef BITCOIN_QML_RESTORE_ASSERT_MACRO
+#endif
+
 #include <util/translation.h>
 
 const TranslateFn G_TRANSLATION_FUN{nullptr};
@@ -19,6 +32,7 @@ int RunOptionsModelTests(int argc, char* argv[]);
 
 int main(int argc, char* argv[])
 {
+    testing::InitGoogleMock(&argc, argv);
     QGuiApplication app(argc, argv);
 
     int status = 0;

--- a/test/test_unit_tests_main.cpp
+++ b/test/test_unit_tests_main.cpp
@@ -4,19 +4,7 @@
 
 #include <QGuiApplication>
 
-#ifdef Assert
-#pragma push_macro("Assert")
-#undef Assert
-#define BITCOIN_QML_RESTORE_ASSERT_MACRO
-#endif
-
-#include <gmock/gmock.h>
-
-#ifdef BITCOIN_QML_RESTORE_ASSERT_MACRO
-#pragma pop_macro("Assert")
-#undef BITCOIN_QML_RESTORE_ASSERT_MACRO
-#endif
-
+#include <test/gmocktestfixture.h>
 #include <util/translation.h>
 
 const TranslateFn G_TRANSLATION_FUN{nullptr};
@@ -33,6 +21,7 @@ int RunOptionsModelTests(int argc, char* argv[]);
 int main(int argc, char* argv[])
 {
     testing::InitGoogleMock(&argc, argv);
+    testing::UnitTest::GetInstance()->listeners().Append(new QtestGmockListener());
     QGuiApplication app(argc, argv);
 
     int status = 0;


### PR DESCRIPTION
Fixed bug where GMock failures where not being seen by QtTest because there were no QtTest assertions leading to test cases passing even with GMock errors. Added QVERIFY at the end of tests so that QtTest is aware of the GMock output. Added GMock initialization to the test's main(), GMock partially works without it but this makes sure GMock's global state is working correctly. 

Fixed bug in OptionsModelTests::onboardWritesProxy where updateRwSetting being called with something other than proxy first would cause a GMock error (previously hidden because of above bug). Added catch-all so other updateRwSetting calls (ex. listen) wouldn't lead to a failing test case, as the test case should only fail in absence of proxy but not in the presence of other calls.