### PR TITLE
Implement Addresses list and Sign/Verify in Wallet Settings

### DIFF
--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -106,6 +106,7 @@ jobs:
           python3 test/functional/qml_test_settings_display.py
           python3 test/functional/qml_test_password_wallet.py
           python3 test/functional/qml_test_send_receive.py
+          python3 test/functional/qml_test_addresses.py
           python3 test/functional/qml_test_send_review.py
           python3 test/functional/qml_test_wallet_migration.py
           python3 test/functional/qml_test_wallet_rbf.py

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -29,6 +29,7 @@
 #include <qml/imageprovider.h>
 #include <qml/initexecutor.h>
 #include <qml/models/activitylistmodel.h>
+#include <qml/models/addresslistmodel.h>
 #include <qml/models/banlistmodel.h>
 #include <qml/models/bitcoinaddress.h>
 #include <qml/models/bumptransactionmodel.h>
@@ -425,6 +426,7 @@ int QmlGuiMain(int argc, char* argv[])
     qmlRegisterUncreatableType<DebugLogModel>("org.bitcoincore.qt", 1, 0, "DebugLogModel", "");
     qmlRegisterType<BitcoinAmount>("org.bitcoincore.qt", 1, 0, "BitcoinAmount");
     qmlRegisterType<BitcoinAddress>("org.bitcoincore.qt", 1, 0, "BitcoinAddress");
+    qmlRegisterUncreatableType<AddressListModel>("org.bitcoincore.qt", 1, 0, "AddressListModel", "");
     qmlRegisterType<PaymentRequest>("org.bitcoincore.qt", 1, 0, "PaymentRequest");
     qmlRegisterUncreatableType<Transaction>("org.bitcoincore.qt", 1, 0, "Transaction", "");
     qmlRegisterUncreatableType<SendRecipient>("org.bitcoincore.qt", 1, 0, "SendRecipient", "");

--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -63,6 +63,7 @@
         <file>controls/ProgressIndicator.qml</file>
         <file>controls/QRImage.qml</file>
         <file>controls/qmldir</file>
+        <file>controls/ReceiveOptionsPopup.qml</file>
         <file>controls/SendOptionsPopup.qml</file>
         <file>controls/SegmentedPicker.qml</file>
         <file>controls/Setting.qml</file>
@@ -104,6 +105,9 @@
         <file>pages/settings/SettingsTheme.qml</file>
         <file>pages/wallet/Activity.qml</file>
         <file>pages/wallet/ActivityDetails.qml</file>
+        <file>pages/wallet/AddressList.qml</file>
+        <file>pages/wallet/AddressDetails.qml</file>
+        <file>pages/wallet/AddressRow.qml</file>
         <file>pages/wallet/CoinSelection.qml</file>
         <file>pages/wallet/CreateBackup.qml</file>
         <file>pages/wallet/CreateConfirm.qml</file>

--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -27,6 +27,7 @@
         <file>components/StorageOptions.qml</file>
         <file>components/StorageSettings.qml</file>
         <file>components/ThemeSettings.qml</file>
+        <file>components/Toast.qml</file>
         <file>components/TotalBytesIndicator.qml</file>
         <file>components/Tooltip.qml</file>
         <file>components/LabeledValueField.qml</file>
@@ -125,6 +126,7 @@
         <file>pages/wallet/SendResult.qml</file>
         <file>pages/wallet/SendReview.qml</file>
         <file>pages/wallet/SpeedUpOverlay.qml</file>
+        <file>pages/wallet/SignVerifyMessage.qml</file>
         <file>pages/wallet/WalletBadge.qml</file>
         <file>pages/wallet/WalletPasswordSettings.qml</file>
         <file>pages/wallet/WalletSettings.qml</file>

--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -64,6 +64,7 @@
         <file>controls/QRImage.qml</file>
         <file>controls/qmldir</file>
         <file>controls/SendOptionsPopup.qml</file>
+        <file>controls/SegmentedPicker.qml</file>
         <file>controls/Setting.qml</file>
         <file>controls/Skeleton.qml</file>
         <file>controls/TextButton.qml</file>

--- a/qml/components/Toast.qml
+++ b/qml/components/Toast.qml
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import "../controls"
+
+Rectangle {
+    id: root
+
+    property url iconSource: ""
+    property color iconColor: Theme.color.white
+    property string text: ""
+    property string textObjectName: ""
+    property color textColor: Theme.color.white
+    property color backgroundColor: Theme.color.neutral2
+    property bool showsCloseButton: false
+    property string actionText: ""
+
+    signal actionTriggered()
+    signal dismissed()
+
+    color: backgroundColor
+    radius: 5
+    implicitHeight: Math.max(50, contentRow.implicitHeight + 20)
+
+    RowLayout {
+        id: contentRow
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: 20
+        anchors.rightMargin: 12
+        spacing: 12
+
+        Icon {
+            visible: root.iconSource != ""
+            source: root.iconSource
+            color: root.iconColor
+            size: 18
+            Layout.alignment: Qt.AlignVCenter
+        }
+
+        CoreText {
+            objectName: root.textObjectName
+            Layout.fillWidth: true
+            text: root.text
+            color: root.textColor
+            font: Theme.text.description.font
+            horizontalAlignment: root.iconSource != "" ? Text.AlignLeft : Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            wrapMode: Text.WordWrap
+        }
+
+        Button {
+            id: actionButton
+            visible: root.actionText !== ""
+            text: root.actionText
+            padding: 6
+            background: null
+            contentItem: CoreText {
+                text: actionButton.text
+                color: root.textColor
+                font: Theme.text.description.font
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                opacity: actionButton.hovered ? 0.75 : 1.0
+            }
+            onClicked: root.actionTriggered()
+            HoverHandler {
+                cursorShape: Qt.PointingHandCursor
+            }
+        }
+
+        Rectangle {
+            visible: root.actionText !== "" && root.showsCloseButton
+            Layout.preferredWidth: 1
+            Layout.preferredHeight: 20
+            color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.4)
+        }
+
+        Icon {
+            visible: root.showsCloseButton
+            source: "image://images/cross"
+            color: root.textColor
+            size: 14
+            enabled: true
+            padding: 6
+            onClicked: root.dismissed()
+            HoverHandler {
+                cursorShape: Qt.PointingHandCursor
+            }
+        }
+    }
+}

--- a/qml/controls/EllipsisMenuToggleItem.qml
+++ b/qml/controls/EllipsisMenuToggleItem.qml
@@ -8,19 +8,21 @@ import QtQuick.Layouts 1.15
 import org.bitcoincore.qt 1.0
 
 Button {
+    id: root
     property int bgRadius: 5
     property color bgDefaultColor: "transparent"
     property color bgHoverColor: Theme.color.neutral2
     property color textColor: Theme.color.neutral7
     property color textHoverColor: Theme.color.neutral9
     property color textActiveColor: Theme.color.neutral7
-
-    id: root
+    property int contentHorizontalPadding: 10
+    property int contentTopPadding: 10
+    property int contentBottomPadding: 10
     checkable: true
-    checked: optionSwitch.checked
     hoverEnabled: AppMode.isDesktop
 
     implicitWidth: 280
+    implicitHeight: optionSwitch.implicitHeight + root.contentTopPadding + root.contentBottomPadding
 
     MouseArea {
         anchors.fill: parent
@@ -29,15 +31,14 @@ Button {
         cursorShape: Qt.PointingHandCursor
     }
 
-    onClicked: {
-        optionSwitch.checked = !optionSwitch.checked
-    }
-
     contentItem: RowLayout {
         spacing: 7
         anchors.fill: parent
         anchors.centerIn: parent
-        anchors.margins: 10
+        anchors.leftMargin: root.contentHorizontalPadding
+        anchors.rightMargin: root.contentHorizontalPadding
+        anchors.topMargin: root.contentTopPadding
+        anchors.bottomMargin: root.contentBottomPadding
         CoreText {
             id: buttonText
             Layout.fillWidth: true
@@ -52,6 +53,7 @@ Button {
             Layout.preferredWidth: 40
             Layout.preferredHeight: 24
             checked: root.checked
+            onToggled: root.checked = checked
         }
     }
 
@@ -61,15 +63,24 @@ Button {
         radius: root.bgRadius
 
         Behavior on color {
-            ColorAnimation { duration: 150 }
+            ColorAnimation {
+                duration: 150
+            }
         }
     }
 
     states: [
         State {
-            name: "HOVER"; when: root.hovered
-            PropertyChanges { target: bg; color: root.bgHoverColor }
-            PropertyChanges { target: buttonText; color: root.textHoverColor }
+            name: "HOVER"
+            when: root.hovered
+            PropertyChanges {
+                target: bg
+                color: root.bgHoverColor
+            }
+            PropertyChanges {
+                target: buttonText
+                color: root.textHoverColor
+            }
         }
     ]
 }

--- a/qml/controls/ReceiveOptionsPopup.qml
+++ b/qml/controls/ReceiveOptionsPopup.qml
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import "../components"
+import "../controls"
+
+OptionPopup {
+    id: root
+
+    property alias addressFormatEnabled: addressFormatToggle.checked
+
+    implicitWidth: 300
+    implicitHeight: 58
+
+    clip: true
+    modal: true
+    dim: false
+
+    ColumnLayout {
+        anchors.centerIn: parent
+        anchors.margins: 10
+        spacing: 0
+
+        EllipsisMenuToggleItem {
+            id: addressFormatToggle
+            Layout.fillWidth: true
+            text: qsTr("Choose address type")
+        }
+    }
+}

--- a/qml/controls/SegmentedPicker.qml
+++ b/qml/controls/SegmentedPicker.qml
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Control {
+    id: root
+
+    property var model: []
+    property int currentIndex: 0
+    readonly property string currentText: model.length > currentIndex ? optionText(model[currentIndex]) : ""
+
+    signal selected(int index, var option)
+
+    function optionText(option) {
+        if (typeof option === "object" && option !== null && option.text !== undefined) {
+            return option.text
+        }
+        return option
+    }
+
+    implicitHeight: 45
+    implicitWidth: 360
+    padding: 5
+
+    background: Rectangle {
+        color: Theme.color.neutral3
+        radius: 8
+
+        Behavior on color {
+            ColorAnimation { duration: 150 }
+        }
+    }
+
+    contentItem: RowLayout {
+        spacing: 5
+
+        Repeater {
+            model: root.model
+
+            ToggleButton {
+                required property int index
+                required property var modelData
+
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredWidth: 1
+                Layout.minimumWidth: 0
+                autoExclusive: true
+                checked: index === root.currentIndex
+                text: root.optionText(modelData)
+                bgRadius: 5
+                textColor: Theme.color.white
+                textHoverColor: Theme.color.orangeLight1
+                textActiveColor: Theme.color.white
+                textActiveBold: true
+                bgHoverColor: checked ? Theme.color.neutral6 : Theme.color.neutral4
+                bgActiveColor: Theme.color.neutral6
+                bgDefaultColor: Theme.color.neutral3
+
+                onClicked: {
+                    root.selected(index, modelData)
+                }
+            }
+        }
+    }
+}

--- a/qml/controls/SendOptionsPopup.qml
+++ b/qml/controls/SendOptionsPopup.qml
@@ -17,7 +17,7 @@ OptionPopup {
     property alias multipleRecipientsEnabled: multipleRecipientsToggle.checked
 
     implicitWidth: 300
-    implicitHeight: 100
+    implicitHeight: columnLayout.implicitHeight + 20
 
     clip: true
     modal: true

--- a/qml/controls/ToggleButton.qml
+++ b/qml/controls/ToggleButton.qml
@@ -14,6 +14,8 @@ Button {
     property color textColor: Theme.color.neutral7
     property color textHoverColor: Theme.color.orangeLight1
     property color textActiveColor: Theme.color.neutral9
+    property bool textBold: false
+    property bool textActiveBold: textBold
 
     id: root
     checkable: true
@@ -26,7 +28,8 @@ Button {
     contentItem: CoreText {
         id: buttonText
         text: parent.text
-        font.pixelSize: 13
+        font.pixelSize: Theme.text.caption.pixelSize
+        bold: root.textBold
         color: root.textColor
 
         Behavior on color {
@@ -49,6 +52,7 @@ Button {
             name: "CHECKED"; when: root.checked
             PropertyChanges { target: bg; color: root.bgActiveColor }
             PropertyChanges { target: buttonText; color: root.textActiveColor }
+            PropertyChanges { target: buttonText; bold: root.textActiveBold }
         },
         State {
             name: "HOVER"; when: root.hovered

--- a/qml/models/addresslistmodel.cpp
+++ b/qml/models/addresslistmodel.cpp
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/addresslistmodel.h>
+
+#include <addresstype.h>
+#include <interfaces/wallet.h>
+#include <key_io.h>
+#include <qml/bitcoinunits.h>
+#include <qml/models/bitcoinaddress.h>
+#include <qml/models/walletqmlmodel.h>
+#include <wallet/types.h>
+
+#include <QVariantMap>
+
+using wallet::AddressPurpose;
+using wallet::ISMINE_NO;
+
+namespace {
+QString CategoryName(AddressListModel::Category category)
+{
+    switch (category) {
+    case AddressListModel::SingleUse: return QStringLiteral("single-use");
+    case AddressListModel::Change: return QStringLiteral("change");
+    }
+    return {};
+}
+
+QString ScriptTypeName(const CTxDestination& destination)
+{
+    if (std::get_if<PKHash>(&destination)) return QStringLiteral("P2PKH");
+    if (std::get_if<ScriptHash>(&destination)) return QStringLiteral("P2SH");
+    if (std::get_if<WitnessV0KeyHash>(&destination)) return QStringLiteral("P2WPKH");
+    if (std::get_if<WitnessV0ScriptHash>(&destination)) return QStringLiteral("P2WSH");
+    if (std::get_if<WitnessV1Taproot>(&destination)) return QStringLiteral("P2TR");
+    if (std::get_if<PayToAnchor>(&destination)) return QStringLiteral("P2A");
+    if (std::get_if<WitnessUnknown>(&destination)) return QStringLiteral("Witness");
+    if (std::get_if<PubKeyDestination>(&destination)) return QStringLiteral("P2PK");
+    return {};
+}
+
+QString DisplayAmount(CAmount amount)
+{
+    if (amount == 0) return QStringLiteral("₿ 0.0");
+    return QStringLiteral("₿ ") + QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, amount);
+}
+} // namespace
+
+AddressListModel::AddressListModel(WalletQmlModel* parent)
+    : QAbstractListModel(parent)
+    , m_wallet_model(parent)
+{
+    if (m_wallet_model) {
+        connect(m_wallet_model, &WalletQmlModel::addressListChanged, this, &AddressListModel::refresh);
+        connect(m_wallet_model, &WalletQmlModel::balanceChanged, this, &AddressListModel::refresh);
+    }
+    refresh();
+}
+
+int AddressListModel::rowCount(const QModelIndex& parent) const
+{
+    if (parent.isValid()) return 0;
+    return static_cast<int>(m_entries.size());
+}
+
+int AddressListModel::count() const
+{
+    return static_cast<int>(m_entries.size());
+}
+
+QVariant AddressListModel::data(const QModelIndex& index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= static_cast<int>(m_entries.size())) {
+        return {};
+    }
+
+    const AddressEntry& entry{m_entries.at(index.row())};
+    switch (role) {
+    case AddressRole:
+        return entry.address;
+    case FormattedAddressRole:
+        return BitcoinAddress::formattedAddress(entry.address);
+    case EllipsesAddressRole:
+        return BitcoinAddress::ellipsesAddress(entry.address);
+    case LabelRole:
+        return entry.label;
+    case CategoryRole:
+        return CategoryName(entry.category);
+    case UsedRole:
+        return entry.used;
+    case CurrentBalanceRole:
+        return QmlBitcoinUnits::format(QmlBitcoinUnits::Unit::BTC, entry.current_balance);
+    case DisplayAmountRole:
+        return DisplayAmount(entry.current_balance);
+    case HasAmountRole:
+        return entry.current_balance != 0;
+    case ScriptTypeRole:
+        return entry.script_type;
+    case CanEditLabelRole:
+        return entry.can_edit_label;
+    case CanCreatePaymentRequestRole:
+        return entry.can_create_payment_request;
+    }
+    return {};
+}
+
+QHash<int, QByteArray> AddressListModel::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[AddressRole] = "address";
+    roles[FormattedAddressRole] = "formattedAddress";
+    roles[EllipsesAddressRole] = "ellipsesAddress";
+    roles[LabelRole] = "label";
+    roles[CategoryRole] = "category";
+    roles[UsedRole] = "isUsed";
+    roles[CurrentBalanceRole] = "currentBalance";
+    roles[DisplayAmountRole] = "displayAmount";
+    roles[HasAmountRole] = "hasAmount";
+    roles[ScriptTypeRole] = "scriptType";
+    roles[CanEditLabelRole] = "canEditLabel";
+    roles[CanCreatePaymentRequestRole] = "canCreatePaymentRequest";
+    return roles;
+}
+
+AddressListModel::Category AddressListModel::category() const
+{
+    return m_category;
+}
+
+void AddressListModel::setCategory(Category category)
+{
+    if (m_category == category) return;
+    m_category = category;
+    Q_EMIT categoryChanged();
+    rebuild();
+}
+
+QVariantList AddressListModel::categoryOptions() const
+{
+    return {
+        QVariantMap{{QStringLiteral("value"), static_cast<int>(SingleUse)}, {QStringLiteral("text"), tr("Single-use")}},
+        QVariantMap{{QStringLiteral("value"), static_cast<int>(Change)}, {QStringLiteral("text"), tr("Change")}},
+    };
+}
+
+bool AddressListModel::showUsed() const
+{
+    return m_show_used;
+}
+
+void AddressListModel::setShowUsed(bool show_used)
+{
+    if (m_show_used == show_used) return;
+    m_show_used = show_used;
+    Q_EMIT showUsedChanged();
+    rebuild();
+}
+
+void AddressListModel::refresh()
+{
+    rebuild();
+}
+
+bool AddressListModel::setAddressLabel(const QString& address, const QString& label)
+{
+    if (!m_wallet_model || address.isEmpty()) return false;
+    if (!m_wallet_model->setAddressLabel(address, label)) return false;
+    refresh();
+    return true;
+}
+
+QString AddressListModel::addressAt(int row) const
+{
+    if (row < 0 || row >= static_cast<int>(m_entries.size())) return {};
+    return m_entries.at(row).address;
+}
+
+void AddressListModel::rebuild()
+{
+    beginResetModel();
+    m_entries = collectEntries();
+    endResetModel();
+    Q_EMIT countChanged();
+}
+
+std::vector<AddressListModel::AddressEntry> AddressListModel::collectEntries() const
+{
+    std::vector<AddressEntry> entries;
+    if (!m_wallet_model) return entries;
+
+    const auto balances{m_wallet_model->addressBalances()};
+    const auto used_addresses{m_wallet_model->usedAddresses()};
+
+    if (m_category == Change) {
+        const auto change_addresses{m_wallet_model->changeAddresses()};
+        entries.reserve(change_addresses.size());
+        for (const QString& address : change_addresses) {
+            AddressEntry entry;
+            entry.address = address;
+            entry.label = m_wallet_model->getAddressLabel(address);
+            entry.category = Change;
+            entry.used = used_addresses.count(address) > 0;
+            entry.script_type = ScriptTypeName(DecodeDestination(address.toStdString()));
+            const auto balance_it{balances.find(address)};
+            entry.current_balance = balance_it == balances.end() ? 0 : balance_it->second;
+            entry.can_edit_label = false;
+            entry.can_create_payment_request = false;
+            entries.push_back(entry);
+        }
+        return entries;
+    }
+
+    for (const interfaces::WalletAddress& wallet_address : m_wallet_model->getAddresses()) {
+        if (wallet_address.purpose != AddressPurpose::RECEIVE || wallet_address.is_mine == ISMINE_NO) {
+            continue;
+        }
+
+        const QString address{QString::fromStdString(EncodeDestination(wallet_address.dest))};
+        if (address.isEmpty()) continue;
+
+        const bool used{used_addresses.count(address) > 0};
+        if (used && !m_show_used) {
+            continue;
+        }
+
+        AddressEntry entry;
+        entry.address = address;
+        entry.label = QString::fromStdString(wallet_address.name);
+        entry.category = SingleUse;
+        entry.used = used;
+        entry.script_type = ScriptTypeName(wallet_address.dest);
+        const auto balance_it{balances.find(address)};
+        entry.current_balance = balance_it == balances.end() ? 0 : balance_it->second;
+        entry.can_edit_label = true;
+        entry.can_create_payment_request = true;
+        entries.push_back(entry);
+    }
+
+    return entries;
+}

--- a/qml/models/addresslistmodel.h
+++ b/qml/models/addresslistmodel.h
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_ADDRESSLISTMODEL_H
+#define BITCOIN_QML_MODELS_ADDRESSLISTMODEL_H
+
+#include <consensus/amount.h>
+
+#include <QAbstractListModel>
+#include <QString>
+#include <QVariantList>
+
+#include <vector>
+
+class WalletQmlModel;
+
+class AddressListModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(Category category READ category WRITE setCategory NOTIFY categoryChanged)
+    Q_PROPERTY(QVariantList categoryOptions READ categoryOptions CONSTANT)
+    Q_PROPERTY(bool showUsed READ showUsed WRITE setShowUsed NOTIFY showUsedChanged)
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+
+public:
+    enum Category {
+        SingleUse,
+        Change
+    };
+    Q_ENUM(Category)
+
+    enum AddressRoles {
+        AddressRole = Qt::UserRole + 1,
+        FormattedAddressRole,
+        EllipsesAddressRole,
+        LabelRole,
+        CategoryRole,
+        UsedRole,
+        CurrentBalanceRole,
+        DisplayAmountRole,
+        HasAmountRole,
+        ScriptTypeRole,
+        CanEditLabelRole,
+        CanCreatePaymentRequestRole
+    };
+
+    explicit AddressListModel(WalletQmlModel* parent = nullptr);
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int count() const;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    Category category() const;
+    void setCategory(Category category);
+    QVariantList categoryOptions() const;
+    bool showUsed() const;
+    void setShowUsed(bool show_used);
+
+    Q_INVOKABLE void refresh();
+    Q_INVOKABLE bool setAddressLabel(const QString& address, const QString& label);
+    Q_INVOKABLE QString addressAt(int row) const;
+
+Q_SIGNALS:
+    void categoryChanged();
+    void showUsedChanged();
+    void countChanged();
+
+private:
+    struct AddressEntry {
+        QString address;
+        QString label;
+        Category category{SingleUse};
+        bool used{false};
+        CAmount current_balance{0};
+        QString script_type;
+        bool can_edit_label{false};
+        bool can_create_payment_request{false};
+    };
+
+    void rebuild();
+    std::vector<AddressEntry> collectEntries() const;
+
+    WalletQmlModel* m_wallet_model{nullptr};
+    std::vector<AddressEntry> m_entries;
+    Category m_category{SingleUse};
+    bool m_show_used{false};
+};
+
+#endif // BITCOIN_QML_MODELS_ADDRESSLISTMODEL_H

--- a/qml/models/paymentrequest.cpp
+++ b/qml/models/paymentrequest.cpp
@@ -52,6 +52,20 @@ void PaymentRequest::setMessage(const QString& message)
     Q_EMIT messageChanged();
 }
 
+QString PaymentRequest::addressType() const
+{
+    return m_address_type;
+}
+
+void PaymentRequest::setAddressType(const QString& address_type)
+{
+    if (m_address_type == address_type) {
+        return;
+    }
+    m_address_type = address_type;
+    Q_EMIT addressTypeChanged();
+}
+
 BitcoinAmount* PaymentRequest::amount() const
 {
     return m_amount;
@@ -86,6 +100,34 @@ void PaymentRequest::setId(unsigned int id)
     Q_EMIT idChanged();
 }
 
+bool PaymentRequest::needsUnlock() const
+{
+    return m_needs_unlock;
+}
+
+void PaymentRequest::setNeedsUnlock(bool needs_unlock)
+{
+    if (m_needs_unlock == needs_unlock) {
+        return;
+    }
+    m_needs_unlock = needs_unlock;
+    Q_EMIT needsUnlockChanged();
+}
+
+QString PaymentRequest::unlockError() const
+{
+    return m_unlock_error;
+}
+
+void PaymentRequest::setUnlockError(const QString& error)
+{
+    if (m_unlock_error == error) {
+        return;
+    }
+    m_unlock_error = error;
+    Q_EMIT unlockErrorChanged();
+}
+
 void PaymentRequest::setDestination(const CTxDestination& destination)
 {
     m_destination = destination;
@@ -102,14 +144,20 @@ void PaymentRequest::clear()
     m_destination = CNoDestination();
     m_label.clear();
     m_message.clear();
+    m_address_type.clear();
     m_amount->clear();
     m_amountError.clear();
     m_id.clear();
+    m_needs_unlock = false;
+    m_unlock_error.clear();
     Q_EMIT addressChanged();
     Q_EMIT labelChanged();
     Q_EMIT messageChanged();
+    Q_EMIT addressTypeChanged();
     Q_EMIT amountErrorChanged();
     Q_EMIT idChanged();
+    Q_EMIT needsUnlockChanged();
+    Q_EMIT unlockErrorChanged();
 }
 
 QString PaymentRequest::FormatAddress(const QString& address)

--- a/qml/models/paymentrequest.h
+++ b/qml/models/paymentrequest.h
@@ -19,9 +19,12 @@ class PaymentRequest : public QObject
     Q_PROPERTY(QString addressFormatted READ addressFormatted NOTIFY addressChanged)
     Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
     Q_PROPERTY(QString message READ message WRITE setMessage NOTIFY messageChanged)
+    Q_PROPERTY(QString addressType READ addressType WRITE setAddressType NOTIFY addressTypeChanged)
     Q_PROPERTY(BitcoinAmount* amount READ amount CONSTANT)
     Q_PROPERTY(QString amountError READ amountError NOTIFY amountErrorChanged)
     Q_PROPERTY(QString id READ id NOTIFY idChanged)
+    Q_PROPERTY(bool needsUnlock READ needsUnlock NOTIFY needsUnlockChanged)
+    Q_PROPERTY(QString unlockError READ unlockError NOTIFY unlockErrorChanged)
 
 public:
     explicit PaymentRequest(QObject* parent = nullptr);
@@ -35,12 +38,21 @@ public:
     QString message() const;
     void setMessage(const QString& message);
 
+    QString addressType() const;
+    void setAddressType(const QString& address_type);
+
     BitcoinAmount* amount() const;
     QString amountError() const;
     void setAmountError(const QString& error);
 
     QString id() const;
     void setId(unsigned int id);
+
+    bool needsUnlock() const;
+    void setNeedsUnlock(bool needs_unlock);
+
+    QString unlockError() const;
+    void setUnlockError(const QString& error);
 
     void setDestination(const CTxDestination& destination);
     CTxDestination destination() const;
@@ -51,8 +63,11 @@ Q_SIGNALS:
     void addressChanged();
     void labelChanged();
     void messageChanged();
+    void addressTypeChanged();
     void amountErrorChanged();
     void idChanged();
+    void needsUnlockChanged();
+    void unlockErrorChanged();
 
 private:
     static QString FormatAddress(const QString& address);
@@ -60,9 +75,12 @@ private:
     CTxDestination m_destination;
     QString m_label;
     QString m_message;
+    QString m_address_type;
     QString m_amountError;
     BitcoinAmount* m_amount;
     QString m_id;
+    bool m_needs_unlock{false};
+    QString m_unlock_error;
 };
 
 #endif // BITCOIN_QML_MODELS_PAYMENTREQUEST_H

--- a/qml/models/signverifymessagemodel.cpp
+++ b/qml/models/signverifymessagemodel.cpp
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/signverifymessagemodel.h>
+
+#include <common/signmessage.h>
+#include <key_io.h>
+#include <qml/models/walletunlock.h>
+#include <qml/util.h>
+#include <support/allocators/secure.h>
+
+namespace {
+std::optional<PKHash> LegacyP2PKHFromAddress(const QString& address)
+{
+    const CTxDestination destination{DecodeDestination(address.trimmed().toStdString())};
+    if (const auto* pkhash{std::get_if<PKHash>(&destination)}) {
+        return *pkhash;
+    }
+    return std::nullopt;
+}
+} // namespace
+
+SignVerifyMessageModel::SignVerifyMessageModel(interfaces::Wallet* wallet, QObject* parent)
+    : QObject(parent), m_wallet(wallet)
+{
+}
+
+void SignVerifyMessageModel::setWallet(interfaces::Wallet* wallet)
+{
+    if (m_wallet == wallet) {
+        return;
+    }
+    m_wallet = wallet;
+    clear();
+}
+
+void SignVerifyMessageModel::setSecurityStateChangedFn(SecurityStateChangedFn fn)
+{
+    m_security_state_changed = std::move(fn);
+}
+
+bool SignVerifyMessageModel::isLegacyP2PKHAddress(const QString& address) const
+{
+    return LegacyP2PKHFromAddress(address).has_value();
+}
+
+bool SignVerifyMessageModel::signMessage(const QString& address, const QString& message)
+{
+    return signMessageInternal(address, message, std::nullopt);
+}
+
+bool SignVerifyMessageModel::signMessageWithPassphrase(const QString& address, const QString& message, const QString& passphrase)
+{
+    return signMessageInternal(address, message, passphrase);
+}
+
+bool SignVerifyMessageModel::signMessageInternal(const QString& address, const QString& message, const std::optional<QString>& passphrase)
+{
+    clearSigningStatus();
+    setSignature(QString());
+
+    if (!m_wallet) {
+        setSigningStatus(tr("No wallet is selected."));
+        return false;
+    }
+    const auto pkhash{LegacyP2PKHFromAddress(address)};
+    if (!pkhash) {
+        setSigningStatus(tr("Enter a legacy P2PKH bitcoin address."));
+        return false;
+    }
+
+    bool relock{false};
+    if (!unlockForSigning(passphrase, relock)) {
+        return false;
+    }
+
+    WalletRelockGuard relock_guard{*m_wallet, [this] { notifySecurityStateChanged(); }, relock};
+
+    std::string signature;
+    const SigningResult result{m_wallet->signMessage(message.toStdString(), *pkhash, signature)};
+
+    if (result != SigningResult::OK) {
+        setSigningStatus(QString::fromStdString(SigningResultString(result)));
+        return false;
+    }
+
+    setSignature(QString::fromStdString(signature));
+    return true;
+}
+
+bool SignVerifyMessageModel::verifyMessage(const QString& address, const QString& message, const QString& signature) const
+{
+    if (!LegacyP2PKHFromAddress(address)) {
+        return false;
+    }
+    if (signature.trimmed().isEmpty()) {
+        return false;
+    }
+    return MessageVerify(
+        address.trimmed().toStdString(),
+        signature.trimmed().toStdString(),
+        message.toStdString()) == MessageVerificationResult::OK;
+}
+
+void SignVerifyMessageModel::clear()
+{
+    clearSigningStatus();
+    setSignature(QString());
+}
+
+void SignVerifyMessageModel::clearSigningStatus()
+{
+    setSigningStatus(QString());
+}
+
+bool SignVerifyMessageModel::unlockForSigning(const std::optional<QString>& passphrase, bool& relock)
+{
+    relock = false;
+    if (!m_wallet) {
+        return true;
+    }
+    if (!m_wallet->isCrypted() || !m_wallet->isLocked()) {
+        return true;
+    }
+    if (!passphrase.has_value()) {
+        setSigningStatus(tr("Enter your wallet password to sign this message."), true);
+        return false;
+    }
+
+    SecureString secure_passphrase{QmlUtil::SecureStringFromQString(*passphrase)};
+    switch (TryUnlockWithPassphrase(*m_wallet, secure_passphrase)) {
+    case WalletUnlockResult::IncorrectPassphrase:
+        setSigningStatus(tr("The wallet password you entered was incorrect."));
+        return false;
+    case WalletUnlockResult::AlreadyUnlocked:
+        return true;
+    case WalletUnlockResult::UnlockedNowRelockRequired:
+        relock = true;
+        notifySecurityStateChanged();
+        return true;
+    }
+    return false;
+}
+
+void SignVerifyMessageModel::setSigningStatus(const QString& error, bool needs_unlock)
+{
+    if (m_signing_error != error) {
+        m_signing_error = error;
+        Q_EMIT signingErrorChanged();
+    }
+    if (m_signing_needs_unlock != needs_unlock) {
+        m_signing_needs_unlock = needs_unlock;
+        Q_EMIT signingNeedsUnlockChanged();
+    }
+}
+
+void SignVerifyMessageModel::setSignature(const QString& signature)
+{
+    if (m_signature != signature) {
+        m_signature = signature;
+        Q_EMIT signatureChanged();
+    }
+}
+
+void SignVerifyMessageModel::notifySecurityStateChanged()
+{
+    if (m_security_state_changed) {
+        m_security_state_changed();
+    }
+}

--- a/qml/models/signverifymessagemodel.h
+++ b/qml/models/signverifymessagemodel.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_SIGNVERIFYMESSAGEMODEL_H
+#define BITCOIN_QML_MODELS_SIGNVERIFYMESSAGEMODEL_H
+
+#include <interfaces/wallet.h>
+
+#include <functional>
+#include <optional>
+
+#include <QObject>
+#include <QString>
+
+class SignVerifyMessageModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString signingError READ signingError NOTIFY signingErrorChanged)
+    Q_PROPERTY(bool signingNeedsUnlock READ signingNeedsUnlock NOTIFY signingNeedsUnlockChanged)
+    Q_PROPERTY(QString signature READ signature NOTIFY signatureChanged)
+
+public:
+    using SecurityStateChangedFn = std::function<void()>;
+
+    explicit SignVerifyMessageModel(interfaces::Wallet* wallet = nullptr, QObject* parent = nullptr);
+
+    QString signingError() const { return m_signing_error; }
+    bool signingNeedsUnlock() const { return m_signing_needs_unlock; }
+    QString signature() const { return m_signature; }
+
+    void setWallet(interfaces::Wallet* wallet);
+    void setSecurityStateChangedFn(SecurityStateChangedFn fn);
+
+    Q_INVOKABLE bool isLegacyP2PKHAddress(const QString& address) const;
+    Q_INVOKABLE bool signMessage(const QString& address, const QString& message);
+    Q_INVOKABLE bool signMessageWithPassphrase(const QString& address, const QString& message, const QString& passphrase);
+    Q_INVOKABLE bool verifyMessage(const QString& address, const QString& message, const QString& signature) const;
+    Q_INVOKABLE void clear();
+    Q_INVOKABLE void clearSigningStatus();
+
+Q_SIGNALS:
+    void signingErrorChanged();
+    void signingNeedsUnlockChanged();
+    void signatureChanged();
+
+private:
+    bool signMessageInternal(const QString& address, const QString& message, const std::optional<QString>& passphrase);
+    bool unlockForSigning(const std::optional<QString>& passphrase, bool& relock);
+    void setSigningStatus(const QString& error, bool needs_unlock = false);
+    void setSignature(const QString& signature);
+    void notifySecurityStateChanged();
+
+    interfaces::Wallet* m_wallet{nullptr};
+    SecurityStateChangedFn m_security_state_changed;
+    QString m_signing_error;
+    bool m_signing_needs_unlock{false};
+    QString m_signature;
+};
+
+#endif // BITCOIN_QML_MODELS_SIGNVERIFYMESSAGEMODEL_H

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -8,10 +8,13 @@
 #include <common/messages.h>
 #include <qml/bitcoinamount.h>
 #include <qml/models/activitylistmodel.h>
