### PR TITLE
qml: Validate wallet name during wallet creation

### DIFF
--- a/qml/pages/wallet/CreateExternalWallet.qml
+++ b/qml/pages/wallet/CreateExternalWallet.qml
@@ -15,6 +15,7 @@ Page {
     signal next
 
     property string defaultWalletName: ""
+    property string walletNameError: ""
     readonly property bool creatingWallet: walletController.walletLoadInProgress
 
     background: null
@@ -86,18 +87,21 @@ Page {
             enabled: !root.creatingWallet
             placeholderText: qsTr("Eg. hardware_wallet")
             text: root.defaultWalletName
-            validator: RegularExpressionValidator { regularExpression: /^[a-zA-Z0-9_]{1,20}$/ }
-            onTextChanged: walletController.clearWalletLoadStatus()
+            onTextChanged: {
+                root.walletNameError = ""
+                walletController.clearWalletLoadStatus()
+            }
         }
 
         CoreText {
+            objectName: "externalWalletNameError"
             Layout.fillWidth: true
             Layout.leftMargin: 20
             Layout.rightMargin: 20
-            visible: walletController.walletLoadError.length > 0
+            visible: root.walletNameError.length > 0 || walletController.walletLoadError.length > 0
             color: Theme.color.red
             wrapMode: Text.WordWrap
-            text: walletController.walletLoadError
+            text: root.walletNameError.length > 0 ? root.walletNameError : walletController.walletLoadError
         }
 
         RowLayout {
@@ -129,10 +133,15 @@ Page {
             Layout.leftMargin: 20
             Layout.rightMargin: 20
             Layout.alignment: Qt.AlignCenter
-            enabled: !root.creatingWallet && walletNameInput.acceptableInput && walletController.canCreateExternalSignerWallet
+            enabled: !root.creatingWallet && walletNameInput.text.length > 0 && walletController.canCreateExternalSignerWallet
             text: root.creatingWallet ? qsTr("Creating wallet...") : qsTr("Create wallet")
             onClicked: {
                 walletController.clearWalletLoadStatus()
+                const availabilityError = walletController.walletNameAvailabilityError(walletNameInput.text)
+                if (availabilityError.length > 0) {
+                    root.walletNameError = availabilityError
+                    return
+                }
                 walletController.createExternalSignerWallet(walletNameInput.text)
             }
         }

--- a/qml/pages/wallet/CreateName.qml
+++ b/qml/pages/wallet/CreateName.qml
@@ -79,7 +79,7 @@ Page {
             text: root.walletNameError.length > 0 ? root.walletNameError : walletController.walletLoadError
             color: Theme.color.red
             horizontalAlignment: Text.AlignLeft
-            font.pixelSize: 14
+            font: Theme.text.caption.font
         }
 
         ContinueButton {
@@ -97,7 +97,7 @@ Page {
                     root.walletNameError = availabilityError
                     return
                 }
-                root.walletName = walletNameInput.text.trim()
+                root.walletName = walletNameInput.text
                 root.next()
             }
         }

--- a/qml/pages/wallet/CreateName.qml
+++ b/qml/pages/wallet/CreateName.qml
@@ -20,6 +20,7 @@ Page {
     property int walletType: CreateName.WalletType.SingleSig
     property string initialWalletName: ""
     readonly property bool externalSignerWallet: walletType === CreateName.WalletType.ExternalSigner
+    property string walletNameError: ""
     background: null
 
     Component.onCompleted: {
@@ -61,22 +62,24 @@ Page {
             placeholderText: root.externalSignerWallet
                 ? qsTr("Eg. Hardware wallet...")
                 : qsTr("Eg. My bitcoin wallet...")
-            validator: RegularExpressionValidator { regularExpression: /^[a-zA-Z0-9_]{1,20}$/ }
             onTextChanged: {
                 walletController.clearWalletLoadStatus()
                 root.walletName = walletNameInput.text
+                root.walletNameError = ""
                 continueButton.enabled = walletNameInput.text.length > 0
             }
         }
 
         CoreText {
-            visible: walletController.walletLoadError.length > 0
+            objectName: "walletNameError"
             Layout.fillWidth: true
             Layout.leftMargin: 20
             Layout.rightMargin: 20
+            visible: root.walletNameError.length > 0 || walletController.walletLoadError.length > 0
+            text: root.walletNameError.length > 0 ? root.walletNameError : walletController.walletLoadError
             color: Theme.color.red
-            wrapMode: Text.WordWrap
-            text: walletController.walletLoadError
+            horizontalAlignment: Text.AlignLeft
+            font.pixelSize: 14
         }
 
         ContinueButton {
@@ -89,8 +92,12 @@ Page {
             enabled: walletNameInput.text.length > 0
             text: root.externalSignerWallet ? qsTr("Create wallet") : qsTr("Continue")
             onClicked: {
-                console.log("Creating wallet with name: " + walletNameInput.text)
-                root.walletName = walletNameInput.text
+                const availabilityError = walletController.walletNameAvailabilityError(walletNameInput.text)
+                if (availabilityError.length > 0) {
+                    root.walletNameError = availabilityError
+                    return
+                }
+                root.walletName = walletNameInput.text.trim()
                 root.next()
             }
         }

--- a/qml/walletqmlcontroller.cpp
+++ b/qml/walletqmlcontroller.cpp
@@ -184,8 +184,9 @@ bool WalletQmlController::createExternalSignerWallet(const QString& name)
     m_warning_messages.clear();
 
     const QString wallet_name = name.trimmed();
-    if (wallet_name.isEmpty()) {
-        setWalletLoadError(tr("Choose a wallet name."));
+    const QString name_error = walletNameAvailabilityError(wallet_name);
+    if (!name_error.isEmpty()) {
+        setWalletLoadError(name_error);
         return false;
     }
 
@@ -214,7 +215,7 @@ bool WalletQmlController::createExternalSignerWallet(const QString& name)
     m_pending_wallet_load_action = WalletLoadAction::Load;
     setWalletLoadInProgress(true);
 
-    QTimer::singleShot(0, m_worker, [this, wallet_name, flags]() {
+    QTimer::singleShot(0, m_worker, [this, wallet_name]() {
         std::vector<bilingual_str> warning_messages;
         const SecureString empty_passphrase;
         auto wallet = m_node.walletLoader().createWallet(

--- a/qml/walletqmlcontroller.cpp
+++ b/qml/walletqmlcontroller.cpp
@@ -15,6 +15,7 @@
 #include <wallet/walletutil.h>
 #include <wallet/scriptpubkeyman.h>
 #include <wallet/wallet.h>
+#include <util/translation.h>
 #include <util/threadnames.h>
 
 #include <stdexcept>
@@ -142,12 +143,23 @@ void WalletQmlController::unloadWallets()
 
 bool WalletQmlController::createSingleSigWallet(const QString &name, const QString &passphrase)
 {
+    return createWallet(name, passphrase, wallet::WALLET_FLAG_DESCRIPTORS);
+}
+
+bool WalletQmlController::createWallet(const QString& name, const QString& passphrase, uint64_t wallet_creation_flags)
+{
     clearWalletLoadStatus();
     clearWalletMigrationStatus();
     m_warning_messages.clear();
+    const QString name_error = walletNameAvailabilityError(name);
+    if (!name_error.isEmpty()) {
+        m_error_message = Untranslated(name_error.toStdString());
+        setWalletLoadError(name_error);
+        return false;
+    }
     const SecureString secure_passphrase{passphrase.toStdString()};
-    const std::string wallet_name{name.toStdString()};
-    auto wallet{m_node.walletLoader().createWallet(wallet_name, secure_passphrase, wallet::WALLET_FLAG_DESCRIPTORS, m_warning_messages)};
+    const std::string wallet_name{trimmedWalletName(name).toStdString()};
+    auto wallet{m_node.walletLoader().createWallet(wallet_name, secure_passphrase, wallet_creation_flags, m_warning_messages)};
     setWalletLoadWarnings(JoinWarnings(m_warning_messages));
     QMutexLocker locker(&m_wallets_mutex);
     if (wallet) {
@@ -304,6 +316,55 @@ bool WalletQmlController::walletPathExists(const QString& path) const
 {
     const QString normalized = normalizeWalletPath(path);
     return !normalized.isEmpty() && QFileInfo::exists(normalized);
+}
+
+QString WalletQmlController::trimmedWalletName(const QString& name) const
+{
+    return name.trimmed();
+}
+
+bool WalletQmlController::walletNameExists(const QString& name) const
+{
+    const QString candidate = QDir::cleanPath(trimmedWalletName(name));
+    if (candidate.isEmpty()) {
+        return false;
+    }
+
+    for (const auto& [wallet_path, info] : m_node.walletLoader().listWalletDir()) {
+        Q_UNUSED(info);
+        if (QDir::cleanPath(QString::fromStdString(wallet_path)).compare(candidate, Qt::CaseInsensitive) == 0) {
+            return true;
+        }
+    }
+
+    QMutexLocker locker(&m_wallets_mutex);
+    for (WalletQmlModel* wallet : m_wallets) {
+        if (wallet->name().compare(candidate, Qt::CaseInsensitive) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+QString WalletQmlController::walletNameAvailabilityError(const QString& name) const
+{
+    const QString candidate = trimmedWalletName(name);
+    static const QRegularExpression valid_name(QStringLiteral("^[A-Za-z0-9_]{1,20}$"));
+
+    if (candidate.isEmpty()) {
+        return tr("Enter a wallet name.");
+    }
+
+    if (!valid_name.match(candidate).hasMatch()) {
+        return tr("Wallet names can use 1-20 letters, numbers, and underscores.");
+    }
+
+    if (walletNameExists(candidate)) {
+        return tr("A wallet with this name already exists.");
+    }
+
+    return {};
 }
 
 QString WalletQmlController::walletImportErrorTitle() const

--- a/qml/walletqmlcontroller.cpp
+++ b/qml/walletqmlcontroller.cpp
@@ -158,7 +158,7 @@ bool WalletQmlController::createWallet(const QString& name, const QString& passp
         return false;
     }
     const SecureString secure_passphrase{passphrase.toStdString()};
-    const std::string wallet_name{trimmedWalletName(name).toStdString()};
+    const std::string wallet_name{name.toStdString()};
     auto wallet{m_node.walletLoader().createWallet(wallet_name, secure_passphrase, wallet_creation_flags, m_warning_messages)};
     setWalletLoadWarnings(JoinWarnings(m_warning_messages));
     QMutexLocker locker(&m_wallets_mutex);
@@ -183,7 +183,7 @@ bool WalletQmlController::createExternalSignerWallet(const QString& name)
     clearWalletMigrationStatus();
     m_warning_messages.clear();
 
-    const QString wallet_name = name.trimmed();
+    const QString wallet_name = name;
     const QString name_error = walletNameAvailabilityError(wallet_name);
     if (!name_error.isEmpty()) {
         setWalletLoadError(name_error);
@@ -319,14 +319,9 @@ bool WalletQmlController::walletPathExists(const QString& path) const
     return !normalized.isEmpty() && QFileInfo::exists(normalized);
 }
 
-QString WalletQmlController::trimmedWalletName(const QString& name) const
-{
-    return name.trimmed();
-}
-
 bool WalletQmlController::walletNameExists(const QString& name) const
 {
-    const QString candidate = QDir::cleanPath(trimmedWalletName(name));
+    const QString candidate = QDir::cleanPath(name);
     if (candidate.isEmpty()) {
         return false;
     }
@@ -350,18 +345,11 @@ bool WalletQmlController::walletNameExists(const QString& name) const
 
 QString WalletQmlController::walletNameAvailabilityError(const QString& name) const
 {
-    const QString candidate = trimmedWalletName(name);
-    static const QRegularExpression valid_name(QStringLiteral("^[A-Za-z0-9_]{1,20}$"));
-
-    if (candidate.isEmpty()) {
+    if (name.isEmpty()) {
         return tr("Enter a wallet name.");
     }
 
-    if (!valid_name.match(candidate).hasMatch()) {
-        return tr("Wallet names can use 1-20 letters, numbers, and underscores.");
-    }
-
-    if (walletNameExists(candidate)) {
+    if (walletNameExists(name)) {
         return tr("A wallet with this name already exists.");
     }
 

--- a/qml/walletqmlcontroller.h
+++ b/qml/walletqmlcontroller.h
@@ -52,6 +52,7 @@ public:
     Q_INVOKABLE void clearWalletMigrationStatus();
     Q_INVOKABLE QString normalizeWalletPath(const QString& path) const;
     Q_INVOKABLE bool walletPathExists(const QString& path) const;
+    Q_INVOKABLE QString walletNameAvailabilityError(const QString& name) const;
     Q_INVOKABLE void requestOpenWalletSettings();
     Q_INVOKABLE void refreshExternalSignerStatus();
 
@@ -113,6 +114,9 @@ private:
     QString resolveManagedWalletReference(const QString& path) const;
     QString inferWalletLoadTarget(const QString& normalized_path) const;
     QString inferRestoreWalletName(const QString& normalized_path) const;
+    QString trimmedWalletName(const QString& name) const;
+    bool walletNameExists(const QString& name) const;
+    bool createWallet(const QString& name, const QString& passphrase, uint64_t wallet_creation_flags);
     QString describeImportedWalletKeyScheme(interfaces::Wallet& wallet) const;
     void setWalletLoadInProgress(bool in_progress);
     void setWalletLoadError(const QString& error);
@@ -130,7 +134,7 @@ private:
     WalletQmlModel* m_selected_wallet;
     QObject* m_worker;
     QThread* m_worker_thread;
-    QMutex m_wallets_mutex;
+    mutable QMutex m_wallets_mutex;
     std::vector<WalletQmlModel*> m_wallets;
     std::unique_ptr<interfaces::Handler> m_handler_load_wallet;
     bool m_is_wallet_loaded{false};

--- a/qml/walletqmlcontroller.h
+++ b/qml/walletqmlcontroller.h
@@ -114,7 +114,6 @@ private:
     QString resolveManagedWalletReference(const QString& path) const;
     QString inferWalletLoadTarget(const QString& normalized_path) const;
     QString inferRestoreWalletName(const QString& normalized_path) const;
-    QString trimmedWalletName(const QString& name) const;
     bool walletNameExists(const QString& name) const;
     bool createWallet(const QString& name, const QString& passphrase, uint64_t wallet_creation_flags);
     QString describeImportedWalletKeyScheme(interfaces::Wallet& wallet) const;

--- a/test/functional/qml_test_create_wallet_name.py
+++ b/test/functional/qml_test_create_wallet_name.py
@@ -103,7 +103,7 @@ def run_case(case_name, case_body):
 def case_name_availability(harness):
     closed_wallet = "duplicate_closed"
     loaded_wallet = "duplicate_loaded"
-    available_wallet = "available_name"
+    available_wallet = "My new wallet"
 
     # Pre-create one wallet before GUI launch so startup skips onboarding and
     # exposes the main wallet entry point used by this flow.
@@ -122,10 +122,6 @@ def case_name_availability(harness):
     submit_name(gui, loaded_wallet)
     gui.wait_for_page("createWalletNamePage", timeout_ms=10000)
     wait_for_text_contains(gui, "walletNameError", "already exists")
-
-    submit_name(gui, "invalid-name")
-    gui.wait_for_page("createWalletNamePage", timeout_ms=10000)
-    wait_for_text_contains(gui, "walletNameError", "letters, numbers, and underscores")
 
     submit_name(gui, available_wallet)
     gui.wait_for_page("createWalletPasswordPage", timeout_ms=10000)

--- a/test/functional/qml_test_create_wallet_name.py
+++ b/test/functional/qml_test_create_wallet_name.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""End-to-end GUI tests for create-wallet name availability checks."""
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+
+from qml_driver import QmlDriverError
+from qml_test_harness import dump_qml_tree
+from qml_wallet_test_lib import WalletFlowHarness, rpc_call, wait_for_rpc
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Create-wallet name GUI functional test")
+    return parser.parse_args()
+
+
+def wait_for_text_contains(gui, object_name, expected_substring, timeout_ms=10000):
+    deadline = time.time() + (timeout_ms / 1000)
+    last_text = ""
+    while time.time() < deadline:
+        last_text = gui.get_text(object_name)
+        if expected_substring in last_text:
+            return last_text
+        time.sleep(0.25)
+    raise AssertionError(
+        f"Expected {object_name} text to contain {expected_substring!r}, got {last_text!r}"
+    )
+
+
+def open_create_wallet_name_page(gui):
+    gui.wait_for_property("walletBadge", "loading", False, timeout_ms=20000)
+    gui.click("walletBadge")
+    try:
+        gui.wait_for_property("walletSelectPopup", "opened", True, timeout_ms=2000)
+        gui.click("walletSelectAddWalletButton")
+    except QmlDriverError:
+        pass
+    gui.wait_for_property("createWalletButton", "visible", True, timeout_ms=10000)
+    gui.click("createWalletButton")
+    gui.wait_for_property("createWalletIntroStartButton", "visible", True, timeout_ms=10000)
+    gui.click("createWalletIntroStartButton")
+    gui.wait_for_page("createWalletNamePage", timeout_ms=10000)
+
+
+def submit_name(gui, wallet_name):
+    gui.set_text("createWalletNameInput", wallet_name)
+    gui.click("createWalletNameContinueButton")
+    gui.settle()
+
+
+def create_closed_wallet_fixture(harness, wallet_name):
+    process = subprocess.Popen(
+        [harness.bitcoind_binary, f"-datadir={harness.gui_datadir}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        wait_for_rpc(harness.gui_rpc_port)
+        rpc_call(harness.gui_rpc_port, "createwallet", {"wallet_name": wallet_name})
+        rpc_call(harness.gui_rpc_port, "unloadwallet", [wallet_name])
+        rpc_call(harness.gui_rpc_port, "stop")
+        process.wait(timeout=20)
+    except Exception:
+        if process.poll() is None:
+            process.send_signal(signal.SIGTERM)
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+        raise
+
+
+def run_case(case_name, case_body):
+    harness = WalletFlowHarness(case_name, port_offset=70)
+    try:
+        print(f"[{case_name}] starting")
+        case_body(harness)
+        print(f"[{case_name}] completed")
+        return 0
+    except Exception as err:  # noqa: BLE001 - preserve GUI state and logs
+        print(f"\nFAILED [{case_name}]: {err}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        gui_output = harness.process_output(harness.gui_process)
+        if gui_output:
+            print("\n--- GUI process output ---", file=sys.stderr)
+            print(gui_output, file=sys.stderr)
+        if harness.driver is not None:
+            dump_qml_tree(harness.driver)
+        return 1
+    finally:
+        harness.stop()
+
+
+def case_name_availability(harness):
+    closed_wallet = "duplicate_closed"
+    loaded_wallet = "duplicate_loaded"
+    available_wallet = "available_name"
+
+    # Pre-create one wallet before GUI launch so startup skips onboarding and
+    # exposes the main wallet entry point used by this flow.
+    create_closed_wallet_fixture(harness, closed_wallet)
+    harness.start_gui()
+    gui = harness.driver
+    wait_for_rpc(harness.gui_rpc_port)
+    rpc_call(harness.gui_rpc_port, "createwallet", {"wallet_name": loaded_wallet})
+
+    open_create_wallet_name_page(gui)
+
+    submit_name(gui, closed_wallet)
+    gui.wait_for_page("createWalletNamePage", timeout_ms=10000)
+    wait_for_text_contains(gui, "walletNameError", "already exists")
+
+    submit_name(gui, loaded_wallet)
+    gui.wait_for_page("createWalletNamePage", timeout_ms=10000)
+    wait_for_text_contains(gui, "walletNameError", "already exists")
+
+    submit_name(gui, "invalid-name")
+    gui.wait_for_page("createWalletNamePage", timeout_ms=10000)
+    wait_for_text_contains(gui, "walletNameError", "letters, numbers, and underscores")
+
+    submit_name(gui, available_wallet)
+    gui.wait_for_page("createWalletPasswordPage", timeout_ms=10000)
+
+
+def run_test(_args):
+    return run_case("qml_create_wallet_name_availability", case_name_availability)
+
+
+if __name__ == "__main__":
+    sys.exit(run_test(parse_args()))


### PR DESCRIPTION
Fixes https://github.com/bitcoin-core/gui-qml/issues/571

When creating a wallet, the name is checked for
- invalid/empty names
- discovered wallet names in wallet dir
- existing loaded wallets

The same checks are performed for external-signer wallets.

### Review notes
~~This PR is stacked on top of #547.~~ Now rebased on top of `qt6`

## Screenshots
<img width="1210" height="836" alt="Screenshot 2026-05-06 at 8 50 36 AM" src="https://github.com/user-attachments/assets/1dd48e85-40e7-4899-9f98-13ba0fb20bec" />
