### PR TITLE
Add PSBT import review flow

### DIFF
--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -66,6 +66,7 @@
         <file>controls/LabeledTextInput.qml</file>
         <file>controls/LabeledCoinControlButton.qml</file>
         <file>controls/EllipsisMenuButtonItem.qml</file>
+        <file>controls/EllipsisMenuActionItem.qml</file>
         <file>controls/EllipsisMenuToggleItem.qml</file>
         <file>controls/NavButton.qml</file>
         <file>controls/NavigationBar.qml</file>

--- a/qml/controls/EllipsisMenuActionItem.qml
+++ b/qml/controls/EllipsisMenuActionItem.qml
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
+
+AbstractButton {
+    id: root
+
+    property url leftIconSource
+    property color bgDefaultColor: "transparent"
+    property color bgHoverColor: Theme.color.neutral2
+    property color textColor: Theme.color.neutral7
+    property color textHoverColor: Theme.color.neutral9
+
+    hoverEnabled: AppMode.isDesktop
+    padding: 0
+
+    implicitWidth: 280
+    implicitHeight: 33
+
+    MouseArea {
+        anchors.fill: parent
+        enabled: false
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+    }
+
+    contentItem: RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 10
+        anchors.rightMargin: 5
+        spacing: 5
+
+        RowLayout {
+            Layout.alignment: Qt.AlignVCenter
+            Layout.fillWidth: true
+            spacing: 7
+
+            Item {
+                Layout.alignment: Qt.AlignVCenter
+                Layout.preferredWidth: 18
+                Layout.preferredHeight: 18
+
+                Icon {
+                    anchors.centerIn: parent
+                    source: root.leftIconSource
+                    color: root.hovered ? root.textHoverColor : root.textColor
+                    size: 18
+                }
+            }
+
+            CoreText {
+                id: buttonText
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
+                text: root.text
+                horizontalAlignment: Text.AlignLeft
+                font.pixelSize: 15
+                color: root.hovered ? root.textHoverColor : root.textColor
+            }
+        }
+
+        Item {
+            Layout.alignment: Qt.AlignVCenter
+            Layout.preferredWidth: 18
+            Layout.preferredHeight: 18
+        }
+    }
+
+    background: Rectangle {
+        color: root.hovered ? root.bgHoverColor : root.bgDefaultColor
+        radius: 0
+
+        Behavior on color {
+            ColorAnimation { duration: 150 }
+        }
+    }
+}

--- a/qml/controls/EllipsisMenuToggleItem.qml
+++ b/qml/controls/EllipsisMenuToggleItem.qml
@@ -55,11 +55,7 @@ Button {
             Layout.preferredWidth: 40
             Layout.preferredHeight: 24
             checked: root.checked
-
-            MouseArea {
-                anchors.fill: parent
-                onClicked: root.toggle()
-            }
+            enabled: false
         }
     }
 

--- a/qml/controls/SendOptionsPopup.qml
+++ b/qml/controls/SendOptionsPopup.qml
@@ -18,6 +18,7 @@ OptionPopup {
     property alias multipleRecipientsEnabled: multipleRecipientsToggle.checked
 
     signal importPsbtFromFileRequested()
+    signal clearFormRequested()
 
     implicitWidth: 305
     implicitHeight: columnLayout.implicitHeight + 10
@@ -36,6 +37,12 @@ OptionPopup {
             id: coinControlToggle
             objectName: "sendOptionsCoinControlToggle"
             Layout.fillWidth: true
+            Layout.preferredHeight: 33
+            Layout.minimumHeight: 33
+            Layout.maximumHeight: 33
+            bgRadius: 0
+            contentTopPadding: 4
+            contentBottomPadding: 5
             text: qsTr("Enable Coin control")
         }
 
@@ -43,6 +50,12 @@ OptionPopup {
             id: multipleRecipientsToggle
             objectName: "sendOptionsMultipleRecipientsToggle"
             Layout.fillWidth: true
+            Layout.preferredHeight: 33
+            Layout.minimumHeight: 33
+            Layout.maximumHeight: 33
+            bgRadius: 0
+            contentTopPadding: 4
+            contentBottomPadding: 5
             text: qsTr("Multiple Recipients")
         }
 
@@ -61,75 +74,37 @@ OptionPopup {
             }
         }
 
-        AbstractButton {
+        EllipsisMenuActionItem {
             id: fileImportButton
             objectName: "sendImportPsbtFromFileButton"
             Layout.fillWidth: true
-            Layout.preferredHeight: 33
-            Layout.minimumHeight: 33
-            Layout.maximumHeight: 33
-            hoverEnabled: AppMode.isDesktop
-            padding: 0
-            implicitHeight: 33
             text: qsTr("Import PSBT from file…")
-
-            MouseArea {
-                anchors.fill: parent
-                enabled: false
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-            }
-
-            contentItem: RowLayout {
-                anchors.fill: parent
-                anchors.leftMargin: 10
-                anchors.rightMargin: 5
-                spacing: 5
-
-                RowLayout {
-                    Layout.alignment: Qt.AlignVCenter
-                    Layout.fillWidth: true
-                    spacing: 7
-
-                    Item {
-                        Layout.alignment: Qt.AlignVCenter
-                        Layout.preferredWidth: 18
-                        Layout.preferredHeight: 18
-
-                        Icon {
-                            anchors.centerIn: parent
-                            source: "qrc:/icons/file"
-                            color: fileImportButton.hovered ? Theme.color.neutral9 : Theme.color.neutral7
-                            size: 18
-                        }
-                    }
-
-                    CoreText {
-                        Layout.fillWidth: true
-                        Layout.alignment: Qt.AlignVCenter
-                        text: fileImportButton.text
-                        horizontalAlignment: Text.AlignLeft
-                        font.pixelSize: 15
-                        color: fileImportButton.hovered ? Theme.color.neutral9 : Theme.color.neutral7
-                    }
-                }
-
-                Item {
-                    Layout.alignment: Qt.AlignVCenter
-                    Layout.preferredWidth: 18
-                    Layout.preferredHeight: 18
-                }
-            }
-            background: Rectangle {
-                anchors.fill: parent
-                color: fileImportButton.hovered ? Theme.color.neutral2 : "transparent"
-                radius: 0
-
-                Behavior on color {
-                    ColorAnimation { duration: 150 }
-                }
-            }
+            leftIconSource: "qrc:/icons/file"
             onClicked: root.importPsbtFromFileRequested()
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 9
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: 10
+                anchors.rightMargin: 10
+                anchors.verticalCenter: parent.verticalCenter
+                height: 1
+                color: Theme.color.neutral5
+            }
+        }
+
+        EllipsisMenuActionItem {
+            id: clearFormButton
+            objectName: "sendClearFormButton"
+            Layout.fillWidth: true
+            text: qsTr("Clear form")
+            leftIconSource: "qrc:/icons/cross"
+            onClicked: root.clearFormRequested()
         }
     }
 }

--- a/qml/controls/SendOptionsPopup.qml
+++ b/qml/controls/SendOptionsPopup.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
 
 import "../components"
 import "../controls"
