### PR TITLE
Watch only wallet

### DIFF
--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -112,3 +112,4 @@ jobs:
           python3 test/functional/qml_test_wallet_migration.py
           python3 test/functional/qml_test_wallet_rbf.py
           python3 test/functional/qml_test_wallet_restore.py
+          python3 test/functional/qml_test_watchonly_wallet.py

--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -81,6 +81,7 @@
         <file>controls/ToggleButton.qml</file>
         <file>controls/utils.js</file>
         <file>controls/ValueInput.qml</file>
+        <file>controls/WalletTypeListItem.qml</file>
         <file>pages/initerrormessage.qml</file>
         <file>pages/main.qml</file>
         <file>pages/node/BannedPeers.qml</file>
@@ -126,7 +127,10 @@
         <file>pages/wallet/CreatePassword.qml</file>
         <file>pages/wallet/ImportWalletOptions.qml</file>
         <file>pages/wallet/ImportWalletSuccess.qml</file>
+        <file>pages/wallet/CreateTypeSelector.qml</file>
         <file>pages/wallet/CreateWalletWizard.qml</file>
+        <file>pages/wallet/WatchOnlyIntro.qml</file>
+        <file>pages/wallet/WatchOnlyXpub.qml</file>
         <file>pages/wallet/DesktopWallets.qml</file>
         <file>pages/wallet/MultipleSendReview.qml</file>
         <file>pages/wallet/PaymentRequestDetail.qml</file>

--- a/qml/controls/WalletTypeListItem.qml
+++ b/qml/controls/WalletTypeListItem.qml
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+AbstractButton {
+    id: root
+
+    property string title: ""
+    property string description: ""
+    property string iconSource: ""
+    property color iconColor: Theme.color.neutral9
+
+    padding: 15
+    implicitWidth: 450
+    opacity: enabled ? 1.0 : 0.4
+
+    background: Rectangle {
+        border.width: 1
+        border.color: root.hovered && root.enabled ? Theme.color.neutral9 : Theme.color.neutral5
+        radius: 10
+        color: "transparent"
+        FocusBorder {
+            visible: root.visualFocus
+            borderRadius: 14
+        }
+    }
+
+    contentItem: RowLayout {
+        spacing: 10
+        Icon {
+            source: root.iconSource
+            color: root.iconColor
+            size: 24
+        }
+        ColumnLayout {
+            spacing: 2
+            Layout.fillWidth: true
+            CoreText {
+                Layout.fillWidth: true
+                text: root.title
+                font.pixelSize: 18
+                bold: true
+                color: Theme.color.neutral9
+                horizontalAlignment: Text.AlignLeft
+            }
+            CoreText {
+                Layout.fillWidth: true
+                text: root.description
+                font.pixelSize: 15
+                color: Theme.color.neutral7
+                horizontalAlignment: Text.AlignLeft
+                wrapMode: Text.WordWrap
+            }
+        }
+        CaretRightIcon {
+            Layout.alignment: Qt.AlignVCenter
+        }
+    }
+}