+#include <qml/models/addresslistmodel.h>
 #include <qml/models/paymentrequest.h>
 #include <qml/models/sendrecipient.h>
 #include <qml/models/sendrecipientslistmodel.h>
+#include <qml/models/walletunlock.h>
 #include <qml/models/walletqmlmodeltransaction.h>
+#include <qml/util.h>
 
 #include <chainparams.h>
 #include <consensus/amount.h>
@@ -30,10 +33,12 @@
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 
-#include <QByteArray>
 #include <QDateTime>
 #include <QMetaObject>
 #include <QRegularExpression>
+#include <QSettings>
+#include <QVariantList>
+#include <QVariantMap>
 
 #include <array>
 #include <functional>
@@ -257,56 +262,43 @@ QString LocalizedString(const bilingual_str& value)
     return QString::fromStdString(value.translated.empty() ? value.original : value.translated);
 }
 
-class WalletRelockGuard
+QString OutputTypeId(OutputType type)
 {
-public:
-    WalletRelockGuard(interfaces::Wallet& wallet, std::function<void()> refresh_security_state, bool active)
-        : m_wallet{wallet}, m_refresh_security_state{std::move(refresh_security_state)}, m_active{active}
-    {
-    }
-
-    ~WalletRelockGuard()
-    {
-        relock();
-    }
-
-    WalletRelockGuard(const WalletRelockGuard&) = delete;
-    WalletRelockGuard& operator=(const WalletRelockGuard&) = delete;
-
-    void relock()
-    {
-        if (!m_active) {
-            return;
-        }
-        m_wallet.lock();
-        m_refresh_security_state();
-        m_active = false;
-    }
-
-private:
-    interfaces::Wallet& m_wallet;
-    std::function<void()> m_refresh_security_state;
-    bool m_active;
-};
-
-SecureString SecureStringFromQString(const QString& value)
-{
-    QByteArray bytes{value.toUtf8()};
-    SecureString secure;
-    secure.assign(bytes.constData(), bytes.constData() + bytes.size());
-    if (!bytes.isEmpty()) {
-        memory_cleanse(bytes.data(), static_cast<size_t>(bytes.size()));
-    }
-    return secure;
+    return QString::fromStdString(FormatOutputType(type));
 }
 
-void ClearSecureString(SecureString& value)
+QString OutputTypeLabel(OutputType type)
 {
-    if (value.empty()) {
-        return;
+    switch (type) {
+    case OutputType::BECH32M:
+        return QObject::tr("Bech32m (Taproot)");
+    case OutputType::BECH32:
+        return QObject::tr("Bech32 (SegWit)");
+    case OutputType::P2SH_SEGWIT:
+        return QObject::tr("Base58 (P2SH-SegWit)");
+    case OutputType::LEGACY:
+        return QObject::tr("Base58 (Legacy)");
+    case OutputType::UNKNOWN:
+        return {};
     }
-    memory_cleanse(value.data(), value.size());
-    value.clear();
+    return {};
+}
+
+QString OutputTypeDescription(OutputType type)
+{
+    switch (type) {
+    case OutputType::BECH32M:
+        return QObject::tr("Lower fees · Better privacy");
+    case OutputType::BECH32:
+        return QObject::tr("Lower fees · Widely supported");
+    case OutputType::P2SH_SEGWIT:
+        return QObject::tr("Higher fees · Backward compatible");
+    case OutputType::LEGACY:
+        return QObject::tr("Higher fees · Not recommended");
+    case OutputType::UNKNOWN:
+        return {};
+    }
+    return {};
 }
 
 } // namespace
@@ -316,6 +308,7 @@ WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObje
 {
     m_wallet = std::move(wallet);
     m_activity_list_model = new ActivityListModel(this);
+    m_address_list_model = new AddressListModel(this);
     m_bump_transaction_model = new BumpTransactionModel(m_wallet.get(), this);
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
@@ -329,6 +322,7 @@ WalletQmlModel::WalletQmlModel(QObject* parent)
     : QObject(parent)
 {
     m_activity_list_model = new ActivityListModel(this);
+    m_address_list_model = new AddressListModel(this);
     m_bump_transaction_model = new BumpTransactionModel(nullptr, this);
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
@@ -348,6 +342,7 @@ WalletQmlModel::~WalletQmlModel()
     }
     delete m_fee_estimation_worker;
     delete m_activity_list_model;
+    delete m_address_list_model;
     delete m_coins_list_model;
     delete m_send_recipients;
     delete m_current_payment_request;
@@ -481,16 +476,6 @@ bool WalletQmlModel::canManagePassphrase() const
     return m_wallet && !m_wallet->privateKeysDisabled();
 }
 
-QString WalletQmlModel::newAddress(QString label)
-{
-    if (!m_wallet) {
-        return QString();
-    }
-    OutputType output_type = m_wallet->getDefaultAddressType();
-    util::Result<CTxDestination> dest{m_wallet->getNewDestination(output_type, label.toStdString())};
-    return QString::fromStdString(EncodeDestination(dest.value()));
-}
-
 bool WalletQmlModel::encryptWallet(const QString& passphrase)
 {
     clearSettingsError();
@@ -503,9 +488,9 @@ bool WalletQmlModel::encryptWallet(const QString& passphrase)
         return false;
     }
 
-    SecureString secure_passphrase{SecureStringFromQString(passphrase)};
+    SecureString secure_passphrase{QmlUtil::SecureStringFromQString(passphrase)};
     const bool encrypted{m_wallet->encryptWallet(secure_passphrase)};