@@ -16,8 +17,10 @@ OptionPopup {
     property alias coinControlEnabled: coinControlToggle.checked
     property alias multipleRecipientsEnabled: multipleRecipientsToggle.checked
 
-    implicitWidth: 300
-    implicitHeight: columnLayout.implicitHeight + 20
+    signal importPsbtFromFileRequested()
+
+    implicitWidth: 305
+    implicitHeight: columnLayout.implicitHeight + 10
 
     clip: true
     modal: true
@@ -25,8 +28,8 @@ OptionPopup {
 
     ColumnLayout {
         id: columnLayout
-        anchors.centerIn: parent
-        anchors.margins: 10
+        anchors.fill: parent
+        anchors.margins: 5
         spacing: 0
 
         EllipsisMenuToggleItem {
@@ -36,16 +39,97 @@ OptionPopup {
             text: qsTr("Enable Coin control")
         }
 
-        Separator {
-            id: separator
-            Layout.fillWidth: true
-        }
-
         EllipsisMenuToggleItem {
             id: multipleRecipientsToggle
             objectName: "sendOptionsMultipleRecipientsToggle"
             Layout.fillWidth: true
             text: qsTr("Multiple Recipients")
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 9
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: 10
+                anchors.rightMargin: 10
+                anchors.verticalCenter: parent.verticalCenter
+                height: 1
+                color: Theme.color.neutral5
+            }
+        }
+
+        AbstractButton {
+            id: fileImportButton
+            objectName: "sendImportPsbtFromFileButton"
+            Layout.fillWidth: true
+            Layout.preferredHeight: 33
+            Layout.minimumHeight: 33
+            Layout.maximumHeight: 33
+            hoverEnabled: AppMode.isDesktop
+            padding: 0
+            implicitHeight: 33
+            text: qsTr("Import PSBT from file…")
+
+            MouseArea {
+                anchors.fill: parent
+                enabled: false
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+            }
+
+            contentItem: RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 10
+                anchors.rightMargin: 5
+                spacing: 5
+
+                RowLayout {
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.fillWidth: true
+                    spacing: 7
+
+                    Item {
+                        Layout.alignment: Qt.AlignVCenter
+                        Layout.preferredWidth: 18
+                        Layout.preferredHeight: 18
+
+                        Icon {
+                            anchors.centerIn: parent
+                            source: "qrc:/icons/file"
+                            color: fileImportButton.hovered ? Theme.color.neutral9 : Theme.color.neutral7
+                            size: 18
+                        }
+                    }
+
+                    CoreText {
+                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignVCenter
+                        text: fileImportButton.text
+                        horizontalAlignment: Text.AlignLeft
+                        font.pixelSize: 15
+                        color: fileImportButton.hovered ? Theme.color.neutral9 : Theme.color.neutral7
+                    }
+                }
+
+                Item {
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredWidth: 18
+                    Layout.preferredHeight: 18
+                }
+            }
+            background: Rectangle {
+                anchors.fill: parent
+                color: fileImportButton.hovered ? Theme.color.neutral2 : "transparent"
+                radius: 0
+
+                Behavior on color {
+                    ColorAnimation { duration: 150 }
+                }
+            }
+            onClicked: root.importPsbtFromFileRequested()
         }
     }
 }

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -20,34 +20,52 @@
 #include <qml/util.h>
 
 #include <chainparams.h>
+#include <common/types.h>
 #include <consensus/amount.h>
+#include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
+#include <node/psbt.h>
+#include <node/transaction.h>
+#include <node/types.h>
 #include <addresstype.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
+#include <primitives/transaction.h>
 #include <psbt.h>
 #include <qml/bitcoinunits.h>
+#include <script/solver.h>
+#include <serialize.h>
 #include <streams.h>
 #include <support/allocators/secure.h>
 #include <util/result.h>
+#include <util/strencodings.h>
 #include <util/threadnames.h>
+#include <util/translation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 
+#include <QClipboard>
 #include <QDateTime>
+#include <QFile>
+#include <QGuiApplication>
 #include <QMetaObject>
 #include <QRegularExpression>
 #include <QSettings>
+#include <QUrl>
 #include <QVariantList>
 #include <QVariantMap>
 
 #include <array>
+#include <cstddef>
 #include <functional>
 #include <limits>
 #include <optional>
+#include <span>
+#include <string>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace {
 constexpr unsigned int DEFAULT_STANDARD_FEE_TARGET{2};
@@ -278,11 +296,88 @@ QString OutputTypeDescription(OutputType type)
     }
     return {};
 }
