### PR TITLE
qml: Add typography design tokens to Theme

### DIFF
--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -20,6 +20,7 @@
 #include <noui.h>
 #include <qml/appmode.h>
 #include <qml/bitcoinamount.h>
+#include <qml/buildinfo.h>
 #include <qml/clipboard.h>
 #ifdef __ANDROID__
 #include <qml/androidnotifier.h>
@@ -129,8 +130,10 @@ bool InitErrorMessageBox(
     QQmlApplicationEngine engine;
 
     AppMode app_mode = SetupAppMode();
+    BuildInfo build_info;
 
     qmlRegisterSingletonInstance<AppMode>("org.bitcoincore.qt", 1, 0, "AppMode", &app_mode);
+    qmlRegisterSingletonInstance<BuildInfo>("org.bitcoincore.qt", 1, 0, "BuildInfo", &build_info);
     engine.rootContext()->setContextProperty("message", QString::fromStdString(message.translated));
     engine.load(QUrl(QStringLiteral("qrc:///qml/pages/initerrormessage.qml")));
     if (engine.rootObjects().isEmpty()) {
@@ -351,9 +354,11 @@ int QmlGuiMain(int argc, char* argv[])
     engine.rootContext()->setContextProperty("needOnboarding", need_onboarding);
 
     AppMode app_mode = SetupAppMode();
+    BuildInfo build_info;
     Clipboard clipboard;
 
     qmlRegisterSingletonInstance<AppMode>("org.bitcoincore.qt", 1, 0, "AppMode", &app_mode);
+    qmlRegisterSingletonInstance<BuildInfo>("org.bitcoincore.qt", 1, 0, "BuildInfo", &build_info);
     qmlRegisterSingletonInstance<Clipboard>("org.bitcoincore.qt", 1, 0, "Clipboard", &clipboard);
     qmlRegisterType<BlockClockDial>("org.bitcoincore.qt", 1, 0, "BlockClockDial");
     qmlRegisterType<LineGraph>("org.bitcoincore.qt", 1, 0, "LineGraph");

--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -87,6 +87,7 @@
         <file>pages/settings/SettingsBlockClockDisplayMode.qml</file>
         <file>pages/settings/SettingsConnection.qml</file>
         <file>pages/settings/SettingsDebugLog.qml</file>
+        <file>pages/settings/SettingsDesignSystem.qml</file>
         <file>pages/settings/SettingsDeveloper.qml</file>
         <file>pages/settings/SettingsDisplay.qml</file>
         <file>pages/settings/SettingsProxy.qml</file>

--- a/qml/buildinfo.h
+++ b/qml/buildinfo.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_BUILDINFO_H
+#define BITCOIN_QML_BUILDINFO_H
+
+#include <QObject>
+
+class BuildInfo : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool isDebug READ isDebug CONSTANT)
+
+public:
+    explicit BuildInfo(QObject* parent = nullptr) : QObject(parent) {}
+
+    bool isDebug() const
+    {
+#ifndef NDEBUG
+        return true;
+#else
+        return false;
+#endif
+    }
+};
+
+#endif // BITCOIN_QML_BUILDINFO_H