--- a/qml/pages/wallet/CreateName.qml
+++ b/qml/pages/wallet/CreateName.qml
@@ -20,6 +20,7 @@ Page {
     property int walletType: CreateName.WalletType.SingleSig
     property string initialWalletName: ""
     readonly property bool externalSignerWallet: walletType === CreateName.WalletType.ExternalSigner
+    property bool loading: false
     background: null
 
     Component.onCompleted: {
@@ -86,10 +87,13 @@ Page {
             Layout.leftMargin: 20
             Layout.rightMargin: 20
             Layout.alignment: Qt.AlignCenter
-            enabled: walletNameInput.text.length > 0
-            text: root.externalSignerWallet ? qsTr("Create wallet") : qsTr("Continue")
+            enabled: walletNameInput.text.length > 0 && !root.loading
+            text: {
+                if (root.loading) return qsTr("Initializing...")
+                if (root.externalSignerWallet) return qsTr("Create wallet")
+                return qsTr("Continue")
+            }
             onClicked: {
-                console.log("Creating wallet with name: " + walletNameInput.text)
                 root.walletName = walletNameInput.text
                 root.next()
             }

--- a/qml/pages/wallet/CreatePassword.qml
+++ b/qml/pages/wallet/CreatePassword.qml
@@ -17,7 +17,7 @@ Page {
     signal next
     background: null
 
-    required property string walletName;
+    required property string walletName
 
     Component.onCompleted: walletController.clearWalletCreateStatus()
 

--- a/qml/pages/wallet/CreateTypeSelector.qml
+++ b/qml/pages/wallet/CreateTypeSelector.qml
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import "../../controls"
+import "../../components"
+
+Page {
+    id: root
+    objectName: "createTypeSelector"
+    signal back
+    signal regularSelected
+    signal watchOnlySelected
+    signal importSelected
+    background: null
+
+    header: NavigationBar2 {
+        leftItem: NavButton {
+            objectName: "typeSelectorBackButton"
+            iconSource: "image://images/caret-left"
+            text: qsTr("Back")
+            onClicked: root.back()
+        }
+        centerItem: Item {
+            CoreText {
+                anchors.centerIn: parent
+                text: qsTr("Choose a wallet type")
+                font.pixelSize: 18
+                bold: true
+                color: Theme.color.neutral9
+            }
+        }
+    }
+
+    Flickable {
+        anchors.fill: parent
+        contentHeight: columnLayout.height
+        clip: true
+
+        ColumnLayout {
+            id: columnLayout
+            width: Math.min(parent.width, 450)
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: 10
+
+            Item { Layout.preferredHeight: 10 }
+
+            WalletTypeListItem {
+                objectName: "walletTypeRegular"
+                Layout.fillWidth: true
+                Layout.leftMargin: 20
+                Layout.rightMargin: 20
+                title: qsTr("Regular")
+                description: qsTr("Fully managed in this application.")
+                iconSource: "image://images/singlesig-wallet"
+                onClicked: root.regularSelected()
+            }
+
+            WalletTypeListItem {
+                objectName: "walletTypeMultiKey"
+                Layout.fillWidth: true
+                Layout.leftMargin: 20
+                Layout.rightMargin: 20
+                title: qsTr("Multi-key")
+                description: qsTr("Requires 2 or more wallets or hardware devices to coordinate.")
+                iconSource: "image://images/singlesig-wallet"
+                enabled: false
+            }
+
+            WalletTypeListItem {
+                objectName: "walletTypeViewOnly"
+                Layout.fillWidth: true
+                Layout.leftMargin: 20
+                Layout.rightMargin: 20
+                title: qsTr("Watch-only")
+                description: qsTr("Keep an eye on another wallet you have.")
+                iconSource: "image://images/visible"
+                onClicked: root.watchOnlySelected()
+            }
+
+            WalletTypeListItem {
+                objectName: "walletTypeImport"
+                Layout.fillWidth: true
+                Layout.leftMargin: 20
+                Layout.rightMargin: 20
+                title: qsTr("Import wallet")
+                description: qsTr("Load an existing wallet.dat file.")
+                iconSource: "image://images/file"
+                onClicked: root.importSelected()
+            }
+
+            WalletTypeListItem {
+                objectName: "walletTypeCustom"
+                Layout.fillWidth: true
+                Layout.leftMargin: 20
+                Layout.rightMargin: 20
+                title: qsTr("Custom")
+                description: qsTr("For unique wallet configurations.")
+                iconSource: "image://images/gear-outline"
+                enabled: false
+            }
+        }
+    }
+}

--- a/qml/pages/wallet/CreateWalletWizard.qml
+++ b/qml/pages/wallet/CreateWalletWizard.qml
@@ -18,9 +18,31 @@ PageStack {
 
     signal finished()
     property string walletName: ""
+    property string walletType: ""
+    property string xpub: ""
     property int launchContext: CreateWalletWizard.Context.Onboarding
+    property bool waitingForInit: false
 
-    Component.onCompleted: walletController.refreshExternalSignerStatus()
+    Component.onCompleted: {
+        if (!walletController.initialized) {
+            nodeModel.startNodeInitializionThread()
+        }
+        walletController.refreshExternalSignerStatus()
+    }
+
+    Connections {
+        target: walletController
+        enabled: root.waitingForInit
+        function onInitializedChanged() {
+            if (walletController.initialized) {
+                root.waitingForInit = false
+                walletController.createWatchOnlyWallet(root.walletName, root.xpub)
+                if (walletController.isWalletLoaded) {
+                    root.finished()
+                }
+            }
+        }
+    }
     onVisibleChanged: {
         if (visible) {
             walletController.refreshExternalSignerStatus()
@@ -76,8 +98,8 @@ PageStack {
                 header: qsTr("Add a wallet")
                 headerBold: true
                 description: walletController.canCreateExternalSignerWallet
-                    ? qsTr("Supported wallet types are external signer, view-only, single-key,\nand multi-key.")
-                    : qsTr("Supported wallet types are view-only, single-key,\nand multi-key.")
+                    ? qsTr("Supported wallet types are external signer, watch-only, single-key,\nand multi-key.")
+                    : qsTr("Supported wallet types are watch-only, single-key,\nand multi-key.")
             }
 
             ContinueButton {
@@ -91,7 +113,7 @@ PageStack {
                 enabled: walletController.initialized
                 text: qsTr("Create wallet")
                 onClicked: {
-                    root.push(intro)
+                    root.push(typeSelector)
                 }
             }
 
@@ -160,6 +182,42 @@ PageStack {
         }
     }
     Component {
+        id: typeSelector
+        CreateTypeSelector {
+            onBack: root.pop()
+            onRegularSelected: {
+                root.walletType = "singlesig"
+                root.push(intro)
+            }
+            onWatchOnlySelected: {
+                root.walletType = "watchonly"
+                root.push(watchOnlyIntro)
+            }
+            onImportSelected: {
+                walletController.clearWalletLoadStatus()
+                root.push(import_options)
+            }
+        }
+    }
+    Component {
+        id: watchOnlyIntro
+        WatchOnlyIntro {
+            onBack: root.pop()
+            onNext: root.push(watchOnlyXpub)
+        }
+    }
+    Component {
+        id: watchOnlyXpub
+        WatchOnlyXpub {
+            id: xpubPage
+            onBack: root.pop()
+            onNext: {
+                root.xpub = xpubPage.xpub
+                root.push(name)
+            }
+        }
+    }
+    Component {
         id: import_options
         ImportWalletOptions {
             onBack: root.goBack()
@@ -187,9 +245,22 @@ PageStack {
         id: name
         CreateName {
             id: createName
+            loading: root.waitingForInit
+            onBack: root.pop()
             onNext: {
                 root.walletName = createName.walletName
-                root.push(password)
+                if (root.walletType === "watchonly") {
+                    if (walletController.initialized) {
+                        walletController.createWatchOnlyWallet(root.walletName, root.xpub)
+                        if (walletController.isWalletLoaded) {
+                            root.finished()
+                        }
+                    } else {
+                        root.waitingForInit = true
+                    }
+                } else {
+                    root.push(password)
+                }
             }
         }
     }

--- a/qml/pages/wallet/CreateWalletWizard.qml
+++ b/qml/pages/wallet/CreateWalletWizard.qml
@@ -38,7 +38,7 @@ PageStack {
                 root.waitingForInit = false
                 walletController.createWatchOnlyWallet(root.walletName, root.xpub)
                 if (walletController.isWalletLoaded) {
-                    root.finished()
+                    root.push(watchOnlyConfirm)
                 }
             }
         }
@@ -218,6 +218,15 @@ PageStack {
         }
     }
     Component {
+        id: watchOnlyConfirm
+        CreateConfirm {
+            headerText: qsTr("Your watch-only wallet has been created")
+            descriptionText: qsTr("You can view transactions and balances. Spending requires an external signer. No backup is needed — your wallet can be recreated from the same extended public key.")
+            onBack: root.pop()
+            onNext: root.finished()
+        }
+    }
+    Component {
         id: import_options
         ImportWalletOptions {
             onBack: root.goBack()
@@ -253,7 +262,7 @@ PageStack {
                     if (walletController.initialized) {
                         walletController.createWatchOnlyWallet(root.walletName, root.xpub)
                         if (walletController.isWalletLoaded) {
-                            root.finished()
+                            root.push(watchOnlyConfirm)
                         }
                     } else {
                         root.waitingForInit = true

--- a/qml/pages/wallet/WalletBadge.qml
+++ b/qml/pages/wallet/WalletBadge.qml
@@ -31,7 +31,6 @@ Button {
     checkable: true
     hoverEnabled: AppMode.isDesktop
     implicitHeight: 60
-    implicitWidth: contentItem.width
     bottomPadding: 0
     topPadding: 0
     clip: true
@@ -43,9 +42,11 @@ Button {
     contentItem: Item {
         RowLayout {
             visible: root.loading
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
             anchors.leftMargin: 5
             anchors.rightMargin: 5
-            anchors.centerIn: parent
             spacing: 5
 
             Skeleton {
@@ -81,9 +82,11 @@ Button {
                 NumberAnimation { duration: 400 }
             }
 
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
             anchors.leftMargin: 5
             anchors.rightMargin: 5
-            anchors.centerIn: parent
             clip: true
             spacing: 5
             Icon {
@@ -114,9 +117,11 @@ Button {
                 NumberAnimation { duration: 400 }
             }
 
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
             anchors.leftMargin: 5
             anchors.rightMargin: 5
-            anchors.centerIn: parent
             clip: true
             spacing: 5
             Icon {
@@ -135,6 +140,7 @@ Button {
                     horizontalAlignment: Text.AlignLeft
                     Layout.fillWidth: true
                     wrap: false
+                    elide: Text.ElideRight
                     id: buttonText
                     font.pixelSize: 13
                     text: root.text

--- a/qml/pages/wallet/WatchOnlyIntro.qml
+++ b/qml/pages/wallet/WatchOnlyIntro.qml
@@ -1,0 +1,121 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import "../../controls"
+import "../../components"
+
+Page {
+    id: root
+    objectName: "watchOnlyIntro"
+    signal back
+    signal next
+    background: null
+
+    header: NavigationBar2 {
+        leftItem: NavButton {
+            iconSource: "image://images/caret-left"
+            text: qsTr("Back")
+            onClicked: root.back()
+        }
+        centerItem: Item {
+            CoreText {
+                anchors.centerIn: parent
+                text: qsTr("Create wallet")
+                font.pixelSize: 18
+                bold: true
+                color: Theme.color.neutral9
+            }
+        }
+    }
+
+    ColumnLayout {
+        id: columnLayout
+        width: Math.min(parent.width, 450)
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        Item {
+            Layout.alignment: Qt.AlignCenter
+            Layout.preferredHeight: circle.height
+            Layout.preferredWidth: circle.width
+            Rectangle {
+                id: circle
+                width: 60
+                height: width
+                radius: width / 2
+                color: Theme.color.blue
+            }
+            Icon {
+                source: "image://images/info"
+                color: Theme.color.white
+                width: 30
+                height: width
+                anchors.centerIn: circle
+            }
+        }
+
+        CoreText {
+            Layout.topMargin: 25
+            Layout.fillWidth: true
+            text: qsTr("You are about to add a watch-only bitcoin wallet")
+            font.pixelSize: 21
+            bold: true
+            color: Theme.color.neutral9
+        }
+
+        CoreText {
+            Layout.topMargin: 20
+            Layout.fillWidth: true
+            text: qsTr("You can view transactions and the balance.")
+            font.pixelSize: 18
+            color: Theme.color.neutral7
+        }
+
+        Separator {
+            Layout.topMargin: 10
+            Layout.leftMargin: 20
+            Layout.rightMargin: 20
+            Layout.fillWidth: true
+            color: Theme.color.neutral4
+        }
+
+        CoreText {
+            Layout.topMargin: 10
+            Layout.fillWidth: true
+            text: qsTr("Transactions can be initiated, but require an external signer to complete.")
+            font.pixelSize: 18
+            color: Theme.color.neutral7
+        }
+
+        Separator {
+            Layout.topMargin: 10
+            Layout.leftMargin: 20
+            Layout.rightMargin: 20
+            Layout.fillWidth: true
+            color: Theme.color.neutral4
+        }
+
+        CoreText {
+            Layout.topMargin: 10
+            Layout.fillWidth: true
+            text: qsTr("Setup requires an extended public key (xpub).")
+            font.pixelSize: 18
+            color: Theme.color.neutral7
+        }
+
+        ContinueButton {
+            objectName: "watchOnlyIntroNextButton"
+            Layout.preferredWidth: Math.min(300, parent.width - 2 * Layout.leftMargin)
+            Layout.topMargin: 30
+            Layout.leftMargin: 20
+            Layout.rightMargin: 20
+            Layout.alignment: Qt.AlignCenter
+            text: qsTr("Next")
+            onClicked: root.next()
+        }
+    }
+}

--- a/qml/pages/wallet/WatchOnlyXpub.qml
+++ b/qml/pages/wallet/WatchOnlyXpub.qml
@@ -1,0 +1,118 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
+
+import "../../controls"
+import "../../components"
+
+Page {
+    id: root
+    objectName: "watchOnlyXpub"
+    signal back
+    signal next
+    property string xpub: ""
+    background: null
+
+    readonly property bool isValidXpub: {
+        var t = xpubInput.text.trim()
+        if (t.length < 100) return false
+        return walletController.validateXpub(t)
+    }
+
+    header: NavigationBar2 {
+        leftItem: NavButton {
+            iconSource: "image://images/caret-left"
+            text: qsTr("Back")
+            onClicked: root.back()
+        }
+        centerItem: Item {
+            CoreText {
+                anchors.centerIn: parent
+                text: qsTr("Watch-only wallet")
+                font.pixelSize: 18
+                bold: true
+                color: Theme.color.neutral9
+            }
+        }
+    }
+
+    ColumnLayout {
+        id: columnLayout
+        width: Math.min(parent.width, 450)
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        CoreText {
+            Layout.topMargin: 30
+            Layout.leftMargin: 20
+            Layout.rightMargin: 20
+            font.pixelSize: 15
+            color: Theme.color.neutral9
+            text: qsTr("Enter extended public key (XPUB)")
+            horizontalAlignment: Text.AlignLeft
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.topMargin: 5
+            Layout.leftMargin: 20
+            Layout.rightMargin: 20
+            implicitHeight: 56
+
+            CoreTextField {
+                id: xpubInput
+                objectName: "watchOnlyXpubInput"
+                anchors.fill: parent
+                focus: true
+                placeholderText: qsTr("Enter your key...")
+                rightPadding: 46
+            }
+
+            Icon {
+                objectName: "watchOnlyXpubPasteButton"
+                enabled: true
+                anchors.right: parent.right
+                anchors.rightMargin: 12
+                anchors.verticalCenter: parent.verticalCenter
+                source: "image://images/copy"
+                color: Theme.color.neutral9
+                size: 24
+                ToolTip.visible: hovered
+                ToolTip.text: qsTr("Paste from clipboard")
+                onClicked: {
+                    xpubInput.text = Clipboard.text()
+                }
+            }
+        }
+
+        CoreText {
+            Layout.fillWidth: true
+            Layout.leftMargin: 20
+            Layout.rightMargin: 20
+            visible: xpubInput.text.trim().length > 0 && !root.isValidXpub
+            text: qsTr("Enter a valid extended public key (xpub)")
+            color: Theme.color.orange
+            font.pixelSize: 13
+            horizontalAlignment: Text.AlignLeft
+        }
+
+        ContinueButton {
+            objectName: "watchOnlyXpubNextButton"
+            Layout.preferredWidth: Math.min(300, parent.width - 2 * Layout.leftMargin)
+            Layout.topMargin: 30
+            Layout.leftMargin: 20
+            Layout.rightMargin: 20
+            Layout.alignment: Qt.AlignCenter
+            text: qsTr("Next")
+            enabled: root.isValidXpub
+            onClicked: {
+                root.xpub = xpubInput.text.trim()
+                root.next()
+            }
+        }
+    }
+}

--- a/qml/walletqmlcontroller.cpp
+++ b/qml/walletqmlcontroller.cpp
@@ -10,9 +10,12 @@
 #include <common/args.h>
 #include <common/settings.h>
 #include <interfaces/node.h>
+#include <key_io.h>
+#include <script/descriptor.h>
 #include <support/allocators/secure.h>
 #include <univalue.h>
 #include <util/result.h>
+#include <util/time.h>
 #include <wallet/walletutil.h>
 #include <wallet/scriptpubkeyman.h>
 #include <wallet/wallet.h>
@@ -389,6 +392,83 @@ bool WalletQmlController::createExternalSignerWallet(const QString& name)
     return true;
 }
 
+void WalletQmlController::createWatchOnlyWallet(const QString &name, const QString &xpub)
+{
+    clearWalletLoadStatus();
+    clearWalletMigrationStatus();
+
+    const std::string xpub_str = xpub.trimmed().toStdString();
+    CExtPubKey ext_pubkey = DecodeExtPubKey(xpub_str);
+    if (!ext_pubkey.pubkey.IsValid()) {
+        setWalletLoadError(tr("Invalid extended public key."));
+        return;
+    }
+
+    const std::string wallet_name{name.toStdString()};
+    const uint64_t creation_flags = wallet::WALLET_FLAG_DISABLE_PRIVATE_KEYS |
+                                    wallet::WALLET_FLAG_DESCRIPTORS |
+                                    wallet::WALLET_FLAG_BLANK_WALLET;
+
+    auto wallet_result = m_node.walletLoader().createWallet(wallet_name, SecureString{}, creation_flags, m_warning_messages);
+    if (!wallet_result) {
+        setWalletLoadError(QString::fromStdString(util::ErrorString(wallet_result).translated));
+        return;
+    }
+
+    int descriptors_added = 0;
+    wallet::CWallet* raw_wallet = (*wallet_result)->wallet();
+    if (raw_wallet) {
+        LOCK(raw_wallet->cs_wallet);
+
+        struct DescriptorInfo {
+            std::string desc_str;
+            bool internal;
+        };
+        std::vector<DescriptorInfo> descriptors = {
+            {"wpkh(" + xpub_str + "/0/*)", false},
+            {"wpkh(" + xpub_str + "/1/*)", true},
+        };
+
+        for (const auto& info : descriptors) {
+            FlatSigningProvider keys;
+            std::string error;
+            auto parsed = Parse(info.desc_str, keys, error, /*require_checksum=*/false);
+            if (parsed.empty()) {
+                continue;
+            }
+
+            wallet::WalletDescriptor w_desc(
+                std::move(parsed.at(0)),
+                TicksSinceEpoch<std::chrono::seconds>(Now<NodeSeconds>()),
+                /*range_start=*/0,
+                /*range_end=*/0,
+                /*next_index=*/0);
+
+            auto spk_manager_res = raw_wallet->AddWalletDescriptor(w_desc, keys, /*label=*/"", info.internal);
+            if (spk_manager_res) {
+                raw_wallet->AddActiveScriptPubKeyMan(
+                    spk_manager_res.value().get().GetID(),
+                    OutputType::BECH32,
+                    info.internal);
+                ++descriptors_added;
+            }
+        }
+        raw_wallet->ConnectScriptPubKeyManNotifiers();
+    }
+
+    if (descriptors_added == 0) {
+        setWalletLoadError(tr("Failed to import descriptors into watch-only wallet."));
+        return;
+    }
+
+    QMutexLocker locker(&m_wallets_mutex);
+    m_selected_wallet = new WalletQmlModel(std::move(*wallet_result));
+    m_wallets.push_back(m_selected_wallet);
+    setWalletLoaded(true);
+    setNoWalletsFound(false);
+    Q_EMIT selectedWalletChanged();
+}
+
 void WalletQmlController::importWallet(const QString& path)
 {
     if (!m_initialized) {
@@ -423,6 +503,12 @@ void WalletQmlController::clearWalletMigrationStatus()
 {
     setWalletMigrationInProgress(false);
     setWalletMigrationError(QString());
+}
+
+bool WalletQmlController::validateXpub(const QString& xpub) const
+{
+    CExtPubKey ext_pubkey = DecodeExtPubKey(xpub.trimmed().toStdString());
+    return ext_pubkey.pubkey.IsValid();
 }
 
 void WalletQmlController::requestOpenWalletSettings()

--- a/qml/walletqmlcontroller.h
+++ b/qml/walletqmlcontroller.h
@@ -52,11 +52,13 @@ public:
     Q_INVOKABLE bool setWalletDisplayName(const QString& path, const QString& display_name);
     Q_INVOKABLE bool createSingleSigWallet(const QString &name, const QString &passphrase);
     Q_INVOKABLE bool createExternalSignerWallet(const QString& name);
+    Q_INVOKABLE void createWatchOnlyWallet(const QString &name, const QString &xpub);
     Q_INVOKABLE void importWallet(const QString& path);
     Q_INVOKABLE void clearWalletCreateStatus();
     Q_INVOKABLE void clearWalletLoadStatus();
     Q_INVOKABLE void migrateWallet(const QString& path, const QString& passphrase = QString());
     Q_INVOKABLE void clearWalletMigrationStatus();
+    Q_INVOKABLE bool validateXpub(const QString& xpub) const;
     Q_INVOKABLE QString normalizeWalletPath(const QString& path) const;
     Q_INVOKABLE bool walletPathExists(const QString& path) const;
     Q_INVOKABLE QString homePath() const;

--- a/test/functional/qml_test_addresses.py
+++ b/test/functional/qml_test_addresses.py
@@ -41,6 +41,7 @@ def create_wallet_through_gui(harness, gui):
         gui.wait_for_property("createWalletButton", "visible", True, timeout_ms=5000)
     gui.settle()
     gui.click("createWalletButton")
+    gui.click("walletTypeRegular")
     gui.wait_for_property("createWalletIntroStartButton", "visible", True, timeout_ms=5000)
     gui.click("createWalletIntroStartButton")
     gui.settle()

--- a/test/functional/qml_test_password_wallet.py
+++ b/test/functional/qml_test_password_wallet.py
@@ -126,6 +126,8 @@ def create_password_wallet(gui, wallet_name, password):
     gui.wait_for_property("createWalletButton", "visible", True, timeout_ms=10000)
     gui.wait_for_property("createWalletButton", "enabled", True, timeout_ms=25000)
     gui.click("createWalletButton")
+    gui.click("walletTypeRegular")
+    gui.wait_for_page("createWalletIntroPage", timeout_ms=5000)
     gui.click("createWalletIntroStartButton")
     gui.set_text("createWalletNameInput", wallet_name)
     gui.click("createWalletNameContinueButton")

--- a/test/functional/qml_test_send_review.py
+++ b/test/functional/qml_test_send_review.py
@@ -97,6 +97,7 @@ def wait_until(predicate, timeout=20, interval=0.1, description="condition"):
 def create_wallet(gui, wallet_name):
     gui.wait_for_property("createWalletButton", "visible", True, timeout_ms=20000)
     gui.click("createWalletButton")
+    gui.click("walletTypeRegular")
     gui.wait_for_page("createWalletIntroPage", timeout_ms=10000)
     gui.click("createWalletIntroStartButton")
     gui.wait_for_page("createWalletNamePage", timeout_ms=10000)

--- a/test/functional/qml_test_watchonly_wallet.py
+++ b/test/functional/qml_test_watchonly_wallet.py
@@ -78,8 +78,12 @@ def case_watchonly_creation_flow(harness, test_xpub):
     gui.set_text("createWalletNameInput", "watchonly_test")
     gui.wait_for_property("createWalletNameContinueButton", "enabled", True, timeout_ms=5000)
     gui.click("createWalletNameContinueButton")
+    gui.wait_for_page("createWalletConfirmPage", timeout_ms=15000)
+    print("  Wallet created, confirm page shown")
+
+    gui.click("createWalletConfirmNextButton")
     gui.wait_for_property("walletBadge", "loading", False, timeout_ms=15000)
-    print("  Name entered, wallet created (no password page for watch-only)")
+    print("  Confirm page dismissed")
 
     badge_text = gui.get_text("walletBadge")
     print(f"  Wallet badge: {badge_text}")

--- a/test/functional/qml_test_watchonly_wallet.py
+++ b/test/functional/qml_test_watchonly_wallet.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""End-to-end GUI tests for watch-only wallet creation flow."""
+
+import re
+import sys
+
+from qml_driver import QmlDriverError
+from qml_test_harness import dump_qml_tree
+from qml_wallet_test_lib import WalletFlowHarness, rpc_call
+
+
+def open_create_wallet_page(gui):
+    """Navigate from the post-onboarding main screen to the Create Wallet wizard."""
+    gui.wait_for_property("walletBadge", "loading", False, timeout_ms=20000)
+
+    gui.click("walletBadge")
+    try:
+        gui.wait_for_property("walletSelectPopup", "opened", True, timeout_ms=2000)
+        gui.click("walletSelectAddWalletButton")
+    except QmlDriverError:
+        pass
+    gui.wait_for_property("createWalletButton", "visible", True, timeout_ms=10000)
+
+
+def open_type_selector(gui):
+    """Navigate to the wallet type selector page."""
+    open_create_wallet_page(gui)
+    gui.click("createWalletButton")
+    gui.wait_for_page("createTypeSelector", timeout_ms=5000)
+
+
+def get_test_xpub(harness):
+    """Create a wallet on the source node and extract its account-level xpub."""
+    harness.start_source_node()
+    rpc_call(harness.source_rpc_port, "createwallet", {"wallet_name": "source", "descriptors": True})
+    result = rpc_call(harness.source_rpc_port, "listdescriptors", wallet="source")
+
+    xpub = None
+    for desc_info in result["descriptors"]:
+        desc = desc_info["desc"]
+        if desc.startswith("wpkh(") and not desc_info.get("internal", False):
+            match = re.search(r'([tx]pub[A-Za-z0-9]+)', desc)
+            if match:
+                xpub = match.group(1)
+                break
+
+    harness.stop_source_node()
+    if not xpub:
+        raise RuntimeError("Could not extract xpub from source wallet")
+    return xpub
+
+
+def case_watchonly_creation_flow(harness, test_xpub):
+    """Test the full watch-only wallet creation flow."""
+    harness.start_gui()
+    gui = harness.driver
+
+    open_type_selector(gui)
+    print("  Type selector opened")
+
+    gui.click("walletTypeViewOnly")
+    gui.wait_for_page("watchOnlyIntro", timeout_ms=5000)
+    print("  Watch-only intro page")
+
+    gui.click("watchOnlyIntroNextButton")
+    gui.wait_for_page("watchOnlyXpub", timeout_ms=5000)
+    print("  xpub entry page")
+
+    gui.set_text("watchOnlyXpubInput", test_xpub)
+    gui.wait_for_property("watchOnlyXpubNextButton", "enabled", True, timeout_ms=5000)
+    gui.click("watchOnlyXpubNextButton")
+    gui.wait_for_page("createWalletNamePage", timeout_ms=5000)
+    print("  xpub entered, proceeding to name")
+
+    gui.set_text("createWalletNameInput", "watchonly_test")
+    gui.wait_for_property("createWalletNameContinueButton", "enabled", True, timeout_ms=5000)
+    gui.click("createWalletNameContinueButton")
+    gui.wait_for_property("walletBadge", "loading", False, timeout_ms=15000)
+    print("  Name entered, wallet created (no password page for watch-only)")
+
+    badge_text = gui.get_text("walletBadge")
+    print(f"  Wallet badge: {badge_text}")
+
+    wallet_info = rpc_call(harness.gui_rpc_port, "getwalletinfo", wallet="watchonly_test")
+    assert wallet_info["private_keys_enabled"] is False, \
+        f"Wallet should be watch-only, got private_keys_enabled={wallet_info['private_keys_enabled']}"
+    print("  RPC confirms wallet is watch-only (private_keys_enabled=false)")
+
+    print("  Watch-only creation flow PASSED")
+
+
+def case_type_selector_regular_flow(harness):
+    """Test that regular wallet flow still works through type selector."""
+    harness.start_gui()
+    gui = harness.driver
+
+    open_type_selector(gui)
+    print("  Type selector opened")
+
+    gui.click("walletTypeRegular")
+    gui.wait_for_page("createWalletIntroPage", timeout_ms=5000)
+    print("  CreateIntro page opened")
+
+    print("  Regular wallet type selector flow PASSED")
+
+
+def case_type_selector_import_flow(harness):
+    """Test that import wallet option in type selector routes correctly."""
+    harness.start_gui()
+    gui = harness.driver
+
+    open_type_selector(gui)
+    print("  Type selector opened")
+
+    gui.click("walletTypeImport")
+    gui.wait_for_page("importWalletOptions", timeout_ms=5000)
+    print("  Import wallet page opened from type selector")
+
+    print("  Import wallet type selector flow PASSED")
+
+
+def case_type_selector_disabled_options(harness):
+    """Test that Multi-key and Custom options are disabled."""
+    harness.start_gui()
+    gui = harness.driver
+
+    open_type_selector(gui)
+    print("  Type selector opened")
+
+    multi_key_enabled = gui.get_property("walletTypeMultiKey", "enabled")
+    assert multi_key_enabled is False, f"Multi-key should be disabled, got enabled={multi_key_enabled}"
+
+    custom_enabled = gui.get_property("walletTypeCustom", "enabled")
+    assert custom_enabled is False, f"Custom should be disabled, got enabled={custom_enabled}"
+
+    print("  Disabled options check PASSED")
+
+
+def run_case(case_name, port_offset, case_body):
+    harness = WalletFlowHarness(case_name, port_offset=port_offset)
+    try:
+        print(f"[{case_name}] starting")
+        case_body(harness)
+        print(f"[{case_name}] completed")
+        return 0
+    except Exception as err:
+        print(f"\nFAILED [{case_name}]: {err}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        gui = harness.driver
+        if gui is not None:
+            dump_qml_tree(gui)
+        gui_output = harness.process_output(harness.gui_process)
+        if gui_output:
+            print("\n--- GUI process output ---", file=sys.stderr)
+            print(gui_output, file=sys.stderr)
+        return 1
+    finally:
+        harness.stop()
+
+
+def run_tests():
+    print("Generating test xpub from source node...")
+    xpub_harness = WalletFlowHarness("xpub_gen", port_offset=70)
+    try:
+        test_xpub = get_test_xpub(xpub_harness)
+        print(f"  Test xpub: {test_xpub[:20]}...{test_xpub[-10:]}")
+    finally:
+        xpub_harness.stop()
+
+    failures = 0
+
+    failures += run_case(
+        "watchonly_creation_flow",
+        port_offset=80,
+        case_body=lambda h: case_watchonly_creation_flow(h, test_xpub),
+    )
+
+    failures += run_case(
+        "type_selector_regular",
+        port_offset=90,
+        case_body=case_type_selector_regular_flow,
+    )
+
+    failures += run_case(
+        "type_selector_import",
+        port_offset=100,
+        case_body=case_type_selector_import_flow,
+    )
+
+    failures += run_case(
+        "type_selector_disabled",
+        port_offset=110,
+        case_body=case_type_selector_disabled_options,
+    )
+
+    if failures > 0:
+        print(f"\n{failures} test case(s) FAILED", file=sys.stderr)
+        return 1
+
+    print("\nAll watch-only wallet tests PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_tests())

--- a/test/mocks/qml/org/bitcoincore/qt/Clipboard.qml
+++ b/test/mocks/qml/org/bitcoincore/qt/Clipboard.qml
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+pragma Singleton
+import QtQuick 2.15
+
+QtObject {
+    function text() { return "" }
+}

--- a/test/mocks/qml/org/bitcoincore/qt/qmldir
+++ b/test/mocks/qml/org/bitcoincore/qt/qmldir
@@ -1,2 +1,3 @@
 module org.bitcoincore.qt
 singleton AppMode 1.0 AppMode.qml
+singleton Clipboard 1.0 Clipboard.qml

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -6,8 +6,9 @@
 
 #include <QAbstractListModel>
 #include <QDateTime>
-#include <QQmlEngine>
+#include <QQmlComponent>
 #include <QQmlContext>
+#include <QQmlEngine>
 #include <QRegularExpression>
 #include <QSortFilterProxyModel>
 #include <QStringList>
@@ -1079,6 +1080,7 @@ class MockWalletController : public QObject
     Q_PROPERTY(bool initialized MEMBER m_initialized NOTIFY initializedChanged)
     Q_PROPERTY(bool isWalletLoaded MEMBER m_is_wallet_loaded NOTIFY isWalletLoadedChanged)
     Q_PROPERTY(bool noWalletsFound MEMBER m_no_wallets_found NOTIFY noWalletsFoundChanged)
+    Q_PROPERTY(QString walletLoadError MEMBER m_wallet_load_error NOTIFY walletLoadErrorChanged)
     Q_PROPERTY(QString lastSelectedWalletName READ lastSelectedWalletName NOTIFY lastSelectedWalletNameChanged)
     Q_PROPERTY(QString lastClosedWalletName READ lastClosedWalletName NOTIFY lastClosedWalletNameChanged)
     Q_PROPERTY(int closeWalletCalls READ closeWalletCalls NOTIFY closeWalletCallsChanged)
@@ -1090,6 +1092,7 @@ public:
     bool m_initialized{true};
     bool m_is_wallet_loaded{true};
     bool m_no_wallets_found{false};
+    QString m_wallet_load_error;
     QObject* m_selected_wallet{nullptr};
     QString m_last_selected_wallet_name;
     QString m_last_closed_wallet_name;
@@ -1150,11 +1153,20 @@ public:
         Q_EMIT openReceiveRequestsChanged();
         Q_EMIT openReceiveRequested();
     }
+    Q_INVOKABLE bool validateXpub(const QString& xpub)
+    {
+        QString t = xpub.trimmed();
+        return t.length() >= 100 && (t.startsWith("xpub") || t.startsWith("tpub"));
+    }
+    Q_INVOKABLE void createWatchOnlyWallet(const QString& /*name*/, const QString& /*xpub*/) {}
+    Q_INVOKABLE bool createSingleSigWallet(const QString& /*name*/, const QString& /*passphrase*/) { return true; }
+    Q_INVOKABLE void clearWalletLoadStatus() { m_wallet_load_error.clear(); Q_EMIT walletLoadErrorChanged(); }
 
 Q_SIGNALS:
     void initializedChanged();
     void isWalletLoadedChanged();
     void noWalletsFoundChanged();
+    void walletLoadErrorChanged();
     void lastSelectedWalletNameChanged();
     void lastClosedWalletNameChanged();
     void closeWalletCallsChanged();

--- a/test/qml/tst_createname.qml
+++ b/test/qml/tst_createname.qml
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/pages/wallet"
+
+TestCase {
+    name: "CreateName"
+    when: windowShown
+    width: 500
+    height: 500
+
+    Component {
+        id: namePageComponent
+        CreateName {}
+    }
+
+    function findChild(parent, objectName) {
+        if (!parent) return null
+        if (parent.objectName === objectName) return parent
+        for (var i = 0; i < parent.children.length; i++) {
+            var result = findChild(parent.children[i], objectName)
+            if (result) return result
+        }
+        if (parent.contentItem) {
+            var result = findChild(parent.contentItem, objectName)
+            if (result) return result
+        }
+        return null
+    }
+
+    function test_continue_disabled_when_empty() {
+        const page = createTemporaryObject(namePageComponent, this)
+        verify(page !== null)
+
+        var btn = findChild(page, "createWalletNameContinueButton")
+        verify(btn !== null)
+        verify(!btn.enabled)
+    }
+
+    function test_continue_enabled_with_text() {
+        const page = createTemporaryObject(namePageComponent, this)
+        verify(page !== null)
+
+        var input = findChild(page, "createWalletNameInput")
+        verify(input !== null)
+        input.text = "my_wallet"
+
+        var btn = findChild(page, "createWalletNameContinueButton")
+        verify(btn !== null)
+        tryVerify(function() { return btn.enabled }, 2000)
+    }
+
+    function test_loading_shows_initializing_text() {
+        const page = createTemporaryObject(namePageComponent, this)
+        verify(page !== null)
+
+        var input = findChild(page, "createWalletNameInput")
+        verify(input !== null)
+        input.text = "my_wallet"
+
+        var btn = findChild(page, "createWalletNameContinueButton")
+        verify(btn !== null)
+
+        page.loading = true
+        compare(btn.text, qsTr("Initializing..."))
+
+        page.loading = false
+        compare(btn.text, qsTr("Continue"))
+    }
+
+    function test_error_text_visible_on_error() {
+        const page = createTemporaryObject(namePageComponent, this)
+        verify(page !== null)
+
+        walletController.walletLoadError = "Wallet already exists"
+        waitForRendering(page)
+        walletController.walletLoadError = ""
+    }
+}

--- a/test/qml/tst_createpassword.qml
+++ b/test/qml/tst_createpassword.qml
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/pages/wallet"
+
+TestCase {
+    name: "CreatePassword"
+    when: windowShown
+    width: 500
+    height: 700
+
+    Component {
+        id: passwordPageComponent
+        CreatePassword {
+            walletName: "test_wallet"
+        }
+    }
+
+    function findChild(parent, objectName) {
+        if (!parent) return null
+        if (parent.objectName === objectName) return parent
+        for (var i = 0; i < parent.children.length; i++) {
+            var result = findChild(parent.children[i], objectName)
+            if (result) return result
+        }
+        if (parent.contentItem) {
+            var result = findChild(parent.contentItem, objectName)
+            if (result) return result
+        }
+        if (parent.header) {
+            var result = findChild(parent.header, objectName)
+            if (result) return result
+        }
+        if (parent.footer) {
+            var result = findChild(parent.footer, objectName)
+            if (result) return result
+        }
+        return null
+    }
+
+    function test_skip_button_disabled_when_not_initialized() {
+        walletController.initialized = false
+        const page = createTemporaryObject(passwordPageComponent, this)
+        verify(page !== null)
+
+        var btn = findChild(page, "createWalletPasswordSkipButton")
+        verify(btn !== null)
+        verify(!btn.enabled)
+
+        walletController.initialized = true
+    }
+
+    function test_skip_button_enabled_when_initialized() {
+        walletController.initialized = true
+        const page = createTemporaryObject(passwordPageComponent, this)
+        verify(page !== null)
+
+        var btn = findChild(page, "createWalletPasswordSkipButton")
+        verify(btn !== null)
+        verify(btn.enabled)
+    }
+
+    function test_continue_text_shows_initializing() {
+        walletController.initialized = false
+        const page = createTemporaryObject(passwordPageComponent, this)
+        verify(page !== null)
+
+        walletController.initialized = true
+    }
+}

--- a/test/qml/tst_createtypeselector.qml
+++ b/test/qml/tst_createtypeselector.qml
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/pages/wallet"
+
+TestCase {
+    name: "CreateTypeSelector"
+    when: windowShown
+    width: 500
+    height: 700
+
+    Component {
+        id: selectorComponent
+        CreateTypeSelector {}
+    }
+
+    function findChild(parent, objectName) {
+        if (parent.objectName === objectName) return parent
+        for (var i = 0; i < parent.children.length; i++) {
+            var result = findChild(parent.children[i], objectName)
+            if (result) return result
+        }
+        if (parent.contentItem) {
+            var result = findChild(parent.contentItem, objectName)
+            if (result) return result
+        }
+        return null
+    }
+
+    function test_regular_selected_signal() {
+        const page = createTemporaryObject(selectorComponent, this)
+        verify(page !== null)
+
+        var emitted = false
+        page.regularSelected.connect(function() { emitted = true })
+
+        var btn = findChild(page, "walletTypeRegular")
+        verify(btn !== null)
+        btn.clicked()
+        verify(emitted)
+    }
+
+    function test_watchonly_selected_signal() {
+        const page = createTemporaryObject(selectorComponent, this)
+        verify(page !== null)
+
+        var emitted = false
+        page.watchOnlySelected.connect(function() { emitted = true })
+
+        var btn = findChild(page, "walletTypeViewOnly")
+        verify(btn !== null)
+        btn.clicked()
+        verify(emitted)
+    }
+
+    function test_import_selected_signal() {
+        const page = createTemporaryObject(selectorComponent, this)
+        verify(page !== null)
+
+        var emitted = false
+        page.importSelected.connect(function() { emitted = true })
+
+        var btn = findChild(page, "walletTypeImport")
+        verify(btn !== null)
+        btn.clicked()
+        verify(emitted)
+    }
+
+    function test_multikey_disabled() {
+        const page = createTemporaryObject(selectorComponent, this)
+        verify(page !== null)
+
+        var btn = findChild(page, "walletTypeMultiKey")
+        verify(btn !== null)
+        verify(!btn.enabled)
+    }
+
+    function test_custom_disabled() {
+        const page = createTemporaryObject(selectorComponent, this)
+        verify(page !== null)
+
+        var btn = findChild(page, "walletTypeCustom")
+        verify(btn !== null)
+        verify(!btn.enabled)
+    }
+}

--- a/test/qml/tst_wallettypelistitem.qml
+++ b/test/qml/tst_wallettypelistitem.qml
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/controls"
+
+TestCase {
+    name: "WalletTypeListItem"
+    when: windowShown
+    width: 500
+    height: 300
+
+    Component {
+        id: listItemComponent
+        WalletTypeListItem {
+            width: 450
+            height: 60
+            title: "Regular"
+            description: "Fully managed in this application."
+            iconSource: "image://images/singlesig-wallet"
+        }
+    }
+
+    function test_initial_properties() {
+        const item = createTemporaryObject(listItemComponent, this)
+        verify(item !== null)
+        compare(item.title, "Regular")
+        compare(item.description, "Fully managed in this application.")
+        compare(item.iconSource, "image://images/singlesig-wallet")
+        verify(item.enabled)
+    }
+
+    function test_enabled_opacity() {
+        const item = createTemporaryObject(listItemComponent, this)
+        verify(item !== null)
+        compare(item.opacity, 1.0)
+    }
+
+    function test_disabled_opacity() {
+        const item = createTemporaryObject(listItemComponent, this)
+        verify(item !== null)
+        item.enabled = false
+        compare(item.opacity, 0.4)
+    }
+
+    function test_click_emits_signal() {
+        const item = createTemporaryObject(listItemComponent, this)
+        verify(item !== null)
+
+        var clicked = false
+        item.clicked.connect(function() { clicked = true })
+        item.clicked()
+        verify(clicked)
+    }
+
+    function test_disabled_blocks_click() {
+        const item = createTemporaryObject(listItemComponent, this)
+        verify(item !== null)
+        item.enabled = false
+
+        var clicked = false
+        item.clicked.connect(function() { clicked = true })
+        mouseClick(item, item.width / 2, item.height / 2)
+        verify(!clicked)
+    }
+}

--- a/test/qml/tst_watchonlyxpub.qml
+++ b/test/qml/tst_watchonlyxpub.qml
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/pages/wallet"
+
+TestCase {
+    name: "WatchOnlyXpub"
+    when: windowShown
+    width: 500
+    height: 600
+
+    // Valid BIP32 xpub from Bitcoin Core test vectors
+    readonly property string validXpub:
+        "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
+
+    Component {
+        id: xpubPageComponent
+        WatchOnlyXpub {}
+    }
+
+    function findChild(parent, objectName) {
+        if (parent.objectName === objectName) return parent
+        for (var i = 0; i < parent.children.length; i++) {
+            var result = findChild(parent.children[i], objectName)
+            if (result) return result
+        }
+        if (parent.contentItem) {
+            var result = findChild(parent.contentItem, objectName)
+            if (result) return result
+        }
+        return null
+    }
+
+    function test_next_button_disabled_initially() {
+        const page = createTemporaryObject(xpubPageComponent, this)
+        verify(page !== null)
+
+        var btn = findChild(page, "watchOnlyXpubNextButton")
+        verify(btn !== null)
+        verify(!btn.enabled)
+    }
+
+    function test_invalid_input_keeps_button_disabled() {
+        const page = createTemporaryObject(xpubPageComponent, this)
+        verify(page !== null)
+
+        var input = findChild(page, "watchOnlyXpubInput")
+        verify(input !== null)
+        input.text = "not-a-valid-xpub"
+
+        var btn = findChild(page, "watchOnlyXpubNextButton")
+        verify(btn !== null)
+        verify(!btn.enabled)
+    }
+
+    function test_valid_xpub_enables_button() {
+        const page = createTemporaryObject(xpubPageComponent, this)
+        verify(page !== null)
+
+        var input = findChild(page, "watchOnlyXpubInput")
+        verify(input !== null)
+        input.text = validXpub
+
+        var btn = findChild(page, "watchOnlyXpubNextButton")
+        verify(btn !== null)
+        tryVerify(function() { return btn.enabled }, 2000)
+    }
+
+    function test_next_signal_sets_xpub() {
+        const page = createTemporaryObject(xpubPageComponent, this)
+        verify(page !== null)
+
+        var input = findChild(page, "watchOnlyXpubInput")
+        verify(input !== null)
+        input.text = validXpub
+
+        var btn = findChild(page, "watchOnlyXpubNextButton")
+        verify(btn !== null)
+        tryVerify(function() { return btn.enabled }, 2000)
+
+        var emitted = false
+        page.next.connect(function() { emitted = true })
+        btn.clicked()
+        verify(emitted)
+        compare(page.xpub, validXpub)
+    }
+}

--- a/test/test_nodemodel.cpp
+++ b/test/test_nodemodel.cpp
@@ -80,6 +80,8 @@ private Q_SLOTS:
     void refreshMempoolInfoUpdatesProperties();
     void activatingMempoolPollingEmitsSignalsAndRefreshesImmediately();
     void nodeNotificationHandlersUpdateModelThroughQueuedSignals();
+    void initEmitsRequestedInitialize();
+    void initGuardBlocksSecondEmission();
 };
 
 void NodeModelTests::refreshMempoolInfoUpdatesProperties()
@@ -188,6 +190,27 @@ void NodeModelTests::nodeNotificationHandlersUpdateModelThroughQueuedSignals()
     QCOMPARE(model.verificationProgress(), 0.42);
     QCOMPARE(time_ratio_spy.takeFirst().at(0).toInt(), 1'700'000'000);
     QCOMPARE(model.numOutboundPeers(), 7);
+}
+
+void NodeModelTests::initEmitsRequestedInitialize()
+{
+    NiceMock<MockNode> node;
+    NodeModel model(node);
+
+    QSignalSpy spy(&model, &NodeModel::requestedInitialize);
+    model.startNodeInitializionThread();
+    QCOMPARE(spy.count(), 1);
+}
+
+void NodeModelTests::initGuardBlocksSecondEmission()
+{
+    NiceMock<MockNode> node;
+    NodeModel model(node);
+
+    QSignalSpy spy(&model, &NodeModel::requestedInitialize);
+    model.startNodeInitializionThread();
+    model.startNodeInitializionThread();
+    QCOMPARE(spy.count(), 1);
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN

--- a/test/test_walletqmlcontroller.cpp
+++ b/test/test_walletqmlcontroller.cpp
@@ -4,6 +4,7 @@
 
 #include <QtTest/QtTest>
 
+#include <chainparams.h>
 #include <common/settings.h>
 #include <interfaces/handler.h>
 #include <interfaces/wallet.h>
@@ -47,6 +48,9 @@ std::vector<std::unique_ptr<interfaces::ExternalSigner>> MakeSigners(std::initia
     }
     return signers;
 }
+
+const QString VALID_XPUB{
+    "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"};
 
 class FakeWalletLoader : public interfaces::WalletLoader
 {
@@ -269,6 +273,12 @@ class WalletQmlControllerTests : public QObject
     Q_OBJECT
 
 private Q_SLOTS:
+    void initTestCase();
+    void validateXpubAcceptsValidKey();
+    void validateXpubRejectsGarbage();
+    void validateXpubRejectsEmpty();
+    void validateXpubTrimsWhitespace();
+    void createWatchOnlyInvalidXpubSetsError();
     void externalSignerCreationRequiresConfiguredPath();
     void externalSignerCreationRequiresExactlyOneSigner();
     void externalSignerSuggestionUsesSignerName();
@@ -288,6 +298,61 @@ private Q_SLOTS:
     void initializedControllerHandlesExternalWalletUnload();
     void initializedControllerUnloadWalletsClearsSelectionAndOpenWallets();
 };
+
+void WalletQmlControllerTests::initTestCase()
+{
+    SelectParams(ChainType::MAIN);
+}
+
+void WalletQmlControllerTests::validateXpubAcceptsValidKey()
+{
+    using ::testing::NiceMock;
+    NiceMock<MockNode> node;
+    WalletQmlController controller(node);
+
+    QVERIFY(controller.validateXpub(VALID_XPUB));
+}
+
+void WalletQmlControllerTests::validateXpubRejectsGarbage()
+{
+    using ::testing::NiceMock;
+    NiceMock<MockNode> node;
+    WalletQmlController controller(node);
+
+    QVERIFY(!controller.validateXpub("not-an-xpub"));
+}
+
+void WalletQmlControllerTests::validateXpubRejectsEmpty()
+{
+    using ::testing::NiceMock;
+    NiceMock<MockNode> node;
+    WalletQmlController controller(node);
+
+    QVERIFY(!controller.validateXpub(""));
+}
+
+void WalletQmlControllerTests::validateXpubTrimsWhitespace()
+{
+    using ::testing::NiceMock;
+    NiceMock<MockNode> node;
+    WalletQmlController controller(node);
+
+    QVERIFY(controller.validateXpub("  " + VALID_XPUB + "  "));
+}
+
+void WalletQmlControllerTests::createWatchOnlyInvalidXpubSetsError()
+{
+    using ::testing::NiceMock;
+    NiceMock<MockNode> node;
+    WalletQmlController controller(node);
+
+    QSignalSpy error_spy(&controller, &WalletQmlController::walletLoadErrorChanged);
+    controller.createWatchOnlyWallet("test_wallet", "garbage");
+
+    QVERIFY(!controller.walletLoadError().isEmpty());
+    QVERIFY(!controller.isWalletLoaded());
+    QCOMPARE(error_spy.count(), 1);
+}
 
 void WalletQmlControllerTests::externalSignerCreationRequiresConfiguredPath()
 {


### PR DESCRIPTION
Added the menu for all wallet options when adding a wallet.
Added the watch only wallet creation flow. Currently password protection isn't supported, may want to consider for the future.
Added unit, qml and functional tests for new features.
Fixed bug where the gui would crash when leaving the on-boarding sequence.
Fixed bug where long wallet names would break the wallet name text boxes.
One TODO added. The wallet creation process should be moved to its own worker thread to avoid UI freezes. Out of scope for this PR.
#560 

<img width="660" height="989" alt="image" src="https://github.com/user-attachments/assets/9197a6ce-2cbd-4223-9dd9-e1751f29c67b" />

<img width="660" height="989" alt="image" src="https://github.com/user-attachments/assets/df624d68-6d96-42d8-bbc0-2fab01fc4caa" />

<img width="660" height="989" alt="image" src="https://github.com/user-attachments/assets/dfba5ed8-74e1-46af-a6d8-fb2ca99556f2" />

<img width="660" height="989" alt="image" src="https://github.com/user-attachments/assets/fcd8f3e4-9946-43ed-8e1f-12c8b09dc6c6" />
