### PR TITLE
qml: remove unused qt guiutil include

### DIFF
--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -18,7 +18,6 @@
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <noui.h>
-#include <qt/guiutil.h>
 #include <qml/appmode.h>
 #include <qml/bitcoinamount.h>
 #include <qml/clipboard.h>


### PR DESCRIPTION
This removes the stale `qt/guiutil.h` include from `qml/bitcoin.cpp`. The file no longer references `GUIUtil`, so the include is unnecessary and keeps a `bitcoin/src/qt` dependency visible in the QML runtime source scan.

Related to #505.

Testing:
- `git grep -n -E "#include <qt/guiutil.h>|GUIUtil" -- qml test CMakeLists.txt || true`
- `cmake -S . -B /tmp/gui-qml-remove-guiutil-build -DBUILD_APP_TESTS=ON`
- `cmake --build /tmp/gui-qml-remove-guiutil-build --target bitcoinqml -j2`