-    ClearSecureString(secure_passphrase);
+    QmlUtil::ClearSecureString(secure_passphrase);
     if (!encrypted) {
         setSettingsError(tr("The wallet password could not be set."));
         return false;
@@ -531,11 +516,11 @@ bool WalletQmlModel::changeWalletPassphrase(const QString& old_passphrase, const
         return false;
     }
 
-    SecureString secure_old_passphrase{SecureStringFromQString(old_passphrase)};
-    SecureString secure_new_passphrase{SecureStringFromQString(new_passphrase)};
+    SecureString secure_old_passphrase{QmlUtil::SecureStringFromQString(old_passphrase)};
+    SecureString secure_new_passphrase{QmlUtil::SecureStringFromQString(new_passphrase)};
     const bool changed{m_wallet->changeWalletPassphrase(secure_old_passphrase, secure_new_passphrase)};
-    ClearSecureString(secure_old_passphrase);
-    ClearSecureString(secure_new_passphrase);
+    QmlUtil::ClearSecureString(secure_old_passphrase);
+    QmlUtil::ClearSecureString(secure_new_passphrase);
     if (!changed) {
         setSettingsError(tr("The current wallet password was incorrect."));
         return false;
@@ -570,6 +555,82 @@ void WalletQmlModel::clearSettingsError()
     setSettingsError(QString());
 }
 
+QVariantList WalletQmlModel::availableReceiveAddressTypes() const
+{
+    if (!m_wallet || !m_wallet->canGetAddresses()) {
+        return {};
+    }
+
+    QVariantList types;
+    const std::array ordered_types{
+        OutputType::BECH32M,
+        OutputType::BECH32,
+        OutputType::P2SH_SEGWIT,
+        OutputType::LEGACY,
+    };
+
+    for (const OutputType type : ordered_types) {
+        if (type == OutputType::BECH32M && (!m_wallet || !m_wallet->taprootEnabled())) {
+            continue;
+        }
+        QVariantMap item;
+        item.insert(QStringLiteral("id"), OutputTypeId(type));
+        item.insert(QStringLiteral("label"), OutputTypeLabel(type));
+        item.insert(QStringLiteral("description"), OutputTypeDescription(type));
+        types.append(item);
+    }
+    return types;
+}
+
+QString WalletQmlModel::defaultReceiveAddressType() const
+{
+    const QVariantList available_types = availableReceiveAddressTypes();
+    QSettings settings;
+    const QString saved_type{settings.value(persistedReceiveAddressTypeKey()).toString()};
+    for (const QVariant& item : available_types) {
+        const QVariantMap type{item.toMap()};
+        if (type.value(QStringLiteral("id")).toString() == saved_type) {
+            return saved_type;
+        }
+    }
+
+    const QString core_default{m_wallet ? OutputTypeId(m_wallet->getDefaultAddressType()) : QString()};
+    for (const QVariant& item : available_types) {
+        const QVariantMap type{item.toMap()};
+        if (type.value(QStringLiteral("id")).toString() == core_default) {
+            return core_default;
+        }
+    }
+
+    return available_types.empty()
+        ? QString{}
+        : available_types.front().toMap().value(QStringLiteral("id")).toString();
+}
+
+void WalletQmlModel::setDefaultReceiveAddressType(const QString& address_type)
+{
+    for (const QVariant& item : availableReceiveAddressTypes()) {
+        const QVariantMap type{item.toMap()};
+        if (type.value(QStringLiteral("id")).toString() == address_type) {
+            QSettings settings;
+            settings.setValue(persistedReceiveAddressTypeKey(), address_type);
+            settings.sync();
+            return;
+        }
+    }
+}
+
+QString WalletQmlModel::receiveAddressTypeLabel(const QString& address_type) const
+{
+    for (const QVariant& item : availableReceiveAddressTypes()) {
+        const QVariantMap type{item.toMap()};
+        if (type.value(QStringLiteral("id")).toString() == address_type) {
+            return type.value(QStringLiteral("label")).toString();
+        }
+    }
+    return {};
+}
+
 void WalletQmlModel::removeWallet()
 {
     if (!m_wallet) {
@@ -578,29 +639,65 @@ void WalletQmlModel::removeWallet()
     m_wallet->remove();
 }
 
-void WalletQmlModel::commitPaymentRequest()
+bool WalletQmlModel::setCurrentPaymentRequestAddress(QString address)
+{
+    if (!m_wallet || !m_current_payment_request || address.isEmpty()) {
+        return false;
+    }
+
+    const CTxDestination destination{DecodeDestination(address.toStdString())};
+    if (!IsValidDestination(destination)) {
+        return false;
+    }
+
+    m_current_payment_request->clear();
+    m_current_payment_request->setDestination(destination);
+    m_current_payment_request->setLabel(getAddressLabel(address));
+    return true;
+}
+
+bool WalletQmlModel::ensurePaymentRequestDestination()
 {
     if (!m_wallet || !m_current_payment_request) {
-        return;
+        return false;
     }
-
-    if (m_current_payment_request->id().isEmpty()) {
-        m_current_payment_request->setId(nextPaymentRequestId());
+    if (!m_current_payment_request->address().isEmpty()) {
+        return true;
     }
-
-    if (m_current_payment_request->address().isEmpty()) {
-        const OutputType output_type = m_wallet->getDefaultAddressType();
-        const auto destination{m_wallet->getNewDestination(output_type, m_current_payment_request->label().toStdString())};
-        if (!destination) {
-            return;
+    const QString address_type_id = m_current_payment_request->addressType().isEmpty()
+        ? defaultReceiveAddressType()
+        : m_current_payment_request->addressType();
+    OutputType output_type = m_wallet->getDefaultAddressType();
+    if (!address_type_id.isEmpty()) {
+        const auto parsed_type{ParseOutputType(address_type_id.toStdString())};
+        if (!parsed_type) {
+            return false;
         }
-        m_current_payment_request->setDestination(destination.value());
+        output_type = *parsed_type;
     }
+    const auto destination{m_wallet->getNewDestination(output_type, m_current_payment_request->label().toStdString())};
+    if (!destination || !IsValidDestination(destination.value())) {
+        return false;
+    }
+    m_current_payment_request->setAddressType(OutputTypeId(output_type));
+    m_current_payment_request->setDestination(destination.value());
+    return true;
+}
+
+bool WalletQmlModel::saveCurrentPaymentRequest()
+{
+    if (!m_wallet || !m_current_payment_request) {
+        return false;
+    }
+
+    const QString request_id_text = m_current_payment_request->id().isEmpty()
+        ? QString::number(nextPaymentRequestId())
+        : m_current_payment_request->id();
 
     bool parse_ok{false};
-    const int64_t request_id{m_current_payment_request->id().toLongLong(&parse_ok)};
+    const int64_t request_id{request_id_text.toLongLong(&parse_ok)};
     if (!parse_ok || request_id <= 0) {
-        return;
+        return false;
     }
 
     QmlRecentRequestEntry request_entry;
@@ -614,10 +711,68 @@ void WalletQmlModel::commitPaymentRequest()
     DataStream ss{};
     ss << request_entry;
 
-    m_wallet->setAddressReceiveRequest(
+    const bool saved{m_wallet->setAddressReceiveRequest(
         m_current_payment_request->destination(),
-        m_current_payment_request->id().toStdString(),
-        ss.str());
+        request_id_text.toStdString(),
+        ss.str())};
+    if (!saved) {
+        return false;
+    }
+
+    if (m_current_payment_request->id().isEmpty()) {
+        m_current_payment_request->setId(static_cast<unsigned int>(request_id));
+    }
+    return true;
+}
+
+bool WalletQmlModel::commitPaymentRequest()
+{
+    if (!m_wallet || !m_current_payment_request) {
+        return false;
+    }
+
+    if (!ensurePaymentRequestDestination()) {
+        if (m_wallet->isCrypted() && m_wallet->isLocked()) {
+            m_current_payment_request->setNeedsUnlock(true);
+        }
+        return false;
+    }
+    return saveCurrentPaymentRequest();
+}
+
+bool WalletQmlModel::commitPaymentRequestWithPassphrase(const QString& passphrase)
+{
+    if (!m_wallet || !m_current_payment_request) {
+        return false;
+    }
+
+    SecureString secure_passphrase{QmlUtil::SecureStringFromQString(passphrase)};
+    const auto result{TryUnlockWithPassphrase(*m_wallet, secure_passphrase)};
+    switch (result) {
+    case WalletUnlockResult::IncorrectPassphrase:
+        m_current_payment_request->setUnlockError(tr("The wallet password you entered was incorrect."));
+        return false;
+    case WalletUnlockResult::AlreadyUnlocked:
+    case WalletUnlockResult::UnlockedNowRelockRequired:
+        break;
+    }
+
+    const bool need_relock = result == WalletUnlockResult::UnlockedNowRelockRequired;
+    if (need_relock) {
+        refreshSecurityState();
+    }
+    WalletRelockGuard relock_guard{*m_wallet, [this] { refreshSecurityState(); }, need_relock};
+
+    if (!ensurePaymentRequestDestination()) {
+        return false;
+    }
+    if (!saveCurrentPaymentRequest()) {
+        return false;
+    }
+
+    m_current_payment_request->setNeedsUnlock(false);
+    m_current_payment_request->setUnlockError(QString());
+    return true;
 }
 
 unsigned int WalletQmlModel::nextPaymentRequestId() const
@@ -692,6 +847,136 @@ QString WalletQmlModel::getAddressLabel(const QString& address) const
     }
 
     return QString::fromStdString(label);
+}
+
+bool WalletQmlModel::setAddressLabel(const QString& address, const QString& label)
+{
+    if (!m_wallet || address.isEmpty()) {
+        return false;
+    }
+
+    const CTxDestination destination{DecodeDestination(address.toStdString())};
+    if (!IsValidDestination(destination)) {
+        return false;
+    }
+
+    wallet::AddressPurpose purpose{wallet::AddressPurpose::RECEIVE};
+    if (!m_wallet->getAddress(destination, nullptr, nullptr, &purpose)) {
+        return false;
+    }
+
+    return m_wallet->setAddressBook(destination, label.toStdString(), purpose);
+}
+
+std::vector<interfaces::WalletAddress> WalletQmlModel::getAddresses() const
+{
+    if (!m_wallet) {
+        return {};
+    }
+    return m_wallet->getAddresses();
+}
+
+std::map<QString, CAmount> WalletQmlModel::addressBalances() const
+{
+    std::map<QString, CAmount> balances;
+    if (!m_wallet) {
+        return balances;
+    }
+
+    for (const auto& coins_entry : m_wallet->listCoins()) {
+        for (const auto& [outpoint, tx_out] : coins_entry.second) {
+            CTxDestination destination;
+            if (!ExtractDestination(tx_out.txout.scriptPubKey, destination))
+                continue;
+
+            const QString address{QString::fromStdString(EncodeDestination(destination))};
+            if (address.isEmpty())
+                continue;
+
+            balances[address] += tx_out.txout.nValue;
+        }
+    }
+
+    return balances;
+}
+
+std::set<QString> WalletQmlModel::usedAddresses() const
+{
+    std::set<QString> addresses;
+
+    if (!m_wallet)
+        return addresses;
+
+    std::set<QString> receive_addresses;
+    for (const interfaces::WalletAddress& wallet_address : getAddresses()) {
+        if (wallet_address.purpose != wallet::AddressPurpose::RECEIVE || wallet_address.is_mine == wallet::ISMINE_NO) {
+            continue;
+        }
+
+        const QString address{QString::fromStdString(EncodeDestination(wallet_address.dest))};
+        if (!address.isEmpty()) {
+            receive_addresses.insert(address);
+        }
+    }
+
+    for (const interfaces::WalletTx& wallet_tx : m_wallet->getWalletTxs()) {
+        for (size_t i{0}; i < wallet_tx.txout_address.size(); ++i) {
+            if (i >= wallet_tx.txout_address_is_mine.size() || !wallet_tx.txout_address_is_mine[i])
+                continue;
+
+            if (i < wallet_tx.txout_is_change.size() && wallet_tx.txout_is_change[i])
+                continue;
+
+            const QString address{QString::fromStdString(EncodeDestination(wallet_tx.txout_address[i]))};
+            if (!address.isEmpty() && receive_addresses.count(address) > 0)
+                addresses.insert(address);
+        }
+    }
+
+    return addresses;
+}
+
+std::set<QString> WalletQmlModel::changeAddresses() const
+{
+    std::set<QString> addresses;
+    if (!m_wallet) {
+        return addresses;
+    }
+
+    std::set<COutPoint> change_outpoints;
+    for (const interfaces::WalletTx& wallet_tx : m_wallet->getWalletTxs()) {
+        if (!wallet_tx.tx)
+            continue;
+
+        const Txid txid{wallet_tx.tx->GetHash()};
+        for (size_t i{0}; i < wallet_tx.txout_is_change.size(); ++i) {
+            if (!wallet_tx.txout_is_change[i])
+                continue;
+
+            change_outpoints.insert(COutPoint{txid, static_cast<uint32_t>(i)});
+        }
+    }
+
+    for (const auto& coins_entry : m_wallet->listCoins()) {
+        for (const auto& [outpoint, tx_out] : coins_entry.second) {
+            if (tx_out.txout.nValue <= 0)
+                continue;
+
+            if (change_outpoints.count(outpoint) > 0) {
+                CTxDestination destination;
+                if (!ExtractDestination(tx_out.txout.scriptPubKey, destination))
+                    continue;
+
+                const QString address{QString::fromStdString(EncodeDestination(destination))};
+                if (address.isEmpty())
+                    continue;
+
+                addresses.insert(address);
+            }
+        }
+    }
+
+    return addresses;
 }
 
 std::unique_ptr<interfaces::Handler> WalletQmlModel::handleTransactionChanged(TransactionChangedFn fn)
@@ -872,7 +1157,7 @@ bool WalletQmlModel::prepareTransaction()
 
 bool WalletQmlModel::prepareTransactionWithPassphrase(const QString& passphrase)
 {
-    return prepareTransactionInternal(std::optional<SecureString>{SecureStringFromQString(passphrase)});
+    return prepareTransactionInternal(std::optional<SecureString>{QmlUtil::SecureStringFromQString(passphrase)});
 }
 
 bool WalletQmlModel::prepareTransactionInternal(std::optional<SecureString> passphrase)
@@ -880,7 +1165,7 @@ bool WalletQmlModel::prepareTransactionInternal(std::optional<SecureString> pass
     clearTransactionStatus();
     if (!m_wallet || !m_send_recipients || m_send_recipients->recipients().empty()) {
         if (passphrase.has_value()) {
-            ClearSecureString(*passphrase);
+            QmlUtil::ClearSecureString(*passphrase);
             passphrase.reset();
         }
         setTransactionStatus(tr("Enter at least one valid recipient to continue."));
@@ -1197,6 +1482,11 @@ void WalletQmlModel::subscribeToWalletSignals()
             Q_EMIT balanceChanged();
         }, Qt::QueuedConnection);
     });
+    m_handler_address_list_changed = m_wallet->handleAddressBookChanged([this](const CTxDestination&, const std::string&, bool, wallet::AddressPurpose, ChangeType) {
+        QMetaObject::invokeMethod(this, [this] {
+            Q_EMIT addressListChanged();
+        }, Qt::QueuedConnection);
+    });
     m_handler_transaction_changed = handleTransactionChanged([this](const uint256&, ChangeType) {
         QMetaObject::invokeMethod(this, [this] {
             Q_EMIT balanceChanged();
@@ -1213,6 +1503,9 @@ void WalletQmlModel::unsubscribeFromWalletSignals()
 {
     if (m_handler_status_changed) {
         m_handler_status_changed->disconnect();
+    }
+    if (m_handler_address_list_changed) {
+        m_handler_address_list_changed->disconnect();
     }
     if (m_handler_transaction_changed) {
         m_handler_transaction_changed->disconnect();
@@ -1236,28 +1529,34 @@ void WalletQmlModel::refreshSecurityState()
 bool WalletQmlModel::unlockForAction(std::optional<SecureString>& passphrase, bool& relock)
 {
     relock = false;
-    if (!m_wallet || !m_wallet->isCrypted() || !m_wallet->isLocked()) {
+    if (!m_wallet) {
         if (passphrase.has_value()) {
-            ClearSecureString(*passphrase);
+            QmlUtil::ClearSecureString(*passphrase);
             passphrase.reset();
         }
         return true;
     }
     if (!passphrase.has_value()) {
+        // Either the wallet is unlocked already (action proceeds), or it isn't
+        // and the caller asked for an unlock-less attempt — let the action fail
+        // downstream rather than blocking here.
         return true;
     }
 
-    const bool unlocked = m_wallet->unlock(*passphrase);
-    ClearSecureString(*passphrase);
+    const auto result{TryUnlockWithPassphrase(*m_wallet, *passphrase)};
     passphrase.reset();
-    if (!unlocked) {
+    switch (result) {
+    case WalletUnlockResult::IncorrectPassphrase:
         setTransactionStatus(tr("The wallet password you entered was incorrect."));
         return false;
+    case WalletUnlockResult::AlreadyUnlocked:
+        return true;
+    case WalletUnlockResult::UnlockedNowRelockRequired:
+        relock = true;
+        refreshSecurityState();
+        return true;
     }
-
-    relock = true;
-    refreshSecurityState();
-    return true;
+    return false;
 }
 
 void WalletQmlModel::clearTransactionStatus()
@@ -1283,4 +1582,9 @@ void WalletQmlModel::setSettingsError(const QString& error)
         m_settings_error = error;
         Q_EMIT settingsErrorChanged();
     }
+}
+
+QString WalletQmlModel::persistedReceiveAddressTypeKey() const
+{
+    return QStringLiteral("receiveAddressTypes/%1").arg(name());
 }

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -12,6 +12,7 @@
 #include <qml/models/paymentrequest.h>
 #include <qml/models/sendrecipient.h>
 #include <qml/models/sendrecipientslistmodel.h>
+#include <qml/models/signverifymessagemodel.h>
 #include <qml/models/walletunlock.h>
 #include <qml/models/walletqmlmodeltransaction.h>
 #include <qml/util.h>
@@ -312,6 +313,8 @@ WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObje
     m_bump_transaction_model = new BumpTransactionModel(m_wallet.get(), this);
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
+    m_sign_verify_message_model = new SignVerifyMessageModel(m_wallet.get(), this);
+    m_sign_verify_message_model->setSecurityStateChangedFn([this]() { refreshSecurityState(); });
     m_current_payment_request = new PaymentRequest(this);
     initializeFeeEstimator();
     refreshSecurityState();
@@ -326,6 +329,8 @@ WalletQmlModel::WalletQmlModel(QObject* parent)
     m_bump_transaction_model = new BumpTransactionModel(nullptr, this);
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
+    m_sign_verify_message_model = new SignVerifyMessageModel(nullptr, this);
+    m_sign_verify_message_model->setSecurityStateChangedFn([this]() { refreshSecurityState(); });
     m_current_payment_request = new PaymentRequest(this);
     initializeFeeEstimator();
 }
@@ -345,6 +350,7 @@ WalletQmlModel::~WalletQmlModel()
     delete m_address_list_model;
     delete m_coins_list_model;
     delete m_send_recipients;
+    delete m_sign_verify_message_model;
     delete m_current_payment_request;
     if (m_current_transaction) {
         delete m_current_transaction;

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -11,6 +11,7 @@
 #include <qml/models/coinslistmodel.h>
 #include <qml/models/paymentrequest.h>
 #include <qml/models/sendrecipientslistmodel.h>
+#include <qml/models/signverifymessagemodel.h>
 #include <qml/models/walletqmlmodeltransaction.h>
 
 #include <consensus/amount.h>
@@ -44,6 +45,7 @@ class WalletQmlModel : public QObject
     Q_PROPERTY(AddressListModel* addressListModel READ addressListModel CONSTANT)
     Q_PROPERTY(CoinsListModel* coinsListModel READ coinsListModel CONSTANT)
     Q_PROPERTY(SendRecipientsListModel* recipients READ sendRecipientList CONSTANT)
+    Q_PROPERTY(SignVerifyMessageModel* signVerifyMessageModel READ signVerifyMessageModel CONSTANT)
     Q_PROPERTY(PaymentRequest* currentPaymentRequest READ currentPaymentRequest CONSTANT)
     Q_PROPERTY(WalletQmlModelTransaction* currentTransaction READ currentTransaction NOTIFY currentTransactionChanged)
     Q_PROPERTY(unsigned int targetBlocks READ feeTargetBlocks WRITE setFeeTargetBlocks NOTIFY feeTargetBlocksChanged)
@@ -85,6 +87,7 @@ public:
     BumpTransactionModel* bumpModel() const { return m_bump_transaction_model; }
     CoinsListModel* coinsListModel() const { return m_coins_list_model; }
     SendRecipientsListModel* sendRecipientList() const { return m_send_recipients; }
+    SignVerifyMessageModel* signVerifyMessageModel() const { return m_sign_verify_message_model; }
     PaymentRequest* currentPaymentRequest() const { return m_current_payment_request; }
     WalletQmlModelTransaction* currentTransaction() const { return m_current_transaction; }
     QString estimatedFee() const;
@@ -212,6 +215,7 @@ private:
     BumpTransactionModel* m_bump_transaction_model{nullptr};
     CoinsListModel* m_coins_list_model{nullptr};
     SendRecipientsListModel* m_send_recipients{nullptr};
+    SignVerifyMessageModel* m_sign_verify_message_model{nullptr};
     PaymentRequest* m_current_payment_request{nullptr};
     WalletQmlModelTransaction* m_current_transaction{nullptr};
     wallet::CCoinControl m_coin_control;

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QML_MODELS_WALLETQMLMODEL_H
 
 #include <qml/models/activitylistmodel.h>
+#include <qml/models/addresslistmodel.h>
 #include <qml/models/bumptransactionmodel.h>
 #include <qml/models/coinslistmodel.h>
 #include <qml/models/paymentrequest.h>
@@ -18,14 +19,18 @@
 #include <support/allocators/secure.h>
 #include <wallet/coincontrol.h>
 
+#include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <vector>
 
 #include <QHash>
 #include <QObject>
 #include <QThread>
 #include <QTimer>
+#include <QVariantList>
+#include <QVariantMap>
 
 class WalletQmlModel : public QObject
 {
@@ -36,6 +41,7 @@ class WalletQmlModel : public QObject
     Q_PROPERTY(qint64 balanceSatoshi READ balanceSatoshi NOTIFY balanceChanged)
     Q_PROPERTY(bool hasExternalSigner READ hasExternalSigner CONSTANT)
     Q_PROPERTY(ActivityListModel* activityListModel READ activityListModel CONSTANT)
+    Q_PROPERTY(AddressListModel* addressListModel READ addressListModel CONSTANT)
     Q_PROPERTY(CoinsListModel* coinsListModel READ coinsListModel CONSTANT)
     Q_PROPERTY(SendRecipientsListModel* recipients READ sendRecipientList CONSTANT)
     Q_PROPERTY(PaymentRequest* currentPaymentRequest READ currentPaymentRequest CONSTANT)
@@ -71,9 +77,11 @@ public:
     QString balance() const;
     qint64 balanceSatoshi() const;
     bool hasExternalSigner() const { return m_wallet && m_wallet->hasExternalSigner(); }
-    Q_INVOKABLE void commitPaymentRequest();
+    Q_INVOKABLE bool commitPaymentRequest();
+    Q_INVOKABLE bool commitPaymentRequestWithPassphrase(const QString& passphrase);
 
     ActivityListModel* activityListModel() const { return m_activity_list_model; }
+    AddressListModel* addressListModel() const { return m_address_list_model; }
     BumpTransactionModel* bumpModel() const { return m_bump_transaction_model; }
     CoinsListModel* coinsListModel() const { return m_coins_list_model; }
     SendRecipientsListModel* sendRecipientList() const { return m_send_recipients; }
@@ -89,14 +97,18 @@ public:
     Q_INVOKABLE void approveExternalSignerTransaction();
     Q_INVOKABLE bool prepareTransactionWithPassphrase(const QString& passphrase);
     Q_INVOKABLE bool sendTransaction();
-    Q_INVOKABLE QString newAddress(QString label);
+    Q_INVOKABLE QVariantList availableReceiveAddressTypes() const;
+    Q_INVOKABLE QString defaultReceiveAddressType() const;
     Q_INVOKABLE QString estimatedFeeForTarget(unsigned int target_blocks) const;
     Q_INVOKABLE int feeTargetIndex(unsigned int target_blocks) const;
     Q_INVOKABLE void scheduleFeeEstimates();
+    Q_INVOKABLE bool setCurrentPaymentRequestAddress(QString address);
     Q_INVOKABLE bool encryptWallet(const QString& passphrase);
     Q_INVOKABLE bool changeWalletPassphrase(const QString& old_passphrase, const QString& new_passphrase);
     Q_INVOKABLE bool backupWallet(const QString& path);
     Q_INVOKABLE void clearSettingsError();
+    Q_INVOKABLE void setDefaultReceiveAddressType(const QString& address_type);
+    Q_INVOKABLE QString receiveAddressTypeLabel(const QString& address_type) const;
     void removeWallet();
 
     std::set<interfaces::WalletTx> getWalletTxs() const;
@@ -106,6 +118,11 @@ public:
                         int& num_blocks,
                         int64_t& block_time) const;
     QString getAddressLabel(const QString& address) const;
+    bool setAddressLabel(const QString& address, const QString& label);
+    std::vector<interfaces::WalletAddress> getAddresses() const;
+    std::map<QString, CAmount> addressBalances() const;
+    std::set<QString> usedAddresses() const;
+    std::set<QString> changeAddresses() const;
 
     using TransactionChangedFn = std::function<void(const uint256& txid, ChangeType status)>;
     virtual std::unique_ptr<interfaces::Handler> handleTransactionChanged(TransactionChangedFn fn);
@@ -165,6 +182,7 @@ Q_SIGNALS:
     void transactionNeedsUnlockChanged();
     void walletUnloaded();
     void settingsErrorChanged();
+    void addressListChanged();
 
 private:
     void initializeFeeEstimator();
@@ -179,14 +197,18 @@ private:
     void unsubscribeFromWalletSignals();
     void refreshSecurityState();
     bool prepareTransactionInternal(std::optional<SecureString> passphrase);
+    bool ensurePaymentRequestDestination();
+    bool saveCurrentPaymentRequest();
     bool sendTransactionInternal();
     bool unlockForAction(std::optional<SecureString>& passphrase, bool& relock);
     void clearTransactionStatus();
     void setTransactionStatus(const QString& error, bool needs_unlock = false);
     void setSettingsError(const QString& error);
+    QString persistedReceiveAddressTypeKey() const;
 
     std::unique_ptr<interfaces::Wallet> m_wallet;
     ActivityListModel* m_activity_list_model{nullptr};
+    AddressListModel* m_address_list_model{nullptr};
     BumpTransactionModel* m_bump_transaction_model{nullptr};
     CoinsListModel* m_coins_list_model{nullptr};
     SendRecipientsListModel* m_send_recipients{nullptr};
@@ -212,6 +234,7 @@ private:
     QString m_settings_error;
     QString m_display_name;
     std::unique_ptr<interfaces::Handler> m_handler_status_changed;
+    std::unique_ptr<interfaces::Handler> m_handler_address_list_changed;
     std::unique_ptr<interfaces::Handler> m_handler_transaction_changed;
     std::unique_ptr<interfaces::Handler> m_handler_unload;
     int m_display_unit{0};

--- a/qml/models/walletunlock.cpp
+++ b/qml/models/walletunlock.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/walletunlock.h>
+
+#include <interfaces/wallet.h>
+#include <qml/util.h>
+
+#include <utility>
+
+WalletUnlockResult TryUnlockWithPassphrase(interfaces::Wallet& wallet,
+                                           SecureString& passphrase)
+{
+    if (!wallet.isCrypted() || !wallet.isLocked()) {
+        QmlUtil::ClearSecureString(passphrase);
+        return WalletUnlockResult::AlreadyUnlocked;
+    }
+    const bool unlocked{wallet.unlock(passphrase)};
+    QmlUtil::ClearSecureString(passphrase);
+    return unlocked ? WalletUnlockResult::UnlockedNowRelockRequired
+                    : WalletUnlockResult::IncorrectPassphrase;
+}
+
+WalletRelockGuard::WalletRelockGuard(interfaces::Wallet& wallet,
+                                     std::function<void()> refresh_security_state,
+                                     bool active)
+    : m_wallet{wallet}, m_refresh_security_state{std::move(refresh_security_state)}, m_active{active}
+{
+}
+
+WalletRelockGuard::~WalletRelockGuard()
+{
+    relock();
+}
+
+void WalletRelockGuard::relock()
+{
+    if (!m_active) {
+        return;
+    }
+    m_wallet.lock();
+    m_refresh_security_state();
+    m_active = false;
+}

--- a/qml/models/walletunlock.h
+++ b/qml/models/walletunlock.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_WALLETUNLOCK_H
+#define BITCOIN_QML_MODELS_WALLETUNLOCK_H
+
+#include <support/allocators/secure.h>
+
+#include <functional>
+
+namespace interfaces {
+class Wallet;
+} // namespace interfaces
+
+enum class WalletUnlockResult {
+    AlreadyUnlocked,
+    UnlockedNowRelockRequired,
+    IncorrectPassphrase,
+};
+
+//! Try to unlock `wallet` with `passphrase`. `passphrase` is wiped on every return path.
+WalletUnlockResult TryUnlockWithPassphrase(interfaces::Wallet& wallet,
+                                           SecureString& passphrase);
+
+class WalletRelockGuard
+{
+public:
+    WalletRelockGuard(interfaces::Wallet& wallet,
+                      std::function<void()> refresh_security_state,
+                      bool active);
+    ~WalletRelockGuard();
+
+    WalletRelockGuard(const WalletRelockGuard&) = delete;
+    WalletRelockGuard& operator=(const WalletRelockGuard&) = delete;
+
+    void relock();
+
+private:
+    interfaces::Wallet& m_wallet;
+    std::function<void()> m_refresh_security_state;
+    bool m_active;
+};
+
+#endif // BITCOIN_QML_MODELS_WALLETUNLOCK_H

--- a/qml/pages/node/NodeSettings.qml
+++ b/qml/pages/node/NodeSettings.qml
@@ -14,6 +14,7 @@ import "../settings"
 PageStack {
     signal doneClicked
     signal selectWalletRequested
+    signal receiveRequested
 
     property alias showDoneButton: doneButton.visible
     property bool closingWalletSettingsSubpage: false
@@ -23,6 +24,7 @@ PageStack {
 
     function isWalletSettingsSubpage(page_name) {
         return page_name === "walletPasswordSettingsPage"
+            || page_name === "addressListPage"
     }
 
     function closeWalletSettingsSubpage() {
@@ -255,6 +257,16 @@ PageStack {
         }
     }
     Component {
+        id: addresses_page
+        AddressList {
+            onBack: root.pop()
+            onReceiveRequested: {
+                root.pop()
+                root.receiveRequested()
+            }
+        }
+    }
+    Component {
         id: peers_page
         Peers {
             onBack: {
@@ -308,6 +320,10 @@ PageStack {
             onBack: root.pop()
             onSelectWalletRequested: root.selectWalletRequested()
             onPasswordRequested: root.push(wallet_password_page, { "updating": walletController.selectedWallet.isEncrypted })
+            onAddressesRequested: {
+                walletController.selectedWallet.addressListModel.refresh()
+                root.push(addresses_page)
+            }
         }
     }
     Component {

--- a/qml/pages/node/NodeSettings.qml
+++ b/qml/pages/node/NodeSettings.qml
@@ -25,6 +25,7 @@ PageStack {
     function isWalletSettingsSubpage(page_name) {
         return page_name === "walletPasswordSettingsPage"
             || page_name === "addressListPage"
+            || page_name === "signVerifyMessagePage"
     }
 
     function closeWalletSettingsSubpage() {
@@ -320,10 +321,17 @@ PageStack {
             onBack: root.pop()
             onSelectWalletRequested: root.selectWalletRequested()
             onPasswordRequested: root.push(wallet_password_page, { "updating": walletController.selectedWallet.isEncrypted })
+            onSignVerifyMessageRequested: root.push(sign_verify_message_page)
             onAddressesRequested: {
                 walletController.selectedWallet.addressListModel.refresh()
                 root.push(addresses_page)
             }
+        }
+    }
+    Component {
+        id: sign_verify_message_page
+        SignVerifyMessage {
+            onBack: root.pop()
         }
     }
     Component {

--- a/qml/pages/wallet/ActivityDetails.qml
+++ b/qml/pages/wallet/ActivityDetails.qml
@@ -12,6 +12,8 @@ import "../../components"
 import "../settings"
 
 Page {
+    id: root
+
     signal showTransaction(string txid)
 
     property string txid: ""
@@ -50,7 +52,6 @@ Page {
         }
     }
 
-    id: root
     background: null
 
     header: NavigationBar2 {
@@ -141,7 +142,7 @@ Page {
                 id: labelTextInput
                 Layout.fillWidth: true
                 Layout.bottomMargin: 20
-                labelText: qsTr("Label")
+                labelText: qsTr("Note to self")
                 visible: root.label != ""
                 enabled: false
                 text: root.label

--- a/qml/pages/wallet/AddressDetails.qml
+++ b/qml/pages/wallet/AddressDetails.qml
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import "../../controls"
+import "../../components"
+
+ColumnLayout {
+    id: root
+    objectName: "addressDetails"
+
+    property string address
+    property string label
+    property string amount
+    property bool hasAmount
+    property string category
+    property string scriptType
+    property bool used
+
+    signal closeRequested
+    signal copyAddressRequested
+    signal createPaymentRequestRequested
+
+    spacing: 0
+
+    RowLayout {
+        Layout.fillWidth: true
+        Layout.bottomMargin: 22
+
+        Header {
+            Layout.fillWidth: true
+            header: qsTr("Address details")
+            headerBold: true
+            center: false
+        }
+
+        Icon {
+            objectName: "addressDetailsCloseButton"
+            source: "image://images/cross"
+            color: Theme.color.neutral8
+            size: 10
+            enabled: true
+            padding: 0
+            onClicked: root.closeRequested()
+            HoverHandler {
+                cursorShape: Qt.PointingHandCursor
+            }
+        }
+    }
+
+    DetailRow {
+        Layout.fillWidth: true
+        label: qsTr("Address")
+        value: root.address
+        actionIcon: "image://images/copy"
+        onActionClicked: root.copyAddressRequested()
+    }
+
+    DetailRow {
+        Layout.fillWidth: true
+        label: qsTr("Amount")
+        value: root.amount
+        valueColor: root.hasAmount ? Theme.color.green : Theme.color.neutral6
+    }
+
+    DetailRow {
+        Layout.fillWidth: true
+        label: qsTr("Label")
+        value: root.label === "" ? qsTr("No note") : root.label
+    }
+
+    DetailRow {
+        Layout.fillWidth: true
+        label: qsTr("Type")
+        value: root.category === "change" ? qsTr("Change") : qsTr("Single-use (Receive)")
+    }
+
+    DetailRow {
+        Layout.fillWidth: true
+        label: qsTr("Address type")
+        value: root.scriptType === "" ? qsTr("Unknown") : root.scriptType
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        Layout.topMargin: 24
+        spacing: 12
+
+        ContinueButton {
+            Layout.fillWidth: true
+            text: qsTr("Copy address")
+            backgroundColor: "transparent"
+            backgroundHoverColor: Theme.color.neutral2
+            backgroundPressedColor: Theme.color.neutral3
+            borderColor: Theme.color.neutral4
+            textColor: Theme.color.neutral9
+            onClicked: root.copyAddressRequested()
+        }
+
+        ContinueButton {
+            Layout.fillWidth: true
+            text: qsTr("Create payment request")
+            visible: root.category === "single-use" && !root.used
+            backgroundColor: Theme.color.orange
+            backgroundHoverColor: Theme.color.orangeLight1
+            backgroundPressedColor: Theme.color.orangeLight2
+            textColor: Theme.color.white
+            onClicked: root.createPaymentRequestRequested()
+        }
+    }
+
+    component DetailRow: Item {
+        id: detailSectionRoot
+
+        property string label
+        property string value
+        property color valueColor: Theme.color.neutral7
+        property string actionIcon: ""
+        signal actionClicked
+
+        Layout.minimumHeight: sectionContent.height + separator.height + 20
+        implicitHeight: sectionContent.height + separator.height + 20
+
+        Column {
+            id: sectionContent
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.topMargin: 12
+            spacing: 6
+
+            CoreText {
+                width: parent.width
+                text: detailSectionRoot.label
+                color: Theme.color.neutral9
+                font: Theme.text.body.font
+                horizontalAlignment: Text.AlignLeft
+            }
+
+            CoreText {
+                width: parent.width - (detailAction.visible ? detailAction.width + 12 : 0)
+                text: detailSectionRoot.value
+                color: detailSectionRoot.valueColor
+                font: Theme.text.body.font
+                wrapMode: Text.WrapAnywhere
+                horizontalAlignment: Text.AlignLeft
+            }
+        }
+
+        IconButton {
+            id: detailAction
+            anchors.right: parent.right
+            anchors.top: sectionContent.top
+            anchors.topMargin: 24
+            visible: detailSectionRoot.actionIcon !== ""
+            iconSource: detailSectionRoot.actionIcon
+            iconColor: Theme.color.neutral7
+            hoverColor: Theme.color.neutral9
+            size: 30
+            onClicked: detailSectionRoot.actionClicked()
+        }
+
+        Separator {
+            id: separator
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+        }
+    }
+}

--- a/qml/pages/wallet/AddressList.qml
+++ b/qml/pages/wallet/AddressList.qml
@@ -1,0 +1,338 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
+
+import "../../controls"
+import "../../components"
+
+Page {
+    id: root
+    objectName: "addressListPage"
+    background: null
+
+    property WalletQmlModel wallet: walletController.selectedWallet
+    property AddressListModel addressModel: wallet.addressListModel
+    property string selectedAddress: ""
+    property string selectedLabel: ""
+    property string selectedAmount: ""
+    property bool selectedHasAmount: false
+    property string selectedCategory: ""
+    property string selectedScriptType: ""
+    property bool selectedUsed: false
+    property string errorText: ""
+
+    signal back
+    signal receiveRequested
+
+    function openMenuAt(menu, item) {
+        const pos = item.mapToItem(Overlay.overlay, item.width, item.height);
+        menu.x = Math.max(12, Math.min(pos.x - menu.width, Overlay.overlay.width - menu.width - 12));
+        menu.y = Math.max(12, Math.min(pos.y, Overlay.overlay.height - menu.height - 12));
+        menu.open();
+    }
+
+    function createPaymentRequestFromSelected(closeAction) {
+        root.errorText = "";
+        if (wallet && wallet.setCurrentPaymentRequestAddress(root.selectedAddress)) {
+            if (closeAction) {
+                closeAction();
+            }
+            root.receiveRequested();
+            return;
+        }
+        if (closeAction) {
+            closeAction();
+        }
+        addressModel.refresh();
+        root.errorText = qsTr("This address is no longer available.");
+    }
+
+    header: NavigationBar2 {
+        leftItem: NavButton {
+            objectName: "addressListBackButton"
+            iconSource: "image://images/caret-left"
+            text: qsTr("Back")
+            onClicked: root.back()
+        }
+        centerItem: Header {
+            objectName: "addressListHeader"
+            headerBold: true
+            headerSize: 18
+            header: qsTr("Addresses")
+        }
+        rightItem: IconButton {
+            objectName: "addressesMenuButton"
+            iconSource: "image://images/ellipsis"
+            iconColor: Theme.color.neutral9
+            size: 28
+            onClicked: {
+                root.openMenuAt(pageMenu, this);
+            }
+        }
+    }
+
+    Component.onCompleted: addressModel.refresh()
+
+    Popup {
+        id: pageMenu
+        parent: Overlay.overlay
+        width: 300
+        height: pageMenuContent.implicitHeight + 20
+        modal: true
+        focus: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        background: Rectangle {
+            color: Theme.color.neutral0
+            border.color: Theme.color.neutral4
+            radius: 5
+        }
+        contentItem: ColumnLayout {
+            id: pageMenuContent
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 0
+
+            EllipsisMenuToggleItem {
+                Layout.fillWidth: true
+                text: qsTr("Show used addresses")
+                checked: addressModel.showUsed
+                onCheckedChanged: {
+                    if (addressModel.showUsed !== checked) {
+                        addressModel.showUsed = checked;
+                    }
+                }
+            }
+        }
+    }
+
+    Popup {
+        id: rowMenu
+        parent: Overlay.overlay
+        width: 280
+        height: rowMenuContent.implicitHeight + 20
+        modal: true
+        focus: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        background: Rectangle {
+            color: Theme.color.neutral0
+            border.color: Theme.color.neutral4
+            radius: 5
+        }
+        contentItem: ColumnLayout {
+            id: rowMenuContent
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 0
+
+            MenuButton {
+                objectName: "addressRowCreatePaymentRequestButton"
+                text: qsTr("Create payment request")
+                visible: root.selectedCategory === "single-use" && !root.selectedUsed
+                enabled: root.selectedAddress !== ""
+                onClicked: {
+                    root.createPaymentRequestFromSelected(function() { rowMenu.close(); });
+                }
+            }
+            MenuButton {
+                objectName: "addressRowCopyAddressButton"
+                text: qsTr("Copy address")
+                enabled: root.selectedAddress !== ""
+                onClicked: {
+                    Clipboard.setText(root.selectedAddress);
+                    rowMenu.close();
+                }
+            }
+            MenuButton {
+                objectName: "addressRowDetailsButton"
+                text: qsTr("Address details")
+                enabled: root.selectedAddress !== ""
+                onClicked: {
+                    rowMenu.close();
+                    detailsPopup.open();
+                }
+            }
+        }
+    }
+
+    Popup {
+        id: labelPopup
+        objectName: "addressLabelPopup"
+        anchors.centerIn: Overlay.overlay
+        width: 420
+        modal: true
+        focus: true
+        leftPadding: 40
+        rightPadding: 40
+        topPadding: 30
+        bottomPadding: 30
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        background: Rectangle {
+            color: Theme.color.neutral0
+            border.color: Theme.color.neutral4
+            radius: 10
+        }
+        contentItem: ColumnLayout {
+            spacing: 16
+
+            Header {
+                Layout.fillWidth: true
+                header: qsTr("Note to self")
+                headerBold: true
+                center: false
+            }
+            CoreTextField {
+                id: labelInput
+                objectName: "addressLabelInput"
+                Layout.fillWidth: true
+                placeholderText: qsTr("Add note...")
+            }
+            ContinueButton {
+                objectName: "addressLabelSaveButton"
+                Layout.fillWidth: true
+                text: qsTr("Save")
+                onClicked: {
+                    root.errorText = "";
+                    if (addressModel.setAddressLabel(root.selectedAddress, labelInput.text)) {
+                        labelPopup.close();
+                    } else {
+                        labelPopup.close();
+                        addressModel.refresh();
+                        root.errorText = qsTr("This address is no longer available.");
+                    }
+                }
+            }
+        }
+    }
+
+    Popup {
+        id: detailsPopup
+        anchors.centerIn: Overlay.overlay
+        width: 560
+        modal: true
+        focus: true
+        leftPadding: 40
+        rightPadding: 40
+        topPadding: 30
+        bottomPadding: 30
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        background: Rectangle {
+            color: Theme.color.neutral0
+            border.color: Theme.color.neutral4
+            radius: 10
+        }
+        contentItem: AddressDetails {
+            address: root.selectedAddress
+            label: root.selectedLabel
+            amount: root.selectedAmount
+            hasAmount: root.selectedHasAmount
+            category: root.selectedCategory
+            scriptType: root.selectedScriptType
+            used: root.selectedUsed
+            onCloseRequested: detailsPopup.close()
+            onCopyAddressRequested: Clipboard.setText(root.selectedAddress)
+            onCreatePaymentRequestRequested: {
+                root.createPaymentRequestFromSelected(function() { detailsPopup.close(); });
+            }
+        }
+    }
+
+    ScrollView {
+        anchors.fill: parent
+        clip: true
+        contentWidth: width
+
+        ColumnLayout {
+            width: 520
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: 26
+
+            SegmentedPicker {
+                Layout.fillWidth: true
+                Layout.topMargin: 28
+                model: addressModel.categoryOptions
+                currentIndex: Math.max(0, addressModel.categoryOptions.findIndex(option => option.value === addressModel.category))
+                onSelected: (index, option) => {
+                    root.errorText = "";
+                    addressModel.category = option.value;
+                }
+            }
+
+            CoreText {
+                Layout.fillWidth: true
+                visible: root.errorText.length > 0
+                text: root.errorText
+                color: Theme.color.red
+                font: Theme.text.description.font
+                horizontalAlignment: Text.AlignLeft
+            }
+
+            CoreText {
+                Layout.fillWidth: true
+                visible: addressModel.count === 0
+                text: {
+                    if (addressModel.category === AddressListModel.Change) {
+                        return qsTr("No current change addresses.");
+                    }
+                    return addressModel.showUsed ? qsTr("No single-use addresses.") : qsTr("No unused single-use addresses.");
+                }
+                color: Theme.color.neutral6
+                font: Theme.text.body.font
+                horizontalAlignment: Text.AlignLeft
+            }
+
+            ListView {
+                id: addressList
+                objectName: "addressListView"
+                Layout.fillWidth: true
+                Layout.preferredHeight: Math.min(contentHeight, root.height - 230)
+                clip: true
+                model: addressModel
+                spacing: 0
+
+                delegate: AddressRow {
+                    width: addressList.width
+                    onEditLabelRequested: (address, label) => {
+                        root.selectedAddress = address;
+                        root.selectedLabel = label;
+                        labelInput.text = label;
+                        labelPopup.open();
+                    }
+                    onMenuRequested: (address, label, amount, hasAmount, category, scriptType, used, menuButton) => {
+                        root.selectedAddress = address;
+                        root.selectedLabel = label;
+                        root.selectedAmount = amount;
+                        root.selectedHasAmount = hasAmount;
+                        root.selectedCategory = category;
+                        root.selectedScriptType = scriptType;
+                        root.selectedUsed = used;
+                        root.openMenuAt(rowMenu, menuButton);
+                    }
+                }
+            }
+        }
+    }
+
+    component MenuButton: Button {
+        Layout.fillWidth: true
+        implicitHeight: 48
+        padding: 0
+
+        contentItem: CoreText {
+            text: parent.text
+            color: parent.enabled ? Theme.color.neutral7 : Theme.color.neutral4
+            font: Theme.text.body.font
+            horizontalAlignment: Text.AlignLeft
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        background: Rectangle {
+            color: parent.hovered ? Theme.color.neutral2 : "transparent"
+            radius: 4
+        }
+    }
+}

--- a/qml/pages/wallet/AddressRow.qml
+++ b/qml/pages/wallet/AddressRow.qml
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import "../../controls"
+import "../../components"
+
+Item {
+    id: root
+    objectName: "addressRow"
+
+    required property string address
+    required property string ellipsesAddress
+    required property string label
+    required property string category
+    required property string currentBalance
+    required property string displayAmount
+    required property bool hasAmount
+    required property string scriptType
+    required property bool isUsed
+    required property bool canEditLabel
+    required property bool canCreatePaymentRequest
+
+    signal editLabelRequested(string address, string label)
+    signal menuRequested(string address, string label, string amount, bool hasAmount, string category, string scriptType, bool used, Item menuButton)
+
+    height: 100
+
+    Column {
+        id: addressColumn
+        anchors.left: parent.left
+        anchors.right: noteButton.visible ? noteButton.left : menuButton.left
+        anchors.rightMargin: noteButton.visible ? 16 : 12
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: 8
+
+        CoreText {
+            objectName: "addressRowAddressText"
+            width: parent.width
+            text: root.ellipsesAddress
+            color: Theme.color.neutral9
+            font: Theme.text.body.font
+            horizontalAlignment: Text.AlignLeft
+            elide: Text.ElideMiddle
+            wrap: false
+        }
+        CoreText {
+            objectName: "addressRowAmountText"
+            width: parent.width
+            text: root.displayAmount
+            color: root.hasAmount ? Theme.color.green : Theme.color.neutral6
+            font: Theme.text.body.font
+            horizontalAlignment: Text.AlignLeft
+            elide: Text.ElideRight
+            wrap: false
+        }
+    }
+
+    Button {
+        id: noteButton
+        objectName: "addressRowNoteButton"
+        anchors.right: menuButton.left
+        anchors.rightMargin: 24
+        anchors.verticalCenter: parent.verticalCenter
+        visible: root.canEditLabel
+        width: Math.min(noteLabel.implicitWidth + 28, 150)
+        height: 36
+        padding: 0
+        text: root.label === "" ? qsTr("Add note to self") : root.label
+        onClicked: root.editLabelRequested(root.address, root.label)
+
+        contentItem: CoreText {
+            id: noteLabel
+            anchors.fill: parent
+            anchors.leftMargin: 14
+            anchors.rightMargin: 14
+            text: noteButton.text
+            font: Theme.text.description.font
+            color: Theme.color.neutral6
+            horizontalAlignment: Text.AlignHCenter
+            elide: Text.ElideRight
+            wrap: false
+        }
+
+        background: Rectangle {
+            color: noteButton.hovered ? Theme.color.neutral3 : Theme.color.neutral2
+            radius: 18
+        }
+    }
+
+    IconButton {
+        id: menuButton
+        objectName: "addressRowMenuButton"
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        iconSource: "image://images/ellipsis"
+        iconColor: Theme.color.neutral9
+        enabled: root.canCreatePaymentRequest || root.address !== ""
+        onClicked: {
+            root.menuRequested(
+                root.address,
+                root.label,
+                root.displayAmount,
+                root.hasAmount,
+                root.category,
+                root.scriptType,
+                root.isUsed,
+                menuButton)
+        }
+    }
+
+    Separator {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+    }
+}

--- a/qml/pages/wallet/DesktopWallets.qml
+++ b/qml/pages/wallet/DesktopWallets.qml
@@ -140,6 +140,7 @@ Page {
                 ButtonGroup.group: navigationTabs
             }
             NavigationTab {
+                id: receiveTabButton
                 objectName: "desktopWalletsReceiveTab"
                 text: qsTr("Receive")
                 property int index: 2
@@ -230,6 +231,9 @@ Page {
             id: nodeSettings
             showDoneButton: false
             onSelectWalletRequested: root.openWalletSelection()
+            onReceiveRequested: {
+                receiveTabButton.checked = true
+            }
         }
     }
 

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import Qt.labs.settings 1.0
 import org.bitcoincore.qt 1.0
 
 import "../../controls"
@@ -13,10 +14,81 @@ import "../settings"
 
 Page {
     id: root
+    objectName: "requestPaymentPage"
     background: null
 
     property WalletQmlModel wallet: walletController.selectedWallet
     property PaymentRequest request: wallet ? wallet.currentPaymentRequest : null
+    property string requestError: ""
+    property var availableAddressTypes: wallet ? wallet.availableReceiveAddressTypes() : []
+    readonly property bool requestReady: root.request !== null
+    readonly property bool requestPersisted: root.requestReady && root.request.id !== ""
+    readonly property bool requestHasAddress: root.requestReady && root.request.address !== ""
+
+    function selectedReceiveAddressType() {
+        if (root.request && root.request.addressType.length > 0) {
+            return root.request.addressType;
+        }
+        return root.wallet ? root.wallet.defaultReceiveAddressType() : "";
+    }
+
+    function addressTypeIndex(addressType) {
+        for (let i = 0; i < root.availableAddressTypes.length; ++i) {
+            if (root.availableAddressTypes[i].id === addressType) {
+                return i;
+            }
+        }
+        return root.availableAddressTypes.length > 0 ? 0 : -1;
+    }
+
+    function ensureAddressTypeSelected() {
+        if (!root.request || root.request.address !== "" || root.request.addressType.length > 0) {
+            return;
+        }
+        root.request.addressType = root.selectedReceiveAddressType();
+    }
+
+    function primaryActionText() {
+        if (root.requestPersisted) {
+            return qsTr("Copy payment request")
+        }
+        if (root.requestHasAddress) {
+            return qsTr("Create payment request")
+        }
+        return qsTr("Create bitcoin address")
+    }
+
+    function runPrimaryAction() {
+        if (!root.requestReady) {
+            return
+        }
+        root.requestError = ""
+        if (!root.requestPersisted) {
+            root.ensureAddressTypeSelected()
+            if (!root.wallet.commitPaymentRequest()) {
+                if (root.request && root.request.needsUnlock) {
+                    commitPassphrasePopup.errorText = ""
+                    commitPassphrasePopup.open()
+                    return
+                }
+                root.requestError = root.requestHasAddress
+                    ? qsTr("The payment request could not be created.")
+                    : qsTr("The new payment address could not be created.")
+            }
+            return
+        }
+        Clipboard.setText(root.request.address)
+    }
+
+    Component.onCompleted: root.ensureAddressTypeSelected()
+
+    onWalletChanged: root.ensureAddressTypeSelected()
+    onRequestChanged: root.ensureAddressTypeSelected()
+
+    Settings {
+        id: settings
+        property alias addressFormatEnabled: receiveOptionsPopup.addressFormatEnabled
+    }
 
     Binding {
         target: root.request ? root.request.amount : null
@@ -30,16 +102,39 @@ Page {
         height: parent.height
         contentWidth: width
 
-        CoreText {
-            id: title
+        Item {
+            id: titleRow
             anchors.left: contentRow.left
+            anchors.right: contentRow.right
             anchors.top: parent.top
             anchors.topMargin: 20
-            text: root.request !== null && root.request.id !== ""
-                ? qsTr("Payment request #") + root.request.id
-                : qsTr("Request a payment")
-            font.pixelSize: 21
-            bold: true
+            height: Math.max(title.height, menuButton.height)
+
+            CoreText {
+                id: title
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.requestPersisted
+                    ? qsTr("Payment request #") + root.request.id
+                    : qsTr("Request a payment")
+                font.pixelSize: 21
+                bold: true
+            }
+
+            IconButton {
+                id: menuButton
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                checked: receiveOptionsPopup.opened
+                iconSource: "image://images/ellipsis"
+                onClicked: receiveOptionsPopup.open()
+            }
+
+            ReceiveOptionsPopup {
+                id: receiveOptionsPopup
+                x: menuButton.x - width + menuButton.width
+                y: menuButton.y + menuButton.height
+            }
         }
 
         RowLayout {
@@ -47,19 +142,19 @@ Page {
 
             enabled: walletController.initialized && root.request !== null
 
-            anchors.top: title.bottom
+            anchors.top: titleRow.bottom
             anchors.topMargin: 40
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: 30
             ColumnLayout {
                 id: columnLayout
                 Layout.minimumWidth: 450
-                Layout.maximumWidth: 470
+                Layout.maximumWidth: AppMode.isDesktop ? 650 : 470
 
                 spacing: 5
 
                 Item {
-                    height: amountInput.height
+                    Layout.preferredHeight: 50
                     Layout.fillWidth: true
                     CoreText {
                         id: amountLabel
@@ -73,6 +168,7 @@ Page {
 
                     TextField {
                         id: amountInput
+                        objectName: "requestPaymentAmountInput"
                         anchors.left: amountLabel.right
                         anchors.verticalCenter: parent.verticalCenter
                         leftPadding: 0
@@ -86,24 +182,23 @@ Page {
                         selectByMouse: true
                         text: root.request ? root.request.amount.display : ""
                         onTextEdited: {
+                            root.requestError = ""
                             if (root.request) {
-                                root.request.amount.display = text
+                                root.request.amount.display = text;
                             }
                         }
                         onEditingFinished: {
                             if (root.request) {
-                                root.request.amount.format()
+                                root.request.amount.format();
                             }
                         }
                         onActiveFocusChanged: {
                             if (!activeFocus && root.request) {
-                                root.request.amount.format()
+                                root.request.amount.format();
                             }
                         }
                         validator: RegularExpressionValidator {
-                            regularExpression: !root.request || root.request.amount.unit === BitcoinAmount.BTC
-                                ? /^(0|[1-9]\d{0,7})(\.\d{0,8})?$/
-                                : /^(0|[1-9]\d{0,15})$/
+                            regularExpression: !root.request || root.request.amount.unit === BitcoinAmount.BTC ? /^(0|[1-9]\d{0,7})(\.\d{0,8})?$/ : /^(0|[1-9]\d{0,15})$/
                         }
                         maximumLength: !root.request || root.request.amount.unit === BitcoinAmount.BTC ? 17 : 16
                     }
@@ -116,7 +211,7 @@ Page {
                             anchors.fill: parent
                             onClicked: {
                                 if (root.request) {
-                                    root.request.amount.flipUnit()
+                                    root.request.amount.flipUnit();
                                 }
                             }
                         }
@@ -164,13 +259,16 @@ Page {
 
                 LabeledTextInput {
                     id: label
+                    objectName: "requestPaymentLabelInput"
                     Layout.fillWidth: true
-                    labelText: qsTr("Label")
-                    placeholderText: qsTr("Enter label...")
+                    Layout.preferredHeight: 50
+                    labelText: qsTr("Note to self")
+                    placeholderText: qsTr("Enter note…")
                     text: root.request ? root.request.label : ""
                     onTextEdited: {
+                        root.requestError = ""
                         if (root.request) {
-                            root.request.label = label.text
+                            root.request.label = label.text;
                         }
                     }
                 }
@@ -181,19 +279,225 @@ Page {
 
                 LabeledTextInput {
                     id: message
+                    objectName: "requestPaymentMessageInput"
                     Layout.fillWidth: true
+                    Layout.preferredHeight: 50
                     labelText: qsTr("Message")
                     placeholderText: qsTr("Enter message...")
                     text: root.request ? root.request.message : ""
                     onTextEdited: {
+                        root.requestError = ""
                         if (root.request) {
-                            root.request.message = message.text
+                            root.request.message = message.text;
                         }
                     }
                 }
 
                 Separator {
                     Layout.fillWidth: true
+                }
+
+                ColumnLayout {
+                    id: addressFormatRow
+                    Layout.fillWidth: true
+                    visible: settings.addressFormatEnabled
+                    spacing: 0
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        height: 40
+
+                        CoreText {
+                            id: addressTypeLabel
+                            Layout.preferredWidth: 150
+                            Layout.minimumWidth: 150
+                            Layout.maximumWidth: 150
+                            Layout.rightMargin: 10
+                            horizontalAlignment: Text.AlignLeft
+                            text: qsTr("Address type")
+                            font.pixelSize: 18
+                            wrapMode: Text.NoWrap
+                        }
+
+                        Button {
+                            id: addressTypePicker
+                            objectName: "receiveAddressTypePicker"
+                            property int selectedIndex: root.addressTypeIndex(root.selectedReceiveAddressType())
+                            property string selectedLabel: selectedIndex >= 0 && root.availableAddressTypes.length > 0 ? root.availableAddressTypes[selectedIndex].label : ""
+
+                            enabled: root.request !== null && root.request.address === "" && count > 0
+                            hoverEnabled: AppMode.isDesktop
+                            Layout.fillWidth: true
+                            leftPadding: 10
+                            rightPadding: 4
+                            topPadding: 2
+                            bottomPadding: 2
+                            height: 28
+                            onPressed: addressTypePopup.open()
+
+                            readonly property int count: root.availableAddressTypes.length
+
+                            HoverHandler {
+                                cursorShape: Qt.PointingHandCursor
+                            }
+
+                            contentItem: RowLayout {
+                                spacing: 0
+
+                                CoreText {
+                                    text: addressTypePicker.selectedLabel
+                                    font.pixelSize: 18
+                                    Layout.fillWidth: true
+                                    horizontalAlignment: Text.AlignRight
+                                    elide: Text.ElideRight
+                                }
+
+                                Icon {
+                                    source: "image://images/caret-down-medium-filled"
+                                    Layout.preferredWidth: 30
+                                    size: 30
+                                    color: addressTypePicker.enabled ? Theme.color.orange : Theme.color.neutral4
+                                }
+                            }
+
+                            background: Rectangle {
+                                id: addressTypePickerBg
+                                color: Theme.color.background
+                                radius: 6
+                                Behavior on color {
+                                    ColorAnimation {
+                                        duration: 150
+                                    }
+                                }
+                            }
+
+                            states: [
+                                State {
+                                    name: "HOVER"
+                                    when: addressTypePicker.hovered
+                                    PropertyChanges {
+                                        target: addressTypePickerBg
+                                        color: Theme.color.neutral2
+                                    }
+                                },
+                                State {
+                                    name: "DISABLED"
+                                    when: !addressTypePicker.enabled
+                                    PropertyChanges {
+                                        target: addressTypePickerBg
+                                        color: Theme.color.background
+                                    }
+                                }
+                            ]
+                        }
+                    }
+
+                    Popup {
+                        id: addressTypePopup
+                        modal: true
+                        dim: false
+
+                        background: Rectangle {
+                            color: Theme.color.background
+                            radius: 6
+                            border.color: Theme.color.neutral4
+                        }
+
+                        width: 300
+                        height: Math.min(addressTypeList.contentHeight + 10, 400)
+                        x: Math.max(0, addressTypePicker.x + addressTypePicker.width - width)
+                        y: addressTypePicker.y + addressTypePicker.height + 2
+                        padding: 5
+
+                        contentItem: ListView {
+                            id: addressTypeList
+                            model: root.availableAddressTypes
+                            interactive: false
+                            width: 300
+                            height: contentHeight
+                            spacing: 2
+                            delegate: ItemDelegate {
+                                id: delegate
+                                required property var modelData
+                                required property int index
+
+                                width: ListView.view.width
+                                leftPadding: 10
+                                rightPadding: 4
+                                topPadding: 6
+                                bottomPadding: 6
+
+                                background: Item {
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        radius: 6
+                                        color: Theme.color.neutral2
+                                        visible: delegate.hovered
+                                    }
+                                }
+
+                                contentItem: RowLayout {
+                                    spacing: 5
+
+                                    Item {
+                                        Layout.alignment: Qt.AlignVCenter
+                                        Layout.preferredWidth: 24
+                                        Layout.preferredHeight: 24
+
+                                        Icon {
+                                            anchors.fill: parent
+                                            visible: delegate.index === addressTypePicker.selectedIndex
+                                            source: "image://images/check"
+                                            color: Theme.color.orange
+                                            size: 24
+                                        }
+                                    }
+
+                                    ColumnLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 2
+
+                                        CoreText {
+                                            text: delegate.modelData.label
+                                            horizontalAlignment: Text.AlignLeft
+                                            Layout.fillWidth: true
+                                            font.pixelSize: 15
+                                            elide: Text.ElideRight
+                                        }
+
+                                        CoreText {
+                                            text: delegate.modelData.description
+                                            horizontalAlignment: Text.AlignLeft
+                                            Layout.fillWidth: true
+                                            font.pixelSize: 13
+                                            color: Theme.color.neutral7
+                                            wrapMode: Text.WordWrap
+                                        }
+                                    }
+                                }
+
+                                HoverHandler {
+                                    cursorShape: Qt.PointingHandCursor
+                                }
+
+                                onClicked: {
+                                    if (!root.request) {
+                                        return;
+                                    }
+                                    root.request.addressType = delegate.modelData.id;
+                                    if (root.wallet) {
+                                        root.wallet.setDefaultReceiveAddressType(delegate.modelData.id);
+                                    }
+                                    addressTypePopup.close();
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Separator {
+                    Layout.fillWidth: true
+                    visible: settings.addressFormatEnabled
                 }
 
                 Item {
@@ -230,6 +534,7 @@ Page {
                         radius: 5
                         CoreText {
                             id: address
+                            objectName: "requestPaymentAddressText"
                             anchors.fill: parent
                             anchors.leftMargin: 5
                             horizontalAlignment: Text.AlignLeft
@@ -249,7 +554,7 @@ Page {
                         anchors.bottom: parent.bottom
                         hoverEnabled: true
                         cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                        enabled: root.request !== null && root.request.address !== ""
+                        enabled: root.requestHasAddress
                         onClicked: Clipboard.setText(root.request.address)
                     }
 
@@ -261,27 +566,36 @@ Page {
                         anchors.bottom: parent.bottom
                         hoverEnabled: true
                         cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                        enabled: root.request !== null && root.request.address !== ""
+                        enabled: root.requestHasAddress
                         onClicked: Clipboard.setText(root.request.address)
                     }
                 }
 
                 ContinueButton {
                     id: continueButton
+                    objectName: "requestPaymentCreateButton"
                     Layout.fillWidth: true
                     Layout.topMargin: 30
-                    text: root.request !== null && root.request.id !== ""
-                        ? qsTr("Copy payment request")
-                        : qsTr("Create bitcoin address")
-                    onClicked: {
-                        if (!root.request) {
-                            return
-                        }
-                        if (root.request.address === "") {
-                            root.wallet.commitPaymentRequest()
-                        } else {
-                            Clipboard.setText(root.request.address)
-                        }
+                    text: root.primaryActionText()
+                    onClicked: root.runPrimaryAction()
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    visible: root.requestError.length > 0
+
+                    Icon {
+                        source: "image://images/alert-filled"
+                        size: 22
+                        color: Theme.color.red
+                    }
+
+                    CoreText {
+                        text: root.requestError
+                        font.pixelSize: 15
+                        color: Theme.color.red
+                        horizontalAlignment: Text.AlignLeft
+                        Layout.fillWidth: true
                     }
                 }
 
@@ -299,7 +613,9 @@ Page {
                     text: qsTr("Clear")
                     onClicked: {
                         if (root.request) {
+                            root.requestError = ""
                             root.request.clear()
+                            root.ensureAddressTypeSelected()
                         }
                     }
                 }
@@ -307,8 +623,10 @@ Page {
                 Connections {
                     target: walletController
                     function onSelectedWalletChanged() {
+                        root.requestError = ""
                         if (root.request) {
-                            root.request.clear()
+                            root.request.clear();
+                            root.ensureAddressTypeSelected();
                         }
                     }
                 }
@@ -330,6 +648,31 @@ Page {
                     code: root.request ? root.request.address : ""
                 }
             }
+        }
+    }
+
+    WalletPassphrasePopup {
+        id: commitPassphrasePopup
+        parent: Overlay.overlay
+        width: Math.min(420, root.width - 40)
+        popupObjectName: "requestPaymentPassphrasePopup"
+        passphraseFieldObjectName: "requestPaymentPassphraseField"
+        errorTextObjectName: "requestPaymentPassphraseErrorText"
+        cancelButtonObjectName: "requestPaymentPassphraseCancelButton"
+        confirmButtonObjectName: "requestPaymentPassphraseConfirmButton"
+        titleText: qsTr("Enter wallet password")
+        descriptionText: qsTr("Enter your wallet password to create a new address.")
+        confirmText: qsTr("Unlock and create")
+        busyConfirmText: qsTr("Unlocking...")
+        onSubmitted: passphrase => {
+            commitPassphrasePopup.busy = true
+            if (root.wallet && root.wallet.commitPaymentRequestWithPassphrase(passphrase)) {
+                commitPassphrasePopup.busy = false
+                commitPassphrasePopup.close()
+                return
+            }
+            commitPassphrasePopup.busy = false
+            commitPassphrasePopup.errorText = root.request ? root.request.unlockError : ""
         }
     }
 }

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -178,9 +178,9 @@ PageStack {
                     visible: settings.multipleRecipientsEnabled
 
                     CoreText {
+                        id: selectAndAddRecipientsLabel
                         Layout.fillWidth: true
                         Layout.alignment: Qt.AlignLeft
-                        id: selectAndAddRecipientsLabel
                         text: qsTr("Recipient %1 of %2").arg(wallet.recipients.currentIndex).arg(wallet.recipients.count)
                         horizontalAlignment: Text.AlignLeft
                         font.pixelSize: 18
@@ -378,7 +378,7 @@ PageStack {
                     inputObjectName: "sendNoteInput"
                     Layout.fillWidth: true
                     labelText: qsTr("Note to self")
-                    placeholderText: qsTr("Enter ...")
+                    placeholderText: qsTr("Enter note…")
                     text: root.recipient.label
                     onTextEdited: root.recipient.label = label.text
                 }

--- a/qml/pages/wallet/SignVerifyMessage.qml
+++ b/qml/pages/wallet/SignVerifyMessage.qml
@@ -1,0 +1,426 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import org.bitcoincore.qt 1.0
+
+import "../../controls"
+import "../../components"
+
+Page {
+    id: root
+    objectName: "signVerifyMessagePage"
+    background: null
+
+    property WalletQmlModel wallet: walletController.selectedWallet
+    property var signVerifyModel: wallet ? wallet.signVerifyMessageModel : null
+    property string verifyResultText: ""
+    property bool verifyResultSuccess: false
+
+    signal back
+
+    ButtonGroup {
+        id: messageTabs
+    }
+
+    function clearSignForm() {
+        signAddress.text = "";
+        signMessageText.text = "";
+        if (root.signVerifyModel) {
+            root.signVerifyModel.clear();
+        }
+    }
+
+    function clearVerifyForm() {
+        verifyAddress.text = "";
+        verifyMessageText.text = "";
+        verifySignature.text = "";
+        root.verifyResultText = "";
+        root.verifyResultSuccess = false;
+    }
+
+    function addressErrorText(address) {
+        if (address.length === 0 || (root.signVerifyModel && root.signVerifyModel.isLegacyP2PKHAddress(address))) {
+            return "";
+        }
+        return qsTr("Not a valid P2PKH address.");
+    }
+
+    function submitSign(passphrase) {
+        if (!root.signVerifyModel) {
+            return;
+        }
+        const signed = passphrase === undefined ? root.signVerifyModel.signMessage(signAddress.text, signMessageText.text) : root.signVerifyModel.signMessageWithPassphrase(signAddress.text, signMessageText.text, passphrase);
+        if (signed) {
+            signPassphrasePopup.close();
+            return;
+        }
+        if (root.signVerifyModel.signingNeedsUnlock) {
+            signPassphrasePopup.errorText = "";
+            signPassphrasePopup.open();
+        }
+    }
+
+    function submitVerify() {
+        const verified = root.signVerifyModel && root.signVerifyModel.verifyMessage(verifyAddress.text, verifyMessageText.text, verifySignature.text);
+        root.verifyResultSuccess = verified;
+        root.verifyResultText = verified ? qsTr("Message verified successfully.") : qsTr("Message verification failed.");
+    }
+
+    header: NavigationBar2 {
+        leftItem: NavButton {
+            objectName: "signVerifyMessageBackButton"
+            iconSource: "image://images/caret-left"
+            text: qsTr("Back")
+            onClicked: root.back()
+        }
+        centerItem: Header {
+            headerBold: true
+            headerSize: 18
+            header: qsTr("Sign or Verify Message")
+        }
+    }
+
+    ScrollView {
+        clip: true
+        anchors.fill: parent
+        contentWidth: width
+
+        ColumnLayout {
+            width: Math.min(parent.width - 40, 706)
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: 0
+
+            RowLayout {
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: 18
+                spacing: 0
+
+                NavigationTab {
+                    id: signTabButton
+                    objectName: "signMessageTab"
+                    text: qsTr("Sign Message")
+                    checked: true
+                    Layout.preferredWidth: 254
+                    property int index: 0
+                    ButtonGroup.group: messageTabs
+                }
+
+                NavigationTab {
+                    objectName: "verifyMessageTab"
+                    text: qsTr("Verify Message")
+                    Layout.preferredWidth: 254
+                    property int index: 1
+                    ButtonGroup.group: messageTabs
+                }
+            }
+
+            StackLayout {
+                Layout.fillWidth: true
+                currentIndex: messageTabs.checkedButton.index
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 0
+
+                    CoreText {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 36
+                        text: qsTr("You can sign messages or agreements with your legacy P2PKH addresses to prove you can receive bitcoin sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully detailed statements you agree to.")
+                        color: Theme.color.neutral7
+                        font: Theme.text.description.font
+                        wrapMode: Text.WordWrap
+                    }
+
+                    LineTextField {
+                        id: signAddress
+                        objectName: "signMessageAddressField"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 22
+                        placeholderText: qsTr("Enter a bitcoin address")
+                    }
+
+                    AddressError {
+                        objectName: "signMessageAddressError"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 8
+                        text: root.addressErrorText(signAddress.text)
+                    }
+
+                    LineTextArea {
+                        id: signMessageText
+                        objectName: "signMessageMessageField"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 22
+                        Layout.preferredHeight: 150
+                        placeholderText: qsTr("Enter the message you want to sign here")
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 32
+                        spacing: 15
+
+                        ContinueButton {
+                            objectName: "signMessageButton"
+                            Layout.preferredWidth: 206
+                            text: qsTr("Sign Message")
+                            enabled: root.signVerifyModel && root.signVerifyModel.isLegacyP2PKHAddress(signAddress.text)
+                            onClicked: root.submitSign()
+                        }
+
+                        OutlineButton {
+                            objectName: "signMessageClearButton"
+                            Layout.preferredWidth: 140
+                            text: qsTr("Clear All")
+                            onClicked: root.clearSignForm()
+                        }
+                    }
+
+                    CoreText {
+                        objectName: "signMessageErrorText"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 28
+                        visible: root.signVerifyModel && root.signVerifyModel.signingError.length > 0 && !root.signVerifyModel.signingNeedsUnlock
+                        text: root.signVerifyModel ? root.signVerifyModel.signingError : ""
+                        color: Theme.color.red
+                        font: Theme.text.caption.font
+                        wrapMode: Text.WordWrap
+                    }
+
+                    ColumnLayout {
+                        objectName: "signMessageSignatureOutput"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 28
+                        visible: root.signVerifyModel && root.signVerifyModel.signature.length > 0
+                        spacing: 10
+
+                        CoreText {
+                            text: qsTr("Signature")
+                            color: Theme.color.neutral7
+                            font: Theme.text.body.font
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            implicitHeight: Math.max(70, signatureText.contentHeight + 34)
+                            color: Theme.color.neutral3
+                            radius: 5
+
+                            CoreText {
+                                id: signatureText
+                                objectName: "signMessageSignatureText"
+                                anchors.left: parent.left
+                                anchors.right: copySignatureButton.left
+                                anchors.verticalCenter: parent.verticalCenter
+                                anchors.leftMargin: 22
+                                anchors.rightMargin: 10
+                                text: root.signVerifyModel ? root.signVerifyModel.signature : ""
+                                color: Theme.color.neutral9
+                                font: Theme.text.body.font
+                                wrapMode: Text.WrapAnywhere
+                            }
+
+                            IconButton {
+                                id: copySignatureButton
+                                objectName: "signMessageCopySignatureButton"
+                                anchors.right: parent.right
+                                anchors.rightMargin: 22
+                                anchors.verticalCenter: parent.verticalCenter
+                                iconSource: "image://images/copy"
+                                iconColor: Theme.color.neutral7
+                                hoverColor: Theme.color.orange
+                                onClicked: Clipboard.setText(root.signVerifyModel ? root.signVerifyModel.signature : "")
+                            }
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 0
+
+                    CoreText {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 36
+                        text: qsTr("Enter the receiver's address, message (ensure you copy line breaks), spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction.")
+                        color: Theme.color.neutral7
+                        font: Theme.text.description.font
+                        wrapMode: Text.WordWrap
+                    }
+
+                    LineTextField {
+                        id: verifyAddress
+                        objectName: "verifyMessageAddressField"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 22
+                        placeholderText: qsTr("Enter a bitcoin address")
+                    }
+
+                    AddressError {
+                        objectName: "verifyMessageAddressError"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 8
+                        text: root.addressErrorText(verifyAddress.text)
+                    }
+
+                    LineTextArea {
+                        id: verifyMessageText
+                        objectName: "verifyMessageMessageField"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 22
+                        Layout.preferredHeight: 150
+                        placeholderText: qsTr("Enter the message you want to verify here")
+                    }
+
+                    CoreText {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 28
+                        text: qsTr("Signature")
+                        color: Theme.color.neutral7
+                        font: Theme.text.body.font
+                        horizontalAlignment: Text.AlignLeft
+                    }
+
+                    LineTextArea {
+                        id: verifySignature
+                        objectName: "verifyMessageSignatureField"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 12
+                        Layout.preferredHeight: 68
+                        placeholderText: qsTr("The signature when the message was signed")
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 32
+                        spacing: 15
+
+                        ContinueButton {
+                            objectName: "verifyMessageButton"
+                            Layout.preferredWidth: 220
+                            text: qsTr("Verify Message")
+                            enabled: root.signVerifyModel && root.signVerifyModel.isLegacyP2PKHAddress(verifyAddress.text) && verifySignature.text.length > 0
+                            onClicked: root.submitVerify()
+                        }
+
+                        OutlineButton {
+                            objectName: "verifyMessageClearButton"
+                            Layout.preferredWidth: 140
+                            text: qsTr("Clear All")
+                            onClicked: root.clearVerifyForm()
+                        }
+                    }
+
+                    Toast {
+                        objectName: "verifyMessageResultBanner"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 28
+                        visible: root.verifyResultText.length > 0
+                        backgroundColor: root.verifyResultSuccess ? Theme.color.green : Theme.color.red
+                        iconSource: root.verifyResultSuccess ? "image://images/check" : "image://images/info-filled"
+                        text: root.verifyResultText
+                        textObjectName: "verifyMessageResultText"
+                    }
+                }
+            }
+        }
+    }
+
+    WalletPassphrasePopup {
+        id: signPassphrasePopup
+        parent: Overlay.overlay
+        width: Math.min(420, root.width - 40)
+        popupObjectName: "signMessagePassphrasePopup"
+        passphraseFieldObjectName: "signMessagePassphraseField"
+        errorTextObjectName: "signMessagePassphraseErrorText"
+        cancelButtonObjectName: "signMessagePassphraseCancelButton"
+        confirmButtonObjectName: "signMessagePassphraseConfirmButton"
+        titleText: qsTr("Enter wallet password")
+        descriptionText: qsTr("Enter the wallet password to sign this message.")
+        confirmText: qsTr("Unlock and sign")
+        busyConfirmText: qsTr("Signing...")
+        onSubmitted: passphrase => {
+            signPassphrasePopup.busy = true;
+            if (root.signVerifyModel.signMessageWithPassphrase(signAddress.text, signMessageText.text, passphrase)) {
+                signPassphrasePopup.busy = false;
+                signPassphrasePopup.close();
+                return;
+            }
+            signPassphrasePopup.busy = false;
+            signPassphrasePopup.errorText = root.signVerifyModel.signingError;
+        }
+    }
+
+    component LineTextField: TextField {
+        id: lineField
+        selectByMouse: true
+        font: Theme.text.body.font
+        color: Theme.color.neutral9
+        placeholderTextColor: Theme.color.neutral6
+        leftPadding: 0
+        rightPadding: 0
+        background: Rectangle {
+            implicitHeight: 45
+            color: "transparent"
+            border.color: "transparent"
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                height: 1
+                color: Theme.color.neutral5
+            }
+        }
+    }
+
+    component AddressError: RowLayout {
+        property alias text: errorText.text
+
+        visible: errorText.text.length > 0
+        spacing: 8
+
+        Icon {
+            source: "image://images/alert-filled"
+            size: 22
+            color: Theme.color.red
+        }
+
+        CoreText {
+            id: errorText
+            color: Theme.color.red
+            font: Theme.text.description.font
+            horizontalAlignment: Text.AlignLeft
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+        }
+    }
+
+    component LineTextArea: TextArea {
+        id: lineArea
+        selectByMouse: true
+        wrapMode: TextEdit.Wrap
+        font: Theme.text.body.font
+        color: Theme.color.neutral9
+        placeholderTextColor: Theme.color.neutral6
+        leftPadding: 0
+        rightPadding: 0
+        topPadding: 0
+        bottomPadding: 10
+        background: Rectangle {
+            color: "transparent"
+            border.color: "transparent"
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                height: 1
+                color: Theme.color.neutral5
+            }
+        }
+    }
+}

--- a/qml/pages/wallet/WalletPasswordSettings.qml
+++ b/qml/pages/wallet/WalletPasswordSettings.qml
@@ -112,6 +112,7 @@ Page {
             Layout.topMargin: root.updating ? 5 : 0
             Layout.leftMargin: 20
             Layout.rightMargin: 20
+            focus: root.updating
             hideText: true
             placeholderText: qsTr("Enter current password...")
             onTextEdited: root.errorText = ""
@@ -135,7 +136,7 @@ Page {
             Layout.topMargin: 5
             Layout.leftMargin: 20
             Layout.rightMargin: 20
-            focus: true
+            focus: !root.updating
             hideText: true
             placeholderText: root.updating ? qsTr("Enter new password...") : qsTr("Enter password...")
             onTextEdited: root.errorText = ""

--- a/qml/pages/wallet/WalletSettings.qml
+++ b/qml/pages/wallet/WalletSettings.qml
@@ -23,6 +23,7 @@ Page {
     signal back()
     signal selectWalletRequested()
     signal passwordRequested()
+    signal addressesRequested()
 
     readonly property bool walletLoaded: walletController.isWalletLoaded
     readonly property bool canManagePassphrase: root.wallet !== null && root.wallet.canManagePassphrase
@@ -262,6 +263,22 @@ Page {
                 objectName: "walletSettingsExternalSignerValue"
                 text: root.wallet ? root.wallet.externalSignerStatus : ""
             }
+        }
+
+        Rectangle { Layout.fillWidth: true; height: 1; color: Theme.color.neutral4 }
+
+        Setting {
+            id: addressesSetting
+            objectName: "settingsAddresses"
+            Layout.fillWidth: true
+            header: qsTr("Addresses")
+            filledStateColor: Theme.color.neutral7
+            hoverStateColor: Theme.color.orange
+            activeStateColor: Theme.color.orange
+            actionItem: CaretRightIcon {
+                color: addressesSetting.stateColor
+            }
+            onClicked: root.addressesRequested()
         }
 
         Rectangle {

--- a/qml/pages/wallet/WalletSettings.qml
+++ b/qml/pages/wallet/WalletSettings.qml
@@ -23,6 +23,7 @@ Page {
     signal back()
     signal selectWalletRequested()
     signal passwordRequested()
+    signal signVerifyMessageRequested()
     signal addressesRequested()
 
     readonly property bool walletLoaded: walletController.isWalletLoaded
@@ -317,6 +318,22 @@ Page {
                 color: backupSetting.stateColor
             }
             onClicked: root.startBackup()
+        }
+
+        Rectangle { Layout.fillWidth: true; height: 1; color: Theme.color.neutral4 }
+
+        Setting {
+            id: signVerifyMessageSetting
+            objectName: "walletSettingsSignVerifyMessageRow"
+            Layout.fillWidth: true
+            header: qsTr("Sign or Verify Message")
+            filledStateColor: Theme.color.neutral7
+            hoverStateColor: Theme.color.orange
+            activeStateColor: Theme.color.orange
+            actionItem: CaretRightIcon {
+                color: signVerifyMessageSetting.stateColor
+            }
+            onClicked: root.signVerifyMessageRequested()
         }
 
         CoreText {

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -40,9 +40,7 @@ QByteArray clickObject(QObject* obj)
 
     // Preferred path: AbstractButton::click() runs the full press/release/
     // clicked pipeline synchronously and toggles `checked` when checkable.
-    // This is the canonical Qt API for "click this button" and works
-    // regardless of where the button is in screen space (e.g., mid-animation
-    // during a StackView page transition).
+    // Available on QQuickAbstractButton from Qt 6.8+ (Q_REVISION(6, 8)).
     const QMetaObject* meta = obj->metaObject();
     if (int idx = meta->indexOfMethod("click()"); idx >= 0) {
         if (meta->method(idx).invoke(obj, Qt::DirectConnection)) return okResponse();
@@ -51,10 +49,26 @@ QByteArray clickObject(QObject* obj)
         if (meta->method(idx).invoke(obj, Qt::DirectConnection)) return okResponse();
     }
 
-    // Fallback for non-Button items (bare Item + MouseArea, IconButton, etc.):
-    // synthesize a real mouse press + release at the item's center and
-    // dispatch it through the window so MouseArea / HoverHandler wiring
-    // fires the same way it would for a user click.
+    // Fallback for Qt < 6.8 (no QQuickAbstractButton::click()): invoke both
+    // toggle() (if checkable) and the clicked() signal. We can't tell which
+    // one a given control needs - NavigationTab + ButtonGroup react to
+    // `checked` changes via toggle(), while NavButton / ContinueButton react
+    // to QML-defined onClicked handlers via the clicked() signal. Firing
+    // both covers both shapes without per-component special cases.
+    bool invoked_any{false};
+    if (obj->property("checkable").toBool()) {
+        if (int idx = meta->indexOfMethod("toggle()"); idx >= 0) {
+            invoked_any |= meta->method(idx).invoke(obj, Qt::DirectConnection);
+        }
+    }
+    if (int idx = meta->indexOfSignal("clicked()"); idx >= 0) {
+        invoked_any |= meta->method(idx).invoke(obj, Qt::DirectConnection);
+    }
+    if (invoked_any) return okResponse();
+
+    // Last resort for items without click()/trigger()/toggle()/clicked()
+    // (bare Item + MouseArea, etc.): synthesize a real mouse press + release
+    // at the item's center.
     if (auto* item = qobject_cast<QQuickItem*>(obj)) {
         QQuickWindow* window = item->window();
         if (window && item->isVisible() && item->width() > 0 && item->height() > 0) {

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -38,56 +38,29 @@ QByteArray clickObject(QObject* obj)
         return QJsonDocument(resp).toJson(QJsonDocument::Compact);
     }
 
-    auto* item = qobject_cast<QQuickItem*>(obj);
+    // Preferred path: AbstractButton::click() runs the full press/release/
+    // clicked pipeline synchronously and toggles `checked` when checkable.
+    // This is the canonical Qt API for "click this button" and works
+    // regardless of where the button is in screen space (e.g., mid-animation
+    // during a StackView page transition).
     const QMetaObject* meta = obj->metaObject();
-
-    const QString class_name = QString::fromLatin1(meta->className());
-    if (class_name.startsWith(QStringLiteral("EllipsisMenuToggleItem"))) {
-        int clicked_index = meta->indexOfSignal("clicked()");
-        if (clicked_index >= 0 && meta->method(clicked_index).invoke(obj, Qt::DirectConnection)) {
-            return okResponse();
-        }
+    if (int idx = meta->indexOfMethod("click()"); idx >= 0) {
+        if (meta->method(idx).invoke(obj, Qt::DirectConnection)) return okResponse();
+    }
+    if (int idx = meta->indexOfMethod("trigger()"); idx >= 0) {
+        if (meta->method(idx).invoke(obj, Qt::DirectConnection)) return okResponse();
     }
 
-    bool invoked = false;
-    int click_method_index = meta->indexOfMethod("click()");
-    if (click_method_index >= 0) {
-        invoked = meta->method(click_method_index).invoke(obj, Qt::DirectConnection);
-        if (invoked) {
-            return okResponse();
-        }
-    }
-
-    const bool checkable = obj->property("checkable").toBool();
-    int toggle_index = meta->indexOfMethod("toggle()");
-    if (checkable && toggle_index >= 0) {
-        invoked = meta->method(toggle_index).invoke(obj, Qt::DirectConnection);
-    }
-
-    int clicked_index = meta->indexOfSignal("clicked()");
-    if (clicked_index >= 0) {
-        if (meta->method(clicked_index).invoke(obj, Qt::DirectConnection)) {
-            return okResponse();
-        }
-    }
-
-    int trigger_index = meta->indexOfMethod("trigger()");
-    if (trigger_index >= 0) {
-        if (meta->method(trigger_index).invoke(obj, Qt::DirectConnection)) {
-            return okResponse();
-        }
-    }
-
-    if (invoked) {
-        return okResponse();
-    }
-
-    if (item) {
+    // Fallback for non-Button items (bare Item + MouseArea, IconButton, etc.):
+    // synthesize a real mouse press + release at the item's center and
+    // dispatch it through the window so MouseArea / HoverHandler wiring
+    // fires the same way it would for a user click.
+    if (auto* item = qobject_cast<QQuickItem*>(obj)) {
         QQuickWindow* window = item->window();
-        if (window && item->width() > 0 && item->height() > 0) {
-            QPointF center = item->mapToScene(
+        if (window && item->isVisible() && item->width() > 0 && item->height() > 0) {
+            const QPointF center = item->mapToScene(
                 QPointF(item->width() / 2.0, item->height() / 2.0));
-            QPoint pos = center.toPoint();
+            const QPoint pos = center.toPoint();
 
             QMouseEvent press(QEvent::MouseButtonPress, pos, window->mapToGlobal(pos),
                               Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
@@ -96,7 +69,6 @@ QByteArray clickObject(QObject* obj)
 
             QCoreApplication::sendEvent(window, &press);
             QCoreApplication::sendEvent(window, &release);
-
             return okResponse();
         }
     }

--- a/qml/util.cpp
+++ b/qml/util.cpp
@@ -4,9 +4,13 @@
 
 #include <qml/util.h>
 
+#include <support/cleanse.h>
+
 #include <cassert>
+#include <cstddef>
 #include <string>
 
+#include <QByteArray>
 #include <QQuickWindow>
 #include <QSGRendererInterface>
 #include <QString>
@@ -31,6 +35,26 @@ QString GraphicsApi(QQuickWindow* window)
 #endif
     } // no default case, so the compiler can warn about missing cases
     assert(false);
+}
+
+SecureString SecureStringFromQString(const QString& value)
+{
+    QByteArray bytes{value.toUtf8()};
+    SecureString secure;
+    secure.assign(bytes.constData(), bytes.constData() + bytes.size());
+    if (!bytes.isEmpty()) {
+        memory_cleanse(bytes.data(), static_cast<std::size_t>(bytes.size()));
+    }
+    return secure;
+}
+
+void ClearSecureString(SecureString& value)
+{
+    if (value.empty()) {
+        return;
+    }
+    memory_cleanse(value.data(), value.size());
+    value.clear();
 }
 
 } // namespace QmlUtil

--- a/qml/util.h
+++ b/qml/util.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_QML_UTIL_H
 #define BITCOIN_QML_UTIL_H
 
+#include <support/allocators/secure.h>
+
 #include <QString>
 #include <QtGlobal>
 
@@ -21,6 +23,9 @@ namespace QmlUtil {
 * that is in use by the Qt Quick scene graph renderer.
 */
 QString GraphicsApi(QQuickWindow* window);
+
+SecureString SecureStringFromQString(const QString& value);
+void ClearSecureString(SecureString& value);
 
 } // namespace QmlUtil
 

--- a/qml/walletqmlcontroller.cpp
+++ b/qml/walletqmlcontroller.cpp
@@ -5,6 +5,7 @@
 #include <qml/walletqmlcontroller.h>
 
 #include <qml/models/walletqmlmodel.h>
+#include <qml/util.h>
 
 #include <common/args.h>
 #include <common/settings.h>
@@ -21,7 +22,6 @@
 #include <stdexcept>
 #include <utility>
 
-#include <QByteArray>
 #include <QDir>
 #include <QFileInfo>
 #include <QMetaObject>
@@ -41,26 +41,6 @@ QString JoinWarnings(const std::vector<bilingual_str>& warnings)
         }
     }
     return lines.join('\n');
-}
-
-SecureString SecureStringFromQString(const QString& value)
-{
-    QByteArray bytes{value.toUtf8()};
-    SecureString secure;
-    secure.assign(bytes.constData(), bytes.constData() + bytes.size());
-    if (!bytes.isEmpty()) {
-        memory_cleanse(bytes.data(), static_cast<size_t>(bytes.size()));
-    }
-    return secure;
-}
-
-void ClearSecureString(SecureString& value)
-{
-    if (value.empty()) {
-        return;
-    }
-    memory_cleanse(value.data(), value.size());
-    value.clear();
 }
 
 bool IsBackupLikeFile(const QFileInfo& file_info)
@@ -312,10 +292,10 @@ bool WalletQmlController::createSingleSigWallet(const QString &name, const QStri
         setWalletCreateError(tr("Wallets are still loading. Try again in a moment."));
         return false;
     }
-    SecureString secure_passphrase{SecureStringFromQString(passphrase)};
+    SecureString secure_passphrase{QmlUtil::SecureStringFromQString(passphrase)};
     const std::string wallet_name{name.toStdString()};
     auto wallet{m_node.walletLoader().createWallet(wallet_name, secure_passphrase, wallet::WALLET_FLAG_DESCRIPTORS, m_warning_messages)};
-    ClearSecureString(secure_passphrase);
+    QmlUtil::ClearSecureString(secure_passphrase);
     setWalletLoadWarnings(JoinWarnings(m_warning_messages));
     if (wallet) {
         const QString loaded_wallet_name = QString::fromStdString((*wallet)->getWalletName());
@@ -436,7 +416,7 @@ void WalletQmlController::migrateWallet(const QString& path, const QString& pass
         setWalletMigrationError(tr("Wallets are still loading. Try again in a moment."));
         return;
     }
-    startWalletMigration(path, SecureStringFromQString(passphrase));
+    startWalletMigration(path, QmlUtil::SecureStringFromQString(passphrase));
 }
 
 void WalletQmlController::clearWalletMigrationStatus()
@@ -937,7 +917,7 @@ void WalletQmlController::startWalletMigration(const QString& path, SecureString
     clearWalletMigrationStatus();
 
     if (path.trimmed().isEmpty()) {
-        ClearSecureString(passphrase);
+        QmlUtil::ClearSecureString(passphrase);
         setWalletMigrationError(tr("Choose a wallet to update."));
         Q_EMIT walletMigrationFailed();
         return;
@@ -945,7 +925,7 @@ void WalletQmlController::startWalletMigration(const QString& path, SecureString
 
     const QString wallet_reference = resolveManagedWalletReference(path);
     if (wallet_reference.isEmpty()) {
-        ClearSecureString(passphrase);
+        QmlUtil::ClearSecureString(passphrase);
         setWalletMigrationError(tr("The selected wallet is not available in the wallet directory."));
         Q_EMIT walletMigrationFailed();
         return;
@@ -960,7 +940,7 @@ void WalletQmlController::startWalletMigration(const QString& path, SecureString
 
     QTimer::singleShot(0, m_worker, [this, wallet_reference, passphrase = std::move(passphrase)]() mutable {
         auto result = m_node.walletLoader().migrateWallet(wallet_reference.toStdString(), passphrase);
-        ClearSecureString(passphrase);
+        QmlUtil::ClearSecureString(passphrase);
 
         if (!result) {
             const QString error = QString::fromStdString(util::ErrorString(result).translated);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(bitcoinqml_unit_tests
   test_bumptransactionmodel.cpp
   test_walletqmlcontroller.cpp
   test_display_settings.cpp
+  test_addresslistmodel.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
 )
 

--- a/test/functional/qml_test_addresses.py
+++ b/test/functional/qml_test_addresses.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""End-to-end GUI test for wallet address list receive integration."""
+
+import sys
+import time
+
+from qml_driver import QmlDriverError
+from qml_test_harness import complete_onboarding, dump_qml_tree
+from qml_wallet_test_lib import WalletFlowHarness, rpc_call, wait_for_rpc
+
+
+WALLET_NAME = "Alice"
+ADDRESS_LABEL = "invoice 1024"
+
+
+def wait_for_text(gui, object_name, expected, timeout_ms=10000):
+    deadline = time.time() + timeout_ms / 1000
+    last_text = ""
+    while time.time() < deadline:
+        last_text = gui.get_text(object_name)
+        if last_text == expected:
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"Expected {object_name} text {expected!r}, got {last_text!r}")
+
+
+def create_wallet_through_gui(harness, gui):
+    complete_onboarding(gui)
+    gui.click("createWalletWizardExitButton")
+    gui.wait_for_property("walletBadge", "loading", False, timeout_ms=30000)
+    wait_for_rpc(harness.gui_rpc_port, timeout=30)
+    gui.click("walletBadge")
+    try:
+        gui.wait_for_property("createWalletButton", "visible", True, timeout_ms=3000)
+    except QmlDriverError:
+        gui.wait_for_property("walletSelectPopup", "opened", True, timeout_ms=5000)
+        gui.click("walletSelectAddWalletButton")
+        gui.wait_for_property("createWalletButton", "visible", True, timeout_ms=5000)
+    gui.settle()
+    gui.click("createWalletButton")
+    gui.wait_for_property("createWalletIntroStartButton", "visible", True, timeout_ms=5000)
+    gui.click("createWalletIntroStartButton")
+    gui.settle()
+    gui.set_text("createWalletNameInput", WALLET_NAME)
+    gui.click("createWalletNameContinueButton")
+    gui.settle()
+    gui.click("createWalletPasswordSkipButton")
+    gui.settle()
+    gui.click("createWalletConfirmNextButton")
+    gui.settle()
+    gui.click("createWalletBackupDoneButton")
+    gui.settle()
+    try:
+        wizard_visible = gui.get_property("createWalletWizard", "visible")
+    except QmlDriverError as err:
+        if "Object not found: createWalletWizard" not in str(err):
+            raise
+        wizard_visible = False
+    if wizard_visible:
+        gui.click("createWalletWizardExitButton")
+        gui.settle()
+    gui.wait_for_property("walletBadge", "text", WALLET_NAME, timeout_ms=20000)
+
+
+def fund_wallet_for_send_context(harness):
+    wait_for_rpc(harness.gui_rpc_port, timeout=30)
+    mining_address = rpc_call(
+        harness.gui_rpc_port,
+        "getnewaddress",
+        ["mining rewards"],
+        wallet=WALLET_NAME,
+    )
+    rpc_call(harness.gui_rpc_port, "generatetoaddress", [101, mining_address])
+
+
+def create_labeled_receive_address(harness):
+    return rpc_call(
+        harness.gui_rpc_port,
+        "getnewaddress",
+        [ADDRESS_LABEL],
+        wallet=WALLET_NAME,
+    )
+
+
+def open_address_list_from_settings(gui):
+    gui.click("desktopWalletSettingsTabButton")
+    gui.wait_for_property("desktopWalletSettingsTabButton", "checked", True, timeout_ms=5000)
+    gui.settle()
+    gui.click("settingsWallet")
+    gui.wait_for_property("walletSettingsPage", "visible", True, timeout_ms=5000)
+    gui.click("settingsAddresses")
+    gui.wait_for_property("addressListPage", "visible", True, timeout_ms=10000)
+
+
+def create_payment_request_from_first_unused_address(gui, expected_address):
+    gui.click("addressRowMenuButton")
+    gui.wait_for_property("addressRowCreatePaymentRequestButton", "visible", True, timeout_ms=5000)
+    gui.click("addressRowCreatePaymentRequestButton")
+    gui.settle()
+    wait_for_text(gui, "requestPaymentLabelInput", ADDRESS_LABEL)
+    address = "".join(gui.get_text("requestPaymentAddressText").split())
+    assert address == expected_address, (
+        f"Expected receive view address {expected_address!r}, got {address!r}"
+    )
+
+
+def run_test():
+    harness = WalletFlowHarness("qml_addresses", port_offset=70)
+    try:
+        harness.start_gui(reset_gui_settings=True)
+        gui = harness.driver
+        create_wallet_through_gui(harness, gui)
+        fund_wallet_for_send_context(harness)
+        new_address = create_labeled_receive_address(harness)
+        open_address_list_from_settings(gui)
+        create_payment_request_from_first_unused_address(gui, new_address)
+        print("Address list receive integration flow passed.")
+        return 0
+    except Exception as err:  # noqa: BLE001 - preserve GUI context on failures
+        print(f"\nFAILED [qml_addresses]: {err}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        if harness.driver:
+            dump_qml_tree(harness.driver)
+        gui_output = harness.process_output(harness.gui_process)
+        if gui_output:
+            print("\n--- GUI process output ---", file=sys.stderr)
+            print(gui_output, file=sys.stderr)
+        return 1
+    finally:
+        harness.stop()
+
+
+if __name__ == "__main__":
+    sys.exit(run_test())

--- a/test/functional/qml_test_wallet_settings.py
+++ b/test/functional/qml_test_wallet_settings.py
@@ -279,6 +279,58 @@ def case_backup_uses_automation_path(harness, checkpoints):
     checkpoints.checkpoint("wallet backup created", gui)
 
 
+def case_sign_verify_message(harness, checkpoints):
+    wallet_name = "settings_sign_verify_wallet"
+    message = "I control this address."
+
+    prepare_managed_wallet(harness, wallet_name, WALLET_PASSWORD)
+    checkpoints.checkpoint("managed wallet fixture prepared")
+
+    harness.start_gui(reset_gui_settings=True)
+    gui = harness.driver
+    checkpoints.checkpoint("GUI launched", gui)
+    harness.finish_onboarding()
+    checkpoints.checkpoint("onboarding completed", gui)
+    dismiss_create_wallet_wizard(gui)
+    load_wallet(gui, harness, wallet_name)
+    checkpoints.checkpoint("managed wallet loaded", gui)
+
+    address = rpc_call(harness.gui_rpc_port, "getnewaddress", ["", "legacy"], wallet=wallet_name)
+
+    open_wallet_settings(gui)
+    gui.click("walletSettingsSignVerifyMessageRow")
+    gui.wait_for_page("signVerifyMessagePage", timeout_ms=10000)
+    checkpoints.checkpoint("sign verify message page opened", gui)
+
+    gui.set_text("signMessageAddressField", address)
+    gui.set_text("signMessageMessageField", message)
+    gui.wait_for_property("signMessageButton", "enabled", True, timeout_ms=5000)
+    gui.click("signMessageButton")
+    gui.wait_for_property("signMessagePassphrasePopup", "opened", True, timeout_ms=5000)
+    gui.set_text("signMessagePassphraseField", WALLET_PASSWORD)
+    gui.click("signMessagePassphraseConfirmButton")
+    gui.wait_for_property("signMessageSignatureOutput", "visible", True, timeout_ms=10000)
+    signature = gui.get_text("signMessageSignatureText")
+    assert signature, "Signing should reveal a signature"
+    checkpoints.checkpoint("message signed", gui)
+
+    gui.click("verifyMessageTab")
+    gui.set_text("verifyMessageAddressField", address)
+    gui.set_text("verifyMessageMessageField", message)
+    gui.set_text("verifyMessageSignatureField", signature)
+    gui.wait_for_property("verifyMessageButton", "enabled", True, timeout_ms=5000)
+    gui.click("verifyMessageButton")
+    gui.wait_for_property("verifyMessageResultBanner", "visible", True, timeout_ms=5000)
+    assert gui.get_text("verifyMessageResultText") == "Message verified successfully."
+    checkpoints.checkpoint("message verified", gui)
+
+    gui.set_text("verifyMessageMessageField", message + " changed")
+    gui.click("verifyMessageButton")
+    gui.wait_for_property("verifyMessageResultBanner", "visible", True, timeout_ms=5000)
+    assert gui.get_text("verifyMessageResultText") == "Message verification failed."
+    checkpoints.checkpoint("message verification failure displayed", gui)
+
+
 def case_subpages_close_when_wallet_becomes_unselected(harness, checkpoints):
     wallet_name = "settings_subpage_wallet"
 
@@ -386,9 +438,10 @@ def run_test(args):
     cases = [
         ("qml_wallet_settings_rename", 400, case_rename_persists_across_restart),
         ("qml_wallet_settings_backup", 410, case_backup_uses_automation_path),
-        ("qml_wallet_settings_subpage_close", 420, case_subpages_close_when_wallet_becomes_unselected),
-        ("qml_wallet_settings_password_context_change", 430, case_password_page_closes_when_selected_wallet_changes),
-        ("qml_wallet_settings_password_failure_clears_current", 440, case_wrong_current_password_clears_current_field),
+        ("qml_wallet_settings_sign_verify_message", 420, case_sign_verify_message),
+        ("qml_wallet_settings_subpage_close", 430, case_subpages_close_when_wallet_becomes_unselected),
+        ("qml_wallet_settings_password_context_change", 440, case_password_page_closes_when_selected_wallet_changes),
+        ("qml_wallet_settings_password_failure_clears_current", 450, case_wrong_current_password_clears_current_field),
     ]
 
     exit_code = 0

--- a/test/functional/qml_wallet_test_lib.py
+++ b/test/functional/qml_wallet_test_lib.py
@@ -152,7 +152,7 @@ def update_settings_json(datadir, updates):
 
 
 class WalletFlowHarness:
-    """Launches a source bitcoind and the QML GUI with isolated datadirs."""
+    """Launches the QML GUI and optional source bitcoind with isolated datadirs."""
 
     def __init__(self, name, port_offset):
         self.name = name
@@ -188,8 +188,11 @@ class WalletFlowHarness:
         return os.path.join(self.source_datadir, "regtest", "wallets")
 
     def start_source_node(self, extra_args=None, binary=None):
-        bitcoind_binary = binary or self.bitcoind_binary or find_bitcoind()
-        self.bitcoind_binary = bitcoind_binary
+        bitcoind_binary = binary
+        if bitcoind_binary is None:
+            if self.bitcoind_binary is None:
+                self.bitcoind_binary = find_bitcoind()
+            bitcoind_binary = self.bitcoind_binary
         args = [bitcoind_binary, f"-datadir={self.source_datadir}"]
         if extra_args:
             args.extend(extra_args)
@@ -267,6 +270,8 @@ class WalletFlowHarness:
 
     def process_output(self, process):
         if not process:
+            return ""
+        if process.poll() is None:
             return ""
         stdout = process.stdout.read().decode("utf-8", errors="replace") if process.stdout else ""
         stderr = process.stderr.read().decode("utf-8", errors="replace") if process.stderr else ""

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -9,6 +9,7 @@
 #include <QQmlContext>
 #include <QRegularExpression>
 #include <QStringList>
+#include <QVariantList>
 #include <qqml.h>
 
 #include <algorithm>
@@ -155,6 +156,60 @@ class MockBitcoinAddress : public QObject
     Q_OBJECT
 };
 
+class MockAddressListModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(Category category READ category WRITE setCategory NOTIFY categoryChanged)
+    Q_PROPERTY(QVariantList categoryOptions READ categoryOptions CONSTANT)
+    Q_PROPERTY(bool showUsed READ showUsed WRITE setShowUsed NOTIFY showUsedChanged)
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+
+public:
+    enum Category {
+        SingleUse,
+        Change
+    };
+    Q_ENUM(Category)
+
+    Category category() const { return m_category; }
+    QVariantList categoryOptions() const
+    {
+        return {
+            QVariantMap{{QStringLiteral("value"), static_cast<int>(SingleUse)}, {QStringLiteral("text"), QStringLiteral("Single-use")}},
+            QVariantMap{{QStringLiteral("value"), static_cast<int>(Change)}, {QStringLiteral("text"), QStringLiteral("Change")}},
+        };
+    }
+    bool showUsed() const { return m_show_used; }
+    int count() const { return 0; }
+
+    void setCategory(const Category category)
+    {
+        if (m_category == category) return;
+        m_category = category;
+        Q_EMIT categoryChanged();
+    }
+
+    void setShowUsed(const bool show_used)
+    {
+        if (m_show_used == show_used) return;
+        m_show_used = show_used;
+        Q_EMIT showUsedChanged();
+    }
+
+    Q_INVOKABLE void refresh() {}
+    Q_INVOKABLE bool setAddressLabel(const QString&, const QString&) { return false; }
+    Q_INVOKABLE QString addressAt(int) const { return {}; }
+
+Q_SIGNALS:
+    void categoryChanged();
+    void showUsedChanged();
+    void countChanged();
+
+private:
+    Category m_category{SingleUse};
+    bool m_show_used{false};
+};
+
 class MockPaymentRequest : public QObject
 {
     Q_OBJECT
@@ -165,6 +220,8 @@ class MockPaymentRequest : public QObject
     Q_PROPERTY(QString message MEMBER m_message NOTIFY messageChanged)
     Q_PROPERTY(QString address MEMBER m_address NOTIFY addressChanged)
     Q_PROPERTY(QString addressFormatted READ addressFormatted NOTIFY addressChanged)
+    Q_PROPERTY(bool needsUnlock MEMBER m_needs_unlock NOTIFY needsUnlockChanged)
+    Q_PROPERTY(QString unlockError MEMBER m_unlock_error NOTIFY unlockErrorChanged)
 
 public:
     QString m_id;
@@ -172,6 +229,8 @@ public:
     QString m_label;
     QString m_message;
     QString m_address;
+    bool m_needs_unlock{false};
+    QString m_unlock_error;
     MockBitcoinAmount m_amount{};
 
     QObject* amount() { return &m_amount; }
@@ -183,6 +242,8 @@ public:
         m_label.clear();
         m_message.clear();
         m_address.clear();
+        m_needs_unlock = false;
+        m_unlock_error.clear();
         m_amount.m_display = QStringLiteral("0.00000000");
         m_amount.m_unit = MockBitcoinAmount::BTC;
         Q_EMIT idChanged();
@@ -190,6 +251,8 @@ public:
         Q_EMIT labelChanged();
         Q_EMIT messageChanged();
         Q_EMIT addressChanged();
+        Q_EMIT needsUnlockChanged();
+        Q_EMIT unlockErrorChanged();
     }
 
 Q_SIGNALS:
@@ -198,6 +261,8 @@ Q_SIGNALS:
     void labelChanged();
     void messageChanged();
     void addressChanged();
+    void needsUnlockChanged();
+    void unlockErrorChanged();
 };
 
 class MockTransaction : public QObject
@@ -521,6 +586,7 @@ class MockWalletQmlModel : public QObject
     Q_PROPERTY(QObject* coinsListModel READ coinsListModel CONSTANT)
     Q_PROPERTY(QObject* currentTransaction READ currentTransaction CONSTANT)
     Q_PROPERTY(QObject* currentPaymentRequest READ currentPaymentRequest CONSTANT)
+    Q_PROPERTY(MockAddressListModel* addressListModel READ addressListModel CONSTANT)
     Q_PROPERTY(int targetBlocks READ targetBlocks WRITE setTargetBlocks NOTIFY targetBlocksChanged)
     Q_PROPERTY(QString estimatedFee READ estimatedFee NOTIFY feeEstimateRevisionChanged)
     Q_PROPERTY(bool customFeeEnabled READ customFeeEnabled WRITE setCustomFeeEnabled NOTIFY customFeeEnabledChanged)
@@ -563,6 +629,7 @@ public:
     QObject* coinsListModel() const { return m_coins_list_model; }
     QObject* currentTransaction() const { return m_current_transaction; }
     QObject* currentPaymentRequest() const { return m_current_payment_request; }
+    MockAddressListModel* addressListModel() { return &m_address_list_model; }
     int targetBlocks() const { return m_target_blocks; }
     QString estimatedFee() const
     {
@@ -684,14 +751,19 @@ public:
         }
         return m_send_transaction_result;
     }
-    Q_INVOKABLE void commitPaymentRequest()
+    Q_INVOKABLE bool commitPaymentRequest()
     {
         auto* request = qobject_cast<MockPaymentRequest*>(m_current_payment_request);
-        if (!request) return;
+        if (!request) return false;
         request->m_id = QStringLiteral("1");
         request->m_address = QStringLiteral("bcrt1qrequestaddress0000000000000000000000");
         Q_EMIT request->idChanged();
         Q_EMIT request->addressChanged();
+        return true;
+    }
+    Q_INVOKABLE bool commitPaymentRequestWithPassphrase(const QString&)
+    {
+        return commitPaymentRequest();
     }
     Q_INVOKABLE void clearSettingsError()
     {
@@ -783,6 +855,7 @@ private:
     int m_prepare_transaction_calls{0};
     int m_schedule_fee_estimates_calls{0};
     int m_send_transaction_calls{0};
+    MockAddressListModel m_address_list_model;
 };
 
 class MockWalletQmlModelTransaction : public QObject
@@ -1377,6 +1450,7 @@ public Q_SLOTS:
         );
         qmlRegisterType<MockBitcoinAmount>("org.bitcoincore.qt", 1, 0, "BitcoinAmount");
         qmlRegisterType<MockBitcoinAddress>("org.bitcoincore.qt", 1, 0, "BitcoinAddress");
+        qmlRegisterUncreatableType<MockAddressListModel>("org.bitcoincore.qt", 1, 0, "AddressListModel", "Test stub type");
         qmlRegisterType<MockPaymentRequest>("org.bitcoincore.qt", 1, 0, "PaymentRequest");
         qmlRegisterUncreatableType<MockTransaction>("org.bitcoincore.qt", 1, 0, "Transaction", "Test stub type");
         qmlRegisterUncreatableType<MockSendRecipient>("org.bitcoincore.qt", 1, 0, "SendRecipient", "Test stub type");

--- a/test/qml/tst_address_components.qml
+++ b/test/qml/tst_address_components.qml
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtTest 1.2
+import "../../qml/pages/wallet"
+
+TestCase {
+    name: "AddressComponents"
+    when: windowShown
+    width: 720
+    height: 480
+
+    function findObject(root, objectName) {
+        if (!root) {
+            return null
+        }
+        if (root.objectName === objectName) {
+            return root
+        }
+        const objectChildren = root.children || []
+        for (let i = 0; i < objectChildren.length; ++i) {
+            const childMatch = findObject(objectChildren[i], objectName)
+            if (childMatch) {
+                return childMatch
+            }
+        }
+        const visualChildren = root.childItems || []
+        for (let j = 0; j < visualChildren.length; ++j) {
+            const visualMatch = findObject(visualChildren[j], objectName)
+            if (visualMatch) {
+                return visualMatch
+            }
+        }
+        return null
+    }
+
+    Component {
+        id: rowComponent
+        AddressRow {
+            width: 520
+            address: "bcrt1qexampleaddress"
+            ellipsesAddress: "bcrt1qexa ... dress"
+            label: ""
+            category: "single-use"
+            currentBalance: "0.00000000"
+            displayAmount: "₿ 0.0"
+            hasAmount: false
+            scriptType: "P2WPKH"
+            isUsed: false
+            canEditLabel: true
+            canCreatePaymentRequest: true
+        }
+    }
+
+    Component {
+        id: detailsComponent
+        AddressDetails {
+            width: 480
+            address: "bcrt1qexampleaddress"
+            label: "Pizza"
+            amount: "₿ 1.25000000"
+            hasAmount: true
+            category: "single-use"
+            scriptType: "P2WPKH"
+            used: false
+        }
+    }
+
+    function test_row_uses_display_amount_and_emits_actions() {
+        const row = createTemporaryObject(rowComponent, this)
+        verify(row !== null)
+
+        const amountText = findObject(row, "addressRowAmountText")
+        verify(amountText !== null)
+        compare(amountText.text, "₿ 0.0")
+
+        let editRequested = false
+        row.editLabelRequested.connect(function(address, label) {
+            editRequested = address === "bcrt1qexampleaddress" && label === ""
+        })
+        const noteButton = findObject(row, "addressRowNoteButton")
+        verify(noteButton !== null)
+        noteButton.clicked()
+        verify(editRequested)
+
+        let menuRequested = false
+        row.menuRequested.connect(function(address, label, amount, hasAmount, category, scriptType, used, menuButton) {
+            menuRequested = address === "bcrt1qexampleaddress"
+                && amount === "₿ 0.0"
+                && hasAmount === false
+                && category === "single-use"
+                && scriptType === "P2WPKH"
+                && used === false
+                && menuButton !== null
+        })
+        const menuButton = findObject(row, "addressRowMenuButton")
+        verify(menuButton !== null)
+        menuButton.clicked()
+        verify(menuRequested)
+    }
+
+    function test_details_has_no_status_row_and_emits_actions() {
+        const details = createTemporaryObject(detailsComponent, this)
+        verify(details !== null)
+
+        let sawAmount = false
+        let sawStatus = false
+        function scanText(root) {
+            if (!root) {
+                return
+            }
+            if (root.text !== undefined) {
+                sawAmount = sawAmount || root.text === "₿ 1.25000000"
+                sawStatus = sawStatus || root.text === "Status"
+            }
+            const objectChildren = root.children || []
+            for (let i = 0; i < objectChildren.length; ++i) {
+                scanText(objectChildren[i])
+            }
+            const visualChildren = root.childItems || []
+            for (let j = 0; j < visualChildren.length; ++j) {
+                scanText(visualChildren[j])
+            }
+        }
+        scanText(details)
+        verify(sawAmount)
+        verify(!sawStatus)
+
+        let closed = false
+        details.closeRequested.connect(function() { closed = true })
+        const closeButton = findObject(details, "addressDetailsCloseButton")
+        if (closeButton !== null) {
+            closeButton.clicked()
+            verify(closed)
+        }
+    }
+}

--- a/test/qml/tst_walletsettings.qml
+++ b/test/qml/tst_walletsettings.qml
@@ -34,9 +34,18 @@ TestCase {
     function test_wallet_settings_password_and_backup_actions_remain_available() {
         const page = createWalletSettingsPage()
         let passwordRequests = 0
+        let addressRequests = 0
         page.passwordRequested.connect(function() {
             ++passwordRequests
         })
+        page.addressesRequested.connect(function() {
+            ++addressRequests
+        })
+
+        const addressesRow = findChild(page, "settingsAddresses")
+        verify(addressesRow !== null)
+        addressesRow.clicked()
+        compare(addressRequests, 1)
 
         const passwordRow = findChild(page, "walletSettingsPasswordRow")
         verify(passwordRow !== null)

--- a/test/test_addresslistmodel.cpp
+++ b/test/test_addresslistmodel.cpp
@@ -178,6 +178,7 @@ void AddressListModelTests::changeAddressesComeFromUnspentChangeOutputs()
     };
     interfaces::WalletTxOut change_out;
     change_out.txout = CTxOut{2 * COIN, GetScriptForDestination(change)};
+    change_out.time = 0;
 
     TestAddressWallet* wallet_ptr{wallet.get()};
     WalletQmlModel wallet_model{std::move(wallet)};

--- a/test/test_addresslistmodel.cpp
+++ b/test/test_addresslistmodel.cpp
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <test/mocks/mockwallet.h>
+
+#include <QVariantMap>
+
+#include <addresstype.h>
+#include <chainparams.h>
+#include <key_io.h>
+#include <outputtype.h>
+#include <primitives/transaction.h>
+#include <qml/models/addresslistmodel.h>
+#include <qml/models/walletqmlmodel.h>
+#include <uint256.h>
+#include <wallet/coincontrol.h>
+#include <wallet/types.h>
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace {
+CTxDestination TestDestination(uint8_t seed)
+{
+    std::vector<unsigned char> bytes(20, seed);
+    return WitnessV0KeyHash{uint160{bytes}};
+}
+
+CTransactionRef TransactionWithOutputs(const std::vector<CTxDestination>& destinations, const std::vector<CAmount>& amounts)
+{
+    CMutableTransaction tx;
+    tx.version = 2;
+    for (size_t i{0}; i < destinations.size(); ++i) {
+        tx.vout.emplace_back(amounts.at(i), GetScriptForDestination(destinations.at(i)));
+    }
+    return MakeTransactionRef(tx);
+}
+
+class TestAddressWallet final : public StubWallet
+{
+public:
+    std::string m_name{"test_wallet"};
+    std::vector<interfaces::WalletAddress> m_addresses;
+    std::map<CTxDestination, std::string> m_labels;
+    interfaces::Wallet::CoinsList m_coins;
+    std::set<interfaces::WalletTx> m_txs;
+    CTxDestination m_next_destination{TestDestination(100)};
+
+    std::string getWalletName() override { return m_name; }
+    util::Result<CTxDestination> getNewDestination(const OutputType, const std::string& label) override
+    {
+        m_labels[m_next_destination] = label;
+        m_addresses.emplace_back(m_next_destination, wallet::ISMINE_SPENDABLE, wallet::AddressPurpose::RECEIVE, label);
+        return m_next_destination;
+    }
+    bool isSpendable(const CTxDestination&) override { return true; }
+    bool setAddressBook(const CTxDestination& dest, const std::string& name, const std::optional<wallet::AddressPurpose>&) override
+    {
+        m_labels[dest] = name;
+        for (auto& address : m_addresses) {
+            if (address.dest == dest) {
+                address.name = name;
+            }
+        }
+        return true;
+    }
+    bool delAddressBook(const CTxDestination&) override { return false; }
+    bool getAddress(const CTxDestination& dest, std::string* name, wallet::isminetype* is_mine, wallet::AddressPurpose* purpose) override
+    {
+        for (const auto& address : m_addresses) {
+            if (address.dest != dest) continue;
+            if (name) *name = address.name;
+            if (is_mine) *is_mine = address.is_mine;
+            if (purpose) *purpose = address.purpose;
+            return true;
+        }
+        return false;
+    }
+    std::vector<interfaces::WalletAddress> getAddresses() override { return m_addresses; }
+    bool setAddressReceiveRequest(const CTxDestination&, const std::string&, const std::string&) override { return true; }
+    std::set<interfaces::WalletTx> getWalletTxs() override { return m_txs; }
+    interfaces::Wallet::CoinsList listCoins() override { return m_coins; }
+    bool hdEnabled() override { return true; }
+    bool canGetAddresses() override { return true; }
+    bool taprootEnabled() override { return true; }
+};
+
+interfaces::WalletTx WalletTxFor(const std::vector<CTxDestination>& destinations, const std::vector<CAmount>& amounts, const std::vector<bool>& is_change)
+{
+    interfaces::WalletTx wallet_tx;
+    wallet_tx.tx = TransactionWithOutputs(destinations, amounts);
+    wallet_tx.txout_address = destinations;
+    wallet_tx.txout_address_is_mine.assign(destinations.size(), wallet::ISMINE_SPENDABLE);
+    wallet_tx.txout_is_change = is_change;
+    return wallet_tx;
+}
+} // namespace
+
+class AddressListModelTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase();
+    void receiveAddressesHideUsedUntilEnabled();
+    void labelsCanBeEdited();
+    void changeAddressesComeFromUnspentChangeOutputs();
+};
+
+void AddressListModelTests::initTestCase()
+{
+    SelectParams(ChainType::REGTEST);
+}
+
+void AddressListModelTests::receiveAddressesHideUsedUntilEnabled()
+{
+    auto wallet{std::make_unique<TestAddressWallet>()};
+    const CTxDestination unused{TestDestination(1)};
+    const CTxDestination used{TestDestination(2)};
+    wallet->m_addresses = {
+        {unused, wallet::ISMINE_SPENDABLE, wallet::AddressPurpose::RECEIVE, "unused"},
+        {used, wallet::ISMINE_SPENDABLE, wallet::AddressPurpose::RECEIVE, "used"},
+        {TestDestination(3), wallet::ISMINE_SPENDABLE, wallet::AddressPurpose::SEND, "send"},
+    };
+
+    TestAddressWallet* wallet_ptr{wallet.get()};
+    WalletQmlModel wallet_model{std::move(wallet)};
+    AddressListModel* model{wallet_model.addressListModel()};
+    wallet_ptr->m_txs.insert(WalletTxFor({used}, {COIN}, {false}));
+    model->refresh();
+
+    QCOMPARE(model->rowCount(), 1);
+    QCOMPARE(model->data(model->index(0), AddressListModel::LabelRole).toString(), QStringLiteral("unused"));
+    QCOMPARE(model->data(model->index(0), AddressListModel::DisplayAmountRole).toString(), QStringLiteral("₿ 0.0"));
+    QCOMPARE(model->data(model->index(0), AddressListModel::HasAmountRole).toBool(), false);
+
+    model->setShowUsed(true);
+    QCOMPARE(model->rowCount(), 2);
+}
+
+void AddressListModelTests::labelsCanBeEdited()
+{
+    auto wallet{std::make_unique<TestAddressWallet>()};
+    const CTxDestination dest{TestDestination(1)};
+    wallet->m_addresses = {
+        {dest, wallet::ISMINE_SPENDABLE, wallet::AddressPurpose::RECEIVE, "first label"},
+    };
+    WalletQmlModel wallet_model{std::move(wallet)};
+    AddressListModel* model{wallet_model.addressListModel()};
+    model->refresh();
+
+    const QString address{QString::fromStdString(EncodeDestination(dest))};
+    QCOMPARE(model->rowCount(), 1);
+    QCOMPARE(model->data(model->index(0), AddressListModel::LabelRole).toString(), QStringLiteral("first label"));
+
+    QVERIFY(model->setAddressLabel(address, QStringLiteral("updated label")));
+    QCOMPARE(model->data(model->index(0), AddressListModel::LabelRole).toString(), QStringLiteral("updated label"));
+}
+
+void AddressListModelTests::changeAddressesComeFromUnspentChangeOutputs()
+{
+    auto wallet{std::make_unique<TestAddressWallet>()};
+    const CTxDestination receive{TestDestination(10)};
+    const CTxDestination change{TestDestination(11)};
+    const CTxDestination spent_change{TestDestination(12)};
+    const interfaces::WalletTx change_tx{WalletTxFor({receive, change, spent_change}, {COIN, 2 * COIN, 3 * COIN}, {false, true, true})};
+    const Txid txid{change_tx.tx->GetHash()};
+    wallet->m_addresses = {
+        {receive, wallet::ISMINE_SPENDABLE, wallet::AddressPurpose::RECEIVE, "receive"},
+    };
+    interfaces::WalletTxOut change_out;
+    change_out.txout = CTxOut{2 * COIN, GetScriptForDestination(change)};
+
+    TestAddressWallet* wallet_ptr{wallet.get()};
+    WalletQmlModel wallet_model{std::move(wallet)};
+    AddressListModel* model{wallet_model.addressListModel()};
+    wallet_ptr->m_txs.insert(change_tx);
+    wallet_ptr->m_coins[receive].push_back({COutPoint{txid, 1}, change_out});
+    model->setCategory(AddressListModel::Change);
+
+    QCOMPARE(model->rowCount(), 1);
+    QCOMPARE(model->data(model->index(0), AddressListModel::AddressRole).toString(), QString::fromStdString(EncodeDestination(change)));
+    QCOMPARE(model->data(model->index(0), AddressListModel::CategoryRole).toString(), QStringLiteral("change"));
+    QCOMPARE(model->data(model->index(0), AddressListModel::DisplayAmountRole).toString(), QStringLiteral("₿ 2.00000000"));
+    QCOMPARE(model->data(model->index(0), AddressListModel::HasAmountRole).toBool(), true);
+}
+
+#ifdef BITCOINQML_NO_TEST_MAIN
+#include <test/qt_test_registry.h>
+BITCOINQML_REGISTER_QT_TEST(AddressListModelTests)
+#else
+QTEST_MAIN(AddressListModelTests)
+#endif
+#include "test_addresslistmodel.moc"

--- a/test/test_bumptransactionmodel.cpp
+++ b/test/test_bumptransactionmodel.cpp
@@ -214,10 +214,10 @@ private Q_SLOTS:
     }
 };
 
-int RunBumpTransactionModelTests(int argc, char* argv[])
-{
-    BumpTransactionModelTests test;
-    return QTest::qExec(&test, argc, argv);
-}
-
+#ifdef BITCOINQML_NO_TEST_MAIN
+#include <test/qt_test_registry.h>
+BITCOINQML_REGISTER_QT_TEST(BumpTransactionModelTests)
+#else
+QTEST_MAIN(BumpTransactionModelTests)
+#endif
 #include "test_bumptransactionmodel.moc"

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -348,6 +348,16 @@ private Q_SLOTS:
     void encryptWalletUpdatesSecurityState();
     void changeWalletPassphraseForwardsPasswords();
     void backupWalletForwardsPath();
+    void signVerifyMessageRejectsNonP2PKHAddress();
+    void signVerifyMessageSignsWithLegacyP2PKHAddress();
+    void signVerifyMessageSignsEmptyMessage();
+    void signVerifyMessageWithPassphraseUnlocksSignsAndRelocks();
+    void signVerifyMessageWrongPassphraseSurfacesErrorAndDoesNotRelock();
+    void signVerifyMessageSurfacesSigningFailure();
+    void signVerifyMessageWithoutWalletSurfacesError();
+    void signVerifyMessageClearResetsState();
+    void signVerifyMessageVerifiesValidSignature();
+    void signVerifyMessageVerifyRejectsEmptySignature();
 };
 
 void WalletQmlModelTests::initTestCase()
@@ -1154,6 +1164,161 @@ void WalletQmlModelTests::sendTransactionCommitsPreparedTransactionWithoutUnlock
     QVERIFY(wallet->fill_psbt_sign_args.empty());
     QVERIFY(model->transactionError().isEmpty());
     QVERIFY(!model->transactionNeedsUnlock());
+}
+
+void WalletQmlModelTests::signVerifyMessageRejectsNonP2PKHAddress()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    auto* sign_verify = model->signVerifyMessageModel();
+
+    QVERIFY(!sign_verify->isLegacyP2PKHAddress(QString::fromLatin1(NON_P2PKH_ADDRESS)));
+    QVERIFY(!sign_verify->signMessage(QString::fromLatin1(NON_P2PKH_ADDRESS), "message"));
+    QCOMPARE(sign_verify->signingError(), QString("Enter a legacy P2PKH bitcoin address."));
+    QCOMPARE(wallet->sign_message_calls, 0);
+}
+
+void WalletQmlModelTests::signVerifyMessageSignsWithLegacyP2PKHAddress()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->encrypted = false;
+    wallet->locked = false;
+    auto* sign_verify = model->signVerifyMessageModel();
+
+    QVERIFY(sign_verify->isLegacyP2PKHAddress(VALID_MAINNET_ADDRESS));
+    QVERIFY(sign_verify->signMessage(VALID_MAINNET_ADDRESS, "hello"));
+    QCOMPARE(wallet->sign_message_calls, 1);
+    QCOMPARE(wallet->last_signed_message, std::string("hello"));
+    QCOMPARE(sign_verify->signature(), QString("fake-signature"));
+    QVERIFY(sign_verify->signingError().isEmpty());
+    QVERIFY(!sign_verify->signingNeedsUnlock());
+}
+
+void WalletQmlModelTests::signVerifyMessageWithPassphraseUnlocksSignsAndRelocks()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    auto* sign_verify = model->signVerifyMessageModel();
+
+    QVERIFY(!sign_verify->signMessage(VALID_MAINNET_ADDRESS, "hello"));
+    QVERIFY(sign_verify->signingNeedsUnlock());
+    QCOMPARE(wallet->unlock_calls, 0);
+
+    QVERIFY(sign_verify->signMessageWithPassphrase(VALID_MAINNET_ADDRESS, "hello", "secret"));
+    QCOMPARE(wallet->unlock_calls, 1);
+    QCOMPARE(wallet->lock_calls, 1);
+    QVERIFY(wallet->locked);
+    QCOMPARE(sign_verify->signature(), QString("fake-signature"));
+}
+
+void WalletQmlModelTests::signVerifyMessageSurfacesSigningFailure()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->encrypted = false;
+    wallet->locked = false;
+    wallet->sign_message_fn = [](const std::string&, const PKHash&, std::string&) {
+        return SigningResult::PRIVATE_KEY_NOT_AVAILABLE;
+    };
+    auto* sign_verify = model->signVerifyMessageModel();
+
+    QVERIFY(!sign_verify->signMessage(VALID_MAINNET_ADDRESS, "hello"));
+    QVERIFY(sign_verify->signature().isEmpty());
+    QCOMPARE(sign_verify->signingError(), QString("Private key not available"));
+}
+
+void WalletQmlModelTests::signVerifyMessageVerifiesValidSignature()
+{
+    CKey key;
+    key.MakeNewKey(true);
+    const QString address{QString::fromStdString(EncodeDestination(PKHash(key.GetPubKey())))};
+    const QString message{"hello"};
+    std::string signature;
+    QVERIFY(MessageSign(key, message.toStdString(), signature));
+
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    auto* sign_verify = model->signVerifyMessageModel();
+
+    QVERIFY(sign_verify->isLegacyP2PKHAddress(address));
+    QVERIFY(sign_verify->verifyMessage(address, message, QString::fromStdString(signature)));
+    QVERIFY(!sign_verify->verifyMessage(address, message + "!", QString::fromStdString(signature)));
+    QVERIFY(!sign_verify->verifyMessage(QString::fromLatin1(NON_P2PKH_ADDRESS), message, QString::fromStdString(signature)));
+}
+
+void WalletQmlModelTests::signVerifyMessageSignsEmptyMessage()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->encrypted = false;
+    wallet->locked = false;
+    auto* sign_verify = model->signVerifyMessageModel();
+
+    QVERIFY(sign_verify->signMessage(VALID_MAINNET_ADDRESS, QString()));
+    QCOMPARE(wallet->sign_message_calls, 1);
+    QCOMPARE(wallet->last_signed_message, std::string{});
+    QCOMPARE(sign_verify->signature(), QString("fake-signature"));
+    QVERIFY(sign_verify->signingError().isEmpty());
+}
+
+void WalletQmlModelTests::signVerifyMessageWrongPassphraseSurfacesErrorAndDoesNotRelock()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->unlock_fn = [wallet](const SecureString& passphrase) {
+        ++wallet->unlock_calls;
+        wallet->unlock_passphrases.emplace_back(passphrase.begin(), passphrase.end());
+        return false;
+    };
+    auto* sign_verify = model->signVerifyMessageModel();
+
+    QVERIFY(!sign_verify->signMessageWithPassphrase(VALID_MAINNET_ADDRESS, "hello", "wrong"));
+    QCOMPARE(wallet->unlock_calls, 1);
+    QCOMPARE(wallet->lock_calls, 0);
+    QCOMPARE(wallet->sign_message_calls, 0);
+    QCOMPARE(sign_verify->signingError(), QString("The wallet password you entered was incorrect."));
+    QVERIFY(sign_verify->signature().isEmpty());
+}
+
+void WalletQmlModelTests::signVerifyMessageWithoutWalletSurfacesError()
+{
+    SignVerifyMessageModel sign_verify{nullptr};
+
+    QVERIFY(!sign_verify.signMessage(VALID_MAINNET_ADDRESS, "hello"));
+    QCOMPARE(sign_verify.signingError(), QString("No wallet is selected."));
+    QVERIFY(sign_verify.signature().isEmpty());
+}
+
+void WalletQmlModelTests::signVerifyMessageClearResetsState()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->encrypted = false;
+    wallet->locked = false;
+    auto* sign_verify = model->signVerifyMessageModel();
+
+    QVERIFY(sign_verify->signMessage(VALID_MAINNET_ADDRESS, "hello"));
+    QVERIFY(!sign_verify->signature().isEmpty());
+
+    QVERIFY(!sign_verify->signMessage(QString::fromLatin1(NON_P2PKH_ADDRESS), "hello"));
+    QVERIFY(!sign_verify->signingError().isEmpty());
+    QVERIFY(sign_verify->signature().isEmpty());
+
+    sign_verify->clear();
+    QVERIFY(sign_verify->signature().isEmpty());
+    QVERIFY(sign_verify->signingError().isEmpty());
+    QVERIFY(!sign_verify->signingNeedsUnlock());
+}
+
+void WalletQmlModelTests::signVerifyMessageVerifyRejectsEmptySignature()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    auto* sign_verify = model->signVerifyMessageModel();
+
+    QVERIFY(!sign_verify->verifyMessage(VALID_MAINNET_ADDRESS, "hello", QString()));
+    QVERIFY(!sign_verify->verifyMessage(VALID_MAINNET_ADDRESS, "hello", QStringLiteral("   ")));
 }
 
 void WalletQmlModelTests::sendTransactionWithPrivateKeysDisabledDoesNotCommit()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -11,26 +11,45 @@
 #include <qml/models/walletqmlmodeltransaction.h>
 
 #include <chainparams.h>
+#include <addresstype.h>
 #include <common/messages.h>
+#include <common/signmessage.h>
+#include <interfaces/handler.h>
+#include <interfaces/wallet.h>
+#include <key.h>
 #include <key_io.h>
+#include <outputtype.h>
 #include <psbt.h>
 #include <primitives/transaction.h>
+#include <wallet/coincontrol.h>
+#include <wallet/types.h>
 
+#include <QSettings>
 #include <QSignalSpy>
 #include <QSemaphore>
+#include <QVariantList>
+#include <QVariantMap>
 
 #include <algorithm>
 #include <atomic>
+#include <functional>
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
-#include <QSettings>
-
 namespace {
+std::unique_ptr<interfaces::Handler> MakeNoopHandler()
+{
+    return interfaces::MakeCleanupHandler([] {});
+}
+
+constexpr auto NON_P2PKH_ADDRESS{"bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj"};
+
+using ::testing::AtLeast;
 using ::testing::Invoke;
 using ::testing::NiceMock;
 using ::testing::Return;
-using ::testing::AtLeast;
 
 constexpr auto FEE_ESTIMATE_TIMEOUT_MS{3'000};
 const auto VALID_MAINNET_ADDRESS = QStringLiteral("1BoatSLRHtKNngkdXEeobR76b53LETtpyT");
@@ -95,6 +114,8 @@ public:
     bool locked{true};
     bool private_keys_disabled{false};
     bool external_signer{false};
+    bool taproot_enabled{true};
+    OutputType default_address_type{OutputType::BECH32};
     CAmount balance{50'000};
     int encrypt_calls{0};
     int change_passphrase_calls{0};
@@ -104,9 +125,14 @@ public:
     int unlock_calls{0};
     int lock_calls{0};
     int commit_calls{0};
+    int get_new_destination_calls{0};
     std::vector<std::string> unlock_passphrases;
+    std::vector<OutputType> new_destination_types;
+    std::vector<std::string> new_destination_labels;
     std::vector<bool> create_transaction_sign_args;
     std::vector<bool> fill_psbt_sign_args;
+    int sign_message_calls{0};
+    std::string last_signed_message;
 
     std::function<util::Result<CTransactionRef>(const std::vector<wallet::CRecipient>&,
                                                 const wallet::CCoinControl&,
@@ -128,6 +154,12 @@ public:
         locked = false;
         return true;
     };
+    std::function<util::Result<CTxDestination>(OutputType, const std::string&)> get_new_destination_fn = [this](OutputType type, const std::string& label) -> util::Result<CTxDestination> {
+        ++get_new_destination_calls;
+        new_destination_types.push_back(type);
+        new_destination_labels.push_back(label);
+        return DecodeDestination(VALID_MAINNET_ADDRESS.toStdString());
+    };
     std::function<std::optional<common::PSBTError>(std::optional<int>,
                                                    bool,
                                                    bool,
@@ -143,6 +175,13 @@ public:
             fill_psbt_sign_args.push_back(sign);
             complete = sign;
             return std::nullopt;
+        };
+    std::function<SigningResult(const std::string&, const PKHash&, std::string&)>
+        sign_message_fn = [this](const std::string& message, const PKHash&, std::string& signature) {
+            ++sign_message_calls;
+            last_signed_message = message;
+            signature = "fake-signature";
+            return SigningResult::OK;
         };
 
     bool encryptWallet(const SecureString& passphrase) override
@@ -162,6 +201,10 @@ public:
     }
     bool unlock(const SecureString& wallet_passphrase) override { return unlock_fn(wallet_passphrase); }
     bool isLocked() override { return locked; }
+    util::Result<CTxDestination> getNewDestination(const OutputType type, const std::string& label) override
+    {
+        return get_new_destination_fn(type, label);
+    }
     bool changeWalletPassphrase(const SecureString& old_passphrase, const SecureString& new_passphrase) override
     {
         ++change_passphrase_calls;
@@ -178,14 +221,10 @@ public:
         return !path.empty();
     }
     std::string getWalletName() override { return "fake-wallet"; }
-    util::Result<CTxDestination> getNewDestination(const OutputType, const std::string&) override
-    {
-        return CTxDestination{CNoDestination{}};
-    }
     bool getPubKey(const CScript&, const CKeyID&, CPubKey&) override { return false; }
-    SigningResult signMessage(const std::string&, const PKHash&, std::string&) override
+    SigningResult signMessage(const std::string& message, const PKHash& pkhash, std::string& signature) override
     {
-        return SigningResult::PRIVATE_KEY_NOT_AVAILABLE;
+        return sign_message_fn(message, pkhash, signature);
     }
     bool isSpendable(const CTxDestination&) override { return false; }
     bool setAddressBook(const CTxDestination&, const std::string&, const std::optional<wallet::AddressPurpose>&) override { return true; }
@@ -235,9 +274,17 @@ public:
     bool hdEnabled() override { return true; }
     bool canGetAddresses() override { return true; }
     bool privateKeysDisabled() override { return private_keys_disabled; }
-    bool taprootEnabled() override { return true; }
+    bool taprootEnabled() override { return taproot_enabled; }
     bool hasExternalSigner() override { return external_signer; }
-    OutputType getDefaultAddressType() override { return OutputType::BECH32; }
+    OutputType getDefaultAddressType() override { return default_address_type; }
+    CAmount getDefaultMaxTxFee() override { return COIN; }
+    void remove() override {}
+    std::unique_ptr<interfaces::Handler> handleUnload(UnloadFn) override { return MakeNoopHandler(); }
+    std::unique_ptr<interfaces::Handler> handleShowProgress(ShowProgressFn) override { return MakeNoopHandler(); }
+    std::unique_ptr<interfaces::Handler> handleStatusChanged(StatusChangedFn) override { return MakeNoopHandler(); }
+    std::unique_ptr<interfaces::Handler> handleAddressBookChanged(AddressBookChangedFn) override { return MakeNoopHandler(); }
+    std::unique_ptr<interfaces::Handler> handleTransactionChanged(TransactionChangedFn) override { return MakeNoopHandler(); }
+    std::unique_ptr<interfaces::Handler> handleCanGetAddressesChanged(CanGetAddressesChangedFn) override { return MakeNoopHandler(); }
 };
 
 std::unique_ptr<WalletQmlModel> MakeWalletModel(FakePasswordWallet*& wallet_out)
@@ -263,8 +310,12 @@ class WalletQmlModelTests : public QObject
 {
     Q_OBJECT
 
+private:
+    std::unique_ptr<ECC_Context> m_ecc_context;
+
 private Q_SLOTS:
     void initTestCase();
+    void cleanupTestCase();
     void feeTargetIndex_mapsStandardTargets();
     void estimatedFeeForTarget_returnsEmptyWhenUnavailable();
     void scheduleFeeEstimates_populatesFormattedEstimates();
@@ -278,6 +329,12 @@ private Q_SLOTS:
     void scheduleFeeEstimates_usesSelectedCoinsInCoinControl();
     void scheduleFeeEstimates_debouncesRapidRestarts();
     void transactionChangedEmitsBalanceChanged();
+    void commitPaymentRequestUsesSelectedAddressType();
+    void commitPaymentRequestOnLockedWalletSignalsNeedsUnlock();
+    void commitPaymentRequestWithPassphraseUnlocksRetriesAndRelocks();
+    void commitPaymentRequestWithPassphraseWrongPasswordSurfacesError();
+    void availableReceiveAddressTypesHideUnavailableTaproot();
+    void receiveAddressTypeDefaultPersistsPerWallet();
     void prepareTransactionOnLockedWalletRequiresPassword();
     void prepareTransactionWithPrivateKeysDisabledDoesNotRequirePassword();
     void prepareTransactionWithPassphraseForwardsUtf8Bytes();
@@ -296,6 +353,12 @@ private Q_SLOTS:
 void WalletQmlModelTests::initTestCase()
 {
     SelectParams(ChainType::MAIN);
+    m_ecc_context = std::make_unique<ECC_Context>();
+}
+
+void WalletQmlModelTests::cleanupTestCase()
+{
+    m_ecc_context.reset();
 }
 
 void WalletQmlModelTests::displayNameDefaultsToWalletName()
@@ -366,6 +429,48 @@ void WalletQmlModelTests::backupWalletForwardsPath()
     QCOMPARE(wallet->backup_calls, 1);
     QCOMPARE(wallet->last_backup_path, std::string("/tmp/fake-wallet.bak"));
     QVERIFY(model->settingsError().isEmpty());
+}
+
+void WalletQmlModelTests::availableReceiveAddressTypesHideUnavailableTaproot()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+
+    QVariantList types = model->availableReceiveAddressTypes();
+    QCOMPARE(types.size(), 4);
+    QCOMPARE(types.front().toMap().value("id").toString(), QString("bech32m"));
+
+    wallet->taproot_enabled = false;
+    types = model->availableReceiveAddressTypes();
+    QCOMPARE(types.size(), 3);
+    for (const QVariant& type : types) {
+        QVERIFY(type.toMap().value("id").toString() != QString("bech32m"));
+    }
+}
+
+void WalletQmlModelTests::receiveAddressTypeDefaultPersistsPerWallet()
+{
+    QSettings settings;
+    settings.remove("receiveAddressTypes/fake-wallet");
+    settings.sync();
+
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->default_address_type = OutputType::BECH32;
+
+    QCOMPARE(model->defaultReceiveAddressType(), QString("bech32"));
+
+    model->setDefaultReceiveAddressType("p2sh-segwit");
+    QCOMPARE(model->defaultReceiveAddressType(), QString("p2sh-segwit"));
+
+    model->setDefaultReceiveAddressType("bech32m");
+    QCOMPARE(model->defaultReceiveAddressType(), QString("bech32m"));
+
+    wallet->taproot_enabled = false;
+    QCOMPARE(model->defaultReceiveAddressType(), QString("bech32"));
+
+    settings.remove("receiveAddressTypes/fake-wallet");
+    settings.sync();
 }
 
 void WalletQmlModelTests::feeTargetIndex_mapsStandardTargets()
@@ -831,6 +936,100 @@ void WalletQmlModelTests::transactionChangedEmitsBalanceChanged()
 
     QTRY_COMPARE(balance_spy.count(), 1);
     QCOMPARE(model.balance(), QStringLiteral("75.00000000"));
+}
+
+void WalletQmlModelTests::commitPaymentRequestUsesSelectedAddressType()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+
+    model->currentPaymentRequest()->setLabel(QStringLiteral("typed receive"));
+    model->currentPaymentRequest()->setAddressType(QStringLiteral("bech32m"));
+
+    QVERIFY(model->commitPaymentRequest());
+    QCOMPARE(wallet->get_new_destination_calls, 1);
+    QCOMPARE(wallet->new_destination_types.size(), size_t{1});
+    QCOMPARE(wallet->new_destination_types.front(), OutputType::BECH32M);
+    QCOMPARE(wallet->new_destination_labels.size(), size_t{1});
+    QCOMPARE(wallet->new_destination_labels.front(), std::string{"typed receive"});
+}
+
+void WalletQmlModelTests::commitPaymentRequestOnLockedWalletSignalsNeedsUnlock()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->get_new_destination_fn = [wallet](OutputType, const std::string& label) -> util::Result<CTxDestination> {
+        ++wallet->get_new_destination_calls;
+        wallet->new_destination_labels.push_back(label);
+        if (wallet->locked) {
+            return util::Error{Untranslated("keypool empty")};
+        }
+        return DecodeDestination(VALID_MAINNET_ADDRESS.toStdString());
+    };
+
+    QVERIFY(!model->commitPaymentRequest());
+    QVERIFY(model->currentPaymentRequest()->needsUnlock());
+    QVERIFY(model->currentPaymentRequest()->unlockError().isEmpty());
+    QCOMPARE(wallet->get_new_destination_calls, 1);
+    QCOMPARE(wallet->unlock_calls, 0);
+    QVERIFY(wallet->locked);
+}
+
+void WalletQmlModelTests::commitPaymentRequestWithPassphraseUnlocksRetriesAndRelocks()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->get_new_destination_fn = [wallet](OutputType, const std::string& label) -> util::Result<CTxDestination> {
+        ++wallet->get_new_destination_calls;
+        wallet->new_destination_labels.push_back(label);
+        if (wallet->locked) {
+            return util::Error{Untranslated("keypool empty")};
+        }
+        return DecodeDestination(VALID_MAINNET_ADDRESS.toStdString());
+    };
+
+    QVERIFY(!model->commitPaymentRequest());
+    QVERIFY(model->currentPaymentRequest()->needsUnlock());
+
+    const QString passphrase{QString::fromUtf8("secret")};
+    QVERIFY(model->commitPaymentRequestWithPassphrase(passphrase));
+    QCOMPARE(wallet->unlock_calls, 1);
+    QCOMPARE(wallet->unlock_passphrases.size(), size_t{1});
+    QCOMPARE(wallet->unlock_passphrases.back(), std::string{"secret"});
+    QCOMPARE(wallet->lock_calls, 1);
+    QVERIFY(wallet->locked);
+    QCOMPARE(wallet->get_new_destination_calls, 2);
+    QVERIFY(!model->currentPaymentRequest()->needsUnlock());
+    QVERIFY(model->currentPaymentRequest()->unlockError().isEmpty());
+    QVERIFY(!model->currentPaymentRequest()->address().isEmpty());
+}
+
+void WalletQmlModelTests::commitPaymentRequestWithPassphraseWrongPasswordSurfacesError()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->get_new_destination_fn = [wallet](OutputType, const std::string& label) -> util::Result<CTxDestination> {
+        ++wallet->get_new_destination_calls;
+        wallet->new_destination_labels.push_back(label);
+        if (wallet->locked) {
+            return util::Error{Untranslated("keypool empty")};
+        }
+        return DecodeDestination(VALID_MAINNET_ADDRESS.toStdString());
+    };
+    wallet->unlock_fn = [wallet](const SecureString& passphrase) {
+        ++wallet->unlock_calls;
+        wallet->unlock_passphrases.emplace_back(passphrase.begin(), passphrase.end());
+        return false;
+    };
+
+    QVERIFY(!model->commitPaymentRequest());
+    QVERIFY(!model->commitPaymentRequestWithPassphrase(QStringLiteral("wrong")));
+    QCOMPARE(wallet->unlock_calls, 1);
+    QCOMPARE(wallet->lock_calls, 0);
+    QCOMPARE(wallet->get_new_destination_calls, 1);
+    QCOMPARE(model->currentPaymentRequest()->unlockError(),
+             QStringLiteral("The wallet password you entered was incorrect."));
+    QVERIFY(model->currentPaymentRequest()->address().isEmpty());
 }
 
 void WalletQmlModelTests::prepareTransactionOnLockedWalletRequiresPassword()


### PR DESCRIPTION
Add support to view receive and change addresses. (Fixes https://github.com/bitcoin-core/gui-qml/issues/519)

- Add `addresslistmodel` 
  - exposes wallet-owned receive and change addresses to QML including labels, usage state, balances, formatter amounts, script type etc.
  - This will be owned by `WalletQmlModel` which provides helper methods related to addresses.
- Add a reusable control `SegmentedPicker.qml` for segmented picker with multiple options.

Implement Sign/verify message page in Wallet Settings. Fixes https://github.com/bitcoin-core/gui-qml/issues/524

Add SignVerifyMessageModel to coordinate signing/verifying and will be owned
by WalletQmlModel.
This change was dependent on generating a legacy P2PKH addresses which
was missing in the receive flow. Implemented a picker to choose address types.
Implement functional, unit tests.

#### Tests
- Updated functional wallet harness so app-only GUI tests do not require a built bitcoind.

### Screenshots

<details>
<summary>Address list</summary>

<img width="1179" height="978" alt="Single use address" src="https://github.com/user-attachments/assets/63a41210-b7cc-4267-959e-4bbf471a7d85" />

<img width="1179" height="978" alt="Change address" src="https://github.com/user-attachments/assets/b2cc1a82-37f1-42f7-b4b5-2e7f30332bf7" />

<img width="1226" height="1092" alt="Screenshot 2026-05-18 at 5 17 45 PM" src="https://github.com/user-attachments/assets/8a9771ab-e12e-41bd-b014-9b9281c2ac0e" />

</details> 

<details>
<summary> Sign / Verify message </summary>

<img width="1179" height="978" alt="Screenshot 2026-05-18 at 4 54 42 PM" src="https://github.com/user-attachments/assets/c44279fc-4d11-4bcd-9bd1-ee208134d433" />

<img width="1218" height="1023" alt="Screenshot 2026-05-18 at 4 55 07 PM" src="https://github.com/user-attachments/assets/f3ebc75c-62fa-41cc-956e-82c5cac9e6d5" />

<img width="1218" height="1023" alt="Screenshot 2026-05-18 at 4 55 03 PM" src="https://github.com/user-attachments/assets/762cd549-7afb-46c3-acc8-62396d566adb" />

</details> 