--- a/qml/components/ThemeSettings.qml
+++ b/qml/components/ThemeSettings.qml
@@ -6,11 +6,14 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import Qt.labs.settings 1.0
+import org.bitcoincore.qt 1.0
 import "../controls"
 
 ColumnLayout {
     id: root
     spacing: 4
+
+    signal designSystemRequested
 
     Settings {
         id: settings
@@ -44,5 +47,30 @@ ColumnLayout {
         onClicked: {
             Theme.dark = true;
         }
+    }
+    CoreText {
+        Layout.topMargin: 36
+        Layout.fillWidth: true
+        Layout.leftMargin: 4
+        visible: BuildInfo.isDebug
+        horizontalAlignment: Text.AlignLeft
+        bold: true
+        font.pixelSize: 13
+        color: Theme.color.neutral7
+        text: qsTr("Developer")
+    }
+    Separator {
+        Layout.fillWidth: true
+        visible: BuildInfo.isDebug
+    }
+    Setting {
+        id: gotoDesignSystem
+        Layout.fillWidth: true
+        visible: BuildInfo.isDebug
+        header: qsTr("Design system")
+        actionItem: CaretRightIcon {
+            color: gotoDesignSystem.stateColor
+        }
+        onClicked: root.designSystemRequested()
     }
 }

--- a/qml/controls/Theme.qml
+++ b/qml/controls/Theme.qml
@@ -146,7 +146,7 @@ Control {
 
     component TextSet: QtObject {
         id: textSetRoot
-        readonly property string family: "Inter"
+        readonly property string family: "BitcoinCoreSans"
         readonly property string monoFamily: "Roboto Mono"
 
         // Headers — Semi Bold

--- a/qml/controls/Theme.qml
+++ b/qml/controls/Theme.qml
@@ -6,9 +6,10 @@ import Qt.labs.settings 1.0
 Control {
     id: root
     property bool dark: true
-    property real blockclocksize: (5/12)
+    property real blockclocksize: (5 / 12)
     readonly property ColorSet color: dark ? darkColorSet : lightColorSet
     readonly property ImageSet image: dark ? darkImageSet : lightImageSet
+    readonly property TextSet text: TextSet {}
 
     Settings {
         id: settings
@@ -45,6 +46,22 @@ Control {
         required property url network
         required property url storage
         required property url tooltipArrow
+    }
+
+    component TextStyle: QtObject {
+        required property string family
+        required property string styleName
+        required property int pixelSize
+
+        // Default line height is 140% of pixelSize; each role overrides with the spec value.
+        // Use with `lineHeightMode: Text.FixedHeight` on the consumer Text element.
+        property int lineHeight: Math.round(pixelSize * 1.4)
+
+        readonly property font font: Qt.font({
+            family: family,
+            styleName: styleName,
+            pixelSize: pixelSize
+        })
     }
 
     ColorSet {
@@ -125,6 +142,108 @@ Control {
         network: "image://images/network-light"
         storage: "image://images/storage-light"
         tooltipArrow: "qrc:/icons/tooltip-arrow-light"
+    }
+
+    component TextSet: QtObject {
+        id: textSetRoot
+        readonly property string family: "Inter"
+        readonly property string monoFamily: "Roboto Mono"
+
+        // Headers — Semi Bold
+        readonly property TextStyle display: TextStyle {
+            family: textSetRoot.family
+            styleName: "Semi Bold"
+            pixelSize: 36
+            lineHeight: 44
+        }
+        readonly property TextStyle headline: TextStyle {
+            family: textSetRoot.family
+            styleName: "Semi Bold"
+            pixelSize: 28
+            lineHeight: 34
+        }
+        readonly property TextStyle title: TextStyle {
+            family: textSetRoot.family
+            styleName: "Semi Bold"
+            pixelSize: 24
+            lineHeight: 28
+        }
+        readonly property TextStyle subtitle: TextStyle {
+            family: textSetRoot.family
+            styleName: "Semi Bold"
+            pixelSize: 21
+            lineHeight: 25
+        }
+        readonly property TextStyle heading: TextStyle {
+            family: textSetRoot.family
+            styleName: "Semi Bold"
+            pixelSize: 18
+            lineHeight: 21
+        }
+        readonly property TextStyle subheading: TextStyle {
+            family: textSetRoot.family
+            styleName: "Semi Bold"
+            pixelSize: 15
+            lineHeight: 18
+        }
+
+        // Body — Regular
+        readonly property TextStyle lead: TextStyle {
+            family: textSetRoot.family
+            styleName: "Regular"
+            pixelSize: 24
+            lineHeight: 36
+        }
+        readonly property TextStyle bodyLarge: TextStyle {
+            family: textSetRoot.family
+            styleName: "Regular"
+            pixelSize: 21
+            lineHeight: 31
+        }
+        readonly property TextStyle body: TextStyle {
+            family: textSetRoot.family
+            styleName: "Regular"
+            pixelSize: 18
+            lineHeight: 27
+        }
+        readonly property TextStyle description: TextStyle {
+            family: textSetRoot.family
+            styleName: "Regular"
+            pixelSize: 15
+            lineHeight: 22
+        }
+        readonly property TextStyle caption: TextStyle {
+            family: textSetRoot.family
+            styleName: "Regular"
+            pixelSize: 13
+            lineHeight: 19
+        }
+
+        // Mono — Roboto Mono Regular
+        readonly property TextStyle monoLead: TextStyle {
+            family: textSetRoot.monoFamily
+            styleName: "Regular"
+            pixelSize: 24
+            lineHeight: 36
+        }
+        readonly property TextStyle monoBody: TextStyle {
+            family: textSetRoot.monoFamily
+            styleName: "Regular"
+            pixelSize: 18
+            lineHeight: 27
+        }
+        readonly property TextStyle monoDescription: TextStyle {
+            family: textSetRoot.monoFamily
+            styleName: "Regular"
+            pixelSize: 15
+            lineHeight: 22
+        }
+        readonly property TextStyle monoCaption: TextStyle {
+            family: textSetRoot.monoFamily
+            styleName: "Regular"
+            pixelSize: 13
+            lineHeight: 19
+        }
     }
 
     function toggleDark() {

--- a/qml/pages/settings/SettingsDesignSystem.qml
+++ b/qml/pages/settings/SettingsDesignSystem.qml
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../../controls"
+import "../../components"
+
+Page {
+    signal back
+
+    id: root
+    background: null
+    implicitWidth: 450
+    leftPadding: 20
+    rightPadding: 20
+    topPadding: 30
+
+    readonly property var typographyRoles: [
+        { name: "display", group: "Headers" },
+        { name: "headline", group: "Headers" },
+        { name: "title", group: "Headers" },
+        { name: "subtitle", group: "Headers" },
+        { name: "heading", group: "Headers" },
+        { name: "subheading", group: "Headers" },
+        { name: "lead", group: "Body" },
+        { name: "bodyLarge", group: "Body" },
+        { name: "body", group: "Body" },
+        { name: "description", group: "Body" },
+        { name: "caption", group: "Body" },
+        { name: "monoLead", group: "Mono" },
+        { name: "monoBody", group: "Mono" },
+        { name: "monoDescription", group: "Mono" },
+        { name: "monoCaption", group: "Mono" }
+    ]
+
+    readonly property var paletteTokens: [
+        "background", "white",
+        "orange", "orangeLight1", "orangeLight2",
+        "red", "green", "blue", "amber", "purple",
+        "neutral0", "neutral1", "neutral2", "neutral3", "neutral4",
+        "neutral5", "neutral6", "neutral7", "neutral8", "neutral9"
+    ]
+
+    header: NavigationBar2 {
+        leftItem: NavButton {
+            iconSource: "image://images/caret-left"
+            text: qsTr("Back")
+            onClicked: root.back()
+        }
+        centerItem: Header {
+            headerBold: true
+            headerSize: 18
+            header: qsTr("Design system")
+        }
+    }
+
+    Flickable {
+        anchors.fill: parent
+        contentWidth: width
+        contentHeight: contentColumn.height
+        clip: true
+
+        ColumnLayout {
+            id: contentColumn
+            width: Math.min(parent.width, 450)
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: 24
+
+            // ── Typography ──────────────────────────────────────────
+            Text {
+                Layout.topMargin: 8
+                Layout.fillWidth: true
+                font: Theme.text.title.font
+                color: Theme.color.neutral9
+                text: qsTr("Typography")
+            }
+
+            Repeater {
+                model: root.typographyRoles
+                delegate: ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 4
+
+                    Text {
+                        Layout.fillWidth: true
+                        font: Theme.text[modelData.name].font
+                        lineHeight: Theme.text[modelData.name].lineHeight
+                        lineHeightMode: Text.FixedHeight
+                        color: Theme.color.neutral9
+                        text: modelData.name
+                        elide: Text.ElideRight
+                    }
+                    Text {
+                        Layout.fillWidth: true
+                        font: Theme.text.caption.font
+                        color: Theme.color.neutral6
+                        text: Theme.text[modelData.name].family + " " +
+                              Theme.text[modelData.name].styleName + " · " +
+                              Theme.text[modelData.name].pixelSize + "/" +
+                              Theme.text[modelData.name].lineHeight + " · " +
+                              modelData.group
+                    }
+                    Rectangle {
+                        Layout.topMargin: 8
+                        Layout.fillWidth: true
+                        height: 1
+                        color: Theme.color.neutral3
+                    }
+                }
+            }
+
+            // ── Colors ──────────────────────────────────────────────
+            Text {
+                Layout.topMargin: 16
+                Layout.fillWidth: true
+                font: Theme.text.title.font
+                color: Theme.color.neutral9
+                text: qsTr("Colors")
+            }
+            Text {
+                Layout.fillWidth: true
+                font: Theme.text.caption.font
+                color: Theme.color.neutral6
+                text: qsTr("Palette tokens for the active theme. Toggle Theme to compare.")
+                wrapMode: Text.WordWrap
+            }
+
+            GridLayout {
+                Layout.fillWidth: true
+                columns: 2
+                columnSpacing: 12
+                rowSpacing: 8
+
+                Repeater {
+                    model: root.paletteTokens
+                    delegate: RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 10
+
+                        Rectangle {
+                            Layout.preferredWidth: 32
+                            Layout.preferredHeight: 32
+                            radius: 4
+                            color: Theme.color[modelData]
+                            border.color: Theme.color.neutral4
+                            border.width: 1
+                        }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 0
+                            Text {
+                                Layout.fillWidth: true
+                                font: Theme.text.description.font
+                                color: Theme.color.neutral9
+                                text: modelData
+                                elide: Text.ElideRight
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                font: Theme.text.caption.font
+                                color: Theme.color.neutral6
+                                text: Theme.color[modelData].toString().toUpperCase()
+                            }
+                        }
+                    }
+                }
+            }
+
+            Item { Layout.preferredHeight: 24 }
+        }
+    }
+}

--- a/qml/pages/settings/SettingsDisplay.qml
+++ b/qml/pages/settings/SettingsDisplay.qml
@@ -73,11 +73,22 @@ Item {
             onBack: {
                 displaySettingsView.pop()
             }
+            onDesignSystemRequested: {
+                displaySettingsView.push(design_system_page)
+            }
         }
     }
     Component {
         id: blockclocksize_page
         SettingsBlockClockDisplayMode {
+            onBack: {
+                displaySettingsView.pop()
+            }
+        }
+    }
+    Component {
+        id: design_system_page
+        SettingsDesignSystem {
             onBack: {
                 displaySettingsView.pop()
             }

--- a/qml/pages/settings/SettingsTheme.qml
+++ b/qml/pages/settings/SettingsTheme.qml
@@ -10,6 +10,7 @@ import "../../components"
 
 Page {
     signal back
+    signal designSystemRequested
 
     id: root
     background: null
@@ -33,5 +34,6 @@ Page {
     ThemeSettings {
         width: Math.min(parent.width, 450)
         anchors.horizontalCenter: parent.horizontalCenter
+        onDesignSystemRequested: root.designSystemRequested()
     }
 }


### PR DESCRIPTION
Currently every text hardcodes `font.family: "Inter"` and raw pixel sizes.
This PR establishes a typography layer of the design system inside the existing `Theme`.
It introduces semantic text roles so consumers can write font: `Theme.text.body.font` instead

Additionally, add a debug-only preview page to visually verify all roles in one place. 
It lives under Settings → Display → Theme, in a new "Developer" section that's hidden in release builds.

<img width="1441" height="1157" alt="Screenshot 2026-05-04 at 11 55 12 AM" src="https://github.com/user-attachments/assets/69c65f8c-5f36-4f6f-995a-fb541ece2c58" />
<img width="1441" height="1157" alt="Screenshot 2026-05-04 at 11 41 50 AM" src="https://github.com/user-attachments/assets/5b6e0572-a14e-4328-94f1-8adb287fa8ff" />
<img width="1441" height="1157" alt="Screenshot 2026-05-04 at 11 42 04 AM" src="https://github.com/user-attachments/assets/0b3e33bf-59ab-438a-b05a-313a11f615ac" />