-} // namespace
-WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObject *parent)
-    : QObject(parent)
+
+QString LocalFilePath(const QString& path)
 {
-    m_wallet = std::move(wallet);
+    const QUrl url(path);
+    if (url.isLocalFile()) {
+        return url.toLocalFile();
+    }
+    return path;
+}
+
+QString FormatBtc(CAmount amount)
+{
+    return QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, amount) + QStringLiteral(" BTC");
+}
+
+QString SerializePsbtBase64(const PartiallySignedTransaction& psbt)
+{
+    DataStream stream{};
+    stream << psbt;
+    return QString::fromStdString(EncodeBase64(stream.str()));
+}
+
+QByteArray SerializePsbtRaw(const PartiallySignedTransaction& psbt)
+{
+    DataStream stream{};
+    stream << psbt;
+    const std::string raw{stream.str()};
+    return QByteArray(raw.data(), static_cast<qsizetype>(raw.size()));
+}
+
+bool IsMultisigScript(const CScript& script)
+{
+    if (script.empty()) {
+        return false;
+    }
+
+    std::vector<std::vector<unsigned char>> solutions;
+    return Solver(script, solutions) == TxoutType::MULTISIG || MatchMultiA(script).has_value();
+}
+
+bool IsMultisigPsbtInput(const PartiallySignedTransaction& psbt, size_t index)
+{
+    const PSBTInput& input{psbt.inputs[index]};
+    if (IsMultisigScript(input.redeem_script) || IsMultisigScript(input.witness_script)) {
+        return true;
+    }
+
+    CTxOut utxo;
+    return psbt.GetInputUTXO(utxo, index) && IsMultisigScript(utxo.scriptPubKey);
+}
+
+bool DecodePsbtFromBytes(const QByteArray& bytes, PartiallySignedTransaction& psbt, std::string& error)
+{
+    std::vector<std::byte> raw;
+    raw.reserve(bytes.size());
+    for (const char ch : bytes) {
+        raw.push_back(static_cast<std::byte>(static_cast<unsigned char>(ch)));
+    }
+    return DecodeRawPSBT(psbt, std::span<const std::byte>{raw.data(), raw.size()}, error);
+}
+
+QString PsbtErrorText(common::PSBTError error)
+{
+    return QString::fromStdString(common::PSBTErrorString(error).translated);
+}
+
+QString TransactionErrorText(node::TransactionError error)
+{
+    return QString::fromStdString(common::TransactionErrorString(error).translated);
+}
+} // namespace
+
+WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObject *parent)
+    : WalletQmlModel(std::move(wallet), nullptr, parent)
+{
+}
+
+WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, interfaces::Node* node, QObject *parent)
+    : QObject(parent)
+    , m_wallet(std::move(wallet))
+    , m_node(node)
+{
     m_receive_requests = new ReceiveRequestHistoryModel(this);
     reloadReceiveRequests();
     m_activity_list_model = new ActivityListModel(this);
@@ -1437,6 +1532,346 @@ bool WalletQmlModel::sendTransactionInternal()
 
     clearTransactionStatus();
     return true;
+}
+
+void WalletQmlModel::setImportedPsbtError(const QString& error)
+{
+    m_imported_psbt.reset();
+    m_imported_psbt_mode.clear();
+    m_imported_psbt_status.clear();
+    m_imported_psbt_error = error;
+    m_imported_psbt_summary.clear();
+    m_imported_psbt_can_sign = false;
+    m_imported_psbt_can_broadcast = false;
+    m_imported_psbt_complete = false;
+    m_imported_psbt_unsigned_inputs = 0;
+    m_imported_psbt_could_sign_inputs = 0;
+    Q_EMIT importedPsbtChanged();
+}
+
+void WalletQmlModel::clearImportedPsbt()
+{
+    m_imported_psbt.reset();
+    m_imported_psbt_mode.clear();
+    m_imported_psbt_status.clear();
+    m_imported_psbt_error.clear();
+    m_imported_psbt_summary.clear();
+    m_imported_psbt_can_sign = false;
+    m_imported_psbt_can_broadcast = false;
+    m_imported_psbt_complete = false;
+    m_imported_psbt_unsigned_inputs = 0;
+    m_imported_psbt_could_sign_inputs = 0;
+    Q_EMIT importedPsbtChanged();
+}
+
+QString WalletQmlModel::importPsbtFromFile(const QString& path)
+{
+    const QString file_path{LocalFilePath(path)};
+    QFile file(file_path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        setImportedPsbtError(tr("Could not open PSBT file: %1").arg(file.errorString()));
+        return QStringLiteral("unsupported");
+    }
+
+    const QByteArray bytes{file.readAll()};
+    PartiallySignedTransaction psbt;
+    std::string error;
+    if (!DecodePsbtFromBytes(bytes, psbt, error)) {
+        psbt = PartiallySignedTransaction{};
+        std::string base64_error;
+        if (!DecodeBase64PSBT(psbt, QString::fromUtf8(bytes).trimmed().toStdString(), base64_error)) {
+            setImportedPsbtError(tr("Could not decode PSBT: %1").arg(QString::fromStdString(base64_error.empty() ? error : base64_error)));
+            return QStringLiteral("unsupported");
+        }
+    }
+
+    return importPsbt(std::move(psbt));
+}
+
+QString WalletQmlModel::importPsbt(PartiallySignedTransaction psbt)
+{
+    QString mode;
+    QString reason;
+    if (tryImportPsbtToReview(psbt, mode, reason)) {
+        clearImportedPsbt();
+        return mode;
+    }
+
+    setImportedPsbtError(reason.isEmpty() ? tr("This PSBT is not supported yet.") : reason);
+    return QStringLiteral("unsupported");
+}
+
+bool WalletQmlModel::tryImportPsbtToReview(const PartiallySignedTransaction& psbt, QString& mode, QString& reason)
+{
+    if (!m_wallet) {
+        reason = tr("No wallet is loaded.");
+        return false;
+    }
+    if (!psbt.tx) {
+        reason = tr("The PSBT does not contain an unsigned transaction.");
+        return false;
+    }
+    if (psbt.tx->vin.empty() || psbt.tx->vout.empty()) {
+        reason = tr("The PSBT has no inputs or outputs.");
+        return false;
+    }
+    if (psbt.inputs.size() != psbt.tx->vin.size() || psbt.outputs.size() != psbt.tx->vout.size()) {
+        reason = tr("The PSBT is malformed.");
+        return false;
+    }
+
+    for (size_t i{0}; i < psbt.inputs.size(); ++i) {
+        if (!m_wallet->txinIsMine(psbt.tx->vin[i])) {
+            reason = tr("Only PSBTs that spend this wallet's own inputs are supported right now.");
+            return false;
+        }
+    }
+
+    PartiallySignedTransaction signed_psbt{psbt};
+    bool complete{false};
+    size_t signed_inputs{0};
+    const std::optional<common::PSBTError> fill_error{
+        m_wallet->fillPSBT(std::nullopt, /*sign=*/true, /*bip32derivs=*/true, &signed_inputs, signed_psbt, complete)};
+
+    for (size_t i{0}; i < signed_psbt.inputs.size(); ++i) {
+        if (IsMultisigPsbtInput(signed_psbt, i)) {
+            reason = tr("Multisignature PSBTs are not supported yet.");
+            return false;
+        }
+    }
+
+    if (fill_error || !complete) {
+        reason = tr("Only PSBTs this wallet can fully sign are supported right now.");
+        return false;
+    }
+
+    struct DraftRecipient {
+        QString address;
+        QString label;
+        CAmount amount;
+    };
+    std::vector<DraftRecipient> draft_recipients;
+    CAmount recipient_total{0};
+    for (const CTxOut& output : signed_psbt.tx->vout) {
+        CTxDestination destination;
+        if (!ExtractDestination(output.scriptPubKey, destination)) {
+            reason = tr("Only PSBTs with standard address outputs are supported right now.");
+            return false;
+        }
+        if (m_wallet->txoutIsMine(output)) {
+            continue;
+        }
+        const QString address{QString::fromStdString(EncodeDestination(destination))};
+        draft_recipients.push_back({address, getAddressLabel(address), output.nValue});
+        recipient_total += output.nValue;
+    }
+
+    if (draft_recipients.empty()) {
+        reason = tr("The PSBT does not have any recipient outputs to review.");
+        return false;
+    }
+    if (draft_recipients.size() > 25) {
+        reason = tr("The PSBT has more recipients than this send flow supports.");
+        return false;
+    }
+    if (recipient_total <= 0) {
+        reason = tr("The PSBT does not send a positive amount.");
+        return false;
+    }
+
+    const node::PSBTAnalysis analysis{node::AnalyzePSBT(signed_psbt)};
+    CMutableTransaction mutable_tx;
+    if (!FinalizeAndExtractPSBT(signed_psbt, mutable_tx)) {
+        reason = tr("Only PSBTs this wallet can fully sign are supported right now.");
+        return false;
+    }
+
+    m_send_recipients->clear();
+    for (size_t i{0}; i < draft_recipients.size(); ++i) {
+        if (i > 0) {
+            m_send_recipients->add();
+        }
+        SendRecipient* recipient{m_send_recipients->currentRecipient()};
+        recipient->setAddress(draft_recipients[i].address);
+        recipient->setLabel(draft_recipients[i].label);
+        recipient->amount()->setSatoshi(draft_recipients[i].amount);
+        recipient->setMessage(QString());
+    }
+    m_send_recipients->setCurrentIndex(0);
+
+    if (m_current_transaction) {
+        delete m_current_transaction;
+    }
+    m_current_transaction = new WalletQmlModelTransaction(m_send_recipients, this);
+    m_current_transaction->setWtx(MakeTransactionRef(std::move(mutable_tx)));
+    if (analysis.fee) {
+        m_current_transaction->setTransactionFee(*analysis.fee);
+    }
+    Q_EMIT currentTransactionChanged();
+
+    mode = draft_recipients.size() > 1 ? QStringLiteral("multiple-review") : QStringLiteral("single-review");
+    return true;
+}
+
+QStringList WalletQmlModel::buildPsbtSummary(const PartiallySignedTransaction& psbt) const
+{
+    QStringList lines;
+    if (!psbt.tx) {
+        lines << tr("PSBT does not contain an unsigned transaction.");
+        return lines;
+    }
+
+    CAmount total{0};
+    for (const CTxOut& output : psbt.tx->vout) {
+        total += output.nValue;
+        CTxDestination destination;
+        const QString address{ExtractDestination(output.scriptPubKey, destination) ? QString::fromStdString(EncodeDestination(destination)) : tr("unknown destination")};
+        const bool own_address{m_wallet && m_wallet->txoutIsMine(output)};
+        lines << tr("Sends %1 to %2%3").arg(FormatBtc(output.nValue), address, own_address ? tr(" (own address)") : QString());
+    }
+
+    const node::PSBTAnalysis analysis{node::AnalyzePSBT(psbt)};
+    if (!analysis.error.empty()) {
+        lines << tr("Analysis: %1").arg(QString::fromStdString(analysis.error));
+    }
+    if (analysis.fee) {
+        lines << tr("Pays transaction fee: %1").arg(FormatBtc(*analysis.fee));
+    } else {
+        lines << tr("Transaction fee is not available.");
+    }
+    lines << tr("Total output amount: %1").arg(FormatBtc(total));
+
+    const int unsigned_inputs{static_cast<int>(CountPSBTUnsignedInputs(psbt))};
+    if (unsigned_inputs > 0) {
+        lines << tr("Unsigned inputs: %1").arg(unsigned_inputs);
+    }
+    return lines;
+}
+
+void WalletQmlModel::refreshImportedPsbtState(const QString& status_override)
+{
+    if (!m_imported_psbt) {
+        return;
+    }
+
+    bool complete{FinalizePSBT(*m_imported_psbt)};
+    size_t could_sign{0};
+    std::optional<common::PSBTError> fill_error;
+    if (m_wallet) {
+        fill_error = m_wallet->fillPSBT(std::nullopt, /*sign=*/false, /*bip32derivs=*/true, &could_sign, *m_imported_psbt, complete);
+    }
+
+    m_imported_psbt_error = fill_error ? PsbtErrorText(*fill_error) : QString();
+    m_imported_psbt_complete = complete;
+    m_imported_psbt_can_broadcast = complete;
+    m_imported_psbt_could_sign_inputs = static_cast<int>(could_sign);
+    m_imported_psbt_unsigned_inputs = static_cast<int>(CountPSBTUnsignedInputs(*m_imported_psbt));
+    m_imported_psbt_can_sign = !complete && m_wallet && !m_wallet->privateKeysDisabled() && could_sign > 0;
+    m_imported_psbt_summary = buildPsbtSummary(*m_imported_psbt);
+
+    if (!status_override.isEmpty()) {
+        m_imported_psbt_status = status_override;
+    } else if (!m_imported_psbt_error.isEmpty()) {
+        m_imported_psbt_status = m_imported_psbt_error;
+    } else if (complete) {
+        m_imported_psbt_status = tr("Transaction is fully signed and ready for broadcast.");
+    } else if (!m_wallet) {
+        m_imported_psbt_status = tr("No wallet is loaded. You can inspect, copy, or save this PSBT.");
+    } else if (m_wallet->privateKeysDisabled()) {
+        m_imported_psbt_status = tr("This wallet cannot sign transactions because private keys are disabled.");
+    } else if (could_sign > 0) {
+        m_imported_psbt_status = tr("This wallet can sign %1 input(s).").arg(static_cast<int>(could_sign));
+    } else {
+        m_imported_psbt_status = tr("This wallet does not have the right keys to sign this PSBT.");
+    }
+
+    Q_EMIT importedPsbtChanged();
+}
+
+void WalletQmlModel::signImportedPsbt()
+{
+    if (!m_imported_psbt || !m_wallet) {
+        setImportedPsbtError(tr("No signable PSBT is loaded."));
+        return;
+    }
+    if (m_wallet->privateKeysDisabled()) {
+        refreshImportedPsbtState(tr("This wallet cannot sign transactions because private keys are disabled."));
+        return;
+    }
+
+    bool complete{false};
+    size_t signed_inputs{0};
+    const std::optional<common::PSBTError> error{m_wallet->fillPSBT(std::nullopt, /*sign=*/true, /*bip32derivs=*/true, &signed_inputs, *m_imported_psbt, complete)};
+    if (error) {
+        refreshImportedPsbtState(tr("Could not sign PSBT: %1").arg(PsbtErrorText(*error)));
+        return;
+    }
+
+    if (complete) {
+        refreshImportedPsbtState(tr("PSBT signed. Transaction is ready for broadcast."));
+    } else if (signed_inputs > 0) {
+        refreshImportedPsbtState(tr("Signed %1 input(s). More signatures are still required.").arg(static_cast<int>(signed_inputs)));
+    } else {
+        refreshImportedPsbtState(tr("This wallet could not add any signatures to the PSBT."));
+    }
+}
+
+void WalletQmlModel::broadcastImportedPsbt()
+{
+    if (!m_imported_psbt) {
+        setImportedPsbtError(tr("No PSBT is loaded."));
+        return;
+    }
+    if (!m_node) {
+        refreshImportedPsbtState(tr("Cannot broadcast from this context because the node interface is unavailable."));
+        return;
+    }
+
+    CMutableTransaction mutable_tx;
+    if (!FinalizeAndExtractPSBT(*m_imported_psbt, mutable_tx)) {
+        refreshImportedPsbtState(tr("PSBT is not complete and cannot be broadcast."));
+        return;
+    }
+
+    const CTransactionRef tx{MakeTransactionRef(std::move(mutable_tx))};
+    std::string error_string;
+    const node::TransactionError error{m_node->broadcastTransaction(tx, node::DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK(), error_string)};
+    if (error == node::TransactionError::OK) {
+        refreshImportedPsbtState(tr("Transaction broadcast successfully. Transaction ID: %1").arg(QString::fromStdString(tx->GetHash().ToString())));
+    } else {
+        QString message{TransactionErrorText(error)};
+        if (!error_string.empty()) {
+            message += QStringLiteral(": ") + QString::fromStdString(error_string);
+        }
+        refreshImportedPsbtState(tr("Transaction broadcast failed: %1").arg(message));
+    }
+}
+
+void WalletQmlModel::copyImportedPsbtToClipboard()
+{
+    if (!m_imported_psbt) {
+        return;
+    }
+    QGuiApplication::clipboard()->setText(SerializePsbtBase64(*m_imported_psbt));
+    refreshImportedPsbtState(tr("PSBT copied to clipboard."));
+}
+
+void WalletQmlModel::saveImportedPsbtToFile(const QString& path)
+{
+    if (!m_imported_psbt) {
+        return;
+    }
+    QFile file(LocalFilePath(path));
+    if (!file.open(QIODevice::WriteOnly)) {
+        refreshImportedPsbtState(tr("Could not save PSBT: %1").arg(file.errorString()));
+        return;
+    }
+    const QByteArray raw{SerializePsbtRaw(*m_imported_psbt)};
+    if (file.write(raw) != raw.size()) {
+        refreshImportedPsbtState(tr("Could not write the complete PSBT file."));
+        return;
+    }
+    refreshImportedPsbtState(tr("PSBT saved."));
 }
 
 bool WalletQmlModel::canBumpTransaction(const uint256& txid) const

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -19,6 +19,7 @@
 #include <consensus/amount.h>
 #include <interfaces/handler.h>
 #include <interfaces/wallet.h>
