### PR TITLE
qml: Remove back button after wallet creation

### DIFF
--- a/qml/controls/NavigationBar2.qml
+++ b/qml/controls/NavigationBar2.qml
@@ -10,6 +10,12 @@ Pane {
     property alias leftItem: left_section.contentItem
     property alias centerItem: center_section.contentItem
     property alias rightItem: right_section.contentItem
+    property var navigationStack: null
+    property bool showBackButton: navigationStack ? navigationStack.canGoBack : false
+    property string backButtonObjectName: ""
+    property string backButtonText: qsTr("Back")
+
+    signal backClicked
 
     background: null
     padding: 4
@@ -18,6 +24,18 @@ Pane {
             id: left_div
             Layout.preferredWidth: Math.floor(Math.max(left_div.implicitWidth, right_div.implicitWidth))
             contentItem: RowLayout {
+                NavButton {
+                    objectName: backButtonObjectName
+                    visible: showBackButton
+                    iconSource: "image://images/caret-left"
+                    text: backButtonText
+                    onClicked: {
+                        if (navigationStack) {
+                            navigationStack.goBack()
+                        }
+                        backClicked()
+                    }
+                }
                 Section {
                     id: left_section
                 }

--- a/qml/controls/PageStack.qml
+++ b/qml/controls/PageStack.qml
@@ -7,6 +7,13 @@ import QtQuick.Controls 2.15
 
 StackView {
     property bool vertical: false
+    readonly property bool canGoBack: depth > 1 && currentItem && currentItem.navigationBackEnabled !== false
+
+    function goBack() {
+        if (canGoBack) {
+            pop()
+        }
+    }
 
     pushEnter: Transition {
         NumberAnimation {

--- a/qml/pages/wallet/CreateBackup.qml
+++ b/qml/pages/wallet/CreateBackup.qml
@@ -12,20 +12,11 @@ import "../settings"
 
 Page {
     id: root
-    signal back
+    property bool navigationBackEnabled: false
     signal next
     background: null
 
-    header: NavigationBar2 {
-        id: navbar
-        leftItem: NavButton {
-            iconSource: "image://images/caret-left"
-            text: qsTr("Back")
-            onClicked: {
-                root.back()
-            }
-        }
-    }
+    header: NavigationBar2 {}
 
     ColumnLayout {
         id: columnLayout

--- a/qml/pages/wallet/CreateConfirm.qml
+++ b/qml/pages/wallet/CreateConfirm.qml
@@ -1,4 +1,4 @@
- // Copyright (c) 2024 The Bitcoin Core developers
+// Copyright (c) 2024 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,20 +12,11 @@ import "../settings"
 
 Page {
     id: root
-    signal back
+    property bool navigationBackEnabled: false
     signal next
     background: null
 
-    header: NavigationBar2 {
-        id: navbar
-        leftItem: NavButton {
-            iconSource: "image://images/caret-left"
-            text: qsTr("Back")
-            onClicked: {
-                root.back()
-            }
-        }
-    }
+    header: NavigationBar2 {}
 
     ColumnLayout {
         id: columnLayout

--- a/qml/pages/wallet/CreateIntro.qml
+++ b/qml/pages/wallet/CreateIntro.qml
@@ -12,19 +12,11 @@ import "../settings"
 
 Page {
     id: root
-    signal back
     signal next
     background: null
 
     header: NavigationBar2 {
-        id: navbar
-        leftItem: NavButton {
-            iconSource: "image://images/caret-left"
-            text: qsTr("Back")
-            onClicked: {
-                root.back()
-            }
-        }
+        navigationStack: root.StackView.view
     }
 
     ColumnLayout {

--- a/qml/pages/wallet/CreateName.qml
+++ b/qml/pages/wallet/CreateName.qml
@@ -12,20 +12,12 @@ import "../settings"
 
 Page {
     id: root
-    signal back
     signal next
     property string walletName: ""
     background: null
 
     header: NavigationBar2 {
-        id: navbar
-        leftItem: NavButton {
-            iconSource: "image://images/caret-left"
-            text: qsTr("Back")
-            onClicked: {
-                root.back()
-            }
-        }
+        navigationStack: root.StackView.view
     }
 
     ColumnLayout {

--- a/qml/pages/wallet/CreatePassword.qml
+++ b/qml/pages/wallet/CreatePassword.qml
@@ -12,21 +12,13 @@ import "../settings"
 
 Page {
     id: root
-    signal back
     signal next
     background: null
 
     required property string walletName;
 
     header: NavigationBar2 {
-        id: navbar
-        leftItem: NavButton {
-            iconSource: "image://images/caret-left"
-            text: qsTr("Back")
-            onClicked: {
-                root.back()
-            }
-        }
+        navigationStack: root.StackView.view
         rightItem: NavButton {
             text: qsTr("Skip")
             onClicked: {

--- a/qml/pages/wallet/CreateWalletWizard.qml
+++ b/qml/pages/wallet/CreateWalletWizard.qml
@@ -22,6 +22,7 @@ PageStack {
 
     initialItem: Page {
         background: null
+        property bool navigationBackEnabled: false
 
         header: NavigationBar2 {
             id: navbar
@@ -108,14 +109,14 @@ PageStack {
     Component {
         id: import_options
         ImportWalletOptions {
-            onBack: root.pop()
+            onBack: root.goBack()
             onNext: root.push(import_success)
         }
     }
     Component {
         id: import_success
         ImportWalletSuccess {
-            onBack: root.pop()
+            onBack: root.goBack()
             onDone: root.finished()
             onViewSettings: {
                 walletController.requestOpenWalletSettings()
@@ -126,7 +127,6 @@ PageStack {
     Component {
         id: intro
         CreateIntro {
-            onBack: root.pop()
             onNext: root.push(name)
         }
     }
@@ -134,7 +134,6 @@ PageStack {
         id: name
         CreateName {
             id: createName
-            onBack: root.pop()
             onNext: {
                 root.walletName = createName.walletName
                 root.push(password)
@@ -145,21 +144,18 @@ PageStack {
         id: password
         CreatePassword {
             walletName: root.walletName
-            onBack: root.pop()
             onNext: root.push(confirm)
         }
     }
     Component {
         id: confirm
         CreateConfirm {
-            onBack: root.pop()
             onNext: root.push(backup)
         }
     }
     Component {
         id: backup
         CreateBackup {
-            onBack: root.pop()
             onNext: root.finished()
         }
     }


### PR DESCRIPTION
Fixes https://github.com/bitcoin-core/gui-qml/issues/572

This change adds a small shared navigation policy to `PageStack` and ties `NavigationBar2` into it. `PageStack` now exposes `canGoBack` and `goBack()`, 
- pages can opt out by setting `navigationBackEnabled: false` 
- `NavigationBar2` can now take a navigationStack and render a default Back button based on that stack’s `canGoBack`, calling `goBack()` when clicked.

The wallet creation flow now uses this shared behavior instead of hand-rolling Back buttons and back signal.