+#include <psbt.h>
 #include <support/allocators/secure.h>
 #include <wallet/coincontrol.h>
 
@@ -30,10 +31,15 @@
 
 #include <QHash>
 #include <QObject>
+#include <QStringList>
 #include <QThread>
 #include <QTimer>
 #include <QVariantList>
 #include <QVariantMap>
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
 
 class WalletQmlModel : public QObject
 {
@@ -71,9 +77,20 @@ class WalletQmlModel : public QObject
     Q_PROPERTY(QString transactionError READ transactionError NOTIFY transactionErrorChanged)
     Q_PROPERTY(bool transactionNeedsUnlock READ transactionNeedsUnlock NOTIFY transactionNeedsUnlockChanged)
     Q_PROPERTY(QString settingsError READ settingsError NOTIFY settingsErrorChanged)
+    Q_PROPERTY(bool importedPsbtLoaded READ importedPsbtLoaded NOTIFY importedPsbtChanged)
+    Q_PROPERTY(QString importedPsbtMode READ importedPsbtMode NOTIFY importedPsbtChanged)
+    Q_PROPERTY(QString importedPsbtStatus READ importedPsbtStatus NOTIFY importedPsbtChanged)
+    Q_PROPERTY(QString importedPsbtError READ importedPsbtError NOTIFY importedPsbtChanged)
+    Q_PROPERTY(QStringList importedPsbtSummary READ importedPsbtSummary NOTIFY importedPsbtChanged)
+    Q_PROPERTY(bool importedPsbtCanSign READ importedPsbtCanSign NOTIFY importedPsbtChanged)
+    Q_PROPERTY(bool importedPsbtCanBroadcast READ importedPsbtCanBroadcast NOTIFY importedPsbtChanged)
+    Q_PROPERTY(bool importedPsbtComplete READ importedPsbtComplete NOTIFY importedPsbtChanged)
+    Q_PROPERTY(int importedPsbtUnsignedInputCount READ importedPsbtUnsignedInputCount NOTIFY importedPsbtChanged)
+    Q_PROPERTY(int importedPsbtCouldSignInputCount READ importedPsbtCouldSignInputCount NOTIFY importedPsbtChanged)
 
 public:
     WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObject* parent = nullptr);
+    WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, interfaces::Node* node, QObject* parent = nullptr);
     WalletQmlModel(QObject *parent = nullptr);
     ~WalletQmlModel();
 
@@ -123,6 +140,12 @@ public:
     Q_INVOKABLE void clearSettingsError();
     Q_INVOKABLE void setDefaultReceiveAddressType(const QString& address_type);
     Q_INVOKABLE QString receiveAddressTypeLabel(const QString& address_type) const;
+    Q_INVOKABLE QString importPsbtFromFile(const QString& path);
+    Q_INVOKABLE void clearImportedPsbt();
+    Q_INVOKABLE void signImportedPsbt();
+    Q_INVOKABLE void broadcastImportedPsbt();
+    Q_INVOKABLE void copyImportedPsbtToClipboard();
+    Q_INVOKABLE void saveImportedPsbtToFile(const QString& path);
     void removeWallet();
 
     std::set<interfaces::WalletTx> getWalletTxs() const;
@@ -174,6 +197,18 @@ public:
     QString transactionError() const { return m_transaction_error; }
     bool transactionNeedsUnlock() const { return m_transaction_needs_unlock; }
     QString settingsError() const { return m_settings_error; }
+    void setNode(interfaces::Node* node) { m_node = node; }
+
+    bool importedPsbtLoaded() const { return m_imported_psbt || m_imported_psbt_mode == QStringLiteral("draft"); }
+    QString importedPsbtMode() const { return m_imported_psbt_mode; }
+    QString importedPsbtStatus() const { return m_imported_psbt_status; }
+    QString importedPsbtError() const { return m_imported_psbt_error; }
+    QStringList importedPsbtSummary() const { return m_imported_psbt_summary; }
+    bool importedPsbtCanSign() const { return m_imported_psbt_can_sign; }
+    bool importedPsbtCanBroadcast() const { return m_imported_psbt_can_broadcast; }
+    bool importedPsbtComplete() const { return m_imported_psbt_complete; }
+    int importedPsbtUnsignedInputCount() const { return m_imported_psbt_unsigned_inputs; }
+    int importedPsbtCouldSignInputCount() const { return m_imported_psbt_could_sign_inputs; }
 
 Q_SIGNALS:
     void nameChanged();
@@ -197,6 +232,7 @@ Q_SIGNALS:
     void walletUnloaded();
     void settingsErrorChanged();
     void addressListChanged();
+    void importedPsbtChanged();
 
 private:
     void initializeFeeEstimator();
@@ -219,8 +255,14 @@ private:
     void setTransactionStatus(const QString& error, bool needs_unlock = false);
     void setSettingsError(const QString& error);
     QString persistedReceiveAddressTypeKey() const;
+    QString importPsbt(PartiallySignedTransaction psbt);
+    bool tryImportPsbtToReview(const PartiallySignedTransaction& psbt, QString& mode, QString& reason);
+    void refreshImportedPsbtState(const QString& status_override = QString());
+    void setImportedPsbtError(const QString& error);
+    QStringList buildPsbtSummary(const PartiallySignedTransaction& psbt) const;
 
     std::unique_ptr<interfaces::Wallet> m_wallet;
+    interfaces::Node* m_node{nullptr};
     ActivityListModel* m_activity_list_model{nullptr};
     AddressListModel* m_address_list_model{nullptr};
     BumpTransactionModel* m_bump_transaction_model{nullptr};
@@ -255,6 +297,16 @@ private:
     std::unique_ptr<interfaces::Handler> m_handler_transaction_changed;
     std::unique_ptr<interfaces::Handler> m_handler_unload;
     int m_display_unit{0};
+    std::unique_ptr<PartiallySignedTransaction> m_imported_psbt;
+    QString m_imported_psbt_mode;
+    QString m_imported_psbt_status;
+    QString m_imported_psbt_error;
+    QStringList m_imported_psbt_summary;
+    bool m_imported_psbt_can_sign{false};
+    bool m_imported_psbt_can_broadcast{false};
+    bool m_imported_psbt_complete{false};
+    int m_imported_psbt_unsigned_inputs{0};
+    int m_imported_psbt_could_sign_inputs{0};
 };
 
 #endif // BITCOIN_QML_MODELS_WALLETQMLMODEL_H

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Dialogs
 import Qt.labs.settings 1.0
 import org.bitcoincore.qt 1.0
 
@@ -87,7 +88,90 @@ PageStack {
     }
 
     initialItem: Page {
+        id: sendPage
         background: null
+
+        function handlePsbtImportResult(mode) {
+            sendOptionsPopup.close()
+            if (mode === "single-review" || mode === "multiple-review") {
+                const multipleRecipientsEnabled = mode === "multiple-review"
+                settings.multipleRecipientsEnabled = multipleRecipientsEnabled
+                root.transactionPrepared(multipleRecipientsEnabled)
+            } else if (mode === "unsupported") {
+                unsupportedPsbtPopup.message = root.wallet.importedPsbtError.length > 0
+                    ? root.wallet.importedPsbtError
+                    : qsTr("This PSBT is not supported yet.")
+                unsupportedPsbtPopup.open()
+            }
+        }
+
+        FileDialog {
+            id: psbtOpenDialog
+            title: qsTr("Import PSBT")
+            fileMode: FileDialog.OpenFile
+            nameFilters: [qsTr("Partially Signed Bitcoin Transactions (*.psbt)"), qsTr("All files (*)")]
+            onAccepted: sendPage.handlePsbtImportResult(root.wallet.importPsbtFromFile(selectedFile.toString()))
+        }
+
+        // Kept hidden so functional tests can inject a PSBT path until the
+        // native file dialog is automatable through the QML test bridge.
+        TextField {
+            id: psbtAutomationPathField
+            objectName: "psbtImportPathField"
+            visible: false
+        }
+
+        Popup {
+            id: unsupportedPsbtPopup
+            objectName: "unsupportedPsbtPopup"
+            anchors.centerIn: parent
+            modal: true
+            padding: 20
+            width: Math.min(parent.width - 40, 360)
+
+            property string message: ""
+
+            onClosed: root.wallet.clearImportedPsbt()
+
+            background: Rectangle {
+                color: Theme.color.background
+                radius: 8
+                border.color: Theme.color.neutral3
+                border.width: 1
+            }
+
+            ColumnLayout {
+                width: parent.width
+                spacing: 16
+
+                CoreText {
+                    objectName: "unsupportedPsbtPopupTitle"
+                    Layout.fillWidth: true
+                    text: qsTr("Not supported")
+                    bold: true
+                    font.pixelSize: 18
+                    color: Theme.color.neutral9
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                CoreText {
+                    objectName: "unsupportedPsbtPopupMessage"
+                    Layout.fillWidth: true
+                    text: unsupportedPsbtPopup.message
+                    font.pixelSize: 15
+                    color: Theme.color.neutral7
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                ContinueButton {
+                    objectName: "unsupportedPsbtPopupOkButton"
+                    Layout.fillWidth: true
+                    text: qsTr("Ok")
+                    onClicked: unsupportedPsbtPopup.close()
+                }
+            }
+        }
 
         Settings {
             id: settings
@@ -97,7 +181,7 @@ PageStack {
             onMultipleRecipientsEnabledChanged: {
                 if (!multipleRecipientsEnabled) {
                     root.wallet.recipients.clearToFront()
-                } else {
+                } else if (root.wallet.recipients.count === 1) {
                     root.wallet.recipients.add()
                 }
             }
@@ -156,6 +240,16 @@ PageStack {
                         id: sendOptionsPopup
                         x: menuButton.x - width + menuButton.width
                         y: menuButton.y + menuButton.height
+                        onImportPsbtFromFileRequested: {
+                            if (psbtAutomationPathField.text.length > 0) {
+                                const automatedPath = psbtAutomationPathField.text
+                                psbtAutomationPathField.text = ""
+                                sendPage.handlePsbtImportResult(root.wallet.importPsbtFromFile(automatedPath))
+                                return
+                            }
+                            sendOptionsPopup.close()
+                            psbtOpenDialog.open()
+                        }
                     }
                 }
 

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -240,6 +240,10 @@ PageStack {
                         id: sendOptionsPopup
                         x: menuButton.x - width + menuButton.width
                         y: menuButton.y + menuButton.height
+                        onClearFormRequested: {
+                            sendOptionsPopup.close()
+                            root.wallet.recipients.clear()
+                        }
                         onImportPsbtFromFileRequested: {
                             if (psbtAutomationPathField.text.length > 0) {
                                 const automatedPath = psbtAutomationPathField.text
@@ -266,6 +270,7 @@ PageStack {
 
                 RowLayout {
                     id: selectAndAddRecipients
+                    objectName: "sendMultipleRecipientsRow"
                     Layout.fillWidth: true
                     Layout.topMargin: 10
                     Layout.bottomMargin: 10

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -11,6 +11,7 @@
 #include <QMetaObject>
 #include <QEventLoop>
 #include <QFont>
+#include <QKeyEvent>
 #include <QImage>
 #include <QPointer>
 #include <QQuickItem>
@@ -91,6 +92,34 @@ QByteArray clickObject(QObject* obj)
     QJsonObject resp;
     resp[QStringLiteral("error")] = QStringLiteral("Cannot click object");
     return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+}
+
+struct KeyStroke {
+    int key{Qt::Key_unknown};
+    Qt::KeyboardModifiers modifiers{Qt::NoModifier};
+};
+
+std::optional<KeyStroke> ToKeyStroke(const QChar ch)
+{
+    if (ch.isLetter()) {
+        const QChar upper = ch.toUpper();
+        return KeyStroke{Qt::Key_A + upper.unicode() - QChar(u'A').unicode(),
+                         ch.isUpper() ? Qt::ShiftModifier : Qt::NoModifier};
+    }
+    if (ch.isDigit()) {
+        return KeyStroke{Qt::Key_0 + ch.unicode() - QChar(u'0').unicode(), Qt::NoModifier};
+    }
+
+    switch (ch.unicode()) {
+    case u' ': return KeyStroke{Qt::Key_Space, Qt::NoModifier};
+    case u'.': return KeyStroke{Qt::Key_Period, Qt::NoModifier};
+    case u'-': return KeyStroke{Qt::Key_Minus, Qt::NoModifier};
+    case u'_': return KeyStroke{Qt::Key_Minus, Qt::ShiftModifier};
+    case u'/': return KeyStroke{Qt::Key_Slash, Qt::NoModifier};
+    case u'\\': return KeyStroke{Qt::Key_Backslash, Qt::NoModifier};
+    case u':': return KeyStroke{Qt::Key_Semicolon, Qt::ShiftModifier};
+    default: return std::nullopt;
+    }
 }
 } // namespace
 
@@ -376,6 +405,10 @@ QByteArray TestBridge::processCommand(const QByteArray& json_cmd)
         return cmdSetText(
             obj.value(QStringLiteral("objectName")).toString(),
             obj.value(QStringLiteral("text")).toString());
+    } else if (cmd == QLatin1String("type_text")) {
+        return cmdTypeText(
+            obj.value(QStringLiteral("objectName")).toString(),
+            obj.value(QStringLiteral("text")).toString());
     } else if (cmd == QLatin1String("wait_for_page")) {
         return cmdWaitForPage(
             obj.value(QStringLiteral("page")).toString(),
@@ -601,6 +634,43 @@ QByteArray TestBridge::cmdSetText(const QString& object_name, const QString& tex
     }
 
     return errorResponse(QStringLiteral("Object %1 has no 'text' property").arg(object_name));
+}
+
+QByteArray TestBridge::cmdTypeText(const QString& object_name, const QString& text)
+{
+    if (object_name.isEmpty()) {
+        return errorResponse(QStringLiteral("objectName is required"));
+    }
+
+    QObject* obj = findObjectByName(object_name);
+    if (!obj) {
+        return errorResponse(QStringLiteral("Object not found: %1").arg(object_name));
+    }
+
+    auto* item = qobject_cast<QQuickItem*>(obj);
+    if (!item) {
+        return errorResponse(QStringLiteral("Object %1 is not a QQuickItem").arg(object_name));
+    }
+
+    item->forceActiveFocus(Qt::OtherFocusReason);
+    QCoreApplication::processEvents();
+
+    for (const QChar ch : text) {
+        const std::optional<KeyStroke> stroke = ToKeyStroke(ch);
+        if (!stroke) {
+            return errorResponse(QStringLiteral("Unsupported character for type_text: %1").arg(ch));
+        }
+
+        const QString key_text{ch};
+        QKeyEvent press(QEvent::KeyPress, stroke->key, stroke->modifiers, key_text);
+        QKeyEvent release(QEvent::KeyRelease, stroke->key, stroke->modifiers, key_text);
+        QCoreApplication::sendEvent(item, &press);
+        QCoreApplication::sendEvent(item, &release);
+    }
+
+    QJsonObject resp;
+    resp[QStringLiteral("ok")] = true;
+    return QJsonDocument(resp).toJson(QJsonDocument::Compact);
 }
 
 QByteArray TestBridge::cmdWaitForPage(const QString& page_name, int timeout_ms)

--- a/qml/test/testbridge.h
+++ b/qml/test/testbridge.h
@@ -27,6 +27,7 @@
 ///   {"cmd": "get_property", "objectName": "<name>", "prop": "<property>"}
 ///   {"cmd": "click", "objectName": "<name>"}
 ///   {"cmd": "set_text", "objectName": "<name>", "text": "<value>"}
+///   {"cmd": "type_text", "objectName": "<name>", "text": "<value>"}
 ///   {"cmd": "wait_for_page", "page": "<objectName>", "timeout": <ms>}
 ///   {"cmd": "wait_for_property", "objectName": "<name>", "prop": "<property>", ...}
 ///   {"cmd": "get_text", "objectName": "<name>"}
@@ -78,6 +79,7 @@ private:
     QByteArray cmdGetProperty(const QString& object_name, const QString& prop);
     QByteArray cmdClick(const QString& object_name);
     QByteArray cmdSetText(const QString& object_name, const QString& text);
+    QByteArray cmdTypeText(const QString& object_name, const QString& text);
     QByteArray cmdWaitForPage(const QString& page_name, int timeout_ms);
     QByteArray cmdWaitForProperty(const QString& object_name, const QString& prop, int timeout_ms, const QJsonValue& expected, bool has_expected, const QString& contains, bool non_empty);
     QByteArray cmdGetText(const QString& object_name);

--- a/qml/walletqmlcontroller.cpp
+++ b/qml/walletqmlcontroller.cpp
@@ -81,6 +81,7 @@ WalletQmlController::WalletQmlController(interfaces::Node& node, QObject *parent
     , m_worker(new QObject)
     , m_worker_thread(new QThread(this))
 {
+    m_empty_wallet->setNode(&m_node);
     m_worker->moveToThread(m_worker_thread);
     m_worker_thread->start();
     QTimer::singleShot(0, m_worker, []() {
@@ -301,7 +302,7 @@ bool WalletQmlController::createSingleSigWallet(const QString &name, const QStri
         const QString loaded_wallet_name = QString::fromStdString((*wallet)->getWalletName());
         {
             QMutexLocker locker(&m_wallets_mutex);
-            m_selected_wallet = new WalletQmlModel(std::move(*wallet));
+            m_selected_wallet = new WalletQmlModel(std::move(*wallet), &m_node);
             registerWalletModel(m_selected_wallet);
             applyWalletDisplayName(m_selected_wallet);
             m_wallets.push_back(m_selected_wallet);
@@ -792,7 +793,7 @@ void WalletQmlController::handleLoadWallet(std::unique_ptr<interfaces::Wallet> w
     }
 
     const QString loaded_wallet_name = QString::fromStdString(wallet->getWalletName());
-    auto wallet_model = new WalletQmlModel(std::move(wallet));
+    auto wallet_model = new WalletQmlModel(std::move(wallet), &m_node);
     wallet_model->moveToThread(this->thread());
     registerWalletModel(wallet_model);
     {
@@ -827,7 +828,7 @@ void WalletQmlController::initialize()
     loaded_wallet_names.reserve(static_cast<qsizetype>(wallets.size()));
     for (auto& wallet : wallets) {
         loaded_wallet_names.append(QString::fromStdString(wallet->getWalletName()));
-        auto* wallet_model = new WalletQmlModel(std::move(wallet));
+        auto* wallet_model = new WalletQmlModel(std::move(wallet), &m_node);
         registerWalletModel(wallet_model);
         applyWalletDisplayName(wallet_model);
         m_wallets.push_back(wallet_model);

--- a/test/functional/qml_driver.py
+++ b/test/functional/qml_driver.py
@@ -85,6 +85,14 @@ class QmlDriver:
                 f"set_text({object_name!r}) failed: {resp['error']}"
             )
 
+    def type_text(self, object_name, text):
+        """Type text into the named QML object using key events."""
+        resp = self._send({"cmd": "type_text", "objectName": object_name, "text": text})
+        if "error" in resp:
+            raise QmlDriverError(
+                f"type_text({object_name!r}) failed: {resp['error']}"
+            )
+
     def get_text(self, object_name):
         """Return the text property of the named QML object."""
         resp = self._send({"cmd": "get_text", "objectName": object_name})

--- a/test/functional/qml_test_psbt.py
+++ b/test/functional/qml_test_psbt.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""End-to-end GUI tests for PSBT import routing into send review pages."""
+
+import argparse
+import base64
+import os
+import re
+import sys
+from datetime import datetime
+
+from qml_test_harness import dump_qml_tree
+from qml_wallet_test_lib import WalletFlowHarness, rpc_call, wait_for_rpc
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="PSBT GUI functional test",
+        add_help=True,
+    )
+    parser.add_argument(
+        "--save-screenshots",
+        action="store_true",
+        help="Save a PNG at each GUI checkpoint under test/artifacts/",
+    )
+    return parser.parse_args()
+
+
+def make_screenshot_root():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    artifacts_root = os.path.join(repo_root, "test", "artifacts")
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    screenshot_root = os.path.join(artifacts_root, f"qml_test_psbt-{timestamp}")
+    os.makedirs(screenshot_root, exist_ok=True)
+    return screenshot_root
+
+
+class CheckpointRecorder:
+    def __init__(self, case_name, save_screenshots, screenshot_root):
+        self.case_name = case_name
+        self.save_screenshots = save_screenshots
+        self.screenshot_root = screenshot_root
+        self.index = 0
+
+    def _sanitize_label(self, label):
+        return re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-") or "checkpoint"
+
+    def checkpoint(self, label, gui=None):
+        self.index += 1
+        prefix = f"[{self.case_name}] checkpoint {self.index:02d}"
+        print(f"{prefix}: {label}")
+        if gui is None:
+            return
+
+        gui.settle()
+
+        if not self.save_screenshots:
+            return
+
+        case_dir = os.path.join(self.screenshot_root, self.case_name)
+        filename = f"{self.index:02d}-{self._sanitize_label(label)}.png"
+        screenshot_path = os.path.join(case_dir, filename)
+        screenshot = gui.save_screenshot(screenshot_path)
+        print(
+            f"{prefix}: screenshot saved to {screenshot['path']} "
+            f"({screenshot['width']}x{screenshot['height']})"
+        )
+
+
+def wait_for_wallet(gui, wallet_name, timeout_ms=20000):
+    gui.wait_for_property("walletBadge", "loading", False, timeout_ms=timeout_ms)
+    gui.wait_for_property("walletBadge", "text", wallet_name, timeout_ms=timeout_ms)
+    gui.wait_for_property("walletBadge", "noWalletLoaded", False, timeout_ms=timeout_ms)
+
+
+def create_wallet(rpc_port, wallet_name):
+    rpc_call(rpc_port, "createwallet", {"wallet_name": wallet_name})
+
+
+def fund_wallet(rpc_port, wallet_name):
+    mining_address = rpc_call(rpc_port, "getnewaddress", ["psbt-mining"], wallet=wallet_name)
+    rpc_call(rpc_port, "generatetoaddress", [101, mining_address])
+
+
+def write_psbt_fixture(rpc_port, wallet_name, outputs, filename):
+    response = rpc_call(
+        rpc_port,
+        "walletcreatefundedpsbt",
+        [[], outputs, 0, {"fee_rate": 2}, True],
+        wallet=wallet_name,
+    )
+    fixture_path = filename
+    with open(fixture_path, "wb") as fixture:
+        fixture.write(base64.b64decode(response["psbt"]))
+    return fixture_path
+
+
+def navigate_to_send(gui):
+    gui.click("sendTabButton")
+    gui.wait_for_property("sendOptionsButton", "visible", True, timeout_ms=10000)
+
+
+def import_psbt(gui, psbt_path):
+    gui.click("sendOptionsButton")
+    gui.wait_for_property("sendImportPsbtFromFileButton", "visible", True, timeout_ms=5000)
+    gui.set_text("psbtImportPathField", psbt_path)
+    gui.click("sendImportPsbtFromFileButton")
+
+
+def build_fixtures(harness):
+    recipient_wallet = "psbt-recipient"
+    unsupported_wallet = "psbt-unsupported"
+    source_wallet = "psbt-source"
+
+    create_wallet(harness.gui_rpc_port, recipient_wallet)
+    create_wallet(harness.gui_rpc_port, unsupported_wallet)
+    create_wallet(harness.gui_rpc_port, source_wallet)
+
+    recipient_address_1 = rpc_call(
+        harness.gui_rpc_port, "getnewaddress", ["psbt-destination-1"], wallet=recipient_wallet
+    )
+    recipient_address_2 = rpc_call(
+        harness.gui_rpc_port, "getnewaddress", ["psbt-destination-2"], wallet=recipient_wallet
+    )
+
+    fund_wallet(harness.gui_rpc_port, unsupported_wallet)
+    fund_wallet(harness.gui_rpc_port, source_wallet)
+
+    single_review_path = write_psbt_fixture(
+        harness.gui_rpc_port,
+        source_wallet,
+        [{recipient_address_1: 1.0}],
+        os.path.join(harness.tmpdir, "single-review.psbt"),
+    )
+    multiple_review_path = write_psbt_fixture(
+        harness.gui_rpc_port,
+        source_wallet,
+        [{recipient_address_1: 1.0}, {recipient_address_2: 0.5}],
+        os.path.join(harness.tmpdir, "multiple-review.psbt"),
+    )
+    unsupported_path = write_psbt_fixture(
+        harness.gui_rpc_port,
+        unsupported_wallet,
+        [{recipient_address_1: 0.75}],
+        os.path.join(harness.tmpdir, "unsupported.psbt"),
+    )
+    return source_wallet, single_review_path, multiple_review_path, unsupported_path
+
+
+def run_test():
+    args = parse_args()
+    screenshot_root = None
+    if args.save_screenshots:
+        screenshot_root = make_screenshot_root()
+        print(f"Checkpoint screenshots will be saved under: {screenshot_root}")
+
+    harness = WalletFlowHarness("qml_test_psbt", port_offset=40)
+    checkpoints = CheckpointRecorder("psbt-import-routing", args.save_screenshots, screenshot_root)
+    gui = None
+    try:
+        checkpoints.checkpoint("starting harness")
+        harness.start_gui()
+        gui = harness.driver
+        checkpoints.checkpoint("GUI launched", gui)
+        wait_for_rpc(harness.gui_rpc_port)
+        checkpoints.checkpoint("GUI RPC ready", gui)
+
+        source_wallet, single_review_path, multiple_review_path, unsupported_path = build_fixtures(harness)
+        checkpoints.checkpoint("PSBT fixtures created")
+        wait_for_wallet(gui, source_wallet)
+        checkpoints.checkpoint(f"wallet selected: {source_wallet}", gui)
+
+        navigate_to_send(gui)
+        checkpoints.checkpoint("send page opened", gui)
+
+        import_psbt(gui, single_review_path)
+        checkpoints.checkpoint("single-recipient PSBT submitted", gui)
+        gui.wait_for_page("sendReviewPage", timeout_ms=20000)
+        assert gui.get_current_page() == "sendReviewPage", "Expected single-recipient PSBT to open SendReview"
+        checkpoints.checkpoint("single-recipient review displayed", gui)
+        gui.click("sendReviewBackButton")
+        gui.wait_for_property("sendOptionsButton", "visible", True, timeout_ms=10000)
+        checkpoints.checkpoint("returned from single review to send page", gui)
+
+        import_psbt(gui, multiple_review_path)
+        checkpoints.checkpoint("multi-recipient PSBT submitted", gui)
+        gui.wait_for_page("multipleSendReviewPage", timeout_ms=20000)
+        assert gui.get_current_page() == "multipleSendReviewPage", (
+            "Expected multi-recipient PSBT to open MultipleSendReview"
+        )
+        checkpoints.checkpoint("multiple-recipient review displayed", gui)
+        gui.click("multipleSendReviewBackButton")
+        gui.wait_for_property("sendOptionsButton", "visible", True, timeout_ms=10000)
+        checkpoints.checkpoint("returned from multiple review to send page", gui)
+
+        import_psbt(gui, unsupported_path)
+        checkpoints.checkpoint("unsupported PSBT submitted", gui)
+        gui.wait_for_property("unsupportedPsbtPopup", "visible", True, timeout_ms=20000)
+        checkpoints.checkpoint("unsupported PSBT modal displayed", gui)
+        assert gui.get_text("unsupportedPsbtPopupTitle") == "Not supported"
+        assert gui.get_text("unsupportedPsbtPopupMessage") == (
+            "Only PSBTs that spend this wallet's own inputs are supported right now."
+        )
+        gui.click("unsupportedPsbtPopupOkButton")
+        gui.wait_for_property("unsupportedPsbtPopup", "visible", False, timeout_ms=10000)
+        gui.wait_for_property("sendOptionsButton", "visible", True, timeout_ms=10000)
+        checkpoints.checkpoint("unsupported PSBT modal dismissed", gui)
+
+        print("\n" + "=" * 50)
+        print("All tests PASSED")
+        print("=" * 50)
+        return 0
+    except Exception as err:  # noqa: BLE001 - functional test should preserve context
+        print(f"\nFAILED: {err}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        if gui is not None:
+            try:
+                checkpoints.checkpoint("failure state", gui)
+            except Exception as screenshot_err:  # noqa: BLE001 - preserve original failure context
+                print(f"failed to save failure screenshot: {screenshot_err}", file=sys.stderr)
+            dump_qml_tree(gui)
+        gui_output = harness.process_output(harness.gui_process)
+        if gui_output:
+            print("\n--- GUI process output ---", file=sys.stderr)
+            print(gui_output, file=sys.stderr)
+        return 1
+    finally:
+        harness.stop()
+
+
+if __name__ == "__main__":
+    sys.exit(run_test())

--- a/test/functional/qml_test_psbt.py
+++ b/test/functional/qml_test_psbt.py
@@ -146,7 +146,12 @@ def build_fixtures(harness):
         [{recipient_address_1: 0.75}],
         os.path.join(harness.tmpdir, "unsupported.psbt"),
     )
-    return source_wallet, single_review_path, multiple_review_path, unsupported_path
+    return {
+        "source_wallet": source_wallet,
+        "single_review_path": single_review_path,
+        "multiple_review_path": multiple_review_path,
+        "unsupported_path": unsupported_path,
+    }
 
 
 def run_test():
@@ -167,15 +172,15 @@ def run_test():
         wait_for_rpc(harness.gui_rpc_port)
         checkpoints.checkpoint("GUI RPC ready", gui)
 
-        source_wallet, single_review_path, multiple_review_path, unsupported_path = build_fixtures(harness)
+        fixtures = build_fixtures(harness)
         checkpoints.checkpoint("PSBT fixtures created")
-        wait_for_wallet(gui, source_wallet)
-        checkpoints.checkpoint(f"wallet selected: {source_wallet}", gui)
+        wait_for_wallet(gui, fixtures["source_wallet"])
+        checkpoints.checkpoint(f"wallet selected: {fixtures['source_wallet']}", gui)
 
         navigate_to_send(gui)
         checkpoints.checkpoint("send page opened", gui)
 
-        import_psbt(gui, single_review_path)
+        import_psbt(gui, fixtures["single_review_path"])
         checkpoints.checkpoint("single-recipient PSBT submitted", gui)
         gui.wait_for_page("sendReviewPage", timeout_ms=20000)
         assert gui.get_current_page() == "sendReviewPage", "Expected single-recipient PSBT to open SendReview"
@@ -184,7 +189,7 @@ def run_test():
         gui.wait_for_property("sendOptionsButton", "visible", True, timeout_ms=10000)
         checkpoints.checkpoint("returned from single review to send page", gui)
 
-        import_psbt(gui, multiple_review_path)
+        import_psbt(gui, fixtures["multiple_review_path"])
         checkpoints.checkpoint("multi-recipient PSBT submitted", gui)
         gui.wait_for_page("multipleSendReviewPage", timeout_ms=20000)
         assert gui.get_current_page() == "multipleSendReviewPage", (
@@ -195,7 +200,7 @@ def run_test():
         gui.wait_for_property("sendOptionsButton", "visible", True, timeout_ms=10000)
         checkpoints.checkpoint("returned from multiple review to send page", gui)
 
-        import_psbt(gui, unsupported_path)
+        import_psbt(gui, fixtures["unsupported_path"])
         checkpoints.checkpoint("unsupported PSBT submitted", gui)
         gui.wait_for_property("unsupportedPsbtPopup", "visible", True, timeout_ms=20000)
         checkpoints.checkpoint("unsupported PSBT modal displayed", gui)

--- a/test/qml/tst_ellipsismenuactionitem.qml
+++ b/test/qml/tst_ellipsismenuactionitem.qml
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/controls"
+
+TestCase {
+    name: "EllipsisMenuActionItem"
+    when: windowShown
+    width: 400
+    height: 200
+
+    Item {
+        id: host
+        width: parent.width
+        height: parent.height
+    }
+
+    Component {
+        id: actionItemComponent
+
+        EllipsisMenuActionItem {
+            width: 280
+            text: "Import PSBT from file…"
+            leftIconSource: "qrc:/icons/file"
+        }
+    }
+
+    function test_action_item_defaults() {
+        const item = createTemporaryObject(actionItemComponent, host)
+        verify(item !== null)
+
+        compare(item.implicitWidth, 280)
+        compare(item.implicitHeight, 33)
+        compare(item.text, "Import PSBT from file…")
+        verify(item.hoverEnabled)
+        verify(item.leftIconSource.toString().indexOf("file") !== -1)
+    }
+
+    function test_action_item_exposes_button_contract() {
+        const item = createTemporaryObject(actionItemComponent, host)
+        verify(item !== null)
+
+        verify(item.enabled)
+        verify(item.hoverEnabled)
+        compare(item.padding, 0)
+    }
+}

--- a/test/qml/tst_ellipsismenutoggleitem.qml
+++ b/test/qml/tst_ellipsismenutoggleitem.qml
@@ -32,7 +32,7 @@ TestCase {
         verify(item !== null)
 
         compare(item.implicitWidth, 280)
-        compare(item.implicitHeight, 33)
+        compare(item.implicitHeight, 48)
         compare(item.checked, false)
     }
 
@@ -54,6 +54,6 @@ TestCase {
         verify(item.enabled)
         verify(item.hoverEnabled)
         verify(item.checkable)
-        compare(item.padding, 0)
+        compare(item.padding, 10)
     }
 }

--- a/test/qml/tst_ellipsismenutoggleitem.qml
+++ b/test/qml/tst_ellipsismenutoggleitem.qml
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/controls"
+
+TestCase {
+    name: "EllipsisMenuToggleItem"
+    when: windowShown
+    width: 400
+    height: 200
+
+    Item {
+        id: host
+        width: parent.width
+        height: parent.height
+    }
+
+    Component {
+        id: toggleItemComponent
+
+        EllipsisMenuToggleItem {
+            width: 280
+            text: "Multiple Recipients"
+        }
+    }
+
+    function test_toggle_defaults_unchecked() {
+        const item = createTemporaryObject(toggleItemComponent, host)
+        verify(item !== null)
+
+        compare(item.implicitWidth, 280)
+        compare(item.implicitHeight, 33)
+        compare(item.checked, false)
+    }
+
+    function test_external_checked_assignment_is_stable() {
+        const item = createTemporaryObject(toggleItemComponent, host)
+        verify(item !== null)
+
+        item.checked = true
+        compare(item.checked, true)
+
+        item.checked = false
+        compare(item.checked, false)
+    }
+
+    function test_toggle_item_exposes_button_contract() {
+        const item = createTemporaryObject(toggleItemComponent, host)
+        verify(item !== null)
+
+        verify(item.enabled)
+        verify(item.hoverEnabled)
+        verify(item.checkable)
+        compare(item.padding, 0)
+    }
+}

--- a/test/qml/tst_sendoptionspopup.qml
+++ b/test/qml/tst_sendoptionspopup.qml
@@ -75,8 +75,8 @@ TestCase {
 
     function test_clicking_toggles_updates_aliases() {
         const popup = createPopup()
-        const coinToggle = findObject(popup, "sendCoinControlToggle")
-        const multipleToggle = findObject(popup, "sendMultipleRecipientsToggle")
+        const coinToggle = findObject(popup, "sendOptionsCoinControlToggle")
+        const multipleToggle = findObject(popup, "sendOptionsMultipleRecipientsToggle")
 
         verify(coinToggle !== null)
         verify(multipleToggle !== null)

--- a/test/qml/tst_sendoptionspopup.qml
+++ b/test/qml/tst_sendoptionspopup.qml
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtTest 1.2
+import "../../qml/controls"
+
+TestCase {
+    name: "SendOptionsPopup"
+    when: windowShown
+    width: 400
+    height: 300
+
+    Item {
+        id: host
+        width: parent.width
+        height: parent.height
+    }
+
+    Component {
+        id: popupComponent
+
+        SendOptionsPopup {
+            x: 20
+            y: 20
+        }
+    }
+
+    function createPopup() {
+        const popup = createTemporaryObject(popupComponent, host)
+        verify(popup !== null)
+        popup.open()
+        tryCompare(popup, "opened", true)
+        wait(0)
+        return popup
+    }
+
+    function findObject(root, objectName) {
+        if (!root) return null
+        if (root.objectName === objectName) return root
+
+        const extraRoots = []
+        if (root.contentItem) extraRoots.push(root.contentItem)
+        if (root.background) extraRoots.push(root.background)
+
+        for (let i = 0; i < extraRoots.length; ++i) {
+            const extraMatch = findObject(extraRoots[i], objectName)
+            if (extraMatch) return extraMatch
+        }
+
+        const children = root.children || []
+        for (let i = 0; i < children.length; ++i) {
+            const match = findObject(children[i], objectName)
+            if (match) return match
+        }
+        return null
+    }
+
+    function test_aliases_default_to_false() {
+        const popup = createPopup()
+        compare(popup.coinControlEnabled, false)
+        compare(popup.multipleRecipientsEnabled, false)
+    }
+
+    function test_alias_assignments_drive_toggle_state() {
+        const popup = createPopup()
+
+        popup.coinControlEnabled = true
+        popup.multipleRecipientsEnabled = true
+        compare(popup.coinControlEnabled, true)
+        compare(popup.multipleRecipientsEnabled, true)
+    }
+
+    function test_clicking_toggles_updates_aliases() {
+        const popup = createPopup()
+        const coinToggle = findObject(popup, "sendCoinControlToggle")
+        const multipleToggle = findObject(popup, "sendMultipleRecipientsToggle")
+
+        verify(coinToggle !== null)
+        verify(multipleToggle !== null)
+
+        mouseClick(coinToggle, coinToggle.width / 2, coinToggle.height / 2)
+        compare(popup.coinControlEnabled, true)
+
+        mouseClick(multipleToggle, multipleToggle.width / 2, multipleToggle.height / 2)
+        compare(popup.multipleRecipientsEnabled, true)
+    }
+
+    function test_action_rows_emit_signals() {
+        const popup = createPopup()
+        const importButton = findObject(popup, "sendImportPsbtFromFileButton")
+        const clearButton = findObject(popup, "sendClearFormButton")
+
+        verify(importButton !== null)
+        verify(clearButton !== null)
+
+        let importCount = 0
+        let clearCount = 0
+        popup.importPsbtFromFileRequested.connect(function() { importCount += 1 })
+        popup.clearFormRequested.connect(function() { clearCount += 1 })
+
+        mouseClick(importButton, importButton.width / 2, importButton.height / 2)
+        compare(importCount, 1)
+
+        mouseClick(clearButton, clearButton.width / 2, clearButton.height / 2)
+        compare(clearCount, 1)
+    }
+}


### PR DESCRIPTION
<img width="819" height="698" alt="Screenshot from 2026-04-26 00-21-06" src="https://github.com/user-attachments/assets/c8bed9a6-4eb5-4e8d-b041-d49488f87801" />
<img width="819" height="698" alt="Screenshot from 2026-04-26 00-22-06" src="https://github.com/user-attachments/assets/8bddfa7a-394f-46ba-a37e-53a751eb230d" />

Import a PSBT that we can fully sign and move to the SendReivew page. PSBT requiring a signature we can't provide is not supported right now. I think that should be designed around the future multisig flows.

Also, since I was in the send popup, I added the clear form row and qmltests to validate.