### PR TITLE
A bunch of fixes for Preview release target

### DIFF
--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -163,6 +163,7 @@ jobs:
           python3 test/functional/qml_test_wallet_qt_compat.py
           python3 test/functional/qml_test_wallet_rbf.py
           python3 test/functional/qml_test_wallet_restore.py
+          python3 test/functional/qml_test_uri_import.py
           python3 test/functional/qml_test_wallet_settings.py
           python3 test/functional/qml_test_watchonly_wallet.py
           python3 test/functional/qml_test_create_wallet_name.py

--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -151,6 +151,7 @@ jobs:
           python3 test/functional/qml_test_peers.py
           python3 test/functional/qml_test_proxy.py
           python3 test/functional/qml_test_debug_log.py
+          python3 test/functional/qml_test_node_runtime_dialogs.py
           python3 test/functional/qml_test_settings_display.py
           python3 test/functional/qml_test_receive.py
           python3 test/functional/qml_test_activity_filter_export.py
@@ -166,3 +167,4 @@ jobs:
           python3 test/functional/qml_test_watchonly_wallet.py
           python3 test/functional/qml_test_create_wallet_name.py
           python3 test/functional/qml_test_wallet_selector_load.py
+          python3 test/functional/qml_test_shutdown.py

--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       LEGACY_BITCOIND_VERSION: "28.0"
+      QT_COMPAT_VERSION: "31.0"
 
     steps:
       - name: Checkout
@@ -30,6 +31,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential cmake curl pkgconf python3 \
+            xvfb xauth \
             libevent-dev libboost-dev libsqlite3-dev libgl-dev libqrencode-dev \
             qt6-qpa-plugins \
             qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools \
@@ -80,6 +82,47 @@ jobs:
           path: releases/v${{ env.LEGACY_BITCOIND_VERSION }}
           key: ${{ runner.os }}-legacy-bitcoind-v${{ env.LEGACY_BITCOIND_VERSION }}
 
+      - name: Restore bitcoin-qt compatibility cache
+        uses: actions/cache/restore@v4
+        id: bitcoin-qt-compat-cache
+        with:
+          path: releases/v${{ env.QT_COMPAT_VERSION }}
+          key: ${{ runner.os }}-bitcoin-qt-v${{ env.QT_COMPAT_VERSION }}
+
+      - name: Install bitcoin-qt compatibility binary
+        run: |
+          archive="bitcoin-${QT_COMPAT_VERSION}-x86_64-linux-gnu.tar.gz"
+          base_url="https://bitcoincore.org/bin/bitcoin-core-${QT_COMPAT_VERSION}"
+          compat_dir="${GITHUB_WORKSPACE}/releases/v${QT_COMPAT_VERSION}"
+
+          mkdir -p "${compat_dir}"
+
+          if [ ! -x "${compat_dir}/bin/bitcoin-qt" ]; then
+            workdir="$(mktemp -d)"
+            trap 'rm -rf "${workdir}"' EXIT
+
+            curl -fsSLo "${workdir}/${archive}" "${base_url}/${archive}"
+            curl -fsSLo "${workdir}/SHA256SUMS" "${base_url}/SHA256SUMS"
+            (
+              cd "${workdir}"
+              grep " ${archive}$" "SHA256SUMS" | sha256sum -c -
+            )
+
+            tar -xzf "${workdir}/${archive}" \
+              --strip-components=1 \
+              -C "${compat_dir}" \
+              "bitcoin-${QT_COMPAT_VERSION}/bin"
+          fi
+
+          "${compat_dir}/bin/bitcoin-qt" --version | head -n 1
+
+      - name: Save bitcoin-qt compatibility cache
+        uses: actions/cache/save@v4
+        if: github.event_name != 'pull_request' && steps.bitcoin-qt-compat-cache.outputs.cache-hit != 'true'
+        with:
+          path: releases/v${{ env.QT_COMPAT_VERSION }}
+          key: ${{ runner.os }}-bitcoin-qt-v${{ env.QT_COMPAT_VERSION }}
+
       - name: Configure
         run: |
           cmake -B build \
@@ -97,6 +140,8 @@ jobs:
           LIBGL_ALWAYS_SOFTWARE: "1"
         run: |
           export BITCOIND_LEGACY="${GITHUB_WORKSPACE}/releases/v${LEGACY_BITCOIND_VERSION}/bin/bitcoind"
+          export BITCOIN_QT_COMPAT="${GITHUB_WORKSPACE}/releases/v${QT_COMPAT_VERSION}/bin/bitcoin-qt"
+          export BITCOIN_QT_RUNNER="xvfb-run -a"
           python3 test/functional/qml_test_bridge_sanity.py
           python3 test/functional/qml_test_onboarding.py
           python3 test/functional/qml_test_disablewallet_boot.py
@@ -114,6 +159,7 @@ jobs:
           python3 test/functional/qml_test_addresses.py
           python3 test/functional/qml_test_send_review.py
           python3 test/functional/qml_test_wallet_migration.py
+          python3 test/functional/qml_test_wallet_qt_compat.py
           python3 test/functional/qml_test_wallet_rbf.py
           python3 test/functional/qml_test_wallet_restore.py
           python3 test/functional/qml_test_wallet_settings.py

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -456,6 +456,11 @@ int QmlGuiMain(int argc, char* argv[])
     OptionsQmlModel options_model(*node, !need_onboarding.toBool());
     engine.rootContext()->setContextProperty("optionsModel", &options_model);
     engine.rootContext()->setContextProperty("needOnboarding", need_onboarding);
+#ifdef ENABLE_TEST_AUTOMATION
+    engine.rootContext()->setContextProperty("testAutomationEnabled", true);
+#else
+    engine.rootContext()->setContextProperty("testAutomationEnabled", false);
+#endif
 
     // -lang CLI flag overrides the persisted setting (bitcoin-qt compatibility).
     // Must be after gArgs.ParseParameters() and after setupChainQSettings() so

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -33,6 +33,7 @@
 #include <qml/models/addresslistmodel.h>
 #include <qml/models/banlistmodel.h>
 #include <qml/models/bitcoinaddress.h>
+#include <qml/models/bitcoinurimodel.h>
 #include <qml/models/bumptransactionmodel.h>
 #include <qml/models/chainmodel.h>
 #include <qml/models/debuglogmodel.h>
@@ -479,10 +480,12 @@ int QmlGuiMain(int argc, char* argv[])
 
     BuildInfo build_info;
     Clipboard clipboard;
+    BitcoinUriModel bitcoin_uri_model;
 
     qmlRegisterSingletonInstance<AppMode>("org.bitcoincore.qt", 1, 0, "AppMode", &app_mode);
     qmlRegisterSingletonInstance<BuildInfo>("org.bitcoincore.qt", 1, 0, "BuildInfo", &build_info);
     qmlRegisterSingletonInstance<Clipboard>("org.bitcoincore.qt", 1, 0, "Clipboard", &clipboard);
+    qmlRegisterSingletonInstance<BitcoinUriModel>("org.bitcoincore.qt", 1, 0, "BitcoinUri", &bitcoin_uri_model);
     qmlRegisterType<BlockClockDial>("org.bitcoincore.qt", 1, 0, "BlockClockDial");
     qmlRegisterType<LineGraph>("org.bitcoincore.qt", 1, 0, "LineGraph");
     qmlRegisterUncreatableType<PeerDetailsModel>("org.bitcoincore.qt", 1, 0, "PeerDetailsModel", "");

--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -344,16 +344,26 @@ int QmlGuiMain(int argc, char* argv[])
     std::unique_ptr<WalletQmlController> wallet_controller;
     if (wallet_enabled) {
         wallet_controller = std::make_unique<WalletQmlController>(*node);
-        QObject::connect(&init_executor, &QmlInitExecutor::initializeResult, wallet_controller.get(), &WalletQmlController::initialize);
+        QObject::connect(&init_executor, &QmlInitExecutor::initializeResult, wallet_controller.get(), [wallet_controller = wallet_controller.get()](bool success) {
+            if (success) {
+                wallet_controller->initialize();
+            }
+        });
     }
 #endif
     QObject::connect(&node_model, &NodeModel::requestedInitialize, &init_executor, &QmlInitExecutor::initialize);
+    bool shutdown_requested{false};
     QObject::connect(&node_model, &NodeModel::requestedShutdown, [&] {
+        if (shutdown_requested) {
+            return;
+        }
+        shutdown_requested = true;
 #ifdef ENABLE_WALLET
         if (wallet_controller) {
             wallet_controller->unloadWallets();
         }
 #endif
+        node->startShutdown();
         init_executor.shutdown();
     });
     QObject::connect(&init_executor, &QmlInitExecutor::initializeResult, &node_model, &NodeModel::initializeResult);
@@ -376,12 +386,7 @@ int QmlGuiMain(int argc, char* argv[])
 
     qGuiApp->setQuitOnLastWindowClosed(false);
     QObject::connect(qGuiApp, &QGuiApplication::lastWindowClosed, [&] {
-#ifdef ENABLE_WALLET
-        if (wallet_controller) {
-            wallet_controller->unloadWallets();
-        }
-#endif
-        node->startShutdown();
+        node_model.requestShutdown();
     });
 
     PeerListModel peer_model{*node, nullptr};

--- a/qml/clipboard.h
+++ b/qml/clipboard.h
@@ -13,8 +13,15 @@ class Clipboard : public QObject
 {
     Q_OBJECT
 public:
-    explicit Clipboard(QObject *parent = nullptr) : QObject(parent) {}
+    explicit Clipboard(QObject *parent = nullptr) : QObject(parent) {
+        connect(QGuiApplication::clipboard(), &QClipboard::dataChanged,
+                this, &Clipboard::dataChanged);
+    }
 
+Q_SIGNALS:
+    void dataChanged();
+
+public:
     Q_INVOKABLE void setText(const QString &text) {
         QGuiApplication::clipboard()->setText(text);
     }

--- a/qml/components/BitcoinAmountInputField.qml
+++ b/qml/components/BitcoinAmountInputField.qml
@@ -15,9 +15,20 @@ ColumnLayout {
     property var amount
     property string errorText: ""
     property string labelText: qsTr("Amount")
+    property string accessibleName: labelText
+    property alias inputObjectName: amountInput.objectName
+    property alias unitToggleObjectName: unitToggle.objectName
+    property alias unitLabelObjectName: unitLabel.objectName
+    property alias errorTextObjectName: errorTextLabel.objectName
     property bool enabled: true
 
+    signal inputTextChanged
+    signal textEdited
     signal editingFinished(string value)
+
+    function syncFromAmount(force) {
+        amountInput.syncFromAmount(force)
+    }
 
     Layout.fillWidth: true
     spacing: 4
@@ -39,7 +50,41 @@ ColumnLayout {
 
         TextField {
             id: amountInput
+            property bool syncingFromAmount: false
+
+            function amountDisplay() {
+                return root.amount ? root.amount.display : ""
+            }
+
+            // Keep user draft text while focused, then pull from BitcoinAmount
+            // after format() so the field shows the clean canonical display.
+            function syncFromAmount(force) {
+                if (!force && activeFocus) return
+                const display = amountDisplay()
+                if (text === display) return
+                syncingFromAmount = true
+                text = display
+                syncingFromAmount = false
+            }
+
+            function commitAmountText() {
+                if (root.amount && root.amount.display !== text) {
+                    root.amount.display = text
+                }
+            }
+
+            function finishAmountEditing() {
+                commitAmountText()
+                if (root.amount) {
+                    root.amount.format()
+                    root.syncFromAmount(true)
+                }
+                root.editingFinished(text)
+            }
+
+            Accessible.name: root.accessibleName
             anchors.left: lbl.right
+            anchors.right: unitToggle.left
             anchors.verticalCenter: parent.verticalCenter
             leftPadding: 0
             enabled: root.enabled
@@ -52,44 +97,75 @@ ColumnLayout {
             placeholderText: root.amount && root.amount.unit === BitcoinAmount.SAT ? "0" : "0.00000000"
             selectByMouse: true
 
-            text: root.amount ? root.amount.display : ""
+            text: ""
+            Component.onCompleted: root.syncFromAmount(true)
 
-            onEditingFinished: {
-                if (root.amount) {
-                    root.amount.display = text
+            onTextChanged: {
+                if (!syncingFromAmount) {
+                    root.inputTextChanged()
                 }
-                root.editingFinished(text)
             }
+
+            onTextEdited: {
+                commitAmountText()
+                root.textEdited()
+            }
+
+            onEditingFinished: finishAmountEditing()
 
             onActiveFocusChanged: {
-                if (!activeFocus && root.amount) {
-                    root.amount.display = text
-                    root.editingFinished(text)
+                if (!activeFocus) {
+                    finishAmountEditing()
                 }
             }
 
-            validator: RegExpValidator {
-                regExp: /^(0|[1-9]\d*)(\.\d{0,8})?$/
+            // Keep draft input representable as satoshis; leading zeroes are
+            // still allowed until the field syncs from the formatted amount.
+            validator: RegularExpressionValidator {
+                regularExpression: !root.amount || root.amount.unit === BitcoinAmount.BTC
+                    ? /^0*\d{0,8}(\.\d{0,8})?$/
+                    : /^0*\d{0,16}$/
             }
-            maximumLength: 17
+            maximumLength: 32
+
+            Connections {
+                target: root
+                function onAmountChanged() {
+                    root.syncFromAmount(true)
+                }
+            }
+
+            Connections {
+                target: root.amount ? root.amount : null
+                function onDisplayChanged() {
+                    amountInput.syncFromAmount(false)
+                }
+                function onUnitChanged() {
+                    root.syncFromAmount(true)
+                }
+            }
         }
 
         Item {
+            id: unitToggle
             width: unitLabel.width + flipIcon.width
             height: Math.max(unitLabel.height, flipIcon.height)
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             opacity: root.enabled ? 1.0 : 0.5
 
+            function click() {
+                if (!root.enabled || !root.amount) return
+                amountInput.commitAmountText()
+                root.amount.flipUnit()
+            }
+
             MouseArea {
                 anchors.fill: parent
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 enabled: root.enabled && root.amount
-                onClicked: {
-                    root.amount.display = amountInput.text
-                    root.amount.flipUnit()
-                }
+                onClicked: unitToggle.click()
             }
 
             CoreText {
@@ -106,7 +182,7 @@ ColumnLayout {
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
                 source: "image://images/flip-vertical"
-                icon.color: enabled ? Theme.color.neutral8 : Theme.color.neutral4
+                color: enabled ? Theme.color.neutral8 : Theme.color.neutral4
                 size: 30
             }
         }
@@ -124,6 +200,7 @@ ColumnLayout {
         }
 
         CoreText {
+            id: errorTextLabel
             text: root.errorText
             font.pixelSize: 15
             color: Theme.color.red

--- a/qml/controls/LabeledCoinControlButton.qml
+++ b/qml/controls/LabeledCoinControlButton.qml
@@ -9,11 +9,18 @@ import QtQuick.Layouts 1.15
 Item {
     property int coinsSelected: 0
     property int coinCount: 0
+    property string valueObjectName: ""
 
     signal openCoinControl
 
     id: root
     implicitHeight: label.height
+
+    function click() {
+        if (coinCount > 0) {
+            root.openCoinControl()
+        }
+    }
 
     CoreText {
         id: label
@@ -26,6 +33,7 @@ Item {
     }
 
     CoreText {
+        objectName: root.valueObjectName
         anchors.left: label.right
         anchors.verticalCenter: parent.verticalCenter
         horizontalAlignment: Text.AlignLeft
@@ -45,11 +53,7 @@ Item {
 
         MouseArea {
             anchors.fill: parent
-            onClicked: {
-                if (coinCount > 0) {
-                    root.openCoinControl()
-                }
-            }
+            onClicked: root.click()
             cursorShape: Qt.PointingHandCursor
         }
     }

--- a/qml/controls/NavButton.qml
+++ b/qml/controls/NavButton.qml
@@ -58,7 +58,6 @@ AbstractButton {
     }
     contentItem: RowLayout {
         spacing: 0
-        anchors.fill: parent
         Item {
             Layout.fillWidth: !text_background.active
         }

--- a/qml/controls/SendOptionsPopup.qml
+++ b/qml/controls/SendOptionsPopup.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Bitcoin Core developers
+// Copyright (c) 2025-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -16,6 +16,8 @@ OptionPopup {
     property alias coinControlEnabled: coinControlToggle.checked
     property alias multipleRecipientsEnabled: multipleRecipientsToggle.checked
 
+    signal openPaymentRequest()
+
     implicitWidth: 300
     implicitHeight: columnLayout.implicitHeight + 20
 
@@ -25,20 +27,33 @@ OptionPopup {
 
     ColumnLayout {
         id: columnLayout
-        anchors.centerIn: parent
-        anchors.margins: 10
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: 5
+        anchors.leftMargin: 10
+        anchors.rightMargin: 10
         spacing: 0
+
+        EllipsisMenuButtonItem {
+            objectName: "sendOptionsOpenPaymentRequestButton"
+            Layout.fillWidth: true
+            text: qsTr("Open payment request")
+            onClicked: {
+                root.close()
+                root.openPaymentRequest()
+            }
+        }
+
+        Separator {
+            Layout.fillWidth: true
+        }
 
         EllipsisMenuToggleItem {
             id: coinControlToggle
             objectName: "sendOptionsCoinControlToggle"
             Layout.fillWidth: true
             text: qsTr("Enable Coin control")
-        }
-
-        Separator {
-            id: separator
-            Layout.fillWidth: true
         }
 
         EllipsisMenuToggleItem {

--- a/qml/models/bitcoinuri.cpp
+++ b/qml/models/bitcoinuri.cpp
@@ -49,13 +49,9 @@ BitcoinUriParseResult BitcoinUri::Parse(const QString& uri_text)
         result.address.chop(1);
     }
 
-    std::string decode_error;
-    const CTxDestination destination = DecodeDestination(result.address.toStdString(), decode_error);
+    const CTxDestination destination = DecodeDestination(result.address.toStdString());
     if (!IsValidDestination(destination)) {
-        const QString message = decode_error.empty()
-            ? Tr::tr("URI cannot be parsed. Use a valid bitcoin: payment URI.")
-            : QString::fromStdString(decode_error);
-        return BuildError(message);
+        return BuildError(Tr::tr("Not a valid Bitcoin address."));
     }
 
     const QUrlQuery query(uri);

--- a/qml/models/bitcoinuri.cpp
+++ b/qml/models/bitcoinuri.cpp
@@ -29,7 +29,7 @@ BitcoinUriParseResult BitcoinUri::Parse(const QString& uri_text)
 {
     const QString raw = uri_text.trimmed();
     if (raw.isEmpty()) {
-        return BuildError(Tr::tr("Enter a bitcoin: payment URI."));
+        return BuildError(Tr::tr("Enter a Bitcoin payment URI."));
     }
 
     if (raw.startsWith(QStringLiteral("bitcoin://"), Qt::CaseInsensitive)) {
@@ -40,7 +40,7 @@ BitcoinUriParseResult BitcoinUri::Parse(const QString& uri_text)
     // QUrl normalises the scheme to lowercase (RFC 3986 §3.1), so a plain
     // equality check is sufficient and correctly accepts BITCOIN:, Bitcoin:, etc.
     if (!uri.isValid() || uri.scheme() != QStringLiteral("bitcoin")) {
-        return BuildError(Tr::tr("URI cannot be parsed. Use a valid bitcoin: payment URI."));
+        return BuildError(Tr::tr("Not a valid Bitcoin payment URI."));
     }
 
     BitcoinUriParseResult result;
@@ -83,7 +83,7 @@ BitcoinUriParseResult BitcoinUri::Parse(const QString& uri_text)
             if (!value.trimmed().isEmpty()) {
                 const auto amount_sats = ParseMoney(value.toStdString());
                 if (!amount_sats.has_value()) {
-                    return BuildError(Tr::tr("URI cannot be parsed. Invalid bitcoin amount."));
+                    return BuildError(Tr::tr("Invalid Bitcoin amount."));
                 }
                 result.amount_sats = *amount_sats;
                 result.has_amount = true;
@@ -92,7 +92,7 @@ BitcoinUriParseResult BitcoinUri::Parse(const QString& uri_text)
         }
 
         if (required && !handled) {
-            return BuildError(Tr::tr("URI cannot be parsed. Unsupported required parameter: %1").arg(key));
+            return BuildError(Tr::tr("Unsupported required parameter: %1").arg(key));
         }
     }
 

--- a/qml/models/bitcoinuri.cpp
+++ b/qml/models/bitcoinuri.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/bitcoinuri.h>
+
+#include <key_io.h>
+#include <util/moneystr.h>
+
+#include <QCoreApplication>
+#include <QUrl>
+#include <QUrlQuery>
+
+namespace {
+BitcoinUriParseResult BuildError(const QString& message)
+{
+    BitcoinUriParseResult result;
+    result.success = false;
+    result.error = message;
+    return result;
+}
+
+struct Tr {
+    static QString tr(const char* s) { return QCoreApplication::translate("BitcoinUri", s); }
+};
+} // namespace
+
+BitcoinUriParseResult BitcoinUri::Parse(const QString& uri_text)
+{
+    const QString raw = uri_text.trimmed();
+    if (raw.isEmpty()) {
+        return BuildError(Tr::tr("Enter a bitcoin: payment URI."));
+    }
+
+    if (raw.startsWith(QStringLiteral("bitcoin://"), Qt::CaseInsensitive)) {
+        return BuildError(Tr::tr("'bitcoin://' is not a valid URI. Use 'bitcoin:' instead."));
+    }
+
+    const QUrl uri(raw);
+    // QUrl normalises the scheme to lowercase (RFC 3986 §3.1), so a plain
+    // equality check is sufficient and correctly accepts BITCOIN:, Bitcoin:, etc.
+    if (!uri.isValid() || uri.scheme() != QStringLiteral("bitcoin")) {
+        return BuildError(Tr::tr("URI cannot be parsed. Use a valid bitcoin: payment URI."));
+    }
+
+    BitcoinUriParseResult result;
+    result.address = uri.path();
+    if (result.address.endsWith('/')) {
+        result.address.chop(1);
+    }
+
+    std::string decode_error;
+    const CTxDestination destination = DecodeDestination(result.address.toStdString(), decode_error);
+    if (!IsValidDestination(destination)) {
+        const QString message = decode_error.empty()
+            ? Tr::tr("URI cannot be parsed. Use a valid bitcoin: payment URI.")
+            : QString::fromStdString(decode_error);
+        return BuildError(message);
+    }
+
+    const QUrlQuery query(uri);
+    const auto items = query.queryItems(QUrl::FullyDecoded);
+    for (const auto& item : items) {
+        QString key = item.first;
+        const QString value = item.second;
+
+        bool required = false;
+        if (key.startsWith(QStringLiteral("req-"))) {
+            required = true;
+            key.remove(0, 4);
+        }
+
+        bool handled = false;
+        if (key == QLatin1String("label")) {
+            result.label = value;
+            result.has_label = true;
+            handled = true;
+        } else if (key == QLatin1String("message")) {
+            result.message = value;
+            result.has_message = true;
+            handled = true;
+        } else if (key == QLatin1String("amount")) {
+            if (!value.trimmed().isEmpty()) {
+                const auto amount_sats = ParseMoney(value.toStdString());
+                if (!amount_sats.has_value()) {
+                    return BuildError(Tr::tr("URI cannot be parsed. Invalid bitcoin amount."));
+                }
+                result.amount_sats = *amount_sats;
+                result.has_amount = true;
+            }
+            handled = true;
+        }
+
+        if (required && !handled) {
+            return BuildError(Tr::tr("URI cannot be parsed. Unsupported required parameter: %1").arg(key));
+        }
+    }
+
+    result.success = true;
+    return result;
+}

--- a/qml/models/bitcoinuri.h
+++ b/qml/models/bitcoinuri.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_BITCOINURI_H
+#define BITCOIN_QML_MODELS_BITCOINURI_H
+
+#include <consensus/amount.h>
+
+#include <QString>
+
+struct BitcoinUriParseResult
+{
+    bool success{false};
+    QString error;
+    QString address;
+    CAmount amount_sats{0};
+    bool has_amount{false};
+    QString label;
+    bool has_label{false};
+    QString message;
+    bool has_message{false};
+};
+
+class BitcoinUri
+{
+public:
+    static BitcoinUriParseResult Parse(const QString& uri_text);
+};
+
+#endif // BITCOIN_QML_MODELS_BITCOINURI_H

--- a/qml/models/bitcoinurimodel.cpp
+++ b/qml/models/bitcoinurimodel.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/bitcoinurimodel.h>
+
+#include <qml/models/bitcoinuri.h>
+
+#include <QFile>
+#include <QUrl>
+#include <QVariantMap>
+
+namespace {
+QVariantMap BuildBitcoinUriResultMap(const BitcoinUriParseResult& r)
+{
+    return {
+        {QStringLiteral("success"),    r.success},
+        {QStringLiteral("error"),      r.error},
+        {QStringLiteral("address"),    r.address},
+        {QStringLiteral("amountSats"), static_cast<qlonglong>(r.amount_sats)},
+        {QStringLiteral("hasAmount"),  r.has_amount},
+        {QStringLiteral("label"),      r.label},
+        {QStringLiteral("hasLabel"),   r.has_label},
+        // Key is "uriMessage" (not "message") to avoid shadowing the JavaScript
+        // built-in Error.message property when this map is used in QML.
+        {QStringLiteral("uriMessage"), r.message},
+        {QStringLiteral("hasMessage"), r.has_message},
+    };
+}
+} // namespace
+
+BitcoinUriModel::BitcoinUriModel(QObject* parent)
+    : QObject(parent)
+{
+}
+
+QVariantMap BitcoinUriModel::parseBitcoinUri(const QString& uri_text)
+{
+    return BuildBitcoinUriResultMap(BitcoinUri::Parse(uri_text));
+}
+
+QVariantMap BitcoinUriModel::parseBitcoinUriFromFile(const QString& source_path)
+{
+    constexpr qint64 MAX_FILE_SIZE = 1024 * 1024; // 1 MiB
+
+    // Accept either a local file path or a file:// URL (e.g. from a DropArea).
+    // QUrl::toLocalFile() handles the platform-specific conversion correctly,
+    // including the extra leading slash in file:///C:/path on Windows.
+    QString local_path = source_path;
+    const QUrl url(source_path);
+    if (url.isLocalFile()) {
+        local_path = url.toLocalFile();
+    }
+
+    // File is read synchronously on the GUI thread. For local storage the
+    // 1 MiB guard makes this acceptable. For network-mounted paths (NFS, SMB)
+    // this could stall the UI — see issue #541 for the async fix using
+    // QtConcurrent::run.
+    QFile file(local_path);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        BitcoinUriParseResult err;
+        err.error = tr("Cannot open file: %1").arg(file.errorString());
+        return BuildBitcoinUriResultMap(err);
+    }
+    if (file.size() > MAX_FILE_SIZE) {
+        BitcoinUriParseResult err;
+        err.error = tr("File is too large to be a payment URI.");
+        return BuildBitcoinUriResultMap(err);
+    }
+    const QString content = QString::fromUtf8(file.readAll()).trimmed();
+    return BuildBitcoinUriResultMap(BitcoinUri::Parse(content));
+}

--- a/qml/models/bitcoinurimodel.h
+++ b/qml/models/bitcoinurimodel.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_BITCOINURIMODEL_H
+#define BITCOIN_QML_MODELS_BITCOINURIMODEL_H
+
+#include <QObject>
+#include <QVariantMap>
+
+/**
+ * QML-accessible singleton that wraps the BitcoinUri static parser.
+ * Registered as "BitcoinUri" in the org.bitcoincore.qt 1.0 module.
+ *
+ * URI parsing is wallet-agnostic; this class deliberately does not hold
+ * a wallet reference so callers do not need a loaded wallet to parse URIs.
+ */
+class BitcoinUriModel : public QObject
+{
+    Q_OBJECT
+public:
+    explicit BitcoinUriModel(QObject* parent = nullptr);
+
+    /** Parse a bitcoin: URI string. Returns a QVariantMap with keys:
+     *  success, error, address, amountSats, hasAmount,
+     *  label, hasLabel, uriMessage, hasMessage. */
+    Q_INVOKABLE QVariantMap parseBitcoinUri(const QString& uri_text);
+
+    /** Read a local file and parse its contents as a bitcoin: URI.
+     *  Accepts plain paths and file:// URLs (QUrl::toLocalFile is used
+     *  for platform-correct conversion). Capped at 1 MiB. */
+    Q_INVOKABLE QVariantMap parseBitcoinUriFromFile(const QString& source_path);
+};
+
+#endif // BITCOIN_QML_MODELS_BITCOINURIMODEL_H

--- a/qml/models/bumptransactionmodel.cpp
+++ b/qml/models/bumptransactionmodel.cpp
@@ -6,6 +6,8 @@
 
 #include <interfaces/wallet.h>
 #include <qml/bitcoinamount.h>
+#include <qml/models/walletunlock.h>
+#include <qml/util.h>
 #include <wallet/coincontrol.h>
 
 namespace {
@@ -59,11 +61,32 @@ void BumpTransactionModel::setActionType(ActionType type)
     }
 }
 
+void BumpTransactionModel::setNeedsUnlock(bool needs_unlock)
+{
+    if (m_needs_unlock != needs_unlock) {
+        m_needs_unlock = needs_unlock;
+        Q_EMIT needsUnlockChanged();
+    }
+}
+
 void BumpTransactionModel::setError(const QString& error)
 {
     m_error = error;
+    setNeedsUnlock(false);
     setState(Failed);
     Q_EMIT resultChanged();
+}
+
+void BumpTransactionModel::setUnlockRequired(const QString& error)
+{
+    m_error = error;
+    setNeedsUnlock(true);
+    Q_EMIT resultChanged();
+}
+
+void BumpTransactionModel::setSecurityStateChangedFn(std::function<void()> fn)
+{
+    m_security_state_changed_fn = std::move(fn);
 }
 
 void BumpTransactionModel::prepareFeeBump(const QString& txid, unsigned int targetBlocks)
@@ -80,6 +103,7 @@ void BumpTransactionModel::prepareFeeBump(const QString& txid, unsigned int targ
     }
 
     setActionType(SpeedUp);
+    setNeedsUnlock(false);
     setState(Preparing);
 
     wallet::CCoinControl coin_control;
@@ -105,34 +129,101 @@ void BumpTransactionModel::prepareFeeBump(const QString& txid, unsigned int targ
     Q_EMIT resultChanged();
 }
 
-void BumpTransactionModel::confirmFeeBump()
+bool BumpTransactionModel::confirmFeeBump()
+{
+    return confirmFeeBumpInternal(std::nullopt);
+}
+
+bool BumpTransactionModel::confirmFeeBumpWithPassphrase(const QString& passphrase)
+{
+    return confirmFeeBumpInternal(std::optional<SecureString>{QmlUtil::SecureStringFromQString(passphrase)});
+}
+
+bool BumpTransactionModel::confirmFeeBumpInternal(std::optional<SecureString> passphrase)
 {
     if (!m_wallet || m_state != NeedsConfirmation) {
-        return;
+        if (passphrase.has_value()) {
+            QmlUtil::ClearSecureString(*passphrase);
+            passphrase.reset();
+        }
+        return false;
     }
 
+    if (!m_wallet->privateKeysDisabled() && m_wallet->isCrypted() && m_wallet->isLocked() && !passphrase.has_value()) {
+        setUnlockRequired(tr("Enter your wallet password to update this transaction."));
+        return false;
+    }
+
+    bool relock{false};
+    if (!unlockForCommit(passphrase, relock)) {
+        return false;
+    }
+    WalletRelockGuard relock_guard{*m_wallet, [this] {
+        if (m_security_state_changed_fn) {
+            m_security_state_changed_fn();
+        }
+    }, relock};
+
+    setNeedsUnlock(false);
     setState(Committing);
 
     if (!m_wallet->transactionCanBeBumped(m_original_txid)) {
+        relock_guard.relock();
         setError(tr("Transaction can no longer be bumped."));
-        return;
+        return false;
     }
 
     if (!m_wallet->signBumpTransaction(m_bump_mtx)) {
+        relock_guard.relock();
         setError(tr("Failed to sign transaction."));
-        return;
+        return false;
     }
 
     std::vector<bilingual_str> errors;
     Txid bumped_txid;
     if (!m_wallet->commitBumpTransaction(m_original_txid, std::move(m_bump_mtx), errors, bumped_txid)) {
+        relock_guard.relock();
         setError(errors.empty() ? tr("Failed to commit transaction.") : QString::fromStdString(errors[0].translated));
-        return;
+        return false;
     }
 
     m_new_txid = QString::fromStdString(bumped_txid.GetHex());
+    relock_guard.relock();
     setState(Succeeded);
     Q_EMIT resultChanged();
+    return true;
+}
+
+bool BumpTransactionModel::unlockForCommit(std::optional<SecureString>& passphrase, bool& relock)
+{
+    relock = false;
+    if (!m_wallet) {
+        if (passphrase.has_value()) {
+            QmlUtil::ClearSecureString(*passphrase);
+            passphrase.reset();
+        }
+        return false;
+    }
+    if (!passphrase.has_value()) {
+        return true;
+    }
+
+    const auto result{TryUnlockWithPassphrase(*m_wallet, *passphrase)};
+    passphrase.reset();
+    switch (result) {
+    case WalletUnlockResult::IncorrectPassphrase:
+        setUnlockRequired(tr("The wallet password you entered was incorrect."));
+        return false;
+    case WalletUnlockResult::AlreadyUnlocked:
+        return true;
+    case WalletUnlockResult::UnlockedNowRelockRequired:
+        relock = true;
+        if (m_security_state_changed_fn) {
+            m_security_state_changed_fn();
+        }
+        return true;
+    }
+    return false;
 }
 
 void BumpTransactionModel::reset()
@@ -145,8 +236,10 @@ void BumpTransactionModel::reset()
     m_original_txid = Txid{};
     m_new_txid.clear();
     m_error.clear();
+    m_needs_unlock = false;
 
     Q_EMIT stateChanged();
     Q_EMIT actionTypeChanged();
     Q_EMIT resultChanged();
+    Q_EMIT needsUnlockChanged();
 }

--- a/qml/models/bumptransactionmodel.h
+++ b/qml/models/bumptransactionmodel.h
@@ -7,8 +7,11 @@
 
 #include <consensus/amount.h>
 #include <primitives/transaction.h>
+#include <support/allocators/secure.h>
 #include <uint256.h>
 
+#include <functional>
+#include <optional>
 #include <vector>
 
 #include <QObject>
@@ -39,6 +42,7 @@ public:
     Q_PROPERTY(QString oldTxid READ oldTxid NOTIFY resultChanged)
     Q_PROPERTY(QString newTxid READ newTxid NOTIFY resultChanged)
     Q_PROPERTY(QString errorText READ errorText NOTIFY resultChanged)
+    Q_PROPERTY(bool needsUnlock READ needsUnlock NOTIFY needsUnlockChanged)
 
     explicit BumpTransactionModel(interfaces::Wallet* wallet, QObject* parent = nullptr);
 
@@ -50,22 +54,31 @@ public:
     QString oldTxid() const;
     QString newTxid() const { return m_new_txid; }
     QString errorText() const { return m_error; }
+    bool needsUnlock() const { return m_needs_unlock; }
 
     Q_INVOKABLE void prepareFeeBump(const QString& txid, unsigned int targetBlocks);
-    Q_INVOKABLE void confirmFeeBump();
+    Q_INVOKABLE bool confirmFeeBump();
+    Q_INVOKABLE bool confirmFeeBumpWithPassphrase(const QString& passphrase);
     Q_INVOKABLE void reset();
+    void setSecurityStateChangedFn(std::function<void()> fn);
 
 Q_SIGNALS:
     void stateChanged();
     void actionTypeChanged();
     void resultChanged();
+    void needsUnlockChanged();
 
 private:
     void setState(State state);
     void setActionType(ActionType type);
     void setError(const QString& error);
+    void setNeedsUnlock(bool needs_unlock);
+    void setUnlockRequired(const QString& error);
+    bool confirmFeeBumpInternal(std::optional<SecureString> passphrase);
+    bool unlockForCommit(std::optional<SecureString>& passphrase, bool& relock);
 
     interfaces::Wallet* m_wallet{nullptr};
+    std::function<void()> m_security_state_changed_fn;
     State m_state{Idle};
     ActionType m_action_type{SpeedUp};
     CAmount m_old_fee{0};
@@ -74,6 +87,7 @@ private:
     Txid m_original_txid;
     QString m_new_txid;
     QString m_error;
+    bool m_needs_unlock{false};
 };
 
 #endif // BITCOIN_QML_MODELS_BUMPTRANSACTIONMODEL_H

--- a/qml/models/coinslistmodel.cpp
+++ b/qml/models/coinslistmodel.cpp
@@ -100,6 +100,23 @@ void CoinsListModel::toggleCoinSelection(const int index)
         m_wallet_model->selectCoin(outpoint);
         m_total_amount += coin.txout.nValue;
     }
+    const QModelIndex model_index = this->index(index, 0);
+    Q_EMIT dataChanged(model_index, model_index, {SelectedRole});
+    Q_EMIT selectedCoinsCountChanged();
+}
+
+void CoinsListModel::refreshSelection()
+{
+    CAmount total_amount{0};
+    for (const auto& [destination, outpoint, coin] : m_coins) {
+        if (m_wallet_model->isSelectedCoin(outpoint)) {
+            total_amount += coin.txout.nValue;
+        }
+    }
+    m_total_amount = total_amount;
+    if (!m_coins.empty()) {
+        Q_EMIT dataChanged(index(0, 0), index(static_cast<int>(m_coins.size()) - 1, 0), {SelectedRole});
+    }
     Q_EMIT selectedCoinsCountChanged();
 }
 

--- a/qml/models/coinslistmodel.h
+++ b/qml/models/coinslistmodel.h
@@ -44,6 +44,7 @@ public:
 
 public Q_SLOTS:
     void update();
+    void refreshSelection();
     void setSortBy(const QString& roleName);
     void toggleCoinSelection(const int index);
     unsigned int lockedCoinsCount() const;

--- a/qml/models/nodemodel.cpp
+++ b/qml/models/nodemodel.cpp
@@ -417,6 +417,11 @@ void NodeModel::startNodeInitializionThread()
 
 void NodeModel::requestShutdown()
 {
+    if (m_shutdown_requested) {
+        return;
+    }
+    m_shutdown_requested = true;
+    stopShutdownPolling();
     Q_EMIT requestedShutdown();
 }
 
@@ -424,7 +429,7 @@ void NodeModel::initializeResult(bool success, interfaces::BlockAndHeaderTipInfo
 {
     if (!success) {
         if (m_startup_failure_dialog_shown) {
-            Q_EMIT requestedShutdown();
+            requestShutdown();
             Q_EMIT nodeInitialized();
             return;
         }
@@ -436,6 +441,9 @@ void NodeModel::initializeResult(bool success, interfaces::BlockAndHeaderTipInfo
         }
         m_startup_warning_messages.clear();
         setStartupError(startup_error);
+        if (m_node.shutdownRequested()) {
+            requestShutdown();
+        }
     } else {
         m_startup_error_messages.clear();
         m_node_ready = true;
@@ -460,20 +468,28 @@ void NodeModel::handleRunawayException(const QString& message)
 
 void NodeModel::startShutdownPolling()
 {
+    if (m_shutdown_polling_timer_id != 0) {
+        return;
+    }
     m_shutdown_polling_timer_id = startTimer(200ms);
 }
 
 void NodeModel::stopShutdownPolling()
 {
+    if (m_shutdown_polling_timer_id == 0) {
+        return;
+    }
     killTimer(m_shutdown_polling_timer_id);
+    m_shutdown_polling_timer_id = 0;
 }
 
 void NodeModel::timerEvent(QTimerEvent* event)
 {
-    Q_UNUSED(event)
+    if (event->timerId() != m_shutdown_polling_timer_id) {
+        return;
+    }
     if (m_node.shutdownRequested()) {
-        stopShutdownPolling();
-        Q_EMIT requestedShutdown();
+        requestShutdown();
     }
 }
 

--- a/qml/models/nodemodel.cpp
+++ b/qml/models/nodemodel.cpp
@@ -116,6 +116,7 @@ NodeModel::NodeModel(interfaces::Node& node)
 
 NodeModel::~NodeModel()
 {
+    unsubscribeFromCoreSignals();
     setMempoolInfoPollingActive(false);
     if (m_mempool_info_thread) {
         m_mempool_info_thread->quit();
@@ -800,4 +801,17 @@ void NodeModel::ConnectToBannedListChangedSignal()
             Q_EMIT bannedListChanged();
         });
     });
+}
+
+void NodeModel::unsubscribeFromCoreSignals()
+{
+    if (m_handler_notify_block_tip) {
+        m_handler_notify_block_tip->disconnect();
+    }
+    if (m_handler_notify_num_peers_changed) {
+        m_handler_notify_num_peers_changed->disconnect();
+    }
+    if (m_handler_notify_banned_list_changed) {
+        m_handler_notify_banned_list_changed->disconnect();
+    }
 }

--- a/qml/models/nodemodel.cpp
+++ b/qml/models/nodemodel.cpp
@@ -808,8 +808,23 @@ void NodeModel::unsubscribeFromCoreSignals()
     if (m_handler_notify_block_tip) {
         m_handler_notify_block_tip->disconnect();
     }
+    if (m_handler_notify_header_tip) {
+        m_handler_notify_header_tip->disconnect();
+    }
     if (m_handler_notify_num_peers_changed) {
         m_handler_notify_num_peers_changed->disconnect();
+    }
+    if (m_handler_notify_network_active_changed) {
+        m_handler_notify_network_active_changed->disconnect();
+    }
+    if (m_handler_notify_alert_changed) {
+        m_handler_notify_alert_changed->disconnect();
+    }
+    if (m_handler_message_box) {
+        m_handler_message_box->disconnect();
+    }
+    if (m_handler_question) {
+        m_handler_question->disconnect();
     }
     if (m_handler_notify_banned_list_changed) {
         m_handler_notify_banned_list_changed->disconnect();

--- a/qml/models/nodemodel.h
+++ b/qml/models/nodemodel.h
@@ -243,6 +243,7 @@ private:
     void ConnectToAlertChangedSignal();
     void ConnectToRuntimeDialogSignals();
     void ConnectToBannedListChangedSignal();
+    void unsubscribeFromCoreSignals();
     void initializeMempoolInfoPolling();
     void refreshPeerCounts();
     void refreshWarnings();

--- a/qml/models/nodemodel.h
+++ b/qml/models/nodemodel.h
@@ -207,6 +207,7 @@ private:
     int64_t m_header_tip_time{0};
     bool m_node_ready{false};
     bool m_initialization_requested{false};
+    bool m_shutdown_requested{false};
     bool m_runtime_dialogs_enabled{false};
     bool m_startup_failure_dialog_shown{false};
     bool m_runtime_dialog_visible{false};

--- a/qml/models/receiverequestentry.h
+++ b/qml/models/receiverequestentry.h
@@ -15,7 +15,7 @@
 
 struct QmlReceiveRequestRecipient
 {
-    static constexpr int CURRENT_VERSION{2};
+    static constexpr int CURRENT_VERSION{1};
     int nVersion{CURRENT_VERSION};
     std::string address;
     std::string label;
@@ -28,15 +28,12 @@ struct QmlReceiveRequestRecipient
     SERIALIZE_METHODS(QmlReceiveRequestRecipient, obj)
     {
         READWRITE(obj.nVersion, obj.address, obj.label, obj.amount, obj.message, obj.sPaymentRequest, obj.authenticatedMerchant);
-        if (obj.nVersion >= 2) {
-            READWRITE(obj.noteSelf);
-        }
     }
 };
 
 struct QmlRecentRequestEntry
 {
-    static constexpr int CURRENT_VERSION{2};
+    static constexpr int CURRENT_VERSION{1};
     int nVersion{CURRENT_VERSION};
     int64_t id{0};
     QDateTime date;
@@ -44,8 +41,8 @@ struct QmlRecentRequestEntry
 
     SERIALIZE_METHODS(QmlRecentRequestEntry, obj)
     {
-        int64_t date_timet;
-        SER_WRITE(obj, date_timet = obj.date.toSecsSinceEpoch());
+        unsigned int date_timet;
+        SER_WRITE(obj, date_timet = static_cast<unsigned int>(obj.date.toSecsSinceEpoch()));
         READWRITE(obj.nVersion, obj.id, date_timet, obj.recipient);
         SER_READ(obj, obj.date = QDateTime::fromSecsSinceEpoch(date_timet));
     }

--- a/qml/models/receiverequesthistorymodel.cpp
+++ b/qml/models/receiverequesthistorymodel.cpp
@@ -181,6 +181,16 @@ int64_t ReceiveRequestHistoryModel::maxId() const
     return max_id;
 }
 
+// Wallet receive requests are stored in address destdata "rr##" values that
+// bitcoin-qt reads as Qt Widgets RecentRequestEntry records. Keep the serialized
+// prefix byte-compatible with bitcoin/src/qt/recentrequeststablemodel.h and
+// bitcoin/src/qt/sendcoinsrecipient.h: version 1, Qt's unsigned timestamp, and
+// no QML-only fields inside the prefix.
+//
+// QML currently persists noteSelf as an optional trailing string. Released
+// bitcoin-qt builds ignore trailing bytes after RecentRequestEntry, while QML
+// reads the extension when present. If Qt Widgets gains noteSelf support, move
+// this to an explicit shared contract instead of changing the prefix ad hoc.
 std::vector<QmlRecentRequestEntry> ReceiveRequestHistoryModel::DeserializeEntries(const std::vector<std::string>& blobs)
 {
     std::vector<QmlRecentRequestEntry> out;
@@ -191,6 +201,9 @@ std::vector<QmlRecentRequestEntry> ReceiveRequestHistoryModel::DeserializeEntrie
         QmlRecentRequestEntry entry;
         try {
             ss >> entry;
+            if (!ss.empty()) {
+                ss >> entry.recipient.noteSelf;
+            }
         } catch (const std::ios_base::failure& e) {
             qWarning() << "ReceiveRequestHistoryModel: skipping malformed receive request entry:" << e.what();
             continue;
@@ -207,6 +220,9 @@ std::string ReceiveRequestHistoryModel::SerializeEntry(const QmlRecentRequestEnt
 {
     DataStream ss{};
     ss << entry;
+    if (!entry.recipient.noteSelf.empty()) {
+        ss << entry.recipient.noteSelf;
+    }
     return ss.str();
 }
 

--- a/qml/models/sendrecipient.cpp
+++ b/qml/models/sendrecipient.cpp
@@ -147,7 +147,7 @@ void SendRecipient::validateAmount()
             setAmountError(tr("Amount exceeds maximum limit of 21,000,000 BTC"));
         } else if (!m_address->isEmpty() && m_addressError.isEmpty() &&
                    IsDust(CTxOut{m_amount->satoshi(), GetScriptForDestination(DecodeDestination(m_address->address().toStdString()))},
-                          CFeeRate{DUST_RELAY_TX_FEE})) {
+                          m_wallet ? m_wallet->dustRelayFee() : CFeeRate{DUST_RELAY_TX_FEE})) {
             setAmountError(tr("Amount is too small to send."));
         } else if (m_wallet && m_amount->satoshi() > m_wallet->balanceSatoshi()) {
             setAmountError(tr("Amount exceeds available balance"));

--- a/qml/models/sendrecipient.cpp
+++ b/qml/models/sendrecipient.cpp
@@ -9,6 +9,9 @@
 #include <qml/models/walletqmlmodel.h>
 
 #include <key_io.h>
+#include <policy/feerate.h>
+#include <policy/policy.h>
+#include <script/script.h>
 
 SendRecipient::SendRecipient(WalletQmlModel* wallet, QObject* parent)
     : QObject(parent), m_wallet(wallet), m_address(new BitcoinAddress(this)), m_amount(new BitcoinAmount(this))
@@ -132,7 +135,7 @@ void SendRecipient::validateAddress()
         setAddressError("");
     }
 
-    Q_EMIT isValidChanged();
+    validateAmount();
 }
 
 void SendRecipient::validateAmount()
@@ -142,6 +145,10 @@ void SendRecipient::validateAmount()
             setAmountError(tr("Amount must be greater than zero"));
         } else if (m_amount->satoshi() > MAX_MONEY) {
             setAmountError(tr("Amount exceeds maximum limit of 21,000,000 BTC"));
+        } else if (!m_address->isEmpty() && m_addressError.isEmpty() &&
+                   IsDust(CTxOut{m_amount->satoshi(), GetScriptForDestination(DecodeDestination(m_address->address().toStdString()))},
+                          CFeeRate{DUST_RELAY_TX_FEE})) {
+            setAmountError(tr("Amount is too small to send."));
         } else if (m_wallet && m_amount->satoshi() > m_wallet->balanceSatoshi()) {
             setAmountError(tr("Amount exceeds available balance"));
         } else {

--- a/qml/models/sendrecipientslistmodel.cpp
+++ b/qml/models/sendrecipientslistmodel.cpp
@@ -202,6 +202,9 @@ void SendRecipientsListModel::clear()
     Q_EMIT currentRecipientChanged();
     Q_EMIT currentIndexChanged();
     Q_EMIT validationChanged();
+    if (m_wallet) {
+        m_wallet->clearSelectedCoins();
+    }
     Q_EMIT listCleared();
 }
 

--- a/qml/models/sendrecipientslistmodel.cpp
+++ b/qml/models/sendrecipientslistmodel.cpp
@@ -115,6 +115,7 @@ void SendRecipientsListModel::remove()
         delete removed_recipient;
     }
     endRemoveRows();
+    updateTotalAmount();
     Q_EMIT countChanged();
     Q_EMIT validationChanged();
 }
@@ -157,6 +158,8 @@ void SendRecipientsListModel::connectRecipientSignals(SendRecipient* recipient)
     connect(recipient->amount(), &BitcoinAmount::unitChanged, this, [emit_roles_changed] {
         emit_roles_changed({AmountRole, AmountUnitLabelRole});
     });
+    connect(recipient, &SendRecipient::subtractFeeFromAmountChanged,
+            this, &SendRecipientsListModel::subtractFeeFromAmountChanged);
     connect(recipient, &SendRecipient::isValidChanged, this, &SendRecipientsListModel::validationChanged);
 }
 

--- a/qml/models/sendrecipientslistmodel.cpp
+++ b/qml/models/sendrecipientslistmodel.cpp
@@ -5,7 +5,10 @@
 #include <qml/models/sendrecipientslistmodel.h>
 #include <qml/models/walletqmlmodel.h>
 
+#include <key_io.h>
 #include <qml/models/sendrecipient.h>
+
+#include <set>
 
 SendRecipientsListModel::SendRecipientsListModel(QObject* parent)
     : QAbstractListModel(parent)
@@ -68,6 +71,7 @@ void SendRecipientsListModel::add()
 
     endInsertRows();
     Q_EMIT countChanged();
+    Q_EMIT validationChanged();
     setCurrentIndex(row);
 }
 
@@ -112,6 +116,7 @@ void SendRecipientsListModel::remove()
     }
     endRemoveRows();
     Q_EMIT countChanged();
+    Q_EMIT validationChanged();
 }
 
 SendRecipient* SendRecipientsListModel::currentRecipient() const
@@ -152,6 +157,7 @@ void SendRecipientsListModel::connectRecipientSignals(SendRecipient* recipient)
     connect(recipient->amount(), &BitcoinAmount::unitChanged, this, [emit_roles_changed] {
         emit_roles_changed({AmountRole, AmountUnitLabelRole});
     });
+    connect(recipient, &SendRecipient::isValidChanged, this, &SendRecipientsListModel::validationChanged);
 }
 
 int SendRecipientsListModel::recipientRow(const SendRecipient* recipient) const
@@ -195,6 +201,7 @@ void SendRecipientsListModel::clear()
     Q_EMIT totalAmountChanged();
     Q_EMIT currentRecipientChanged();
     Q_EMIT currentIndexChanged();
+    Q_EMIT validationChanged();
     Q_EMIT listCleared();
 }
 
@@ -215,10 +222,53 @@ void SendRecipientsListModel::clearToFront()
 
     if (count_changed) {
         Q_EMIT countChanged();
+        Q_EMIT validationChanged();
     }
 
     if (m_totalAmount != m_recipients[0]->amount()->satoshi()) {
         m_totalAmount = m_recipients[0]->amount()->satoshi();
         Q_EMIT totalAmountChanged();
     }
+}
+
+bool SendRecipientsListModel::allValid() const
+{
+    if (m_recipients.empty()) {
+        return false;
+    }
+
+    std::set<CTxDestination> destinations;
+    for (const auto* recipient : m_recipients) {
+        if (recipient == nullptr || !recipient->isValid()) {
+            return false;
+        }
+
+        const CTxDestination destination{DecodeDestination(recipient->address()->address().toStdString())};
+        if (!destinations.insert(destination).second) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+QString SendRecipientsListModel::validationError() const
+{
+    if (m_recipients.empty()) {
+        return tr("Enter at least one valid recipient to continue.");
+    }
+
+    std::set<CTxDestination> destinations;
+    for (const auto* recipient : m_recipients) {
+        if (recipient == nullptr || !recipient->isValid()) {
+            return m_recipients.size() > 1 ? tr("Complete every recipient before continuing.") : QString{};
+        }
+
+        const CTxDestination destination{DecodeDestination(recipient->address()->address().toStdString())};
+        if (!destinations.insert(destination).second) {
+            return tr("Recipient addresses must be unique.");
+        }
+    }
+
+    return {};
 }

--- a/qml/models/sendrecipientslistmodel.h
+++ b/qml/models/sendrecipientslistmodel.h
@@ -58,6 +58,7 @@ Q_SIGNALS:
     void currentRecipientChanged();
     void countChanged();
     void totalAmountChanged();
+    void subtractFeeFromAmountChanged();
     void listCleared();
     void validationChanged();
 

--- a/qml/models/sendrecipientslistmodel.h
+++ b/qml/models/sendrecipientslistmodel.h
@@ -17,6 +17,8 @@ class SendRecipientsListModel : public QAbstractListModel
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(SendRecipient* current READ currentRecipient NOTIFY currentRecipientChanged)
     Q_PROPERTY(QString totalAmount READ totalAmount NOTIFY totalAmountChanged)
+    Q_PROPERTY(bool allValid READ allValid NOTIFY validationChanged)
+    Q_PROPERTY(QString validationError READ validationError NOTIFY validationChanged)
 
 public:
     enum Roles {
@@ -48,6 +50,8 @@ public:
     QList<SendRecipient*> recipients() const { return m_recipients; }
     QString totalAmount() const;
     qint64 totalAmountSatoshi() const { return m_totalAmount; }
+    bool allValid() const;
+    QString validationError() const;
 
 Q_SIGNALS:
     void currentIndexChanged();
@@ -55,6 +59,7 @@ Q_SIGNALS:
     void countChanged();
     void totalAmountChanged();
     void listCleared();
+    void validationChanged();
 
 private:
     void connectRecipientSignals(SendRecipient* recipient);

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -535,7 +535,10 @@ bool WalletQmlModel::sendAmountExhaustsBalance() const
         return false;
     }
 
-    const CAmount balance{balanceSatoshi()};
+    wallet::CCoinControl coin_control{m_coin_control};
+    ApplySelectedInputsPolicy(coin_control);
+
+    const CAmount balance{m_wallet->getAvailableBalance(coin_control)};
     const CAmount total_amount{m_send_recipients->totalAmountSatoshi()};
     if (total_amount > balance) {
         return true;
@@ -1529,7 +1532,9 @@ bool WalletQmlModel::prepareTransactionInternal(std::optional<SecureString> pass
     CAmount balance = m_wallet->getAvailableBalance(coin_control);
     if (balance < total) {
         relock_guard.relock();
-        setTransactionStatus(tr("The wallet does not have enough balance for this transaction."));
+        setTransactionStatus(coin_control.HasSelected()
+            ? tr("Selected inputs do not cover the amount plus fee")
+            : tr("The wallet does not have enough balance for this transaction."));
         return false;
     }
 
@@ -1705,13 +1710,21 @@ void WalletQmlModel::listLockedCoins(std::vector<COutPoint>& outputs)
 
 void WalletQmlModel::selectCoin(const COutPoint& output)
 {
+    const bool was_selected{m_coin_control.IsSelected(output)};
     m_coin_control.Select(output);
+    if (!was_selected) {
+        Q_EMIT sendAmountExhaustsBalanceChanged();
+    }
     scheduleFeeEstimates();
 }
 
 void WalletQmlModel::unselectCoin(const COutPoint& output)
 {
+    const bool was_selected{m_coin_control.IsSelected(output)};
     m_coin_control.UnSelect(output);
+    if (was_selected) {
+        Q_EMIT sendAmountExhaustsBalanceChanged();
+    }
     scheduleFeeEstimates();
 }
 
@@ -1734,6 +1747,7 @@ void WalletQmlModel::clearSelectedCoins()
     if (m_coins_list_model) {
         m_coins_list_model->refreshSelection();
     }
+    Q_EMIT sendAmountExhaustsBalanceChanged();
     scheduleFeeEstimates();
 }
 

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -1305,10 +1305,37 @@ void WalletQmlModel::scheduleFeeEstimates()
     if (m_fee_estimation_timer == nullptr) {
         return;
     }
+    m_fee_estimation_timer->stop();
 
-    if (!m_wallet || !m_send_recipients) {
+    if (!m_wallet || !m_send_recipients || !BuildRecipients(*m_send_recipients).has_value()) {
         clearFeeEstimates();
         return;
+    }
+
+    ++m_fee_estimate_request_id;
+
+    bool estimates_changed{!m_fee_estimates.isEmpty()};
+    bool custom_estimate_changed{m_custom_fee_estimate.has_value()};
+    if (estimates_changed) {
+        m_fee_estimates.clear();
+    }
+    if (custom_estimate_changed) {
+        m_custom_fee_estimate.reset();
+    }
+    if (estimates_changed || custom_estimate_changed) {
+        Q_EMIT estimatedFeeChanged();
+        Q_EMIT sendAmountExhaustsBalanceChanged();
+    }
+
+    bool pending_changed{!m_fee_estimate_pending};
+    if (pending_changed) {
+        m_fee_estimate_pending = true;
+        Q_EMIT feeEstimatePendingChanged();
+    }
+
+    if (estimates_changed || custom_estimate_changed || pending_changed) {
+        ++m_fee_estimate_revision;
+        Q_EMIT feeEstimateRevisionChanged();
     }
 
     m_fee_estimation_timer->start();
@@ -1763,7 +1790,6 @@ void WalletQmlModel::setFeeTargetBlocks(unsigned int target_blocks)
         Q_EMIT feeTargetBlocksChanged();
         Q_EMIT estimatedFeeChanged();
         Q_EMIT sendAmountExhaustsBalanceChanged();
-        scheduleFeeEstimates();
     }
 }
 

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -321,6 +321,7 @@ WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObje
     m_activity_list_model = new ActivityListModel(this);
     m_address_list_model = new AddressListModel(this);
     m_bump_transaction_model = new BumpTransactionModel(m_wallet.get(), this);
+    m_bump_transaction_model->setSecurityStateChangedFn([this]() { refreshSecurityState(); });
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
     m_sign_verify_message_model = new SignVerifyMessageModel(m_wallet.get(), this);
@@ -338,6 +339,7 @@ WalletQmlModel::WalletQmlModel(QObject* parent)
     m_activity_list_model = new ActivityListModel(this);
     m_address_list_model = new AddressListModel(this);
     m_bump_transaction_model = new BumpTransactionModel(nullptr, this);
+    m_bump_transaction_model->setSecurityStateChangedFn([this]() { refreshSecurityState(); });
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
     m_sign_verify_message_model = new SignVerifyMessageModel(nullptr, this);

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -1331,6 +1331,26 @@ bool WalletQmlModel::prepareTransactionInternal(std::optional<SecureString> pass
         setTransactionStatus(tr("Enter at least one valid recipient to continue."));
         return false;
     }
+
+    if (!m_send_recipients->allValid()) {
+        if (passphrase.has_value()) {
+            QmlUtil::ClearSecureString(*passphrase);
+            passphrase.reset();
+        }
+        setTransactionStatus(m_send_recipients->validationError());
+        return false;
+    }
+
+    const auto vec_send = BuildRecipients(*m_send_recipients);
+    if (!vec_send.has_value()) {
+        if (passphrase.has_value()) {
+            QmlUtil::ClearSecureString(*passphrase);
+            passphrase.reset();
+        }
+        setTransactionStatus(tr("Enter at least one valid recipient to continue."));
+        return false;
+    }
+
     if (!m_wallet->privateKeysDisabled() && m_wallet->isCrypted() && m_wallet->isLocked() && !passphrase.has_value()) {
         refreshSecurityState();
         setTransactionStatus(tr("Enter your wallet password to prepare this transaction."), true);
@@ -1342,11 +1362,6 @@ bool WalletQmlModel::prepareTransactionInternal(std::optional<SecureString> pass
         return false;
     }
     WalletRelockGuard relock_guard{*m_wallet, [this] { refreshSecurityState(); }, relock};
-
-    const auto vec_send = BuildRecipients(*m_send_recipients);
-    if (!vec_send.has_value()) {
-        return false;
-    }
 
     CAmount total = 0;
     bool subtract_fee_from_amount = false;

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -43,6 +43,7 @@
 #include <QVariantList>
 #include <QVariantMap>
 
+#include <algorithm>
 #include <array>
 #include <functional>
 #include <limits>
@@ -73,6 +74,22 @@ QString FormatFeeEstimate(CAmount amount)
     BitcoinAmount bitcoin_amount;
     bitcoin_amount.setSatoshi(amount);
     return bitcoin_amount.displayWithUnit();
+}
+
+bool AnyRecipientSubtractsFeeFromAmount(const SendRecipientsListModel& recipients)
+{
+    const auto recipient_list = recipients.recipients();
+    return std::any_of(recipient_list.begin(), recipient_list.end(), [](const auto* recipient) {
+        return recipient && recipient->subtractFeeFromAmount();
+    });
+}
+
+bool AmountPlusFeeExceedsBalance(const CAmount amount, const CAmount fee, const CAmount balance)
+{
+    if (amount > balance) {
+        return true;
+    }
+    return fee > balance - amount;
 }
 
 std::optional<CAmount> ParseCustomFeeRatePerKvB(const QString& custom_fee_rate)
@@ -160,7 +177,49 @@ std::optional<CAmount> TryPreviewFee(interfaces::Wallet& wallet,
     return fee;
 }
 
-std::optional<QString> EstimatePreviewFee(interfaces::Wallet& wallet,
+std::optional<std::vector<wallet::CRecipient>> WithLargestRecipientPayingFee(const std::vector<wallet::CRecipient>& recipients)
+{
+    if (recipients.empty()) {
+        return std::nullopt;
+    }
+    if (std::any_of(recipients.begin(), recipients.end(), [](const auto& recipient) {
+        return recipient.fSubtractFeeFromAmount;
+    })) {
+        return std::nullopt;
+    }
+
+    std::vector<wallet::CRecipient> adjusted{recipients};
+    auto largest_recipient = std::max_element(adjusted.begin(), adjusted.end(), [](const auto& a, const auto& b) {
+        return a.nAmount < b.nAmount;
+    });
+    if (largest_recipient == adjusted.end()) {
+        return std::nullopt;
+    }
+    largest_recipient->fSubtractFeeFromAmount = true;
+    return adjusted;
+}
+
+std::optional<CAmount> TryPreviewFeeWithFallback(interfaces::Wallet& wallet,
+                                                 const std::vector<wallet::CRecipient>& recipients,
+                                                 const wallet::CCoinControl& coin_control)
+{
+    if (const auto fee = TryPreviewFee(wallet, recipients, coin_control)) {
+        return fee;
+    }
+
+    // The fallback is only for fee previews. If a full-balance send cannot pay
+    // an additional fee, retry the estimate as if the largest recipient pays it
+    // so the UI can still show the expected fee without mutating the actual
+    // send recipients used by prepareTransaction().
+    const auto adjusted_recipients{WithLargestRecipientPayingFee(recipients)};
+    if (!adjusted_recipients.has_value()) {
+        return std::nullopt;
+    }
+
+    return TryPreviewFee(wallet, *adjusted_recipients, coin_control);
+}
+
+std::optional<CAmount> EstimatePreviewFee(interfaces::Wallet& wallet,
                                           const std::vector<wallet::CRecipient>& recipients,
                                           const wallet::CCoinControl& base_coin_control,
                                           const OutputType preview_change_type,
@@ -172,8 +231,8 @@ std::optional<QString> EstimatePreviewFee(interfaces::Wallet& wallet,
     ApplyPreviewChangeDestination(coin_control, preview_change_type);
     ApplyRegtestStaticFeeOverride(coin_control);
 
-    if (const auto fee = TryPreviewFee(wallet, recipients, coin_control)) {
-        return FormatFeeEstimate(*fee);
+    if (const auto fee = TryPreviewFeeWithFallback(wallet, recipients, coin_control)) {
+        return fee;
     }
 
     if (Params().GetChainType() == ChainType::REGTEST) {
@@ -191,14 +250,14 @@ std::optional<QString> EstimatePreviewFee(interfaces::Wallet& wallet,
     // only provide a minimum required feerate.
     fallback_coin_control.m_feerate = CFeeRate{required_fee_per_k * FallbackFeeMultiplier(target)};
 
-    if (const auto fee = TryPreviewFee(wallet, recipients, fallback_coin_control)) {
-        return FormatFeeEstimate(*fee);
+    if (const auto fee = TryPreviewFeeWithFallback(wallet, recipients, fallback_coin_control)) {
+        return fee;
     }
 
     return std::nullopt;
 }
 
-std::optional<QString> EstimateCustomPreviewFee(interfaces::Wallet& wallet,
+std::optional<CAmount> EstimateCustomPreviewFee(interfaces::Wallet& wallet,
                                                 const std::vector<wallet::CRecipient>& recipients,
                                                 const wallet::CCoinControl& base_coin_control,
                                                 const OutputType preview_change_type,
@@ -209,8 +268,8 @@ std::optional<QString> EstimateCustomPreviewFee(interfaces::Wallet& wallet,
     coin_control.m_feerate = CFeeRate{fee_rate_per_kvb};
     ApplyPreviewChangeDestination(coin_control, preview_change_type);
 
-    if (const auto fee = TryPreviewFee(wallet, recipients, coin_control)) {
-        return FormatFeeEstimate(*fee);
+    if (const auto fee = TryPreviewFeeWithFallback(wallet, recipients, coin_control)) {
+        return fee;
     }
 
     return std::nullopt;
@@ -324,6 +383,12 @@ WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObje
     m_bump_transaction_model->setSecurityStateChangedFn([this]() { refreshSecurityState(); });
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
+    connect(m_send_recipients, &SendRecipientsListModel::totalAmountChanged,
+            this, &WalletQmlModel::sendAmountExhaustsBalanceChanged);
+    connect(m_send_recipients, &SendRecipientsListModel::validationChanged,
+            this, &WalletQmlModel::sendAmountExhaustsBalanceChanged);
+    connect(m_send_recipients, &SendRecipientsListModel::subtractFeeFromAmountChanged,
+            this, &WalletQmlModel::sendAmountExhaustsBalanceChanged);
     m_sign_verify_message_model = new SignVerifyMessageModel(m_wallet.get(), this);
     m_sign_verify_message_model->setSecurityStateChangedFn([this]() { refreshSecurityState(); });
     m_current_payment_request = new PaymentRequest(this);
@@ -342,6 +407,12 @@ WalletQmlModel::WalletQmlModel(QObject* parent)
     m_bump_transaction_model->setSecurityStateChangedFn([this]() { refreshSecurityState(); });
     m_coins_list_model = new CoinsListModel(this);
     m_send_recipients = new SendRecipientsListModel(this);
+    connect(m_send_recipients, &SendRecipientsListModel::totalAmountChanged,
+            this, &WalletQmlModel::sendAmountExhaustsBalanceChanged);
+    connect(m_send_recipients, &SendRecipientsListModel::validationChanged,
+            this, &WalletQmlModel::sendAmountExhaustsBalanceChanged);
+    connect(m_send_recipients, &SendRecipientsListModel::subtractFeeFromAmountChanged,
+            this, &WalletQmlModel::sendAmountExhaustsBalanceChanged);
     m_sign_verify_message_model = new SignVerifyMessageModel(nullptr, this);
     m_sign_verify_message_model->setSecurityStateChangedFn([this]() { refreshSecurityState(); });
     m_current_payment_request = new PaymentRequest(this);
@@ -412,9 +483,51 @@ qint64 WalletQmlModel::balanceSatoshi() const
 QString WalletQmlModel::estimatedFee() const
 {
     if (m_custom_fee_enabled) {
-        return customFeeRateValid() ? m_custom_fee_estimate : QString{};
+        return customFeeRateValid() && m_custom_fee_estimate.has_value()
+            ? FormatFeeEstimate(*m_custom_fee_estimate)
+            : QString{};
     }
     return estimatedFeeForTarget(feeTargetBlocks());
+}
+
+std::optional<CAmount> WalletQmlModel::selectedFeeEstimate() const
+{
+    if (m_custom_fee_enabled) {
+        if (!customFeeRateValid() || !m_custom_fee_estimate.has_value()) {
+            return std::nullopt;
+        }
+        return *m_custom_fee_estimate;
+    }
+
+    const auto estimate = m_fee_estimates.constFind(feeTargetBlocks());
+    if (estimate == m_fee_estimates.constEnd()) {
+        return std::nullopt;
+    }
+
+    return estimate.value();
+}
+
+bool WalletQmlModel::sendAmountExhaustsBalance() const
+{
+    if (!m_wallet || !m_send_recipients || !m_send_recipients->allValid()) {
+        return false;
+    }
+
+    const CAmount balance{balanceSatoshi()};
+    const CAmount total_amount{m_send_recipients->totalAmountSatoshi()};
+    if (total_amount > balance) {
+        return true;
+    }
+    if (AnyRecipientSubtractsFeeFromAmount(*m_send_recipients)) {
+        return false;
+    }
+    if (const auto fee = selectedFeeEstimate()) {
+        return AmountPlusFeeExceedsBalance(total_amount, *fee, balance);
+    }
+
+    // Without an estimate, a non fee-included send cannot safely spend the full
+    // balance because prepareTransaction() will still need to add a fee.
+    return total_amount >= balance;
 }
 
 bool WalletQmlModel::customFeeRateValid() const
@@ -424,9 +537,9 @@ bool WalletQmlModel::customFeeRateValid() const
 
 QString WalletQmlModel::estimatedFeeForTarget(const unsigned int target_blocks) const
 {
-    const QString estimate = m_fee_estimates.value(target_blocks);
-    if (!estimate.isEmpty()) {
-        return estimate;
+    const auto estimate = m_fee_estimates.constFind(target_blocks);
+    if (estimate != m_fee_estimates.constEnd()) {
+        return FormatFeeEstimate(estimate.value());
     }
 
     return {};
@@ -1205,8 +1318,8 @@ void WalletQmlModel::requestFeeEstimatesNow()
     }
 
     QTimer::singleShot(0, m_fee_estimation_worker, [this, request_id, recipients = *recipients, base_coin_control, preview_change_type, custom_fee_enabled, custom_fee_rate_per_kvb, wallet]() {
-        QHash<unsigned int, QString> estimates;
-        QString custom_estimate;
+        QHash<unsigned int, CAmount> estimates;
+        std::optional<CAmount> custom_estimate;
 
         for (const unsigned int target : STANDARD_FEE_TARGETS) {
             if (const auto estimate = EstimatePreviewFee(*wallet,
@@ -1234,8 +1347,8 @@ void WalletQmlModel::requestFeeEstimatesNow()
     });
 }
 
-void WalletQmlModel::applyFeeEstimates(const QHash<unsigned int, QString>& estimates,
-                                       const QString& custom_estimate,
+void WalletQmlModel::applyFeeEstimates(const QHash<unsigned int, CAmount>& estimates,
+                                       const std::optional<CAmount>& custom_estimate,
                                        const quint64 request_id)
 {
     if (request_id != m_fee_estimate_request_id) {
@@ -1252,6 +1365,7 @@ void WalletQmlModel::applyFeeEstimates(const QHash<unsigned int, QString>& estim
     }
     if (estimates_changed || custom_estimate_changed) {
         Q_EMIT estimatedFeeChanged();
+        Q_EMIT sendAmountExhaustsBalanceChanged();
     }
 
     bool pending_changed{m_fee_estimate_pending};
@@ -1271,15 +1385,16 @@ void WalletQmlModel::clearFeeEstimates()
     ++m_fee_estimate_request_id;
 
     bool estimates_changed{!m_fee_estimates.isEmpty()};
-    bool custom_estimate_changed{!m_custom_fee_estimate.isEmpty()};
+    bool custom_estimate_changed{m_custom_fee_estimate.has_value()};
     if (estimates_changed) {
         m_fee_estimates.clear();
     }
     if (custom_estimate_changed) {
-        m_custom_fee_estimate.clear();
+        m_custom_fee_estimate.reset();
     }
     if (estimates_changed || custom_estimate_changed) {
         Q_EMIT estimatedFeeChanged();
+        Q_EMIT sendAmountExhaustsBalanceChanged();
     }
 
     bool pending_changed{m_fee_estimate_pending};
@@ -1610,6 +1725,7 @@ void WalletQmlModel::setFeeTargetBlocks(unsigned int target_blocks)
         m_coin_control.m_confirm_target = target_blocks;
         Q_EMIT feeTargetBlocksChanged();
         Q_EMIT estimatedFeeChanged();
+        Q_EMIT sendAmountExhaustsBalanceChanged();
         scheduleFeeEstimates();
     }
 }
@@ -1620,6 +1736,7 @@ void WalletQmlModel::setCustomFeeEnabled(const bool enabled)
         m_custom_fee_enabled = enabled;
         Q_EMIT customFeeEnabledChanged();
         Q_EMIT estimatedFeeChanged();
+        Q_EMIT sendAmountExhaustsBalanceChanged();
         scheduleFeeEstimates();
     }
 }
@@ -1634,13 +1751,14 @@ void WalletQmlModel::setCustomFeeRate(const QString& fee_rate)
     }
 
     m_custom_fee_rate = trimmed_fee_rate;
-    m_custom_fee_estimate.clear();
+    m_custom_fee_estimate.reset();
 
     Q_EMIT customFeeRateChanged();
     if (was_valid != customFeeRateValid()) {
         Q_EMIT customFeeRateValidChanged();
     }
     Q_EMIT estimatedFeeChanged();
+    Q_EMIT sendAmountExhaustsBalanceChanged();
     scheduleFeeEstimates();
 }
 
@@ -1668,6 +1786,7 @@ void WalletQmlModel::subscribeToWalletSignals()
         QMetaObject::invokeMethod(this, [this]() {
             refreshSecurityState();
             Q_EMIT balanceChanged();
+            Q_EMIT sendAmountExhaustsBalanceChanged();
         }, Qt::QueuedConnection);
     });
     m_handler_address_list_changed = m_wallet->handleAddressBookChanged([this](const CTxDestination&, const std::string&, bool, wallet::AddressPurpose, ChangeType) {
@@ -1678,6 +1797,7 @@ void WalletQmlModel::subscribeToWalletSignals()
     m_handler_transaction_changed = handleTransactionChanged([this](const uint256&, ChangeType) {
         QMetaObject::invokeMethod(this, [this] {
             Q_EMIT balanceChanged();
+            Q_EMIT sendAmountExhaustsBalanceChanged();
         }, Qt::QueuedConnection);
     });
     m_handler_unload = handleUnload([this]() {

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -109,15 +109,28 @@ std::optional<CAmount> ParseCustomFeeRatePerKvB(const QString& custom_fee_rate)
     return fee_rate_per_kvb;
 }
 
-void ApplyPreviewChangeDestination(wallet::CCoinControl& coin_control, const QString& preview_change_address)
+std::optional<CTxDestination> PreviewChangeDestination(const OutputType change_type)
 {
-    if (preview_change_address.isEmpty()) {
-        return;
+    const uint160 dummy_key_hash{};
+    switch (change_type) {
+    case OutputType::BECH32M:
+        return WitnessV1Taproot{XOnlyPubKey::NUMS_H};
+    case OutputType::BECH32:
+        return WitnessV0KeyHash{dummy_key_hash};
+    case OutputType::P2SH_SEGWIT:
+        return ScriptHash{GetScriptForDestination(WitnessV0KeyHash{dummy_key_hash})};
+    case OutputType::LEGACY:
+        return PKHash{dummy_key_hash};
+    case OutputType::UNKNOWN:
+        return std::nullopt;
     }
+    return std::nullopt;
+}
 
-    const CTxDestination change_destination = DecodeDestination(preview_change_address.toStdString());
-    if (IsValidDestination(change_destination)) {
-        coin_control.destChange = change_destination;
+void ApplyPreviewChangeDestination(wallet::CCoinControl& coin_control, const OutputType change_type)
+{
+    if (const auto destination = PreviewChangeDestination(change_type)) {
+        coin_control.destChange = *destination;
     }
 }
 
@@ -150,13 +163,13 @@ std::optional<CAmount> TryPreviewFee(interfaces::Wallet& wallet,
 std::optional<QString> EstimatePreviewFee(interfaces::Wallet& wallet,
                                           const std::vector<wallet::CRecipient>& recipients,
                                           const wallet::CCoinControl& base_coin_control,
-                                          const QString& preview_change_address,
+                                          const OutputType preview_change_type,
                                           const unsigned int target)
 {
     wallet::CCoinControl coin_control{base_coin_control};
     coin_control.m_feerate.reset();
     coin_control.m_confirm_target = target;
-    ApplyPreviewChangeDestination(coin_control, preview_change_address);
+    ApplyPreviewChangeDestination(coin_control, preview_change_type);
     ApplyRegtestStaticFeeOverride(coin_control);
 
     if (const auto fee = TryPreviewFee(wallet, recipients, coin_control)) {
@@ -188,13 +201,13 @@ std::optional<QString> EstimatePreviewFee(interfaces::Wallet& wallet,
 std::optional<QString> EstimateCustomPreviewFee(interfaces::Wallet& wallet,
                                                 const std::vector<wallet::CRecipient>& recipients,
                                                 const wallet::CCoinControl& base_coin_control,
-                                                const QString& preview_change_address,
+                                                const OutputType preview_change_type,
                                                 const CAmount fee_rate_per_kvb)
 {
     wallet::CCoinControl coin_control{base_coin_control};
     coin_control.m_confirm_target.reset();
     coin_control.m_feerate = CFeeRate{fee_rate_per_kvb};
-    ApplyPreviewChangeDestination(coin_control, preview_change_address);
+    ApplyPreviewChangeDestination(coin_control, preview_change_type);
 
     if (const auto fee = TryPreviewFee(wallet, recipients, coin_control)) {
         return FormatFeeEstimate(*fee);
@@ -1161,21 +1174,6 @@ void WalletQmlModel::scheduleFeeEstimates()
     m_fee_estimation_timer->start();
 }
 
-QString WalletQmlModel::ensurePreviewChangeAddress()
-{
-    if (!m_wallet || !m_preview_change_address.isEmpty()) {
-        return m_preview_change_address;
-    }
-
-    const auto destination = m_wallet->getNewDestination(m_wallet->getDefaultAddressType(), "qml-fee-preview");
-    if (!destination) {
-        return {};
-    }
-
-    m_preview_change_address = QString::fromStdString(EncodeDestination(destination.value()));
-    return m_preview_change_address;
-}
-
 void WalletQmlModel::requestFeeEstimatesNow()
 {
     if (!m_wallet || !m_send_recipients) {
@@ -1190,8 +1188,8 @@ void WalletQmlModel::requestFeeEstimatesNow()
     }
 
     const quint64 request_id = ++m_fee_estimate_request_id;
-    const QString preview_change_address = ensurePreviewChangeAddress();
     const wallet::CCoinControl base_coin_control{m_coin_control};
+    const OutputType preview_change_type{base_coin_control.m_change_type.value_or(m_wallet->getDefaultAddressType())};
     const bool custom_fee_enabled{m_custom_fee_enabled};
     const std::optional<CAmount> custom_fee_rate_per_kvb{
         ParseCustomFeeRatePerKvB(m_custom_fee_rate)};
@@ -1204,7 +1202,7 @@ void WalletQmlModel::requestFeeEstimatesNow()
         Q_EMIT feeEstimateRevisionChanged();
     }
 
-    QTimer::singleShot(0, m_fee_estimation_worker, [this, request_id, recipients = *recipients, base_coin_control, preview_change_address, custom_fee_enabled, custom_fee_rate_per_kvb, wallet]() {
+    QTimer::singleShot(0, m_fee_estimation_worker, [this, request_id, recipients = *recipients, base_coin_control, preview_change_type, custom_fee_enabled, custom_fee_rate_per_kvb, wallet]() {
         QHash<unsigned int, QString> estimates;
         QString custom_estimate;
 
@@ -1212,7 +1210,7 @@ void WalletQmlModel::requestFeeEstimatesNow()
             if (const auto estimate = EstimatePreviewFee(*wallet,
                                                          recipients,
                                                          base_coin_control,
-                                                         preview_change_address,
+                                                         preview_change_type,
                                                          target)) {
                 estimates.insert(target, *estimate);
             }
@@ -1222,7 +1220,7 @@ void WalletQmlModel::requestFeeEstimatesNow()
             if (const auto estimate = EstimateCustomPreviewFee(*wallet,
                                                                recipients,
                                                                base_coin_control,
-                                                               preview_change_address,
+                                                               preview_change_type,
                                                                *custom_fee_rate_per_kvb)) {
                 custom_estimate = *estimate;
             }

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -9,6 +9,7 @@
 #include <qml/bitcoinamount.h>
 #include <qml/models/activitylistmodel.h>
 #include <qml/models/addresslistmodel.h>
+#include <qml/models/bitcoinuri.h>
 #include <qml/models/paymentrequest.h>
 #include <qml/models/receiverequestentry.h>
 #include <qml/models/receiverequesthistorymodel.h>
@@ -39,9 +40,11 @@
 #include <wallet/wallet.h>
 
 #include <QDateTime>
+#include <QFile>
 #include <QMetaObject>
 #include <QRegularExpression>
 #include <QSettings>
+#include <QUrl>
 #include <QVariantList>
 #include <QVariantMap>
 
@@ -1475,6 +1478,60 @@ std::unique_ptr<interfaces::Handler> WalletQmlModel::handleUnload(UnloadFn fn)
         return nullptr;
     }
     return m_wallet->handleUnload(fn);
+}
+
+static QVariantMap BuildBitcoinUriResultMap(const BitcoinUriParseResult& r)
+{
+    return {
+        {QStringLiteral("success"),    r.success},
+        {QStringLiteral("error"),      r.error},
+        {QStringLiteral("address"),    r.address},
+        {QStringLiteral("amountSats"), (qlonglong)r.amount_sats},
+        {QStringLiteral("hasAmount"),  r.has_amount},
+        {QStringLiteral("label"),      r.label},
+        {QStringLiteral("hasLabel"),   r.has_label},
+        // Key is "uriMessage" (not "message") to avoid shadowing the JavaScript
+        // built-in Error.message property when this map is used in QML.
+        {QStringLiteral("uriMessage"), r.message},
+        {QStringLiteral("hasMessage"), r.has_message},
+    };
+}
+
+QVariantMap WalletQmlModel::parseBitcoinUri(const QString& uri_text)
+{
+    return BuildBitcoinUriResultMap(BitcoinUri::Parse(uri_text));
+}
+
+QVariantMap WalletQmlModel::parseBitcoinUriFromFile(const QString& source_path)
+{
+    constexpr qint64 MAX_FILE_SIZE = 1024 * 1024; // 1 MiB
+
+    // Accept either a local file path or a file:// URL (e.g. from a DropArea).
+    // QUrl::toLocalFile() handles the platform-specific conversion correctly,
+    // including the extra leading slash in file:///C:/path on Windows.
+    QString local_path = source_path;
+    const QUrl url(source_path);
+    if (url.isLocalFile()) {
+        local_path = url.toLocalFile();
+    }
+
+    // File is read synchronously on the GUI thread. For local storage the
+    // 1 MiB guard makes this acceptable. For network-mounted paths (NFS, SMB)
+    // this could stall the UI — see issue #541 for the async fix using
+    // QtConcurrent::run.
+    QFile file(local_path);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        BitcoinUriParseResult err;
+        err.error = tr("Cannot open file: %1").arg(file.errorString());
+        return BuildBitcoinUriResultMap(err);
+    }
+    if (file.size() > MAX_FILE_SIZE) {
+        BitcoinUriParseResult err;
+        err.error = tr("File is too large to be a payment URI.");
+        return BuildBitcoinUriResultMap(err);
+    }
+    const QString content = QString::fromUtf8(file.readAll()).trimmed();
+    return BuildBitcoinUriResultMap(BitcoinUri::Parse(content));
 }
 
 bool WalletQmlModel::prepareTransaction()

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -1511,6 +1511,7 @@ bool WalletQmlModel::sendTransactionInternal()
     m_wallet->commitTransaction(signed_tx, value_map, order_form);
 
     clearTransactionStatus();
+    clearSelectedCoins();
     return true;
 }
 
@@ -1582,6 +1583,18 @@ bool WalletQmlModel::isSelectedCoin(const COutPoint& output)
 std::vector<COutPoint> WalletQmlModel::listSelectedCoins() const
 {
     return m_coin_control.ListSelected();
+}
+
+void WalletQmlModel::clearSelectedCoins()
+{
+    if (!m_coin_control.HasSelected()) {
+        return;
+    }
+    m_coin_control.UnSelectAll();
+    if (m_coins_list_model) {
+        m_coins_list_model->refreshSelection();
+    }
+    scheduleFeeEstimates();
 }
 
 unsigned int WalletQmlModel::feeTargetBlocks() const

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -94,6 +94,12 @@ bool AmountPlusFeeExceedsBalance(const CAmount amount, const CAmount fee, const 
     return fee > balance - amount;
 }
 
+void ApplySelectedInputsPolicy(wallet::CCoinControl& coin_control)
+{
+    // Manually selected coins should be the only wallet inputs used.
+    coin_control.m_allow_other_inputs = !coin_control.HasSelected();
+}
+
 std::optional<CAmount> ParseCustomFeeRatePerKvB(const QString& custom_fee_rate)
 {
     const QString trimmed = custom_fee_rate.trimmed();
@@ -228,6 +234,7 @@ std::optional<CAmount> EstimatePreviewFee(interfaces::Wallet& wallet,
                                           const unsigned int target)
 {
     wallet::CCoinControl coin_control{base_coin_control};
+    ApplySelectedInputsPolicy(coin_control);
     coin_control.m_feerate.reset();
     coin_control.m_confirm_target = target;
     ApplyPreviewChangeDestination(coin_control, preview_change_type);
@@ -266,6 +273,7 @@ std::optional<CAmount> EstimateCustomPreviewFee(interfaces::Wallet& wallet,
                                                 const CAmount fee_rate_per_kvb)
 {
     wallet::CCoinControl coin_control{base_coin_control};
+    ApplySelectedInputsPolicy(coin_control);
     coin_control.m_confirm_target.reset();
     coin_control.m_feerate = CFeeRate{fee_rate_per_kvb};
     ApplyPreviewChangeDestination(coin_control, preview_change_type);
@@ -1502,6 +1510,7 @@ bool WalletQmlModel::prepareTransactionInternal(std::optional<SecureString> pass
     }
 
     wallet::CCoinControl coin_control{m_coin_control};
+    ApplySelectedInputsPolicy(coin_control);
     if (m_custom_fee_enabled) {
         const auto custom_fee_rate_per_kvb = ParseCustomFeeRatePerKvB(m_custom_fee_rate);
         if (!custom_fee_rate_per_kvb.has_value()) {
@@ -1517,7 +1526,7 @@ bool WalletQmlModel::prepareTransactionInternal(std::optional<SecureString> pass
         ApplyRegtestStaticFeeOverride(coin_control);
     }
 
-    CAmount balance = m_wallet->getBalance();
+    CAmount balance = m_wallet->getAvailableBalance(coin_control);
     if (balance < total) {
         relock_guard.relock();
         setTransactionStatus(tr("The wallet does not have enough balance for this transaction."));

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -21,11 +21,13 @@
 
 #include <chainparams.h>
 #include <consensus/amount.h>
+#include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
 #include <addresstype.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
+#include <policy/policy.h>
 #include <psbt.h>
 #include <qml/bitcoinunits.h>
 #include <streams.h>
@@ -371,10 +373,11 @@ QString OutputTypeDescription(OutputType type)
     return {};
 }
 } // namespace
-WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObject *parent)
+WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, interfaces::Node* node, QObject *parent)
     : QObject(parent)
+    , m_wallet(std::move(wallet))
+    , m_node(node)
 {
-    m_wallet = std::move(wallet);
     m_receive_requests = new ReceiveRequestHistoryModel(this);
     reloadReceiveRequests();
     m_activity_list_model = new ActivityListModel(this);
@@ -398,8 +401,9 @@ WalletQmlModel::WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObje
     subscribeToWalletSignals();
 }
 
-WalletQmlModel::WalletQmlModel(QObject* parent)
+WalletQmlModel::WalletQmlModel(interfaces::Node* node, QObject* parent)
     : QObject(parent)
+    , m_node(node)
 {
     m_activity_list_model = new ActivityListModel(this);
     m_address_list_model = new AddressListModel(this);
@@ -419,6 +423,11 @@ WalletQmlModel::WalletQmlModel(QObject* parent)
     m_detail_payment_request = new PaymentRequest(this);
     m_receive_requests = new ReceiveRequestHistoryModel(this);
     initializeFeeEstimator();
+}
+
+WalletQmlModel::WalletQmlModel(QObject* parent)
+    : WalletQmlModel(nullptr, parent)
+{
 }
 
 WalletQmlModel::~WalletQmlModel()
@@ -505,6 +514,11 @@ std::optional<CAmount> WalletQmlModel::selectedFeeEstimate() const
     }
 
     return estimate.value();
+}
+
+CFeeRate WalletQmlModel::dustRelayFee() const
+{
+    return m_node ? m_node->getDustRelayFee() : CFeeRate{DUST_RELAY_TX_FEE};
 }
 
 bool WalletQmlModel::sendAmountExhaustsBalance() const

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -9,7 +9,6 @@
 #include <qml/bitcoinamount.h>
 #include <qml/models/activitylistmodel.h>
 #include <qml/models/addresslistmodel.h>
-#include <qml/models/bitcoinuri.h>
 #include <qml/models/paymentrequest.h>
 #include <qml/models/receiverequestentry.h>
 #include <qml/models/receiverequesthistorymodel.h>
@@ -40,13 +39,10 @@
 #include <wallet/wallet.h>
 
 #include <QDateTime>
-#include <QFile>
 #include <QMetaObject>
 #include <QRegularExpression>
 #include <QSettings>
-#include <QUrl>
 #include <QVariantList>
-#include <QVariantMap>
 
 #include <algorithm>
 #include <array>
@@ -1478,60 +1474,6 @@ std::unique_ptr<interfaces::Handler> WalletQmlModel::handleUnload(UnloadFn fn)
         return nullptr;
     }
     return m_wallet->handleUnload(fn);
-}
-
-static QVariantMap BuildBitcoinUriResultMap(const BitcoinUriParseResult& r)
-{
-    return {
-        {QStringLiteral("success"),    r.success},
-        {QStringLiteral("error"),      r.error},
-        {QStringLiteral("address"),    r.address},
-        {QStringLiteral("amountSats"), (qlonglong)r.amount_sats},
-        {QStringLiteral("hasAmount"),  r.has_amount},
-        {QStringLiteral("label"),      r.label},
-        {QStringLiteral("hasLabel"),   r.has_label},
-        // Key is "uriMessage" (not "message") to avoid shadowing the JavaScript
-        // built-in Error.message property when this map is used in QML.
-        {QStringLiteral("uriMessage"), r.message},
-        {QStringLiteral("hasMessage"), r.has_message},
-    };
-}
-
-QVariantMap WalletQmlModel::parseBitcoinUri(const QString& uri_text)
-{
-    return BuildBitcoinUriResultMap(BitcoinUri::Parse(uri_text));
-}
-
-QVariantMap WalletQmlModel::parseBitcoinUriFromFile(const QString& source_path)
-{
-    constexpr qint64 MAX_FILE_SIZE = 1024 * 1024; // 1 MiB
-
-    // Accept either a local file path or a file:// URL (e.g. from a DropArea).
-    // QUrl::toLocalFile() handles the platform-specific conversion correctly,
-    // including the extra leading slash in file:///C:/path on Windows.
-    QString local_path = source_path;
-    const QUrl url(source_path);
-    if (url.isLocalFile()) {
-        local_path = url.toLocalFile();
-    }
-
-    // File is read synchronously on the GUI thread. For local storage the
-    // 1 MiB guard makes this acceptable. For network-mounted paths (NFS, SMB)
-    // this could stall the UI — see issue #541 for the async fix using
-    // QtConcurrent::run.
-    QFile file(local_path);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        BitcoinUriParseResult err;
-        err.error = tr("Cannot open file: %1").arg(file.errorString());
-        return BuildBitcoinUriResultMap(err);
-    }
-    if (file.size() > MAX_FILE_SIZE) {
-        BitcoinUriParseResult err;
-        err.error = tr("File is too large to be a payment URI.");
-        return BuildBitcoinUriResultMap(err);
-    }
-    const QString content = QString::fromUtf8(file.readAll()).trimmed();
-    return BuildBitcoinUriResultMap(BitcoinUri::Parse(content));
 }
 
 bool WalletQmlModel::prepareTransaction()

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -19,6 +19,7 @@
 #include <consensus/amount.h>
 #include <interfaces/handler.h>
 #include <interfaces/wallet.h>
+#include <policy/feerate.h>
 #include <support/allocators/secure.h>
 #include <wallet/coincontrol.h>
 
@@ -34,6 +35,10 @@
 #include <QTimer>
 #include <QVariantList>
 #include <QVariantMap>
+
+namespace interfaces {
+class Node;
+}
 
 class WalletQmlModel : public QObject
 {
@@ -86,7 +91,8 @@ private:
     Q_PROPERTY(QString settingsError READ settingsError NOTIFY settingsErrorChanged)
 
 public:
-    WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, QObject* parent = nullptr);
+    WalletQmlModel(std::unique_ptr<interfaces::Wallet> wallet, interfaces::Node* node = nullptr, QObject* parent = nullptr);
+    WalletQmlModel(interfaces::Node* node, QObject* parent = nullptr);
     WalletQmlModel(QObject *parent = nullptr);
     ~WalletQmlModel();
 
@@ -115,6 +121,7 @@ public:
     ReceiveRequestHistoryModel* receiveRequests() const { return m_receive_requests; }
     WalletQmlModelTransaction* currentTransaction() const { return m_current_transaction; }
     QString estimatedFee() const;
+    CFeeRate dustRelayFee() const;
     bool sendAmountExhaustsBalance() const;
     bool customFeeEnabled() const { return m_custom_fee_enabled; }
     QString customFeeRate() const { return m_custom_fee_rate; }
@@ -240,6 +247,7 @@ private:
     QString persistedReceiveAddressTypeKey() const;
 
     std::unique_ptr<interfaces::Wallet> m_wallet;
+    interfaces::Node* m_node{nullptr};
     ActivityListModel* m_activity_list_model{nullptr};
     AddressListModel* m_address_list_model{nullptr};
     BumpTransactionModel* m_bump_transaction_model{nullptr};

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -65,6 +65,7 @@ private:
     Q_PROPERTY(WalletQmlModelTransaction* currentTransaction READ currentTransaction NOTIFY currentTransactionChanged)
     Q_PROPERTY(unsigned int targetBlocks READ feeTargetBlocks WRITE setFeeTargetBlocks NOTIFY feeTargetBlocksChanged)
     Q_PROPERTY(QString estimatedFee READ estimatedFee NOTIFY estimatedFeeChanged)
+    Q_PROPERTY(bool sendAmountExhaustsBalance READ sendAmountExhaustsBalance NOTIFY sendAmountExhaustsBalanceChanged)
     Q_PROPERTY(bool customFeeEnabled READ customFeeEnabled WRITE setCustomFeeEnabled NOTIFY customFeeEnabledChanged)
     Q_PROPERTY(QString customFeeRate READ customFeeRate WRITE setCustomFeeRate NOTIFY customFeeRateChanged)
     Q_PROPERTY(bool customFeeRateValid READ customFeeRateValid NOTIFY customFeeRateValidChanged)
@@ -114,6 +115,7 @@ public:
     ReceiveRequestHistoryModel* receiveRequests() const { return m_receive_requests; }
     WalletQmlModelTransaction* currentTransaction() const { return m_current_transaction; }
     QString estimatedFee() const;
+    bool sendAmountExhaustsBalance() const;
     bool customFeeEnabled() const { return m_custom_fee_enabled; }
     QString customFeeRate() const { return m_custom_fee_rate; }
     bool customFeeRateValid() const;
@@ -198,6 +200,7 @@ Q_SIGNALS:
     void currentTransactionChanged();
     void feeTargetBlocksChanged();
     void estimatedFeeChanged();
+    void sendAmountExhaustsBalanceChanged();
     void customFeeEnabledChanged();
     void customFeeRateChanged();
     void customFeeRateValidChanged();
@@ -217,9 +220,10 @@ Q_SIGNALS:
 private:
     void initializeFeeEstimator();
     void requestFeeEstimatesNow();
-    void applyFeeEstimates(const QHash<unsigned int, QString>& estimates,
-                           const QString& custom_estimate,
+    void applyFeeEstimates(const QHash<unsigned int, CAmount>& estimates,
+                           const std::optional<CAmount>& custom_estimate,
                            quint64 request_id);
+    std::optional<CAmount> selectedFeeEstimate() const;
     void clearFeeEstimates();
     unsigned int nextPaymentRequestId() const;
     void subscribeToWalletSignals();
@@ -250,8 +254,8 @@ private:
     QObject* m_fee_estimation_worker{nullptr};
     QThread* m_fee_estimation_thread{nullptr};
     QTimer* m_fee_estimation_timer{nullptr};
-    QHash<unsigned int, QString> m_fee_estimates;
-    QString m_custom_fee_estimate;
+    QHash<unsigned int, CAmount> m_fee_estimates;
+    std::optional<CAmount> m_custom_fee_estimate;
     QString m_custom_fee_rate;
     quint64 m_fee_estimate_request_id{0};
     int m_fee_estimate_revision{0};

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -7,7 +7,6 @@
 
 #include <qml/models/activitylistmodel.h>
 #include <qml/models/addresslistmodel.h>
-#include <qml/models/bitcoinuri.h>
 #include <qml/models/bumptransactionmodel.h>
 #include <qml/models/coinslistmodel.h>
 #include <qml/models/paymentrequest.h>
@@ -35,7 +34,6 @@
 #include <QThread>
 #include <QTimer>
 #include <QVariantList>
-#include <QVariantMap>
 
 namespace interfaces {
 class Node;
@@ -145,8 +143,6 @@ public:
     Q_INVOKABLE void clearSettingsError();
     Q_INVOKABLE void setDefaultReceiveAddressType(const QString& address_type);
     Q_INVOKABLE QString receiveAddressTypeLabel(const QString& address_type) const;
-    Q_INVOKABLE QVariantMap parseBitcoinUri(const QString& uri_text);
-    Q_INVOKABLE QVariantMap parseBitcoinUriFromFile(const QString& source_path);
     void removeWallet();
 
     std::set<interfaces::WalletTx> getWalletTxs() const;

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -220,7 +220,6 @@ private:
                            const QString& custom_estimate,
                            quint64 request_id);
     void clearFeeEstimates();
-    QString ensurePreviewChangeAddress();
     unsigned int nextPaymentRequestId() const;
     void subscribeToWalletSignals();
     void unsubscribeFromWalletSignals();
@@ -253,7 +252,6 @@ private:
     QHash<unsigned int, QString> m_fee_estimates;
     QString m_custom_fee_estimate;
     QString m_custom_fee_rate;
-    QString m_preview_change_address;
     quint64 m_fee_estimate_request_id{0};
     int m_fee_estimate_revision{0};
     bool m_custom_fee_enabled{false};

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -168,6 +168,7 @@ public:
     void unselectCoin(const COutPoint& output);
     bool isSelectedCoin(const COutPoint& output);
     std::vector<COutPoint> listSelectedCoins() const;
+    void clearSelectedCoins();
     unsigned int feeTargetBlocks() const;
     void setFeeTargetBlocks(unsigned int target_blocks);
     void setCustomFeeEnabled(bool enabled);

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -7,6 +7,7 @@
 
 #include <qml/models/activitylistmodel.h>
 #include <qml/models/addresslistmodel.h>
+#include <qml/models/bitcoinuri.h>
 #include <qml/models/bumptransactionmodel.h>
 #include <qml/models/coinslistmodel.h>
 #include <qml/models/paymentrequest.h>
@@ -144,6 +145,8 @@ public:
     Q_INVOKABLE void clearSettingsError();
     Q_INVOKABLE void setDefaultReceiveAddressType(const QString& address_type);
     Q_INVOKABLE QString receiveAddressTypeLabel(const QString& address_type) const;
+    Q_INVOKABLE QVariantMap parseBitcoinUri(const QString& uri_text);
+    Q_INVOKABLE QVariantMap parseBitcoinUriFromFile(const QString& source_path);
     void removeWallet();
 
     std::set<interfaces::WalletTx> getWalletTxs() const;

--- a/qml/pages/node/Shutdown.qml
+++ b/qml/pages/node/Shutdown.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts 1.15
 import "../../controls"
 
 Page {
+    objectName: "shutdownPage"
     background: null
 
     ColumnLayout {

--- a/qml/pages/wallet/CoinSelection.qml
+++ b/qml/pages/wallet/CoinSelection.qml
@@ -13,6 +13,7 @@ import "../../components"
 
 Page {
     id: root
+    objectName: "coinSelectionPage"
 
     property WalletQmlModel wallet: walletController.selectedWallet
 
@@ -25,6 +26,7 @@ Page {
             header: qsTr("Coin Selection")
         }
         rightItem: NavButton {
+            objectName: "coinSelectionDoneButton"
             text: qsTr("Done")
             onClicked: root.done()
         }
@@ -55,6 +57,7 @@ Page {
                 text: qsTr("Total selected")
             }
             CoreText {
+                objectName: "coinSelectionTotalSelectedText"
                 Layout.alignment: Qt.AlignRight
                 color: Theme.color.neutral9
                 font.pixelSize: 18
@@ -99,12 +102,14 @@ Page {
 
         ListView {
             id: listView
+            objectName: "coinSelectionListView"
             width: parent.width
             model: root.wallet.coinsListModel
             spacing: 15
 
             delegate: ItemDelegate {
                 id: delegate
+                objectName: "coinSelectionItem_" + index
                 required property string address;
                 required property string amount;
                 required property string label;
@@ -139,10 +144,16 @@ Page {
                     width: parent.width
                     CoreCheckBox {
                         id: checkBox
+                        objectName: "coinSelectionCheckbox"
                         Layout.minimumWidth: 20
                         enabled: !locked
                         checked: selected
                         visible: !locked
+                        function click() {
+                            if (!locked) {
+                                listView.model.toggleCoinSelection(index)
+                            }
+                        }
                         MouseArea {
                             anchors.fill: parent
                             enabled: false

--- a/qml/pages/wallet/CreateBackup.qml
+++ b/qml/pages/wallet/CreateBackup.qml
@@ -18,6 +18,8 @@ Page {
     signal next
     background: null
 
+    Component.onCompleted: walletController.clearWalletLocationOpenError()
+
     header: NavigationBar2 {}
 
     ColumnLayout {
@@ -69,6 +71,19 @@ Page {
             backgroundColor: "transparent"
             backgroundHoverColor: "transparent"
             backgroundPressedColor: "transparent"
+            onClicked: walletController.openSelectedWalletLocation()
+        }
+
+        CoreText {
+            objectName: "createWalletBackupErrorText"
+            Layout.fillWidth: true
+            Layout.leftMargin: 20
+            Layout.rightMargin: 20
+            visible: text.length > 0
+            text: walletController.walletLocationOpenError
+            color: Theme.color.red
+            font.pixelSize: 15
+            wrapMode: Text.WordWrap
         }
 
         ContinueButton {

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -190,128 +190,19 @@ Page {
                 }
             }
 
-            ColumnLayout {
+            BitcoinAmountInputField {
+                id: amountInput
                 Layout.fillWidth: true
-
-                Item {
-                    Layout.fillWidth: true
-                    height: amountInput.height
-
-                    CoreText {
-                        id: amountLabel
-                        width: 110
-                        anchors.left: parent.left
-                        anchors.verticalCenter: parent.verticalCenter
-                        horizontalAlignment: Text.AlignLeft
-                        text: qsTr("Amount")
-                        font.pixelSize: 18
-                    }
-
-                    TextField {
-                        id: amountInput
-                        objectName: "requestPaymentAmountInput"
-                        Accessible.name: qsTr("Payment amount")
-                        anchors.left: amountLabel.right
-                        anchors.right: unitFlipItem.left
-                        anchors.verticalCenter: parent.verticalCenter
-                        leftPadding: 0
-                        font.family: "BitcoinCoreSans"
-                        font.styleName: "Regular"
-                        font.pixelSize: 18
-                        color: Theme.color.neutral9
-                        placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
-                        background: Item {}
-                        placeholderText: !root.request || root.request.amount.unit === BitcoinAmount.BTC
-                            ? "0.00000000" : "0"
-                        selectByMouse: true
-                        enabled: root.requestIsEditing()
-                        text: root.request ? root.request.amount.display : ""
-                        onTextEdited: {
-                            root.requestError = ""
-                            if (root.request) {
-                                root.request.amount.display = text
-                            }
-                        }
-                        onEditingFinished: {
-                            if (root.request) {
-                                root.request.amount.format()
-                            }
-                        }
-                        onActiveFocusChanged: {
-                            if (!activeFocus && root.request) {
-                                root.request.amount.format()
-                            }
-                        }
-                        validator: RegularExpressionValidator {
-                            regularExpression: !root.request || root.request.amount.unit === BitcoinAmount.BTC
-                                ? /^(0|[1-9]\d{0,7})(\.\d{0,8})?$/
-                                : /^(0|[1-9]\d{0,15})$/
-                        }
-                        maximumLength: !root.request || root.request.amount.unit === BitcoinAmount.BTC ? 17 : 16
-                    }
-
-                    Item {
-                        id: unitFlipItem
-                        width: unitLabel.width + flipIcon.width
-                        height: Math.max(unitLabel.height, flipIcon.height)
-                        anchors.right: parent.right
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        MouseArea {
-                            anchors.fill: parent
-                            enabled: root.requestIsEditing()
-                            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                            onClicked: {
-                                if (root.request) {
-                                    root.request.amount.flipUnit()
-                                }
-                            }
-                        }
-
-                        CoreText {
-                            id: unitLabel
-                            anchors.right: flipIcon.left
-                            anchors.verticalCenter: parent.verticalCenter
-                            text: root.request ? root.request.amount.unitLabel : ""
-                            font.pixelSize: 18
-                            color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
-                        }
-
-                        Icon {
-                            id: flipIcon
-                            anchors.right: parent.right
-                            anchors.verticalCenter: parent.verticalCenter
-                            source: "image://images/flip-vertical"
-                            color: unitLabel.enabled ? Theme.color.neutral8 : Theme.color.neutral4
-                            size: 30
-                        }
-                    }
+                inputObjectName: "requestPaymentAmountInput"
+                accessibleName: qsTr("Payment amount")
+                amount: root.request ? root.request.amount : null
+                errorText: root.request ? root.request.amountError : ""
+                enabled: root.requestIsEditing()
+                onInputTextChanged: {
+                    root.requestError = ""
                 }
-
-                Connections {
-                    target: root.request ? root.request.amount : null
-                    function onDisplayChanged() {
-                        amountInput.text = root.request ? root.request.amount.display : ""
-                    }
-                }
-
-                RowLayout {
-                    Layout.fillWidth: true
-                    visible: root.request !== null && root.request.amountError.length > 0
-
-                    Icon {
-                        source: "image://images/alert-filled"
-                        size: 22
-                        color: Theme.color.red
-                    }
-
-                    CoreText {
-                        text: root.request ? root.request.amountError : ""
-                        font.pixelSize: 15
-                        color: Theme.color.red
-                        horizontalAlignment: Text.AlignLeft
-                        Layout.fillWidth: true
-                    }
+                onTextEdited: {
+                    root.requestError = ""
                 }
             }
 
@@ -877,7 +768,7 @@ Page {
                 target: root.request && root.request.isEditing !== undefined ? root.request : null
                 function onIsEditingChanged() {
                     if (root.request) {
-                        amountInput.text = root.request.amount.display
+                        amountInput.syncFromAmount(true)
                         nameInput.text = root.requestValue("label")
                         messageInput.text = root.requestValue("message")
                         noteSelfInput.text = root.requestValue("noteSelf")

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -267,114 +267,23 @@ PageStack {
                     Layout.fillWidth: true
                 }
 
-                ColumnLayout {
+                BitcoinAmountInputField {
+                    id: amountInput
                     Layout.fillWidth: true
-
-                    Item {
-                        height: amountInput.height
-                        Layout.fillWidth: true
-                        CoreText {
-                            id: amountLabel
-                            width: 110
-                            anchors.left: parent.left
-                            anchors.verticalCenter: parent.verticalCenter
-                            horizontalAlignment: Text.AlignLeft
-                            text: qsTr("Amount")
-                            font.pixelSize: 18
-                        }
-
-                        TextField {
-                            id: amountInput
-                            objectName: "sendAmountInput"
-                            anchors.left: amountLabel.right
-                            anchors.verticalCenter: parent.verticalCenter
-                            leftPadding: 0
-                            font.family: "BitcoinCoreSans"
-                            font.styleName: "Regular"
-                            font.pixelSize: 18
-                            color: Theme.color.neutral9
-                            placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
-                            background: Item {}
-                            placeholderText: root.recipient.amount.unit === BitcoinAmount.SAT ? "0" : "0.00000000"
-                            selectByMouse: true
-                            text: root.recipient.amount.display
-                            onTextChanged: {
-                                root.clearPrepareTransactionError()
-                                if (text !== root.recipient.amount.display) {
-                                    root.recipient.amount.display = text
-                                }
-                                root.scheduleFeeEstimates()
-                            }
-                            onTextEdited: root.recipient.amount.display = text
-                            onEditingFinished: {
-                                root.recipient.amount.format()
-                                root.scheduleFeeEstimates()
-                            }
-                            onActiveFocusChanged: {
-                                if (!activeFocus) {
-                                    root.recipient.amount.format()
-                                    root.scheduleFeeEstimates()
-                                }
-                            }
-                            validator: RegularExpressionValidator {
-                                regularExpression: root.recipient.amount.unit === BitcoinAmount.BTC
-                                    ? /^(0|[1-9]\d{0,7})(\.\d{0,8})?$/
-                                    : /^(0|[1-9]\d{0,15})$/
-                            }
-                            maximumLength: root.recipient.amount.unit === BitcoinAmount.BTC ? 17 : 16
-                        }
-                        Item {
-                            objectName: "sendAmountUnitToggle"
-                            width: unitLabel.width + flipIcon.width
-                            height: Math.max(unitLabel.height, flipIcon.height)
-                            anchors.right: parent.right
-                            anchors.verticalCenter: parent.verticalCenter
-                            function click() {
-                                root.recipient.amount.flipUnit()
-                            }
-                            MouseArea {
-                                anchors.fill: parent
-                                onClicked: root.recipient.amount.flipUnit()
-                            }
-                            CoreText {
-                                id: unitLabel
-                                objectName: "sendAmountUnitLabel"
-                                anchors.right: flipIcon.left
-                                anchors.verticalCenter: parent.verticalCenter
-                                text: root.recipient.amount.unitLabel
-                                font.pixelSize: 18
-                                color: enabled ? Theme.color.neutral7 : Theme.color.neutral4
-                            }
-                            Icon {
-                                id: flipIcon
-                                anchors.right: parent.right
-                                anchors.verticalCenter: parent.verticalCenter
-                                source: "image://images/flip-vertical"
-                                color: unitLabel.enabled ? Theme.color.neutral8 : Theme.color.neutral4
-                                size: 30
-                            }
-                        }
+                    inputObjectName: "sendAmountInput"
+                    unitToggleObjectName: "sendAmountUnitToggle"
+                    unitLabelObjectName: "sendAmountUnitLabel"
+                    errorTextObjectName: "sendAmountErrorText"
+                    amount: root.recipient ? root.recipient.amount : null
+                    errorText: root.recipient ? root.recipient.amountError : ""
+                    onInputTextChanged: {
+                        root.clearPrepareTransactionError()
+                        root.scheduleFeeEstimates()
                     }
-
-                    RowLayout {
-                        Layout.fillWidth: true
-                        visible: root.recipient.amountError.length > 0
-
-                        Icon {
-                            source: "image://images/alert-filled"
-                            size: 22
-                            color: Theme.color.red
-                        }
-
-                        CoreText {
-                            objectName: "sendAmountErrorText"
-                            text: root.recipient.amountError
-                            font.pixelSize: 15
-                            color: Theme.color.red
-                            horizontalAlignment: Text.AlignLeft
-                            Layout.fillWidth: true
-                        }
+                    onTextEdited: {
+                        root.clearPrepareTransactionError()
                     }
+                    onEditingFinished: root.scheduleFeeEstimates()
                 }
 
                 Separator {

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -47,10 +47,24 @@ PageStack {
         }
     }
 
+    // Re-check the clipboard whenever the Send tab becomes visible so the
+    // banner appears even if the URI was copied before navigating here.
+    onVisibleChanged: if (visible) sendPage.checkClipboard()
+
     Connections {
         target: walletController
         function onSelectedWalletChanged() {
             root.pop()
+            // Clear URI import state so stale results from the previous wallet
+            // are not shown when the user switches wallets and returns to Send.
+            sendPage.paymentRequestStatus = ""
+            sendPage.paymentRequestIsError = false
+            sendPage.paymentRequestMessage = ""
+            sendPage.showClipboardUriBanner = false
+            sendPage.m_pendingClipboardUri = ""
+            sendPage.m_filledUri = ""
+            sendPage.m_dismissedUri = ""
+            sendPage.m_applyingUri = false
         }
     }
 
@@ -110,12 +124,63 @@ PageStack {
 
         // Clipboard URI detection
         property bool showClipboardUriBanner: false
+        // Cache the clipboard text at detection time to avoid a TOCTOU race:
+        // the "Fill" button applies this value rather than re-reading the
+        // clipboard, which may have changed since the banner appeared.
+        property string m_pendingClipboardUri: ""
+        // Soft suppress (Fill): URI that was most recently applied to the form.
+        // The banner stays hidden while all URI-specified fields still match the
+        // form; as soon as any field diverges the banner re-appears.
+        property string m_filledUri: ""
+        // Hard suppress (Dismiss): URI the user explicitly dismissed.
+        // The banner only re-appears when the clipboard contains a different URI.
+        property string m_dismissedUri: ""
+        // Guard that prevents field-change Connections from triggering a
+        // re-check while a programmatic URI fill is writing to the form.
+        property bool m_applyingUri: false
 
         function checkClipboard() {
-            // Use the parser rather than a hand-rolled scheme check so the banner
-            // only appears for genuinely valid URIs (e.g. bitcoin:// won't show it).
-            showClipboardUriBanner = root.wallet !== null &&
-                root.wallet.parseBitcoinUri(Clipboard.text()).success
+            // Skip parsing when the Send tab is not visible or no wallet is
+            // loaded (recipient fields depend on the wallet being present).
+            if (!root.visible || root.wallet === null) {
+                showClipboardUriBanner = false
+                return
+            }
+
+            const text = Clipboard.text()
+            const parsed = BitcoinUri.parseBitcoinUri(text)
+            if (!parsed.success) {
+                showClipboardUriBanner = false
+                m_pendingClipboardUri = ""
+                return
+            }
+
+            // Hard suppress: user dismissed this exact URI.
+            // Only lifts when the clipboard changes to a different URI.
+            if (text === m_dismissedUri) {
+                showClipboardUriBanner = false
+                return
+            }
+
+            // Soft suppress: user filled this URI. Hide the banner while every
+            // field the URI specified still matches its current form value.
+            // As soon as any field diverges the banner re-appears automatically.
+            if (text === m_filledUri) {
+                const filled = BitcoinUri.parseBitcoinUri(m_filledUri)
+                const formMatches =
+                    root.recipient.address.address === filled.address
+                    && (!filled.hasAmount || root.recipient.amount.satoshi === filled.amountSats)
+                    && (!filled.hasLabel  || root.recipient.label === filled.label)
+                if (formMatches) {
+                    showClipboardUriBanner = false
+                    return
+                }
+                // Form diverged — lift fill suppression.
+                m_filledUri = ""
+            }
+
+            m_pendingClipboardUri = text
+            showClipboardUriBanner = true
         }
 
         // Apply a pre-parsed URI result to the current recipient form fields.
@@ -125,13 +190,21 @@ PageStack {
                 paymentRequestIsError = true
                 return
             }
+            m_applyingUri = true
             root.recipient.address.setAddress(result.address, 0)
+            // Only fields present in the URI are applied. Amount is intentionally
+            // not cleared when the URI omits 'amount='. This matches Bitcoin Core
+            // Qt's URI import behaviour: only populate what the URI specifies.
             if (result.hasAmount) {
                 root.recipient.amount.satoshi = result.amountSats
             }
             if (result.hasLabel) {
                 root.recipient.label = result.label
             }
+            // Lower the guard only after all writes are done. Field-change
+            // Connections must not fire checkClipboard() before the Fill
+            // handler has had a chance to set m_filledUri.
+            m_applyingUri = false
             paymentRequestMessage = result.hasMessage ? result.uriMessage : ""
             paymentRequestStatus = qsTr("Payment request imported from %1.").arg(source)
             paymentRequestIsError = false
@@ -139,19 +212,43 @@ PageStack {
 
         // Parse a URI from text and apply to form.
         function applyPaymentRequestFromText(text, source) {
-            const result = root.wallet.parseBitcoinUri(text)
+            const result = BitcoinUri.parseBitcoinUri(text)
             applyParsedPaymentRequest(result, source)
         }
 
         // Parse a URI from a file path and apply to form.
         function applyPaymentRequestFromFile(path) {
-            const result = root.wallet.parseBitcoinUriFromFile(path)
+            const result = BitcoinUri.parseBitcoinUriFromFile(path)
             applyParsedPaymentRequest(result, qsTr("file"))
         }
 
         Connections {
             target: Clipboard
             function onDataChanged() { sendPage.checkClipboard() }
+        }
+
+        // Re-check the clipboard whenever any form field changes due to user
+        // input. checkClipboard() compares current values against the filled URI
+        // and re-shows the banner if any specified field has diverged.
+        // The m_applyingUri guard prevents these from firing during a programmatic
+        // fill, which would trigger a re-check before m_filledUri is set.
+        Connections {
+            target: root.recipient.address
+            function onAddressChanged() {
+                if (!sendPage.m_applyingUri) sendPage.checkClipboard()
+            }
+        }
+        Connections {
+            target: root.recipient.amount
+            function onAmountChanged() {
+                if (!sendPage.m_applyingUri) sendPage.checkClipboard()
+            }
+        }
+        Connections {
+            target: root.recipient
+            function onLabelChanged() {
+                if (!sendPage.m_applyingUri) sendPage.checkClipboard()
+            }
         }
 
         Component.onCompleted: sendPage.checkClipboard()
@@ -372,7 +469,13 @@ PageStack {
                                 Layout.preferredWidth: 90
                                 onClicked: {
                                     sendPage.showClipboardUriBanner = false
-                                    sendPage.applyPaymentRequestFromText(Clipboard.text(), qsTr("clipboard"))
+                                    // Use the cached URI captured when the banner appeared,
+                                    // not Clipboard.text(), to avoid applying a different URI
+                                    // if the clipboard changed before the user clicked Fill.
+                                    sendPage.applyPaymentRequestFromText(sendPage.m_pendingClipboardUri, qsTr("clipboard"))
+                                    // Soft-suppress: banner stays hidden while the form
+                                    // still reflects what the URI specified.
+                                    sendPage.m_filledUri = sendPage.m_pendingClipboardUri
                                 }
                             }
 
@@ -383,7 +486,12 @@ PageStack {
                                 fontSize: 14
                                 implicitHeight: 38
                                 Layout.preferredWidth: 90
-                                onClicked: sendPage.showClipboardUriBanner = false
+                                onClicked: {
+                                    // Hard-suppress: banner only reappears if the
+                                    // clipboard changes to a different URI.
+                                    sendPage.m_dismissedUri = sendPage.m_pendingClipboardUri
+                                    sendPage.showClipboardUriBanner = false
+                                }
                             }
                         }
                     }

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -99,7 +99,152 @@ PageStack {
     }
 
     initialItem: Page {
+        id: sendPage
+        objectName: "walletSendPage"
         background: null
+
+        // URI import state
+        property string paymentRequestStatus: ""
+        property bool paymentRequestIsError: false
+        property string paymentRequestMessage: ""
+
+        // Clipboard URI detection
+        property bool showClipboardUriBanner: false
+
+        function checkClipboard() {
+            // Use the parser rather than a hand-rolled scheme check so the banner
+            // only appears for genuinely valid URIs (e.g. bitcoin:// won't show it).
+            showClipboardUriBanner = root.wallet !== null &&
+                root.wallet.parseBitcoinUri(Clipboard.text()).success
+        }
+
+        // Apply a pre-parsed URI result to the current recipient form fields.
+        function applyParsedPaymentRequest(result, source) {
+            if (!result.success) {
+                paymentRequestStatus = result.error
+                paymentRequestIsError = true
+                return
+            }
+            root.recipient.address.setAddress(result.address, 0)
+            if (result.hasAmount) {
+                root.recipient.amount.satoshi = result.amountSats
+            }
+            if (result.hasLabel) {
+                root.recipient.label = result.label
+            }
+            paymentRequestMessage = result.hasMessage ? result.uriMessage : ""
+            paymentRequestStatus = qsTr("Payment request imported from %1.").arg(source)
+            paymentRequestIsError = false
+        }
+
+        // Parse a URI from text and apply to form.
+        function applyPaymentRequestFromText(text, source) {
+            const result = root.wallet.parseBitcoinUri(text)
+            applyParsedPaymentRequest(result, source)
+        }
+
+        // Parse a URI from a file path and apply to form.
+        function applyPaymentRequestFromFile(path) {
+            const result = root.wallet.parseBitcoinUriFromFile(path)
+            applyParsedPaymentRequest(result, qsTr("file"))
+        }
+
+        Connections {
+            target: Clipboard
+            function onDataChanged() { sendPage.checkClipboard() }
+        }
+
+        Component.onCompleted: sendPage.checkClipboard()
+
+        Connections {
+            target: sendOptionsPopup
+            function onOpenPaymentRequest() {
+                uriImportInput.text = ""
+                sendUriImportPopup.open()
+            }
+        }
+
+        // Manual URI entry popup
+        Popup {
+            id: sendUriImportPopup
+            objectName: "sendUriImportPopup"
+            anchors.centerIn: Overlay.overlay
+            width: Math.min(sendPage.width - 40, 420)
+            modal: true
+            padding: 20
+
+            background: Item {
+                anchors.fill: parent
+                Rectangle {
+                    color: Theme.color.neutral0
+                    border.color: Theme.color.neutral4
+                    radius: 5
+                    border.width: 1
+                    anchors.fill: parent
+                }
+            }
+
+            contentItem: ColumnLayout {
+                spacing: 12
+
+                CoreText {
+                    text: qsTr("Open payment request")
+                    font.pixelSize: 16
+                    bold: true
+                    color: Theme.color.neutral9
+                    Layout.fillWidth: true
+                }
+
+                CoreTextField {
+                    id: uriImportInput
+                    objectName: "sendUriImportInput"
+                    Layout.fillWidth: true
+                    placeholderText: qsTr("bitcoin:address?amount=…")
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 10
+
+                    OutlineButton {
+                        Layout.fillWidth: true
+                        text: qsTr("Cancel")
+                        onClicked: sendUriImportPopup.close()
+                    }
+
+                    ContinueButton {
+                        objectName: "sendUriImportApplyButton"
+                        Layout.fillWidth: true
+                        text: qsTr("Apply")
+                        onClicked: {
+                            sendUriImportPopup.close()
+                            sendPage.applyPaymentRequestFromText(uriImportInput.text, qsTr("manual entry"))
+                        }
+                    }
+                }
+            }
+        }
+
+        // Drag-and-drop support
+        DropArea {
+            objectName: "sendDropArea"
+            anchors.fill: parent
+            keys: ["text/uri-list", "text/plain"]
+            onDropped: (drop) => {
+                if (drop.hasUrls && drop.urls.length > 0) {
+                    const url = drop.urls[0].toString()
+                    if (url.startsWith("file://")) {
+                        // Pass the raw file:// URL; C++ uses QUrl::toLocalFile()
+                        // to derive the correct local path on all platforms.
+                        sendPage.applyPaymentRequestFromFile(url)
+                    } else {
+                        sendPage.applyPaymentRequestFromText(url, qsTr("drag and drop"))
+                    }
+                } else if (drop.hasText) {
+                    sendPage.applyPaymentRequestFromText(drop.text, qsTr("drag and drop"))
+                }
+            }
+        }
 
         Settings {
             id: settings
@@ -186,6 +331,120 @@ PageStack {
                     text: qsTr("Make sure you have your external signer at hand to approve this transaction.")
                     font.pixelSize: 18
                     color: Theme.color.neutral7
+                }
+
+                // Clipboard URI detection card
+                Rectangle {
+                    objectName: "clipboardUriBanner"
+                    Layout.fillWidth: true
+                    visible: sendPage.showClipboardUriBanner
+                    color: Theme.color.neutral1
+                    radius: 5
+                    implicitHeight: clipboardBannerContent.implicitHeight + 20
+
+                    ColumnLayout {
+                        id: clipboardBannerContent
+                        anchors.top: parent.top
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.margins: 10
+                        spacing: 10
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 12
+
+                            CoreText {
+                                text: qsTr("You have a Bitcoin invoice in your clipboard.")
+                                font.pixelSize: 14
+                                color: Theme.color.neutral9
+                                horizontalAlignment: Text.AlignLeft
+                                Layout.fillWidth: true
+                                wrapMode: Text.WordWrap
+                            }
+
+                            ContinueButton {
+                                objectName: "clipboardUriPasteButton"
+                                text: qsTr("Fill")
+                                bold: false
+                                textFontPixelSize: 14
+                                implicitHeight: 38
+                                Layout.preferredWidth: 90
+                                onClicked: {
+                                    sendPage.showClipboardUriBanner = false
+                                    sendPage.applyPaymentRequestFromText(Clipboard.text(), qsTr("clipboard"))
+                                }
+                            }
+
+                            OutlineButton {
+                                objectName: "clipboardUriDismissButton"
+                                text: qsTr("Dismiss")
+                                bold: false
+                                fontSize: 14
+                                implicitHeight: 38
+                                Layout.preferredWidth: 90
+                                onClicked: sendPage.showClipboardUriBanner = false
+                            }
+                        }
+                    }
+                }
+
+                // Payment request message (from URI "message=" field)
+                RowLayout {
+                    Layout.fillWidth: true
+                    visible: sendPage.paymentRequestMessage.length > 0
+                    spacing: 8
+
+                    Icon {
+                        source: "image://images/check"
+                        size: 18
+                        color: Theme.color.neutral7
+                    }
+
+                    CoreText {
+                        objectName: "sendPaymentRequestMessageText"
+                        text: sendPage.paymentRequestMessage
+                        font.pixelSize: 14
+                        color: Theme.color.neutral7
+                        horizontalAlignment: Text.AlignLeft
+                        Layout.fillWidth: true
+                        wrapMode: Text.WordWrap
+                    }
+                }
+
+                // Payment request import status (success or error)
+                RowLayout {
+                    Layout.fillWidth: true
+                    visible: sendPage.paymentRequestStatus.length > 0
+                    spacing: 8
+
+                    Icon {
+                        source: sendPage.paymentRequestIsError
+                            ? "image://images/alert-filled"
+                            : "image://images/circle-green-check"
+                        size: 18
+                        color: sendPage.paymentRequestIsError ? Theme.color.red : Theme.color.green
+                    }
+
+                    CoreText {
+                        objectName: "sendPaymentRequestStatusText"
+                        text: sendPage.paymentRequestStatus
+                        font.pixelSize: 14
+                        color: sendPage.paymentRequestIsError ? Theme.color.red : Theme.color.neutral7
+                        horizontalAlignment: Text.AlignLeft
+                        Layout.fillWidth: true
+                        wrapMode: Text.WordWrap
+                    }
+
+                    IconButton {
+                        objectName: "clearPaymentRequestStatusButton"
+                        size: 22
+                        iconSource: "image://images/cross"
+                        onClicked: {
+                            sendPage.paymentRequestStatus = ""
+                            sendPage.paymentRequestIsError = false
+                        }
+                    }
                 }
 
                 RowLayout {
@@ -423,6 +682,66 @@ PageStack {
                             root.prepareTransactionErrorText = root.wallet.transactionError.length > 0
                                 ? root.wallet.transactionError
                                 : (root.selectedInputsActive ? root.selectedInputsBalanceErrorText : root.availableBalanceErrorText)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Automation-only hooks for functional tests. Only loaded when the app
+        // is built with -DENABLE_TEST_AUTOMATION=ON (testAutomationEnabled is a
+        // C++ context property set at startup). In production builds the Loader
+        // is inactive and no hook items exist in the QML object tree.
+        Loader {
+            active: testAutomationEnabled
+            anchors.fill: parent
+            sourceComponent: Component {
+                Item {
+                    anchors.fill: parent
+
+                    CoreTextField {
+                        id: fileImportPathInput
+                        objectName: "sendImportPaymentRequestFilePathInput"
+                        visible: false
+                    }
+
+                    Button {
+                        objectName: "sendApplyPaymentRequestFilePathButton"
+                        visible: false
+                        onClicked: sendPage.applyPaymentRequestFromFile(fileImportPathInput.text)
+                    }
+
+                    CoreTextField {
+                        id: dropUriInput
+                        objectName: "sendDropUriInput"
+                        visible: false
+                    }
+
+                    Button {
+                        objectName: "sendApplyDropUriButton"
+                        visible: false
+                        onClicked: sendPage.applyPaymentRequestFromText(dropUriInput.text, qsTr("drag and drop"))
+                    }
+
+                    // Exercises the DropArea hasUrls + file:// branch.
+                    // Passes the raw URL to applyPaymentRequestFromFile so C++
+                    // handles the platform-correct toLocalFile() conversion.
+                    CoreTextField {
+                        id: dropFileUrlInput
+                        objectName: "sendDropFileUrlInput"
+                        visible: false
+                    }
+
+                    Button {
+                        objectName: "sendApplyDropFileUrlButton"
+                        visible: false
+                        onClicked: {
+                            const url = dropFileUrlInput.text
+                            if (url.startsWith("file://")) {
+                                sendPage.applyPaymentRequestFromFile(url)
+                            } else {
+                                sendPage.applyPaymentRequestFromText(url, qsTr("drag and drop"))
+                            }
                         }
                     }
                 }

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -214,6 +214,13 @@ PageStack {
         function applyPaymentRequestFromText(text, source) {
             const result = BitcoinUri.parseBitcoinUri(text)
             applyParsedPaymentRequest(result, source)
+            // If the applied URI matches what's on the clipboard, treat it like
+            // the Fill button: soft-suppress the banner so it stays hidden while
+            // the form still reflects what the URI specified.
+            if (result.success && Clipboard.text() === text) {
+                m_filledUri = text
+                showClipboardUriBanner = false
+            }
         }
 
         // Parse a URI from a file path and apply to form.

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -332,6 +332,7 @@ PageStack {
                         objectName: "sendUriImportApplyButton"
                         Layout.fillWidth: true
                         text: qsTr("Apply")
+                        enabled: uriImportInput.text.trim().length > 0
                         onClicked: {
                             sendUriImportPopup.close()
                             sendPage.applyPaymentRequestFromText(uriImportInput.text, qsTr("manual entry"))

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -548,6 +548,8 @@ PageStack {
                         objectName: "clearPaymentRequestStatusButton"
                         size: 22
                         iconSource: "image://images/cross"
+                        Accessible.name: qsTr("Clear status")
+                        Accessible.role: Accessible.Button
                         onClicked: {
                             sendPage.paymentRequestStatus = ""
                             sendPage.paymentRequestIsError = false

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -21,8 +21,13 @@ PageStack {
     property string prepareTransactionErrorText: ""
     readonly property bool externalSignerWallet: wallet !== null && wallet.hasExternalSigner
     readonly property string recipientValidationError: wallet ? wallet.recipients.validationError : ""
+    readonly property bool selectedInputsActive: wallet !== null
+        && wallet.coinsListModel !== null
+        && wallet.coinsListModel.selectedCoinsCount > 0
+    readonly property string availableBalanceErrorText: qsTr("Amount plus fee exceeds available balance")
+    readonly property string selectedInputsBalanceErrorText: qsTr("Selected inputs do not cover the amount plus fee")
     readonly property string feeBalanceErrorText: wallet && wallet.sendAmountExhaustsBalance
-        ? qsTr("Amount plus fee exceeds available balance")
+        ? (selectedInputsActive ? selectedInputsBalanceErrorText : availableBalanceErrorText)
         : ""
     readonly property string formErrorText: recipientValidationError.length > 0
         ? recipientValidationError
@@ -417,7 +422,7 @@ PageStack {
                         } else {
                             root.prepareTransactionErrorText = root.wallet.transactionError.length > 0
                                 ? root.wallet.transactionError
-                                : qsTr("Amount plus fee exceeds available balance")
+                                : (root.selectedInputsActive ? root.selectedInputsBalanceErrorText : root.availableBalanceErrorText)
                         }
                     }
                 }

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -103,6 +103,12 @@ PageStack {
                     root.wallet.recipients.add()
                 }
             }
+
+            onCoinControlEnabledChanged: {
+                if (coinControlEnabled && root.wallet) {
+                    root.wallet.coinsListModel.update()
+                }
+            }
         }
 
         ScrollView {
@@ -391,6 +397,8 @@ PageStack {
                 }
 
                 LabeledCoinControlButton {
+                    objectName: "sendCoinControlButton"
+                    valueObjectName: "sendCoinControlButtonText"
                     visible: settings.coinControlEnabled
                     Layout.fillWidth: true
                     coinsSelected: wallet.coinsListModel.selectedCoinsCount

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -21,7 +21,12 @@ PageStack {
     property string prepareTransactionErrorText: ""
     readonly property bool externalSignerWallet: wallet !== null && wallet.hasExternalSigner
     readonly property string recipientValidationError: wallet ? wallet.recipients.validationError : ""
-    readonly property string formErrorText: recipientValidationError.length > 0 ? recipientValidationError : prepareTransactionErrorText
+    readonly property string feeBalanceErrorText: wallet && wallet.sendAmountExhaustsBalance
+        ? qsTr("Amount plus fee exceeds available balance")
+        : ""
+    readonly property string formErrorText: recipientValidationError.length > 0
+        ? recipientValidationError
+        : (feeBalanceErrorText.length > 0 ? feeBalanceErrorText : prepareTransactionErrorText)
 
     signal transactionPrepared(bool multipleRecipientsEnabled)
 
@@ -374,8 +379,7 @@ PageStack {
                 RowLayout {
                     objectName: "sendPrepareTransactionError"
                     Layout.fillWidth: true
-                    visible: root.prepareTransactionErrorText.length > 0
-                        || root.recipientValidationError.length > 0
+                    visible: root.formErrorText.length > 0
 
                     Icon {
                         source: "image://images/alert-filled"
@@ -401,6 +405,7 @@ PageStack {
                     text: root.externalSignerWallet ? qsTr("Review transaction") : qsTr("Review")
                     enabled: root.wallet
                         && root.wallet.recipients.allValid
+                        && !root.wallet.sendAmountExhaustsBalance
                         && (!root.wallet.customFeeEnabled || root.wallet.customFeeRateValid)
                     onClicked: {
                         root.clearPrepareTransactionError()

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -208,6 +208,7 @@ PageStack {
             // Connections must not fire checkClipboard() before the Fill
             // handler has had a chance to set m_filledUri.
             m_applyingUri = false
+            root.scheduleFeeEstimates()
             paymentRequestMessage = result.hasMessage ? result.uriMessage : ""
             paymentRequestStatus = qsTr("Payment request imported from %1.").arg(source)
             paymentRequestIsError = false

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -20,6 +20,8 @@ PageStack {
     property SendRecipient recipient: wallet.recipients.current
     property string prepareTransactionErrorText: ""
     readonly property bool externalSignerWallet: wallet !== null && wallet.hasExternalSigner
+    readonly property string recipientValidationError: wallet ? wallet.recipients.validationError : ""
+    readonly property string formErrorText: recipientValidationError.length > 0 ? recipientValidationError : prepareTransactionErrorText
 
     signal transactionPrepared(bool multipleRecipientsEnabled)
 
@@ -359,6 +361,7 @@ PageStack {
                         }
 
                         CoreText {
+                            objectName: "sendAmountErrorText"
                             text: root.recipient.amountError
                             font.pixelSize: 15
                             color: Theme.color.red
@@ -455,6 +458,7 @@ PageStack {
                     objectName: "sendPrepareTransactionError"
                     Layout.fillWidth: true
                     visible: root.prepareTransactionErrorText.length > 0
+                        || root.recipientValidationError.length > 0
 
                     Icon {
                         source: "image://images/alert-filled"
@@ -464,7 +468,7 @@ PageStack {
 
                     CoreText {
                         objectName: "sendPrepareTransactionErrorText"
-                        text: root.prepareTransactionErrorText
+                        text: root.formErrorText
                         font.pixelSize: 15
                         color: Theme.color.red
                         horizontalAlignment: Text.AlignLeft
@@ -478,8 +482,9 @@ PageStack {
                     Layout.fillWidth: true
                     Layout.topMargin: 30
                     text: root.externalSignerWallet ? qsTr("Review transaction") : qsTr("Review")
-                    enabled: root.recipient.isValid
-                        && (!root.wallet || !root.wallet.customFeeEnabled || root.wallet.customFeeRateValid)
+                    enabled: root.wallet
+                        && root.wallet.recipients.allValid
+                        && (!root.wallet.customFeeEnabled || root.wallet.customFeeRateValid)
                     onClicked: {
                         root.clearPrepareTransactionError()
                         if (root.wallet.prepareTransaction()) {

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -85,6 +85,11 @@ PageStack {
             root.clearPrepareTransactionError()
             root.scheduleFeeEstimates()
         }
+        function onCurrentRecipientChanged() {
+            sendPage.paymentRequestStatus = ""
+            sendPage.paymentRequestIsError = false
+            sendPage.paymentRequestMessage = ""
+        }
     }
 
     Connections {
@@ -242,7 +247,14 @@ PageStack {
         Connections {
             target: root.recipient.address
             function onAddressChanged() {
-                if (!sendPage.m_applyingUri) sendPage.checkClipboard()
+                if (!sendPage.m_applyingUri) {
+                    if (root.recipient.address.address === "") {
+                        sendPage.paymentRequestStatus = ""
+                        sendPage.paymentRequestIsError = false
+                        sendPage.paymentRequestMessage = ""
+                    }
+                    sendPage.checkClipboard()
+                }
             }
         }
         Connections {

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -84,8 +84,6 @@ PageStack {
         function onCurrentRecipientChanged() {
             root.clearPrepareTransactionError()
             root.scheduleFeeEstimates()
-        }
-        function onCurrentRecipientChanged() {
             sendPage.paymentRequestStatus = ""
             sendPage.paymentRequestIsError = false
             sendPage.paymentRequestMessage = ""
@@ -503,7 +501,7 @@ PageStack {
                                 objectName: "clipboardUriDismissButton"
                                 text: qsTr("Dismiss")
                                 bold: false
-                                fontSize: 14
+                                textFontPixelSize: 14
                                 implicitHeight: 38
                                 Layout.preferredWidth: 90
                                 onClicked: {

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -537,6 +537,8 @@ PageStack {
                         horizontalAlignment: Text.AlignLeft
                         Layout.fillWidth: true
                         wrapMode: Text.WordWrap
+                        maximumLineCount: 3
+                        elide: Text.ElideRight
                     }
                 }
 

--- a/qml/pages/wallet/SpeedUpOverlay.qml
+++ b/qml/pages/wallet/SpeedUpOverlay.qml
@@ -164,7 +164,7 @@ Popup {
                     }
                     if (!root.bumpModel.confirmFeeBump() && root.bumpModel.needsUnlock) {
                         speedUpPassphrasePopup.busy = false
-                        speedUpPassphrasePopup.errorText = root.bumpModel.errorText
+                        speedUpPassphrasePopup.errorText = ""
                         speedUpPassphrasePopup.open()
                     }
                 }

--- a/qml/pages/wallet/SpeedUpOverlay.qml
+++ b/qml/pages/wallet/SpeedUpOverlay.qml
@@ -158,13 +158,45 @@ Popup {
                 Layout.fillWidth: true
                 Layout.preferredWidth: 1
                 enabled: root.readyToConfirm
-                //FIXME: Unlock wallet before confirming (PR #548)
                 onClicked: {
-                    if (root.bumpModel) {
-                        root.bumpModel.confirmFeeBump()
+                    if (!root.bumpModel) {
+                        return
+                    }
+                    if (!root.bumpModel.confirmFeeBump() && root.bumpModel.needsUnlock) {
+                        speedUpPassphrasePopup.busy = false
+                        speedUpPassphrasePopup.errorText = root.bumpModel.errorText
+                        speedUpPassphrasePopup.open()
                     }
                 }
             }
+        }
+    }
+
+    WalletPassphrasePopup {
+        id: speedUpPassphrasePopup
+        parent: Overlay.overlay
+        width: Math.min(420, root.width - 40)
+        popupObjectName: "speedUpPassphrasePopup"
+        passphraseFieldObjectName: "speedUpPassphraseField"
+        errorTextObjectName: "speedUpPassphraseErrorText"
+        cancelButtonObjectName: "speedUpPassphraseCancelButton"
+        confirmButtonObjectName: "speedUpPassphraseConfirmButton"
+        titleText: qsTr("Enter wallet password")
+        descriptionText: qsTr("Enter your wallet password to update this transaction.")
+        confirmText: qsTr("Unlock and update")
+        busyConfirmText: qsTr("Unlocking...")
+        onSubmitted: (passphrase) => {
+            if (!root.bumpModel) {
+                return
+            }
+            speedUpPassphrasePopup.busy = true
+            if (root.bumpModel.confirmFeeBumpWithPassphrase(passphrase)) {
+                speedUpPassphrasePopup.busy = false
+                speedUpPassphrasePopup.close()
+                return
+            }
+            speedUpPassphrasePopup.busy = false
+            speedUpPassphrasePopup.errorText = root.bumpModel.errorText
         }
     }
 

--- a/qml/pages/wallet/WalletPasswordSettings.qml
+++ b/qml/pages/wallet/WalletPasswordSettings.qml
@@ -38,6 +38,13 @@ Page {
         clearField(confirmPassword)
     }
 
+    function focusInitialPasswordField() {
+        const field = root.updating ? currentPassword : newPassword
+        if (root.visible && field) {
+            field.forceActiveFocus()
+        }
+    }
+
     header: NavigationBar2 {
         leftItem: NavButton {
             objectName: "walletPasswordBackButton"
@@ -56,11 +63,15 @@ Page {
     Component.onCompleted: {
         if (root.wallet) root.wallet.clearSettingsError()
         root.errorText = ""
+        Qt.callLater(root.focusInitialPasswordField)
     }
+    StackView.onActivated: Qt.callLater(root.focusInitialPasswordField)
     Component.onDestruction: root.clearPasswordFields()
     onVisibleChanged: {
         if (!visible) {
             root.clearPasswordFields()
+        } else {
+            Qt.callLater(root.focusInitialPasswordField)
         }
     }
 

--- a/qml/test/testbridge.cpp
+++ b/qml/test/testbridge.cpp
@@ -4,6 +4,9 @@
 
 #include <qml/test/testbridge.h>
 
+#include <QClipboard>
+#include <QCoreApplication>
+#include <QGuiApplication>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -415,6 +418,8 @@ QByteArray TestBridge::processCommand(const QByteArray& json_cmd)
         return cmdListObjects();
     } else if (cmd == QLatin1String("close_window")) {
         return cmdCloseWindow();
+    } else if (cmd == QLatin1String("set_clipboard_text")) {
+        return cmdSetClipboardText(obj.value(QStringLiteral("text")).toString());
     }
 
     return errorResponse(QStringLiteral("Unknown command: %1").arg(cmd));
@@ -957,6 +962,14 @@ QByteArray TestBridge::cmdCloseWindow()
     QCloseEvent close_event;
     QCoreApplication::sendEvent(window, &close_event);
 
+    QJsonObject resp;
+    resp[QStringLiteral("ok")] = true;
+    return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+}
+
+QByteArray TestBridge::cmdSetClipboardText(const QString& text)
+{
+    QGuiApplication::clipboard()->setText(text);
     QJsonObject resp;
     resp[QStringLiteral("ok")] = true;
     return QJsonDocument(resp).toJson(QJsonDocument::Compact);

--- a/qml/test/testbridge.h
+++ b/qml/test/testbridge.h
@@ -8,6 +8,7 @@
 #include <QByteArray>
 #include <QHash>
 #include <QJsonValue>
+#include <QList>
 #include <QLocalServer>
 #include <QLocalSocket>
 #include <QObject>
@@ -37,6 +38,7 @@
 ///   {"cmd": "answer_runtime_dialog", "button": <uint>}
 ///   {"cmd": "list_objects"}
 ///   {"cmd": "close_window"}
+///   {"cmd": "set_clipboard_text", "text": "<value>"}
 class TestBridge : public QObject
 {
     Q_OBJECT
@@ -88,6 +90,7 @@ private:
     QByteArray cmdAnswerRuntimeDialog(unsigned int button);
     QByteArray cmdListObjects();
     QByteArray cmdCloseWindow();
+    QByteArray cmdSetClipboardText(const QString& text);
 
     /// Build a JSON error response.
     static QByteArray errorResponse(const QString& message);

--- a/qml/walletqmlcontroller.cpp
+++ b/qml/walletqmlcontroller.cpp
@@ -27,6 +27,7 @@
 #include <utility>
 
 #include <QDir>
+#include <QDesktopServices>
 #include <QFileInfo>
 #include <QMetaObject>
 #include <QRegularExpression>
@@ -66,6 +67,9 @@ WalletQmlController::WalletQmlController(interfaces::Node& node, QObject *parent
     , m_selected_wallet(m_empty_wallet)
     , m_worker(new QObject)
     , m_worker_thread(new QThread(this))
+    , m_open_local_path_fn([](const QString& path) {
+        return QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+    })
 {
     m_worker->moveToThread(m_worker_thread);
     m_worker_thread->start();
@@ -156,6 +160,58 @@ void WalletQmlController::subscribeWalletInfo(WalletQmlModel* wallet_model)
 QString WalletQmlController::homePath() const
 {
     return QDir::homePath();
+}
+
+QString WalletQmlController::selectedWalletLocationPath() const
+{
+    if (!m_selected_wallet || m_selected_wallet == m_empty_wallet) {
+        return {};
+    }
+
+    const QString wallet_name{m_selected_wallet->name().trimmed()};
+    if (wallet_name.isEmpty()) {
+        return {};
+    }
+
+    QFileInfo wallet_path{wallet_name};
+    if (!wallet_path.isAbsolute()) {
+        const QDir wallet_dir{QString::fromStdString(m_node.walletLoader().getWalletDir())};
+        wallet_path = QFileInfo{wallet_dir.filePath(wallet_name)};
+    }
+
+    return wallet_path.absoluteFilePath();
+}
+
+bool WalletQmlController::openSelectedWalletLocation()
+{
+    clearWalletLocationOpenError();
+
+    const QString wallet_path{selectedWalletLocationPath()};
+    if (wallet_path.isEmpty()) {
+        setWalletLocationOpenError(tr("No wallet file is available to view."));
+        return false;
+    }
+
+    const QFileInfo wallet_location{wallet_path};
+    if (!wallet_location.exists()) {
+        setWalletLocationOpenError(tr("Wallet file not found: %1").arg(wallet_path));
+        return false;
+    }
+
+    const QString open_path = wallet_location.isDir()
+        ? wallet_location.absoluteFilePath()
+        : wallet_location.absolutePath();
+    if (!m_open_local_path_fn(open_path)) {
+        setWalletLocationOpenError(tr("Could not open wallet file location."));
+        return false;
+    }
+
+    return true;
+}
+
+void WalletQmlController::clearWalletLocationOpenError()
+{
+    setWalletLocationOpenError({});
 }
 
 void WalletQmlController::closeWallet(const QString& path)
@@ -1283,4 +1339,19 @@ void WalletQmlController::setExternalSignerStatus(bool path_configured, int sign
     m_external_signer_error = error;
     m_suggested_external_signer_wallet_name = suggested_name;
     Q_EMIT externalSignerStatusChanged();
+}
+
+void WalletQmlController::setWalletLocationOpenError(const QString& error)
+{
+    if (m_wallet_location_open_error == error) {
+        return;
+    }
+
+    m_wallet_location_open_error = error;
+    Q_EMIT walletLocationOpenErrorChanged();
+}
+
+void WalletQmlController::setOpenLocalPathFnForTesting(OpenLocalPathFn fn)
+{
+    m_open_local_path_fn = std::move(fn);
 }

--- a/qml/walletqmlcontroller.cpp
+++ b/qml/walletqmlcontroller.cpp
@@ -63,7 +63,7 @@ bool ErrorContains(const QString& error, const QString& needle)
 WalletQmlController::WalletQmlController(interfaces::Node& node, QObject *parent)
     : QObject(parent)
     , m_node(node)
-    , m_empty_wallet(new WalletQmlModel(this))
+    , m_empty_wallet(new WalletQmlModel(&node, this))
     , m_selected_wallet(m_empty_wallet)
     , m_worker(new QObject)
     , m_worker_thread(new QThread(this))
@@ -393,7 +393,7 @@ WalletQmlModel* WalletQmlController::addOrSelectWalletModel(std::unique_ptr<inte
     }
 
     const QString loaded_wallet_name = QString::fromStdString(wallet->getWalletName());
-    auto wallet_model = new WalletQmlModel(std::move(wallet));
+    auto wallet_model = new WalletQmlModel(std::move(wallet), &m_node);
     wallet_model->moveToThread(this->thread());
     registerWalletModel(wallet_model);
     {
@@ -1088,7 +1088,7 @@ void WalletQmlController::initialize()
     loaded_wallet_names.reserve(static_cast<qsizetype>(wallets.size()));
     for (auto& wallet : wallets) {
         loaded_wallet_names.append(QString::fromStdString(wallet->getWalletName()));
-        auto* wallet_model = new WalletQmlModel(std::move(wallet));
+        auto* wallet_model = new WalletQmlModel(std::move(wallet), &m_node);
         registerWalletModel(wallet_model);
         applyWalletDisplayName(wallet_model);
         m_wallets.push_back(wallet_model);

--- a/qml/walletqmlcontroller.h
+++ b/qml/walletqmlcontroller.h
@@ -42,8 +42,11 @@ class WalletQmlController : public QObject
     Q_PROPERTY(QString externalSignerName READ externalSignerName NOTIFY externalSignerStatusChanged)
     Q_PROPERTY(QString externalSignerError READ externalSignerError NOTIFY externalSignerStatusChanged)
     Q_PROPERTY(QString suggestedExternalSignerWalletName READ suggestedExternalSignerWalletName NOTIFY externalSignerStatusChanged)
+    Q_PROPERTY(QString walletLocationOpenError READ walletLocationOpenError NOTIFY walletLocationOpenErrorChanged)
 
 public:
+    using OpenLocalPathFn = std::function<bool(const QString&)>;
+
     explicit WalletQmlController(interfaces::Node& node, QObject *parent = nullptr);
     ~WalletQmlController();
 
@@ -65,6 +68,8 @@ public:
     Q_INVOKABLE bool walletPathExists(const QString& path) const;
     Q_INVOKABLE QString homePath() const;
     Q_INVOKABLE QString walletNameAvailabilityError(const QString& name) const;
+    Q_INVOKABLE bool openSelectedWalletLocation();
+    Q_INVOKABLE void clearWalletLocationOpenError();
     Q_INVOKABLE void requestOpenWalletSettings();
     Q_INVOKABLE void refreshExternalSignerStatus();
     Q_INVOKABLE void requestOpenReceive();
@@ -92,6 +97,8 @@ public:
     QString externalSignerName() const { return m_external_signer_name; }
     QString externalSignerError() const { return m_external_signer_error; }
     QString suggestedExternalSignerWalletName() const { return m_suggested_external_signer_wallet_name; }
+    QString walletLocationOpenError() const { return m_wallet_location_open_error; }
+    void setOpenLocalPathFnForTesting(OpenLocalPathFn fn);
 
 Q_SIGNALS:
     void selectedWalletChanged();
@@ -123,6 +130,7 @@ Q_SIGNALS:
     void walletDisplayNamesChanged();
     void openReceiveRequested();
     void closePaymentRequestDetailRequested();
+    void walletLocationOpenErrorChanged();
 
 public Q_SLOTS:
     void initialize();
@@ -155,6 +163,7 @@ private:
     void applyWalletDisplayName(WalletQmlModel* wallet_model) const;
     bool walletNameExists(const QString& name) const;
     QString describeImportedWalletKeyScheme(interfaces::Wallet& wallet) const;
+    QString selectedWalletLocationPath() const;
     void setWalletCreateError(const QString& error);
     void setWalletLoadInProgress(bool in_progress);
     void setWalletLoadError(const QString& error);
@@ -167,6 +176,7 @@ private:
     void setExternalSignerStatus(bool path_configured, int signer_count, const QString& signer_name, const QString& error);
     void publishWalletInfo(WalletQmlModel* wallet_model);
     void subscribeWalletInfo(WalletQmlModel* wallet_model);
+    void setWalletLocationOpenError(const QString& error);
 
     bool m_initialized{false};
     interfaces::Node& m_node;
@@ -192,6 +202,8 @@ private:
     QString m_external_signer_name;
     QString m_external_signer_error;
     QString m_suggested_external_signer_wallet_name;
+    QString m_wallet_location_open_error;
+    OpenLocalPathFn m_open_local_path_fn;
 
     // Suppress the global wallet-loaded notification while a multi-step create
     // flow (watch-only) finishes setup. The worker result publishes the wallet

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(bitcoinqml_unit_tests
   gmocktestfixture.h
   test_bitcoinaddress.cpp
   test_blockclockdial.cpp
+  test_bitcoinuri.cpp
   test_bitcoinamount.cpp
   test_peerlistmodel.cpp
   test_peerstatsutil.cpp
@@ -36,6 +37,7 @@ add_executable(bitcoinqml_unit_tests
   test_transaction.cpp
   test_activityfilterproxymodel.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/bitcoinuri.cpp
 )
 
 target_compile_definitions(bitcoinqml_unit_tests

--- a/test/functional/qml_driver.py
+++ b/test/functional/qml_driver.py
@@ -190,6 +190,8 @@ class QmlDriver:
                 f"wait_for_page({page_name!r}) failed: {resp['error']}"
             )
 
+
+
     def list_objects(self):
         """Return a list of dicts with objectName and className for all
         named objects in the QML tree.  Useful for debugging."""
@@ -250,6 +252,12 @@ class QmlDriver:
         resp = self._send({"cmd": "close_window"})
         if "error" in resp:
             raise QmlDriverError(f"close_window failed: {resp['error']}")
+
+    def set_clipboard_text(self, text):
+        """Set the system clipboard to the given text string."""
+        resp = self._send({"cmd": "set_clipboard_text", "text": text})
+        if "error" in resp:
+            raise QmlDriverError(f"set_clipboard_text failed: {resp['error']}")
 
     def settle(
         self,

--- a/test/functional/qml_driver.py
+++ b/test/functional/qml_driver.py
@@ -245,6 +245,12 @@ class QmlDriver:
         if "error" in resp:
             raise QmlDriverError(f"answer_runtime_dialog({button!r}) failed: {resp['error']}")
 
+    def close_window(self):
+        """Send a close event to the QML application window."""
+        resp = self._send({"cmd": "close_window"})
+        if "error" in resp:
+            raise QmlDriverError(f"close_window failed: {resp['error']}")
+
     def settle(
         self,
         timeout_ms=5000,

--- a/test/functional/qml_test_harness.py
+++ b/test/functional/qml_test_harness.py
@@ -12,6 +12,7 @@ import argparse
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -22,6 +23,14 @@ from qml_driver import QmlDriver, QmlDriverError
 
 # How long to wait for the GUI process to start (seconds).
 GUI_STARTUP_TIMEOUT = 30
+
+
+def pick_unused_port():
+    """Return an available TCP port on 127.0.0.1."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
 
 
 def find_gui_binary():
@@ -46,7 +55,7 @@ def find_gui_binary():
     )
 
 
-def setup_datadir(tmpdir):
+def setup_datadir(tmpdir, rpc_port=None):
     """Create a minimal regtest data directory with bitcoin.conf."""
     datadir = os.path.join(tmpdir, "node0")
     os.makedirs(datadir, exist_ok=True)
@@ -54,6 +63,11 @@ def setup_datadir(tmpdir):
     with open(conf_path, "w", encoding="utf8") as f:
         f.write("regtest=1\n")
         f.write("[regtest]\n")
+        f.write("server=1\n")
+        if rpc_port is not None:
+            f.write(f"rpcport={rpc_port}\n")
+        f.write("rpcbind=127.0.0.1\n")
+        f.write("rpcallowip=127.0.0.1\n")
         f.write("discover=0\n")
         f.write("dnsseed=0\n")
         f.write("fixedseeds=0\n")
@@ -106,6 +120,7 @@ class QmlTestHarness:
             self.socket_path = socket_path
             self.tmpdir = None
             self.datadir = None
+            self.rpc_port = None
         else:
             self.gui_binary = find_gui_binary()
             if datadir is not None:
@@ -114,9 +129,11 @@ class QmlTestHarness:
                 self.datadir = datadir
                 self.socket_path = os.path.join(datadir, "test_bridge.sock")
                 self.config_home = os.path.join(os.path.dirname(datadir), "config")
+                self.rpc_port = None
             else:
                 self.tmpdir = tempfile.mkdtemp(prefix="qml_test_bridge_")
-                self.datadir = setup_datadir(self.tmpdir)
+                self.rpc_port = pick_unused_port()
+                self.datadir = setup_datadir(self.tmpdir, rpc_port=self.rpc_port)
                 self.socket_path = os.path.join(self.tmpdir, "test_bridge.sock")
                 self.config_home = os.path.join(self.tmpdir, "config")
 
@@ -162,6 +179,27 @@ class QmlTestHarness:
             self._dump_startup_failure_context()
             raise
         print("QmlDriver connected to test bridge.")
+
+    def process_output(self):
+        """Return captured stdout+stderr from the GUI process as a string."""
+        if not self.process:
+            return ""
+        if self.process.poll() is None:
+            return ""
+        stdout = (
+            self.process.stdout.read().decode("utf-8", errors="replace")
+            if self.process.stdout else ""
+        )
+        stderr = (
+            self.process.stderr.read().decode("utf-8", errors="replace")
+            if self.process.stderr else ""
+        )
+        parts = []
+        if stdout:
+            parts.append(f"stdout:\n{stdout}")
+        if stderr:
+            parts.append(f"stderr:\n{stderr}")
+        return "\n\n".join(parts)
 
     def stop(self, cleanup=True):
         """Shut down the GUI process (only if we launched it).

--- a/test/functional/qml_test_send_receive.py
+++ b/test/functional/qml_test_send_receive.py
@@ -185,6 +185,25 @@ def assert_no_fee_preview_label(port, wallet_name):
     assert "qml-fee-preview" not in labels, f"Fee preview created address book label: {labels!r}"
 
 
+def assert_receiver_output(port, txid, receiver_address, expected_sats):
+    raw_tx = rpc_call(port, "getrawtransaction", [txid, True])
+    matched_outputs = [
+        vout for vout in raw_tx["vout"]
+        if vout.get("scriptPubKey", {}).get("address") == receiver_address
+    ]
+    assert len(matched_outputs) == 1, (
+        f"Expected one output to {receiver_address}, got {matched_outputs!r} "
+        f"in decoded transaction {raw_tx!r}"
+    )
+    output_sats = int(
+        (Decimal(str(matched_outputs[0]["value"])) * Decimal("100000000")).to_integral_value()
+    )
+    assert output_sats == expected_sats, (
+        f"Expected receiver output {expected_sats} sats, got {output_sats} sats "
+        f"in transaction {txid}"
+    )
+
+
 def enable_coin_control_and_select_first_coin(gui, checkpoints):
     gui.click("sendOptionsButton")
     gui.wait_for_property("sendOptionsPopup", "opened", True, timeout_ms=5000)
@@ -347,6 +366,12 @@ def run_test(*, save_screenshots=False, screenshot_root=None):
         assert rpc_fee_sats == estimated_fee_with_subtract_sats, (
             f"Broadcast fee {rpc_fee_sats} sats did not match preview estimate "
             f"{estimated_fee_with_subtract_sats} sats"
+        )
+        assert_receiver_output(
+            harness.gui_rpc_port,
+            txid,
+            receiver_address,
+            SEND_AMOUNT_SATS - estimated_fee_with_subtract_sats,
         )
         checkpoints.checkpoint("broadcast fee verified", gui)
 

--- a/test/functional/qml_test_send_receive.py
+++ b/test/functional/qml_test_send_receive.py
@@ -185,6 +185,31 @@ def assert_no_fee_preview_label(port, wallet_name):
     assert "qml-fee-preview" not in labels, f"Fee preview created address book label: {labels!r}"
 
 
+def enable_coin_control_and_select_first_coin(gui, checkpoints):
+    gui.click("sendOptionsButton")
+    gui.wait_for_property("sendOptionsPopup", "opened", True, timeout_ms=5000)
+    if not gui.get_property("sendOptionsCoinControlToggle", "checked"):
+        gui.click("sendOptionsCoinControlToggle")
+        gui.wait_for_property("sendOptionsCoinControlToggle", "checked", True, timeout_ms=5000)
+    gui.click("sendOptionsButton")
+    gui.wait_for_property("sendOptionsPopup", "opened", False, timeout_ms=5000)
+    gui.wait_for_property("sendCoinControlButtonText", "text", "Select", timeout_ms=10000)
+
+    gui.click("sendCoinControlButton")
+    gui.wait_for_page("coinSelectionPage", timeout_ms=10000)
+    gui.click_list_item("coinSelectionListView", 0, "coinSelectionCheckbox")
+    gui.wait_for_property(
+        "coinSelectionTotalSelectedText",
+        "text",
+        lambda text: text != "0.00000000",
+        timeout_ms=10000,
+    )
+    checkpoints.checkpoint("one input selected", gui)
+    gui.click("coinSelectionDoneButton")
+    gui.wait_for_page("sendPage", timeout_ms=10000)
+    gui.wait_for_property("sendCoinControlButtonText", "text", "1 input selected", timeout_ms=10000)
+
+
 def run_test(*, save_screenshots=False, screenshot_root=None):
     harness = WalletFlowHarness("qml_test_send_receive", port_offset=60)
     checkpoints = CheckpointRecorder(save_screenshots, screenshot_root)
@@ -228,6 +253,7 @@ def run_test(*, save_screenshots=False, screenshot_root=None):
         gui.click("sendTabButton")
         gui.wait_for_page("sendPage", timeout_ms=10000)
         checkpoints.checkpoint("send page opened", gui)
+        enable_coin_control_and_select_first_coin(gui, checkpoints)
 
         gui.set_text("sendAddressInput", receiver_address)
         gui.set_text("sendAmountInput", SEND_AMOUNT)
@@ -327,6 +353,10 @@ def run_test(*, save_screenshots=False, screenshot_root=None):
         gui.wait_for_page("sendResultPopup", timeout_ms=10000)
         gui.click("sendResultDoneButton")
         gui.wait_for_property("activityTabButton", "visible", True, timeout_ms=10000)
+        gui.click("sendTabButton")
+        gui.wait_for_page("sendPage", timeout_ms=10000)
+        gui.wait_for_property("sendCoinControlButtonText", "text", "Select", timeout_ms=10000)
+        checkpoints.checkpoint("coin control selection cleared after send", gui)
         gui.click("activityTabButton")
         gui.wait_for_property("activitySearchToggle", "visible", True, timeout_ms=10000)
         gui.click("activitySearchToggle")

--- a/test/functional/qml_test_send_receive.py
+++ b/test/functional/qml_test_send_receive.py
@@ -336,7 +336,7 @@ def run_test(*, save_screenshots=False, screenshot_root=None):
         gui.wait_for_property("feeSelectionPopup", "opened", False, timeout_ms=5000)
         gui.wait_for_property("feeSelectionControl", "selectedIndex", LOW_FEE_OPTION_INDEX, timeout_ms=5000)
 
-        estimated_fee_with_subtract_text = gui.get_text("feeSelectionEstimateLabel")
+        estimated_fee_with_subtract_text = wait_for_non_empty_text(gui, "feeSelectionEstimateLabel")
         estimated_fee_with_subtract_sats = btc_text_to_sats(estimated_fee_with_subtract_text)
         assert estimated_fee_with_subtract_sats > 0, (
             f"Expected a positive estimated fee with subtract-fee enabled, got "

--- a/test/functional/qml_test_send_receive.py
+++ b/test/functional/qml_test_send_receive.py
@@ -180,6 +180,11 @@ def wait_for_single_mempool_tx(port):
     return txids[0]
 
 
+def assert_no_fee_preview_label(port, wallet_name):
+    labels = rpc_call(port, "listlabels", wallet=wallet_name)
+    assert "qml-fee-preview" not in labels, f"Fee preview created address book label: {labels!r}"
+
+
 def run_test(*, save_screenshots=False, screenshot_root=None):
     harness = WalletFlowHarness("qml_test_send_receive", port_offset=60)
     checkpoints = CheckpointRecorder(save_screenshots, screenshot_root)
@@ -228,6 +233,7 @@ def run_test(*, save_screenshots=False, screenshot_root=None):
         gui.set_text("sendAmountInput", SEND_AMOUNT)
         gui.wait_for_property("sendReviewButton", "enabled", True, timeout_ms=20000)
         checkpoints.checkpoint("send form populated", gui)
+        assert_no_fee_preview_label(harness.gui_rpc_port, GUI_WALLET_NAME)
 
         gui.wait_for_property("feeSelectionControl", "selectedLabel", DEFAULT_FEE_LABEL, timeout_ms=5000)
         gui.wait_for_property("feeSelectionControl", "selectedDuration", DEFAULT_FEE_DURATION, timeout_ms=5000)

--- a/test/functional/qml_test_send_review.py
+++ b/test/functional/qml_test_send_review.py
@@ -182,6 +182,11 @@ def prepare_multi_send(gui, first_address, first_amount_btc, second_address, sec
     gui.wait_for_page("multipleSendReviewPage", timeout_ms=10000)
 
 
+def wait_for_send_error(gui, expected_text):
+    gui.wait_for_property("sendPrepareTransactionErrorText", "text", expected_text, timeout_ms=10000)
+    assert gui.get_property("sendReviewButton", "enabled") is False
+
+
 def assert_unit_suffix(gui, object_name, unit_suffix):
     text = gui.get_text(object_name)
     if unit_suffix in ("sat", "sats"):
@@ -264,6 +269,39 @@ def case_single_sat(harness, gui, wallet_name, checkpoints):
     assert_unit_suffix(gui, "sendReviewFeeField", "sat")
     assert_unit_suffix(gui, "sendReviewTotalField", "sat")
     return_to_send_page(gui, "sendReviewBackButton")
+
+
+def case_invalid_recipients(harness, gui, wallet_name, checkpoints):
+    first_address = rpc_call(harness.gui_rpc_port, "getnewaddress", wallet=wallet_name)
+    second_address = rpc_call(harness.gui_rpc_port, "getnewaddress", wallet=wallet_name)
+
+    open_send_page(gui)
+    set_multiple_recipients(gui, False)
+    set_amount_unit(gui, "sat")
+    gui.set_text("sendAddressInput", first_address)
+    gui.set_text("sendAmountInput", "1")
+    gui.wait_for_property("sendAmountErrorText", "text", "Amount is too small to send.", timeout_ms=10000)
+    assert gui.get_property("sendReviewButton", "enabled") is False
+    checkpoints.checkpoint("dust amount rejected", gui)
+
+    set_multiple_recipients(gui, True)
+    gui.click("sendRecipientPrevButton")
+    set_amount_unit(gui, "₿")
+    gui.set_text("sendAddressInput", first_address)
+    gui.set_text("sendAmountInput", "0.50000000")
+    wait_for_send_error(gui, "Complete every recipient before continuing.")
+    checkpoints.checkpoint("empty second recipient rejected", gui)
+
+    gui.click("sendRecipientNextButton")
+    set_amount_unit(gui, "₿")
+    gui.set_text("sendAddressInput", first_address)
+    gui.set_text("sendAmountInput", "0.25000000")
+    wait_for_send_error(gui, "Recipient addresses must be unique.")
+    checkpoints.checkpoint("duplicate recipient rejected", gui)
+
+    gui.set_text("sendAddressInput", second_address)
+    gui.wait_for_property("sendReviewButton", "enabled", True, timeout_ms=10000)
+    set_multiple_recipients(gui, False)
 
 
 def case_multi_review(harness, gui, wallet_name, checkpoints):
@@ -362,6 +400,7 @@ def run_tests(args):
         fund_wallet(harness, wallet_name)
         checkpoints.checkpoint("wallet funded", gui)
 
+        case_invalid_recipients(harness, gui, wallet_name, checkpoints)
         case_single_btc(harness, gui, wallet_name, checkpoints)
         case_single_sat(harness, gui, wallet_name, checkpoints)
         case_multi_review(harness, gui, wallet_name, checkpoints)

--- a/test/functional/qml_test_send_review.py
+++ b/test/functional/qml_test_send_review.py
@@ -124,6 +124,20 @@ def fund_wallet(harness, wallet_name):
     )
 
 
+def wallet_txcount(harness, wallet_name):
+    return rpc_call(harness.gui_rpc_port, "getwalletinfo", wallet=wallet_name)["txcount"]
+
+
+def assert_review_has_no_transaction_side_effects(harness, wallet_name, expected_txcount):
+    mempool_txids = rpc_call(harness.gui_rpc_port, "getrawmempool")
+    assert mempool_txids == [], f"Review-only flows should not broadcast transactions, got {mempool_txids}"
+    actual_txcount = wallet_txcount(harness, wallet_name)
+    assert actual_txcount == expected_txcount, (
+        f"Review-only flows should not add wallet transactions, "
+        f"expected txcount {expected_txcount}, got {actual_txcount}"
+    )
+
+
 def open_send_page(gui):
     gui.click("sendTabButton")
     gui.wait_for_page("sendPage", timeout_ms=10000)
@@ -398,12 +412,14 @@ def run_tests(args):
         create_wallet(gui, wallet_name)
         checkpoints.checkpoint("wallet created", gui)
         fund_wallet(harness, wallet_name)
+        funded_txcount = wallet_txcount(harness, wallet_name)
         checkpoints.checkpoint("wallet funded", gui)
 
         case_invalid_recipients(harness, gui, wallet_name, checkpoints)
         case_single_btc(harness, gui, wallet_name, checkpoints)
         case_single_sat(harness, gui, wallet_name, checkpoints)
         case_multi_review(harness, gui, wallet_name, checkpoints)
+        assert_review_has_no_transaction_side_effects(harness, wallet_name, funded_txcount)
 
         print(f"[{case_name}] completed")
         print("Send review flows passed.")

--- a/test/functional/qml_test_shutdown.py
+++ b/test/functional/qml_test_shutdown.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test QML shutdown while load_on_startup wallets are loading."""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+from qml_test_harness import qsettings_sandbox_args
+from qml_wallet_test_lib import WalletFlowHarness, find_bitcoind, rpc_call, wait_for_rpc
+
+
+STARTUP_WALLET_COUNT = 8
+SHUTDOWN_TIMEOUT_SECS = 30
+
+
+def start_node(datadir):
+    process = subprocess.Popen(
+        [find_bitcoind(), f"-datadir={datadir}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return process
+
+
+def stop_node(process, rpc_port):
+    if process.poll() is not None:
+        return
+    try:
+        rpc_call(rpc_port, "stop")
+    except Exception:
+        process.send_signal(signal.SIGTERM)
+    try:
+        process.wait(timeout=SHUTDOWN_TIMEOUT_SECS)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+def create_load_on_startup_wallets(harness, prefix):
+    process = start_node(harness.gui_datadir)
+    try:
+        wait_for_rpc(harness.gui_rpc_port)
+        for index in range(STARTUP_WALLET_COUNT):
+            rpc_call(
+                harness.gui_rpc_port,
+                "createwallet",
+                {
+                    "wallet_name": f"{prefix}_{index}",
+                    "load_on_startup": True,
+                },
+            )
+    finally:
+        stop_node(process, harness.gui_rpc_port)
+
+
+def wait_for_process_exit(process, description):
+    deadline = time.time() + SHUTDOWN_TIMEOUT_SECS
+    while time.time() < deadline:
+        if process.poll() is not None:
+            return process.returncode
+        time.sleep(0.25)
+    raise TimeoutError(f"GUI did not exit after {description}")
+
+
+def debug_log_path(harness):
+    return os.path.join(harness.gui_datadir, "regtest", "debug.log")
+
+
+def read_debug_log(harness):
+    path = debug_log_path(harness)
+    if not os.path.isfile(path):
+        return ""
+    with open(path, "r", encoding="utf8", errors="replace") as log_file:
+        return log_file.read()
+
+
+def wait_for_startup_initialization(harness, process, baseline_wallet_loads_completed):
+    deadline = time.time() + SHUTDOWN_TIMEOUT_SECS
+    initialization_seen_at = None
+    while time.time() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"GUI exited before startup could be interrupted, return code {process.returncode}"
+            )
+
+        debug_log = read_debug_log(harness)
+        wallet_loads_completed = debug_log.count("Wallet completed loading")
+        if (
+            baseline_wallet_loads_completed
+            < wallet_loads_completed
+            < baseline_wallet_loads_completed + STARTUP_WALLET_COUNT
+        ):
+            return
+
+        if "Running initialization in thread" in debug_log:
+            initialization_seen_at = initialization_seen_at or time.time()
+            if time.time() - initialization_seen_at >= 0.2:
+                return
+
+        time.sleep(0.05)
+
+    raise TimeoutError("Timed out waiting for GUI startup initialization")
+
+
+def start_gui_without_driver(harness):
+    env = dict(os.environ)
+    env["QT_QPA_PLATFORM"] = "offscreen"
+    settings_args = qsettings_sandbox_args(env, harness.config_home)
+    args = [
+        harness.gui_binary,
+        f"-datadir={harness.gui_datadir}",
+        f"-test-automation={harness.socket_path}",
+    ] + settings_args + [
+        "-logtimemicros",
+        "-debug",
+        "-debugexclude=libevent",
+        "-debugexclude=leveldb",
+        "-nolisten",
+    ]
+    harness.gui_process = subprocess.Popen(
+        args,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def case_close_window_during_load_on_startup():
+    harness = WalletFlowHarness("qml_shutdown_close", 970)
+    try:
+        create_load_on_startup_wallets(harness, "shutdown_close")
+        harness.start_gui()
+
+        gui = harness.driver
+        gui.close_window()
+        gui.wait_for_page("shutdownPage", timeout_ms=5000)
+
+        return_code = wait_for_process_exit(harness.gui_process, "closing during load_on_startup")
+        assert return_code == 0, f"Expected GUI exit code 0, got {return_code}"
+    finally:
+        harness.stop()
+
+
+def case_sigint_during_load_on_startup():
+    harness = WalletFlowHarness("qml_shutdown_sigint", 980)
+    try:
+        create_load_on_startup_wallets(harness, "shutdown_sigint")
+        baseline_wallet_loads_completed = read_debug_log(harness).count("Wallet completed loading")
+        start_gui_without_driver(harness)
+
+        wait_for_startup_initialization(harness, harness.gui_process, baseline_wallet_loads_completed)
+        harness.gui_process.send_signal(signal.SIGINT)
+
+        return_code = wait_for_process_exit(harness.gui_process, "SIGINT during load_on_startup")
+        assert return_code == 0, f"Expected GUI exit code 0 after SIGINT, got {return_code}"
+    finally:
+        harness.stop()
+
+
+def run_tests():
+    try:
+        case_close_window_during_load_on_startup()
+        print("Close during load_on_startup shutdown completed successfully.")
+
+        case_sigint_during_load_on_startup()
+        print("SIGINT during load_on_startup shutdown completed successfully.")
+    except Exception as err:
+        print(f"\nFAILED: {err}", file=sys.stderr)
+        raise
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/functional/qml_test_uri_import.py
+++ b/test/functional/qml_test_uri_import.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""End-to-end QML URI import test.
+
+Exercises clipboard paste, manual popup entry, malformed URI error feedback,
+file import, and drag-drop simulation via the test automation hooks.
+
+Requires:
+  - bitcoin-core-app built with -DENABLE_TEST_AUTOMATION=ON
+  - bitcoind built with -DBUILD_DAEMON=ON
+"""
+
+import sys
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from qml_test_harness import dump_qml_tree
+from qml_wallet_test_lib import WalletFlowHarness, rpc_call
+
+WALLET_NAME = "testwallet"
+
+
+def navigate_to_send(gui):
+    """Click the Send tab and wait for the Send page to appear."""
+    gui.click("sendTabButton")
+    gui.wait_for_page("sendPage", timeout_ms=15000)
+    gui.wait_for_property("walletSendTitle", "visible", True, timeout_ms=5000)
+
+
+def open_send_options(gui):
+    """Open the Send options (ellipsis) popup."""
+    gui.click("sendOptionsButton")
+    gui.wait_for_property("sendOptionsPopup", "opened", True, timeout_ms=5000)
+
+
+def run_tests():
+    harness = WalletFlowHarness("qml_test_uri_import", port_offset=500)
+    gui = None
+    try:
+        harness.start_gui()
+        gui = harness.driver
+
+        gui.wait_for_property("walletBadge", "loading", False, timeout_ms=20000)
+        gui.wait_for_property("walletBadge", "visible", True, timeout_ms=10000)
+        rpc_call(harness.gui_rpc_port, "createwallet", {"wallet_name": WALLET_NAME})
+        gui.wait_for_property("walletBadge", "text", WALLET_NAME, timeout_ms=20000)
+        gui.wait_for_property("walletBadge", "noWalletLoaded", False, timeout_ms=10000)
+
+        target_address = rpc_call(
+            harness.gui_rpc_port,
+            "getnewaddress",
+            ["uri-test", "bech32"],
+            wallet=WALLET_NAME,
+        )
+        print(f"Test address: {target_address}")
+
+        navigate_to_send(gui)
+        print("Send page open.")
+
+        # ----------------------------------------------------------------
+        # Test 1: Clipboard banner — "Fill" button
+        # The banner appears automatically when a valid bitcoin: URI is
+        # detected in the clipboard. Clicking "Fill" applies the URI fields.
+        # ----------------------------------------------------------------
+        uri_clip = (
+            f"bitcoin:{target_address}"
+            f"?amount=0.01234567&label=clip-label&message=clipboard-note"
+        )
+        gui.set_clipboard_text(uri_clip)
+        gui.wait_for_property("clipboardUriBanner", "visible", True, timeout_ms=5000)
+        gui.click("clipboardUriPasteButton")
+        gui.wait_for_property(
+            "sendPaymentRequestStatusText", "text",
+            lambda v: "clipboard" in str(v), timeout_ms=10000,
+        )
+        gui.wait_for_property(
+            "sendNoteInput", "text",
+            lambda v: "clip-label" in str(v), timeout_ms=5000,
+        )
+        gui.wait_for_property(
+            "sendPaymentRequestMessageText", "text",
+            lambda v: "clipboard-note" in str(v), timeout_ms=5000,
+        )
+        print("Test 1 PASSED: clipboard banner Fill button.")
+
+        # ----------------------------------------------------------------
+        # Test 2: Manual URI popup
+        # ----------------------------------------------------------------
+        uri_manual = (
+            f"bitcoin:{target_address}"
+            f"?amount=0.02000000&label=manual-label&message=manual-note"
+        )
+        open_send_options(gui)
+        gui.click("sendOptionsOpenPaymentRequestButton")
+        gui.wait_for_property("sendUriImportPopup", "opened", True, timeout_ms=5000)
+        gui.set_text("sendUriImportInput", uri_manual)
+        gui.click("sendUriImportApplyButton")
+        gui.wait_for_property("sendUriImportPopup", "opened", False, timeout_ms=5000)
+        gui.wait_for_property(
+            "sendPaymentRequestStatusText", "text",
+            lambda v: "manual entry" in str(v), timeout_ms=10000,
+        )
+        gui.wait_for_property(
+            "sendNoteInput", "text",
+            lambda v: "manual-label" in str(v), timeout_ms=5000,
+        )
+        print("Test 2 PASSED: manual URI popup.")
+
+        # ----------------------------------------------------------------
+        # Test 3: Malformed URI shows error (via manual entry popup)
+        # A bitcoin:// URI is invalid; the banner never appears for it
+        # (parser returns success=False), so the error path is exercised
+        # through the "Open payment request" popup instead.
+        # ----------------------------------------------------------------
+        malformed = f"bitcoin://{target_address}?amount=0.1"
+        open_send_options(gui)
+        gui.click("sendOptionsOpenPaymentRequestButton")
+        gui.wait_for_property("sendUriImportPopup", "opened", True, timeout_ms=5000)
+        gui.set_text("sendUriImportInput", malformed)
+        gui.click("sendUriImportApplyButton")
+        gui.wait_for_property("sendUriImportPopup", "opened", False, timeout_ms=5000)
+        gui.wait_for_property(
+            "sendPaymentRequestStatusText", "text",
+            lambda v: "bitcoin://" in str(v), timeout_ms=10000,
+        )
+        print("Test 3 PASSED: malformed URI shows error.")
+
+        # ----------------------------------------------------------------
+        # Test 4: File import via automation hook
+        # ----------------------------------------------------------------
+        uri_file = (
+            f"bitcoin:{target_address}"
+            f"?amount=0.03000000&label=file-label&message=file-note"
+        )
+        with NamedTemporaryFile("w", suffix=".txt", delete=False, encoding="utf8") as tmp:
+            tmp.write(uri_file)
+            tmp_path = Path(tmp.name)
+        try:
+            gui.set_text("sendImportPaymentRequestFilePathInput", str(tmp_path))
+            gui.click("sendApplyPaymentRequestFilePathButton")
+            gui.wait_for_property(
+                "sendPaymentRequestStatusText", "text",
+                lambda v: "file" in str(v), timeout_ms=10000,
+            )
+            gui.wait_for_property(
+                "sendNoteInput", "text",
+                lambda v: "file-label" in str(v), timeout_ms=5000,
+            )
+            print("Test 4 PASSED: file import.")
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        # ----------------------------------------------------------------
+        # Test 5: Drag-drop simulation via automation hook
+        # ----------------------------------------------------------------
+        uri_drop = (
+            f"bitcoin:{target_address}"
+            f"?amount=0.04000000&label=drop-label"
+        )
+        gui.set_text("sendDropUriInput", uri_drop)
+        gui.click("sendApplyDropUriButton")
+        gui.wait_for_property(
+            "sendPaymentRequestStatusText", "text",
+            lambda v: "drag and drop" in str(v), timeout_ms=10000,
+        )
+        gui.wait_for_property(
+            "sendNoteInput", "text",
+            lambda v: "drop-label" in str(v), timeout_ms=5000,
+        )
+        print("Test 5 PASSED: drag-drop simulation.")
+
+        # ----------------------------------------------------------------
+        # Test 6: DropArea hasUrls + file:// branch
+        # Exercises: strip "file://" prefix → applyPaymentRequestFromFile
+        # ----------------------------------------------------------------
+        uri_drop_file = (
+            f"bitcoin:{target_address}"
+            f"?amount=0.05000000&label=drop-file"
+        )
+        with NamedTemporaryFile("w", suffix=".txt", delete=False, encoding="utf8") as tmp:
+            tmp.write(uri_drop_file)
+            tmp_path = Path(tmp.name)
+        try:
+            gui.set_text("sendDropFileUrlInput", tmp_path.as_uri())
+            gui.click("sendApplyDropFileUrlButton")
+            gui.wait_for_property(
+                "sendPaymentRequestStatusText", "text",
+                lambda v: "file" in str(v), timeout_ms=10000,
+            )
+            gui.wait_for_property(
+                "sendNoteInput", "text",
+                lambda v: "drop-file" in str(v), timeout_ms=5000,
+            )
+            print("Test 6 PASSED: DropArea hasUrls + file:// branch.")
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        # ----------------------------------------------------------------
+        # Test 7: DropArea hasUrls + non-file URL branch
+        # Exercises: non-file URL → applyPaymentRequestFromText("drag and drop")
+        # ----------------------------------------------------------------
+        uri_drop_url = (
+            f"bitcoin:{target_address}"
+            f"?amount=0.06000000&label=drop-url"
+        )
+        gui.set_text("sendDropFileUrlInput", uri_drop_url)
+        gui.click("sendApplyDropFileUrlButton")
+        gui.wait_for_property(
+            "sendPaymentRequestStatusText", "text",
+            lambda v: "drag and drop" in str(v), timeout_ms=10000,
+        )
+        gui.wait_for_property(
+            "sendNoteInput", "text",
+            lambda v: "drop-url" in str(v), timeout_ms=5000,
+        )
+        print("Test 7 PASSED: DropArea hasUrls + non-file URL branch.")
+
+        print("\n" + "=" * 50)
+        print("All URI import tests PASSED (7/7)")
+        print("=" * 50)
+
+    except Exception as exc:
+        print(f"\nFAILED: {exc}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        if gui is not None:
+            dump_qml_tree(gui)
+        output = harness.process_output(harness.gui_process)
+        if output:
+            print("\n--- GUI process output ---", file=sys.stderr)
+            print(output, file=sys.stderr)
+        sys.exit(1)
+    finally:
+        harness.stop()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/functional/qml_test_wallet_qt_compat.py
+++ b/test/functional/qml_test_wallet_qt_compat.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import time
 
+from qml_driver import QmlDriverError
 from qml_test_harness import dump_qml_tree
 from qml_wallet_test_lib import WalletFlowHarness, rpc_call
 
@@ -154,9 +155,27 @@ def set_receive_options(gui):
     gui.wait_for_property("receiveOptionsPopup", "opened", False, timeout_ms=5000)
 
 
+def wait_for_visible_object(gui, object_names, timeout_ms=5000):
+    deadline = time.time() + timeout_ms / 1000
+    last_error = None
+    while time.time() < deadline:
+        for object_name in object_names:
+            try:
+                if gui.get_property(object_name, "visible"):
+                    return object_name
+            except QmlDriverError as err:
+                last_error = err
+        time.sleep(0.05)
+    raise AssertionError(f"Expected one of {object_names} to be visible: {last_error}")
+
+
 def create_unencrypted_wallet(gui, wallet_name):
     gui.wait_for_property("createWalletButton", "enabled", True, timeout_ms=25000)
     gui.click("createWalletButton")
+    next_step = wait_for_visible_object(gui, ("walletTypeRegular", "createWalletIntroStartButton"))
+    if next_step == "walletTypeRegular":
+        gui.click("walletTypeRegular")
+        gui.wait_for_property("createWalletIntroStartButton", "visible", True, timeout_ms=5000)
     gui.click("createWalletIntroStartButton")
     gui.set_text("createWalletNameInput", wallet_name)
     gui.click("createWalletNameContinueButton")

--- a/test/functional/qml_test_wallet_qt_compat.py
+++ b/test/functional/qml_test_wallet_qt_compat.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Regression test for bitcoin-qt loading QML-created wallet request metadata."""
+
+import os
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+from qml_test_harness import dump_qml_tree
+from qml_wallet_test_lib import WalletFlowHarness, rpc_call
+
+
+COMPAT_VERSION = "31.0"
+WALLET_NAME = "qt_compat_wallet"
+REQUEST_AMOUNT = "0.001"
+REQUEST_LABEL = "QML Qt Compat"
+REQUEST_MESSAGE = "Compatibility request from bitcoin-core-app"
+REQUEST_NOTE_SELF = "Private compatibility note"
+
+
+def find_compat_bitcoin_qt():
+    explicit = os.getenv("BITCOIN_QT_COMPAT")
+    if explicit and os.path.isfile(explicit):
+        return explicit
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    releases_root = os.getenv("PREVIOUS_RELEASES_DIR", os.path.join(repo_root, "releases"))
+    candidate = os.path.join(releases_root, f"v{COMPAT_VERSION}", "bin", "bitcoin-qt")
+    if os.path.isfile(candidate):
+        return candidate
+
+    return None
+
+
+def process_output(process):
+    if not process or process.poll() is None:
+        return ""
+    stdout = process.stdout.read().decode("utf-8", errors="replace") if process.stdout else ""
+    stderr = process.stderr.read().decode("utf-8", errors="replace") if process.stderr else ""
+    if stdout and stderr:
+        return f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+    return stdout or stderr
+
+
+def debug_log_tail(datadir, lines=200):
+    debug_log = os.path.join(datadir, "regtest", "debug.log")
+    if not os.path.isfile(debug_log):
+        return ""
+    with open(debug_log, "r", encoding="utf8", errors="replace") as log_file:
+        return "".join(log_file.readlines()[-lines:])
+
+
+def wait_for_rpc_or_process_exit(process, port, timeout=45):
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        if process.poll() is not None:
+            raise AssertionError(
+                f"bitcoin-qt exited before RPC became ready with code {process.returncode}.\n"
+                f"{process_output(process)}"
+            )
+        try:
+            rpc_call(port, "getblockcount")
+            return
+        except Exception as err:  # noqa: BLE001 - startup should tolerate transient RPC errors
+            last_error = err
+            time.sleep(0.25)
+    raise AssertionError(f"bitcoin-qt RPC did not become ready before timeout: {last_error}")
+
+
+def stop_bitcoin_qt(process, rpc_port):
+    if not process:
+        return
+    if process.poll() is not None:
+        return
+    try:
+        rpc_call(rpc_port, "stop")
+    except Exception:
+        process.send_signal(signal.SIGTERM)
+    try:
+        process.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+def bitcoin_qt_command(bitcoin_qt):
+    runner = os.getenv("BITCOIN_QT_RUNNER")
+    if runner:
+        return shlex.split(runner) + [bitcoin_qt]
+    xvfb_run = shutil.which("xvfb-run")
+    if xvfb_run:
+        return [xvfb_run, "-a", bitcoin_qt]
+    if os.getenv("BITCOIN_QT_USE_DISPLAY") == "1" and os.getenv("DISPLAY"):
+        return [bitcoin_qt]
+    return None
+
+
+def has_bitcoin_qt_runner():
+    return bitcoin_qt_command("/bin/true") is not None
+
+
+def bitcoin_qt_runner_skip_message():
+    return (
+        "SKIPPED: bitcoin-qt compatibility test needs DISPLAY, xvfb-run, "
+        "or BITCOIN_QT_RUNNER. Set BITCOIN_QT_USE_DISPLAY=1 to use the "
+        "ambient DISPLAY directly."
+    )
+
+
+def require_bitcoin_qt_command(bitcoin_qt):
+    command = bitcoin_qt_command(bitcoin_qt)
+    if command is None:
+        raise RuntimeError(bitcoin_qt_runner_skip_message())
+    return command
+
+
+def launch_bitcoin_qt(bitcoin_qt, harness):
+    env = dict(os.environ)
+    env.setdefault("XDG_CONFIG_HOME", os.path.join(harness.tmpdir, "qt_compat_config"))
+    os.makedirs(env["XDG_CONFIG_HOME"], exist_ok=True)
+    command = require_bitcoin_qt_command(bitcoin_qt) + [
+        f"-datadir={harness.gui_datadir}",
+        "-nosplash",
+        "-min",
+        "-debug",
+        "-debugexclude=libevent",
+        "-debugexclude=leveldb",
+        "-printtoconsole=1",
+    ]
+    print(f"[qml_wallet_qt_compat] starting bitcoin-qt: {' '.join(command)}")
+    return subprocess.Popen(command, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def set_receive_options(gui):
+    gui.click("receiveOptionsButton")
+    gui.wait_for_property("receiveOptionsPopup", "opened", True, timeout_ms=5000)
+    for toggle_name in (
+        "receiveOptionsNameToggle",
+        "receiveOptionsMessageToggle",
+        "receiveOptionsNoteSelfToggle",
+        "receiveOptionsAddressTypeToggle",
+    ):
+        if not bool(gui.get_property(toggle_name, "checked")):
+            gui.click(toggle_name)
+            gui.wait_for_property(toggle_name, "checked", True, timeout_ms=5000)
+    gui.click("receiveOptionsButton")
+    gui.wait_for_property("receiveOptionsPopup", "opened", False, timeout_ms=5000)
+
+
+def create_unencrypted_wallet(gui, wallet_name):
+    gui.wait_for_property("createWalletButton", "enabled", True, timeout_ms=25000)
+    gui.click("createWalletButton")
+    gui.click("createWalletIntroStartButton")
+    gui.set_text("createWalletNameInput", wallet_name)
+    gui.click("createWalletNameContinueButton")
+    gui.wait_for_page("createWalletPasswordPage", timeout_ms=10000)
+    gui.click("createWalletPasswordSkipButton")
+    gui.wait_for_property("createWalletConfirmNextButton", "visible", True, timeout_ms=10000)
+    gui.click("createWalletConfirmNextButton")
+    gui.wait_for_property("createWalletBackupDoneButton", "visible", True, timeout_ms=10000)
+    gui.click("createWalletBackupDoneButton")
+    gui.wait_for_property("walletBadge", "text", wallet_name, timeout_ms=20000)
+
+
+def create_full_payment_request(gui):
+    gui.click("receiveTabButton")
+    gui.wait_for_page("requestPaymentPage", timeout_ms=10000)
+    set_receive_options(gui)
+
+    gui.wait_for_property("requestPaymentYourNameInput", "visible", True, timeout_ms=5000)
+    gui.wait_for_property("requestPaymentMessageInput", "visible", True, timeout_ms=5000)
+    gui.wait_for_property("requestPaymentNoteSelfInput", "visible", True, timeout_ms=5000)
+    gui.wait_for_property("receiveAddressTypePicker", "visible", True, timeout_ms=5000)
+
+    before = gui.get_property("requestHistoryCount", "count")
+    gui.set_text("requestPaymentAmountInput", REQUEST_AMOUNT)
+    gui.set_text("requestPaymentYourNameInput", REQUEST_LABEL)
+    gui.set_text("requestPaymentMessageInput", REQUEST_MESSAGE)
+    gui.set_text("requestPaymentNoteSelfInput", REQUEST_NOTE_SELF)
+    gui.click("requestPaymentGenerateButton")
+    gui.wait_for_property("requestHistoryCount", "count", before + 1, timeout_ms=20000)
+    gui.wait_for_property("requestPaymentTitle", "text", "Payment request #1", timeout_ms=10000)
+
+
+def run_test():
+    bitcoin_qt = find_compat_bitcoin_qt()
+    if not bitcoin_qt:
+        print(f"SKIPPED: bitcoin-qt {COMPAT_VERSION} not found.")
+        print(
+            f"Set BITCOIN_QT_COMPAT or provide releases/v{COMPAT_VERSION}/bin/bitcoin-qt "
+            "to exercise this flow."
+        )
+        return 77
+    if not has_bitcoin_qt_runner():
+        print(bitcoin_qt_runner_skip_message())
+        return 77
+
+    harness = WalletFlowHarness("qml_wallet_qt_compat", port_offset=95)
+    qt_process = None
+    try:
+        print(f"[qml_wallet_qt_compat] bitcoin-qt located: {bitcoin_qt}")
+        harness.start_gui(reset_gui_settings=True)
+        gui = harness.driver
+        print("[qml_wallet_qt_compat] QML GUI launched")
+        harness.finish_onboarding()
+
+        create_unencrypted_wallet(gui, WALLET_NAME)
+        print("[qml_wallet_qt_compat] wallet created in bitcoin-core-app")
+
+        create_full_payment_request(gui)
+        print("[qml_wallet_qt_compat] payment request with all visible fields created")
+
+        harness.stop_gui()
+        print("[qml_wallet_qt_compat] bitcoin-core-app stopped")
+
+        qt_process = launch_bitcoin_qt(bitcoin_qt, harness)
+        wait_for_rpc_or_process_exit(qt_process, harness.gui_rpc_port)
+        loaded_wallets = rpc_call(harness.gui_rpc_port, "listwallets")
+        assert WALLET_NAME in loaded_wallets, f"Expected {WALLET_NAME} to load, got {loaded_wallets}"
+        wallet_info = rpc_call(harness.gui_rpc_port, "getwalletinfo", wallet=WALLET_NAME)
+        assert wallet_info["walletname"] == WALLET_NAME, f"Unexpected loaded wallet: {wallet_info}"
+
+        time.sleep(3)
+        if qt_process.poll() is not None:
+            raise AssertionError(
+                f"bitcoin-qt exited after loading wallet with code {qt_process.returncode}.\n"
+                f"{process_output(qt_process)}"
+            )
+
+        print("[qml_wallet_qt_compat] bitcoin-qt stayed alive after loading QML-created request metadata")
+        return 0
+    except Exception as err:  # noqa: BLE001 - preserve failure context
+        print(f"\nFAILED [qml_wallet_qt_compat]: {err}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        if harness.driver is not None:
+            dump_qml_tree(harness.driver)
+        qt_output = process_output(qt_process)
+        if qt_output:
+            print("\n--- bitcoin-qt process output ---", file=sys.stderr)
+            print(qt_output, file=sys.stderr)
+        log_tail = debug_log_tail(harness.gui_datadir)
+        if log_tail:
+            print("\n--- debug.log tail ---", file=sys.stderr)
+            print(log_tail, file=sys.stderr)
+        return 1
+    finally:
+        stop_bitcoin_qt(qt_process, harness.gui_rpc_port)
+        harness.stop()
+
+
+if __name__ == "__main__":
+    sys.exit(run_test())

--- a/test/functional/qml_test_wallet_rbf.py
+++ b/test/functional/qml_test_wallet_rbf.py
@@ -41,6 +41,11 @@ def wait_for_wallet_balance(port, wallet_name, *, minimum_balance):
     wait_until(has_balance, timeout=30, description=f"{wallet_name} balance >= {minimum_balance}")
 
 
+def assert_wallet_locked(port, wallet_name):
+    info = rpc_call(port, "getwalletinfo", wallet=wallet_name)
+    assert info["unlocked_until"] == 0, f"Expected locked wallet, got getwalletinfo={info}"
+
+
 def wait_for_mempool_change(port, *, exclude_txid, timeout=20):
     result = [None]
 
@@ -210,6 +215,7 @@ def run_test():
             "The wallet password you entered was incorrect.",
             timeout_ms=10000,
         )
+        assert_wallet_locked(harness.gui_rpc_port, GUI_WALLET_NAME)
         gui.set_text("speedUpPassphraseField", WALLET_PASSWORD)
         gui.click("speedUpPassphraseConfirmButton")
         gui.wait_for_property("speedUpPassphrasePopup", "opened", False, timeout_ms=10000)
@@ -218,6 +224,7 @@ def run_test():
         print("[rbf] waiting for replacement tx")
         new_txid = wait_for_mempool_change(harness.gui_rpc_port, exclude_txid=txid)
         assert new_txid != txid, f"Expected different txid, got same: {txid}"
+        assert_wallet_locked(harness.gui_rpc_port, GUI_WALLET_NAME)
         print(f"[rbf] replacement txid: {new_txid}")
 
         print("[rbf] verifying original tx conflict state")

--- a/test/functional/qml_test_wallet_rbf.py
+++ b/test/functional/qml_test_wallet_rbf.py
@@ -207,6 +207,7 @@ def run_test():
         print("[rbf] confirming bump")
         gui.click("updateTransactionButton")
         gui.wait_for_property("speedUpPassphrasePopup", "opened", True, timeout_ms=10000)
+        gui.wait_for_property("speedUpPassphraseErrorText", "text", "", timeout_ms=10000)
         gui.set_text("speedUpPassphraseField", "wrong password")
         gui.click("speedUpPassphraseConfirmButton")
         gui.wait_for_property(

--- a/test/functional/qml_test_wallet_rbf.py
+++ b/test/functional/qml_test_wallet_rbf.py
@@ -15,6 +15,7 @@ from qml_wallet_test_lib import WalletFlowHarness, rpc_call
 GUI_WALLET_NAME = "rbf_wallet"
 RECEIVER_WALLET_NAME = "rbf_receiver"
 SEND_AMOUNT = "1.00000000"
+WALLET_PASSWORD = "correct horse battery staple"
 
 
 def wait_until(predicate, *, timeout=20, interval=0.25, description="condition"):
@@ -148,7 +149,7 @@ def run_test():
         gui.wait_for_property("walletBadge", "loading", False, timeout_ms=30000)
         gui.wait_for_property("walletBadge", "visible", True, timeout_ms=10000)
 
-        rpc_call(harness.gui_rpc_port, "createwallet", {"wallet_name": GUI_WALLET_NAME})
+        rpc_call(harness.gui_rpc_port, "createwallet", {"wallet_name": GUI_WALLET_NAME, "passphrase": WALLET_PASSWORD})
         gui.wait_for_property("walletBadge", "text", GUI_WALLET_NAME, timeout_ms=20000)
         gui.wait_for_property("walletBadge", "noWalletLoaded", False, timeout_ms=10000)
 
@@ -158,12 +159,14 @@ def run_test():
         wait_for_wallet_balance(harness.gui_rpc_port, GUI_WALLET_NAME, minimum_balance=Decimal("50"))
 
         print("[rbf] sending initial transaction")
+        rpc_call(harness.gui_rpc_port, "walletpassphrase", [WALLET_PASSWORD, 60], wallet=GUI_WALLET_NAME)
         txid = rpc_call(
             harness.gui_rpc_port,
             "sendtoaddress",
             [receiver_address, SEND_AMOUNT],
             wallet=GUI_WALLET_NAME,
         )
+        rpc_call(harness.gui_rpc_port, "walletlock", wallet=GUI_WALLET_NAME)
         print(f"[rbf] sent txid: {txid}")
         wait_for_wallet_tx(harness.gui_rpc_port, GUI_WALLET_NAME, txid)
 
@@ -198,6 +201,18 @@ def run_test():
 
         print("[rbf] confirming bump")
         gui.click("updateTransactionButton")
+        gui.wait_for_property("speedUpPassphrasePopup", "opened", True, timeout_ms=10000)
+        gui.set_text("speedUpPassphraseField", "wrong password")
+        gui.click("speedUpPassphraseConfirmButton")
+        gui.wait_for_property(
+            "speedUpPassphraseErrorText",
+            "text",
+            "The wallet password you entered was incorrect.",
+            timeout_ms=10000,
+        )
+        gui.set_text("speedUpPassphraseField", WALLET_PASSWORD)
+        gui.click("speedUpPassphraseConfirmButton")
+        gui.wait_for_property("speedUpPassphrasePopup", "opened", False, timeout_ms=10000)
         gui.settle()
 
         print("[rbf] waiting for replacement tx")
@@ -223,6 +238,7 @@ def run_test():
         )
 
         print("[rbf] verifying confirmed tx is not bumpable")
+        rpc_call(harness.gui_rpc_port, "walletpassphrase", [WALLET_PASSWORD, 60], wallet=GUI_WALLET_NAME)
         try:
             rpc_call(harness.gui_rpc_port, "bumpfee", [new_txid], wallet=GUI_WALLET_NAME)
             assert False, "bumpfee on confirmed tx should have raised an error"
@@ -231,6 +247,8 @@ def run_test():
             accepted_reasons = ("confirmed", "cannot bump", "already spent")
             assert any(reason in message for reason in accepted_reasons), f"Unexpected error: {rpc_err}"
             print(f"[rbf] confirmed tx correctly rejected: {rpc_err}")
+        finally:
+            rpc_call(harness.gui_rpc_port, "walletlock", wallet=GUI_WALLET_NAME)
 
         print("[rbf] ALL TESTS PASSED")
         return 0

--- a/test/mocks/mockwallet.h
+++ b/test/mocks/mockwallet.h
@@ -121,6 +121,7 @@ public:
     MOCK_METHOD(CTxDestination, getNewDestinationValue, (OutputType, const std::string&));
     MOCK_METHOD((std::set<interfaces::WalletTx>), getWalletTxs, (), (override));
     MOCK_METHOD(CAmount, getBalance, (), (override));
+    MOCK_METHOD(CAmount, getAvailableBalance, (const wallet::CCoinControl&), (override));
     MOCK_METHOD(CAmount, getRequiredFee, (unsigned int), (override));
     MOCK_METHOD(CoinsList, listCoins, (), (override));
     MOCK_METHOD(OutputType, getDefaultAddressType, (), (override));

--- a/test/mocks/qml/org/bitcoincore/qt/BitcoinUri.qml
+++ b/test/mocks/qml/org/bitcoincore/qt/BitcoinUri.qml
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+pragma Singleton
+import QtQuick 2.15
+
+QtObject {
+    function parseBitcoinUri(uriText) {
+        if (!uriText || !uriText.startsWith("bitcoin:")) {
+            return { success: false, error: "Not a valid Bitcoin payment URI." }
+        }
+
+        if (uriText.startsWith("bitcoin://")) {
+            return { success: false, error: "'bitcoin://' is not a valid URI. Use 'bitcoin:' instead." }
+        }
+
+        const payload = uriText.slice("bitcoin:".length)
+        const separator = payload.indexOf("?")
+        const address = separator === -1 ? payload : payload.slice(0, separator)
+        const query = separator === -1 ? "" : payload.slice(separator + 1)
+        const result = {
+            success: address.length > 0,
+            error: address.length > 0 ? "" : "Not a valid Bitcoin payment URI.",
+            address: address,
+            amountSats: 0,
+            hasAmount: false,
+            label: "",
+            hasLabel: false,
+            uriMessage: "",
+            hasMessage: false,
+        }
+
+        if (!result.success) {
+            return result
+        }
+
+        for (const item of query.split("&")) {
+            if (!item)
+                continue
+            const parts = item.split("=")
+            const key = decodeURIComponent(parts[0])
+            const value = decodeURIComponent(parts.length > 1 ? parts.slice(1).join("=") : "")
+            if (key === "amount") {
+                const pieces = value.split(".")
+                const whole = pieces[0] ? Number(pieces[0]) : 0
+                const fraction = (pieces.length > 1 ? pieces[1] : "").slice(0, 8).padEnd(8, "0")
+                result.amountSats = whole * 100000000 + Number(fraction || "0")
+                result.hasAmount = true
+            } else if (key === "label") {
+                result.label = value
+                result.hasLabel = true
+            } else if (key === "message") {
+                result.uriMessage = value
+                result.hasMessage = true
+            }
+        }
+
+        return result
+    }
+
+    function parseBitcoinUriFromFile(_sourcePath) {
+        return { success: false, error: "File parsing is unavailable in QML unit tests." }
+    }
+}

--- a/test/mocks/qml/org/bitcoincore/qt/Clipboard.qml
+++ b/test/mocks/qml/org/bitcoincore/qt/Clipboard.qml
@@ -6,5 +6,9 @@ pragma Singleton
 import QtQuick 2.15
 
 QtObject {
-    function text() { return "" }
+    property string currentText: ""
+
+    signal dataChanged()
+
+    function text() { return currentText }
 }

--- a/test/mocks/qml/org/bitcoincore/qt/qmldir
+++ b/test/mocks/qml/org/bitcoincore/qt/qmldir
@@ -1,4 +1,5 @@
 module org.bitcoincore.qt
 singleton AppMode 1.0 AppMode.qml
+singleton BitcoinUri 1.0 BitcoinUri.qml
 BlockClockDial 1.0 BlockClockDial.qml
 singleton Clipboard 1.0 Clipboard.qml

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -1802,12 +1802,14 @@ class MockBumpTransactionModel : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int state READ state WRITE setState NOTIFY stateChanged)
+    Q_PROPERTY(bool requireUnlock READ requireUnlock WRITE setRequireUnlock NOTIFY resultChanged)
     Q_PROPERTY(QString oldFee MEMBER m_old_fee NOTIFY resultChanged)
     Q_PROPERTY(QString newFee MEMBER m_new_fee NOTIFY resultChanged)
     Q_PROPERTY(QString feeIncrease MEMBER m_fee_increase NOTIFY resultChanged)
     Q_PROPERTY(QString oldTxid MEMBER m_old_txid NOTIFY resultChanged)
     Q_PROPERTY(QString newTxid MEMBER m_new_txid NOTIFY resultChanged)
     Q_PROPERTY(QString errorText MEMBER m_error_text NOTIFY resultChanged)
+    Q_PROPERTY(bool needsUnlock MEMBER m_needs_unlock NOTIFY needsUnlockChanged)
 
 public:
     enum State { Idle, Preparing, NeedsConfirmation, Committing, Succeeded, Failed };
@@ -1817,11 +1819,20 @@ public:
     Q_ENUM(ActionType)
 
     int state() const { return m_state; }
+    bool requireUnlock() const { return m_require_unlock; }
+
     void setState(int state)
     {
         if (m_state == state) return;
         m_state = state;
         Q_EMIT stateChanged();
+    }
+
+    void setRequireUnlock(bool require_unlock)
+    {
+        if (m_require_unlock == require_unlock) return;
+        m_require_unlock = require_unlock;
+        Q_EMIT resultChanged();
     }
 
     Q_INVOKABLE void prepareFeeBump(const QString& txid, unsigned int targetBlocks)
@@ -1835,11 +1846,29 @@ public:
         Q_EMIT resultChanged();
     }
 
-    Q_INVOKABLE void confirmFeeBump()
+    Q_INVOKABLE bool confirmFeeBump()
     {
+        if (m_require_unlock) {
+            m_error_text = QStringLiteral("Enter your wallet password to update this transaction.");
+            m_needs_unlock = true;
+            Q_EMIT resultChanged();
+            Q_EMIT needsUnlockChanged();
+            return false;
+        }
+
         m_new_txid = QStringLiteral("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        m_needs_unlock = false;
         setState(Succeeded);
         Q_EMIT resultChanged();
+        Q_EMIT needsUnlockChanged();
+        return true;
+    }
+
+    Q_INVOKABLE bool confirmFeeBumpWithPassphrase(const QString& passphrase)
+    {
+        Q_UNUSED(passphrase);
+        m_require_unlock = false;
+        return confirmFeeBump();
     }
 
     Q_INVOKABLE void reset()
@@ -1851,14 +1880,18 @@ public:
         m_old_txid.clear();
         m_new_txid.clear();
         m_error_text.clear();
+        m_needs_unlock = false;
+        m_require_unlock = false;
         Q_EMIT stateChanged();
         Q_EMIT resultChanged();
+        Q_EMIT needsUnlockChanged();
     }
 
 Q_SIGNALS:
     void stateChanged();
     void actionTypeChanged();
     void resultChanged();
+    void needsUnlockChanged();
 
 private:
     int m_state{Idle};
@@ -1868,6 +1901,8 @@ private:
     QString m_old_txid;
     QString m_new_txid;
     QString m_error_text;
+    bool m_needs_unlock{false};
+    bool m_require_unlock{false};
 };
 
 class MockActivityListModel : public QAbstractListModel
@@ -2185,6 +2220,7 @@ public Q_SLOTS:
         engine->rootContext()->setContextProperty(QStringLiteral("testSendRecipient"), &send_recipient);
         engine->rootContext()->setContextProperty(QStringLiteral("testRecipientsModel"), &recipients_model);
         engine->rootContext()->setContextProperty(QStringLiteral("testCoinsListModel"), &coins_list_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("testBumpModel"), &bump_model);
         engine->addImportPath(QStringLiteral(BITCOINQML_QML_SOURCE_DIR));
     }
 };

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -749,6 +749,7 @@ class MockWalletQmlModel : public QObject
     Q_PROPERTY(bool customFeeRateValid READ customFeeRateValid NOTIFY customFeeRateValidChanged)
     Q_PROPERTY(bool feeEstimatePending MEMBER m_fee_estimate_pending NOTIFY feeEstimatePendingChanged)
     Q_PROPERTY(int feeEstimateRevision MEMBER m_fee_estimate_revision NOTIFY feeEstimateRevisionChanged)
+    Q_PROPERTY(bool sendAmountExhaustsBalance READ sendAmountExhaustsBalance WRITE setSendAmountExhaustsBalance NOTIFY sendAmountExhaustsBalanceChanged)
     Q_PROPERTY(bool prepareTransactionResult MEMBER m_prepare_transaction_result NOTIFY prepareTransactionResultChanged)
     Q_PROPERTY(bool sendTransactionResult MEMBER m_send_transaction_result NOTIFY sendTransactionResultChanged)
     Q_PROPERTY(int prepareTransactionCalls READ prepareTransactionCalls NOTIFY prepareTransactionCallsChanged)
@@ -843,6 +844,7 @@ public:
     int prepareTransactionCalls() const { return m_prepare_transaction_calls; }
     int scheduleFeeEstimatesCalls() const { return m_schedule_fee_estimates_calls; }
     int sendTransactionCalls() const { return m_send_transaction_calls; }
+    bool sendAmountExhaustsBalance() const { return m_send_amount_exhausts_balance; }
     QString lastBackupPath() const { return m_last_backup_path; }
     int backupWalletCalls() const { return m_backup_wallet_calls; }
     Q_INVOKABLE QString estimatedFeeForTarget(const int target) const
@@ -936,6 +938,12 @@ public:
         }
         Q_EMIT feeEstimateRevisionChanged();
         scheduleFeeEstimates();
+    }
+    void setSendAmountExhaustsBalance(const bool value)
+    {
+        if (m_send_amount_exhausts_balance == value) return;
+        m_send_amount_exhausts_balance = value;
+        Q_EMIT sendAmountExhaustsBalanceChanged();
     }
     Q_INVOKABLE bool prepareTransaction()
     {
@@ -1078,6 +1086,7 @@ Q_SIGNALS:
     void customFeeRateValidChanged();
     void feeEstimatePendingChanged();
     void feeEstimateRevisionChanged();
+    void sendAmountExhaustsBalanceChanged();
     void prepareTransactionResultChanged();
     void sendTransactionResultChanged();
     void prepareTransactionCallsChanged();
@@ -1114,6 +1123,7 @@ private:
     QString m_custom_fee_rate;
     QString m_custom_fee_estimate;
     bool m_fee_estimate_pending{false};
+    bool m_send_amount_exhausts_balance{false};
     bool m_send_transaction_result{true};
     bool m_is_encrypted{false};
     bool m_is_locked{false};

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -131,8 +131,8 @@ Q_SIGNALS:
 class MockBitcoinAmount : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QString display MEMBER m_display NOTIFY displayChanged)
-    Q_PROPERTY(Unit unit MEMBER m_unit NOTIFY unitChanged)
+    Q_PROPERTY(QString display READ display WRITE setDisplay NOTIFY displayChanged)
+    Q_PROPERTY(Unit unit READ unit WRITE setUnit NOTIFY unitChanged)
     Q_PROPERTY(qint64 satoshi READ satoshi NOTIFY displayChanged)
     Q_PROPERTY(QString unitLabel READ unitLabel NOTIFY unitChanged)
     Q_PROPERTY(QString displayWithUnit READ displayWithUnit NOTIFY displayChanged)
@@ -147,6 +147,17 @@ public:
     QString m_display{QStringLiteral("0.00000000")};
     Unit m_unit{BTC};
 
+    QString display() const { return m_display; }
+    Unit unit() const { return m_unit; }
+    void setUnit(Unit unit)
+    {
+        if (m_unit == unit) return;
+        const qint64 sats = satoshi();
+        m_unit = unit;
+        m_display = displayForSatoshi(sats);
+        Q_EMIT unitChanged();
+        Q_EMIT displayChanged();
+    }
     qint64 satoshi() const
     {
         const QString amount_text = m_display.split(u' ').constFirst();
@@ -159,18 +170,59 @@ public:
         const double value = amount_text.toDouble(&ok);
         return ok ? static_cast<qint64>(value * 100000000.0 + 0.5) : 0;
     }
+    void setDisplay(const QString& display)
+    {
+        const QString normalized = normalizedDisplay(display);
+        if (m_display == normalized) return;
+        m_display = normalized;
+        Q_EMIT displayChanged();
+    }
     QString unitLabel() const { return m_unit == BTC ? QStringLiteral("BTC") : QStringLiteral("sat"); }
     QString displayWithUnit() const { return m_display.isEmpty() ? QString{} : m_display + QStringLiteral(" ") + unitLabel(); }
-    Q_INVOKABLE void format() {}
+    Q_INVOKABLE void format()
+    {
+        const QString normalized = normalizedDisplay(m_display);
+        if (m_display != normalized) {
+            m_display = normalized;
+        }
+        Q_EMIT displayChanged();
+    }
     Q_INVOKABLE void flipUnit()
     {
-        m_unit = (m_unit == BTC) ? SAT : BTC;
-        Q_EMIT unitChanged();
+        setUnit(m_unit == BTC ? SAT : BTC);
     }
 
 Q_SIGNALS:
     void displayChanged();
     void unitChanged();
+
+private:
+    QString displayForSatoshi(qint64 sats) const
+    {
+        if (m_unit == SAT) return QString::number(sats);
+        const qint64 whole = sats / 100000000;
+        const qint64 fraction = qAbs(sats % 100000000);
+        return QStringLiteral("%1.%2").arg(whole).arg(fraction, 8, 10, QLatin1Char('0'));
+    }
+
+    QString normalizedDisplay(const QString& display) const
+    {
+        const QString trimmed = display.trimmed();
+        if (trimmed.isEmpty()) return QString{};
+        if (m_unit == SAT) {
+            QString digits_only = trimmed;
+            digits_only.remove(QRegularExpression(QStringLiteral("[^0-9]")));
+            return digits_only.isEmpty() ? QString{} : QString::number(digits_only.toLongLong());
+        }
+
+        QString sanitized = trimmed;
+        sanitized.remove(QRegularExpression(QStringLiteral("[^0-9.]")));
+        const QStringList parts = sanitized.split(u'.');
+        const qint64 whole = parts.value(0).isEmpty() ? 0 : parts.value(0).toLongLong();
+        const QString fraction_text = parts.size() > 1 ? parts.value(1).left(8).leftJustified(8, u'0') : QStringLiteral("00000000");
+        const qint64 fraction = fraction_text.toLongLong();
+        return QStringLiteral("%1.%2").arg(whole).arg(fraction, 8, 10, QLatin1Char('0'));
+    }
 };
 
 class MockBitcoinAddress : public QObject

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -133,7 +133,7 @@ class MockBitcoinAmount : public QObject
     Q_OBJECT
     Q_PROPERTY(QString display READ display WRITE setDisplay NOTIFY displayChanged)
     Q_PROPERTY(Unit unit READ unit WRITE setUnit NOTIFY unitChanged)
-    Q_PROPERTY(qint64 satoshi READ satoshi NOTIFY displayChanged)
+    Q_PROPERTY(qint64 satoshi READ satoshi WRITE setSatoshi NOTIFY amountChanged)
     Q_PROPERTY(QString unitLabel READ unitLabel NOTIFY unitChanged)
     Q_PROPERTY(QString displayWithUnit READ displayWithUnit NOTIFY displayChanged)
 
@@ -170,12 +170,21 @@ public:
         const double value = amount_text.toDouble(&ok);
         return ok ? static_cast<qint64>(value * 100000000.0 + 0.5) : 0;
     }
+    void setSatoshi(qint64 sats)
+    {
+        const QString updated = displayForSatoshi(sats);
+        if (m_display == updated) return;
+        m_display = updated;
+        Q_EMIT displayChanged();
+        Q_EMIT amountChanged();
+    }
     void setDisplay(const QString& display)
     {
         const QString normalized = normalizedDisplay(display);
         if (m_display == normalized) return;
         m_display = normalized;
         Q_EMIT displayChanged();
+        Q_EMIT amountChanged();
     }
     QString unitLabel() const { return m_unit == BTC ? QStringLiteral("BTC") : QStringLiteral("sat"); }
     QString displayWithUnit() const { return m_display.isEmpty() ? QString{} : m_display + QStringLiteral(" ") + unitLabel(); }
@@ -186,6 +195,7 @@ public:
             m_display = normalized;
         }
         Q_EMIT displayChanged();
+        Q_EMIT amountChanged();
     }
     Q_INVOKABLE void flipUnit()
     {
@@ -193,6 +203,7 @@ public:
     }
 
 Q_SIGNALS:
+    void amountChanged();
     void displayChanged();
     void unitChanged();
 
@@ -228,6 +239,32 @@ private:
 class MockBitcoinAddress : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(QString address READ address NOTIFY addressChanged)
+    Q_PROPERTY(QString formattedAddress READ formattedAddress NOTIFY formattedAddressChanged)
+    Q_PROPERTY(QString ellipsesAddress READ ellipsesAddress NOTIFY ellipsesAddressChanged)
+
+public:
+    QString address() const { return m_address; }
+    QString formattedAddress() const { return m_address; }
+    QString ellipsesAddress() const { return m_address; }
+    Q_INVOKABLE int setAddress(const QString& address, int cursorPosition = 0)
+    {
+        if (m_address != address) {
+            m_address = address;
+            Q_EMIT addressChanged();
+            Q_EMIT formattedAddressChanged();
+            Q_EMIT ellipsesAddressChanged();
+        }
+        return cursorPosition;
+    }
+
+Q_SIGNALS:
+    void addressChanged();
+    void formattedAddressChanged();
+    void ellipsesAddressChanged();
+
+private:
+    QString m_address{QStringLiteral("bcrt1qsendtoaddress")};
 };
 
 class MockAddressListModel : public QObject
@@ -422,7 +459,7 @@ public:
 class MockSendRecipient : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QString address MEMBER m_address NOTIFY addressChanged)
+    Q_PROPERTY(QObject* address READ address CONSTANT)
     Q_PROPERTY(QString addressError MEMBER m_address_error NOTIFY addressErrorChanged)
     Q_PROPERTY(QObject* amount READ amount CONSTANT)
     Q_PROPERTY(QString amountError MEMBER m_amount_error NOTIFY amountErrorChanged)
@@ -431,7 +468,7 @@ class MockSendRecipient : public QObject
     Q_PROPERTY(bool isValid MEMBER m_is_valid NOTIFY isValidChanged)
 
 public:
-    QString m_address{QStringLiteral("bcrt1qsendtoaddress")};
+    MockBitcoinAddress m_address{};
     QString m_address_error;
     MockBitcoinAmount m_amount{};
     QString m_amount_error;
@@ -439,6 +476,7 @@ public:
     bool m_subtract_fee_from_amount{false};
     bool m_is_valid{true};
 
+    QObject* address() { return &m_address; }
     QObject* amount() { return &m_amount; }
     bool subtractFeeFromAmount() const { return m_subtract_fee_from_amount; }
     void setSubtractFeeFromAmount(bool value)
@@ -449,7 +487,6 @@ public:
     }
 
 Q_SIGNALS:
-    void addressChanged();
     void addressErrorChanged();
     void amountErrorChanged();
     void labelChanged();
@@ -754,6 +791,7 @@ class MockWalletQmlModel : public QObject
     Q_PROPERTY(QObject* detailPaymentRequest READ detailPaymentRequest CONSTANT)
     Q_PROPERTY(QObject* receiveRequests READ receiveRequests CONSTANT)
     Q_PROPERTY(MockAddressListModel* addressListModel READ addressListModel CONSTANT)
+    Q_PROPERTY(bool hasExternalSigner MEMBER m_has_external_signer NOTIFY walletInfoChanged)
     Q_PROPERTY(int displayUnit MEMBER m_display_unit NOTIFY displayUnitChanged)
     Q_PROPERTY(int targetBlocks READ targetBlocks WRITE setTargetBlocks NOTIFY targetBlocksChanged)
     Q_PROPERTY(QString estimatedFee READ estimatedFee NOTIFY feeEstimateRevisionChanged)
@@ -795,6 +833,7 @@ public:
     QObject* m_current_transaction{nullptr};
     QObject* m_current_payment_request{nullptr};
     MockReceiveRequests m_receive_requests{};
+    bool m_has_external_signer{false};
     int m_display_unit{0};
     QString m_default_receive_address_type{QStringLiteral("bech32")};
     QString m_last_commit_address_type;
@@ -2337,6 +2376,7 @@ public Q_SLOTS:
         engine->rootContext()->setContextProperty(QStringLiteral("testPaymentRequest"), &payment_request);
         engine->rootContext()->setContextProperty(QStringLiteral("testActivityListModel"), &activity_list_model);
         engine->rootContext()->setContextProperty(QStringLiteral("testSendRecipient"), &send_recipient);
+        engine->rootContext()->setContextProperty(QStringLiteral("testAutomationEnabled"), false);
         engine->rootContext()->setContextProperty(QStringLiteral("testRecipientsModel"), &recipients_model);
         engine->rootContext()->setContextProperty(QStringLiteral("testCoinsListModel"), &coins_list_model);
         engine->rootContext()->setContextProperty(QStringLiteral("testBumpModel"), &bump_model);

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -411,6 +411,8 @@ class MockRecipientsModel : public QAbstractListModel
     Q_PROPERTY(QObject* current READ current NOTIFY currentChanged)
     Q_PROPERTY(int currentIndex READ currentIndex WRITE setCurrentIndex NOTIFY currentIndexChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(bool allValid READ allValid WRITE setAllValid NOTIFY validationChanged)
+    Q_PROPERTY(QString validationError READ validationError WRITE setValidationError NOTIFY validationChanged)
 
 public:
     enum Roles {
@@ -437,6 +439,22 @@ public:
     QObject* current() const { return m_current; }
     int currentIndex() const { return m_current_index; } // 1-based, matches QML expectations.
     int count() const { return static_cast<int>(m_rows.size()); }
+    bool allValid() const { return m_all_valid; }
+    QString validationError() const { return m_validation_error; }
+
+    void setAllValid(bool all_valid)
+    {
+        if (m_all_valid == all_valid) return;
+        m_all_valid = all_valid;
+        Q_EMIT validationChanged();
+    }
+
+    void setValidationError(const QString& validation_error)
+    {
+        if (m_validation_error == validation_error) return;
+        m_validation_error = validation_error;
+        Q_EMIT validationChanged();
+    }
 
     void setCurrent(QObject* recipient)
     {
@@ -530,11 +548,14 @@ Q_SIGNALS:
     void currentIndexChanged();
     void countChanged();
     void listCleared();
+    void validationChanged();
 
 private:
     QObject* m_current{nullptr};
     int m_current_index{1};
     std::vector<RecipientRow> m_rows{};
+    bool m_all_valid{true};
+    QString m_validation_error;
 };
 
 class MockCoinsListModel : public QAbstractListModel

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -1175,6 +1175,8 @@ class MockWalletController : public QObject
     Q_PROPERTY(QObject* selectedWallet READ selectedWallet NOTIFY selectedWalletChanged)
     Q_PROPERTY(int closePaymentRequestDetailRequests MEMBER m_close_payment_request_detail_requests NOTIFY closePaymentRequestDetailRequestsChanged)
     Q_PROPERTY(int openReceiveRequests MEMBER m_open_receive_requests NOTIFY openReceiveRequestsChanged)
+    Q_PROPERTY(QString walletLocationOpenError READ walletLocationOpenError NOTIFY walletLocationOpenErrorChanged)
+    Q_PROPERTY(int openSelectedWalletLocationCalls READ openSelectedWalletLocationCalls NOTIFY openSelectedWalletLocationCallsChanged)
 
 public:
     bool m_initialized{true};
@@ -1189,11 +1191,17 @@ public:
     int m_close_wallet_calls{0};
     int m_close_payment_request_detail_requests{0};
     int m_open_receive_requests{0};
+    QString m_wallet_location_open_error;
+    bool m_open_selected_wallet_location_result{true};
+    QString m_open_selected_wallet_location_error;
+    int m_open_selected_wallet_location_calls{0};
 
     QObject* selectedWallet() const { return m_selected_wallet; }
     QString lastSelectedWalletName() const { return m_last_selected_wallet_name; }
     QString lastClosedWalletName() const { return m_last_closed_wallet_name; }
     int closeWalletCalls() const { return m_close_wallet_calls; }
+    QString walletLocationOpenError() const { return m_wallet_location_open_error; }
+    int openSelectedWalletLocationCalls() const { return m_open_selected_wallet_location_calls; }
     Q_INVOKABLE QString homePath() const { return QStringLiteral("/tmp"); }
     Q_INVOKABLE QString normalizeWalletPath(const QString& path) const { return path; }
     Q_INVOKABLE bool walletPathExists(const QString&) const { return false; }
@@ -1225,11 +1233,16 @@ public:
         m_close_wallet_calls = 0;
         m_close_payment_request_detail_requests = 0;
         m_open_receive_requests = 0;
+        m_open_selected_wallet_location_calls = 0;
+        m_open_selected_wallet_location_result = true;
+        m_open_selected_wallet_location_error.clear();
+        clearWalletLocationOpenError();
         Q_EMIT lastSelectedWalletNameChanged();
         Q_EMIT lastClosedWalletNameChanged();
         Q_EMIT closeWalletCallsChanged();
         Q_EMIT closePaymentRequestDetailRequestsChanged();
         Q_EMIT openReceiveRequestsChanged();
+        Q_EMIT openSelectedWalletLocationCallsChanged();
     }
     Q_INVOKABLE void requestClosePaymentRequestDetail()
     {
@@ -1252,6 +1265,31 @@ public:
     Q_INVOKABLE void createSingleSigWallet(const QString& /*name*/, const QString& /*passphrase*/) { Q_EMIT walletCreateSucceeded(); }
     Q_INVOKABLE void clearWalletLoadStatus() { m_wallet_load_error.clear(); Q_EMIT walletLoadErrorChanged(); }
     Q_INVOKABLE void clearWalletCreateStatus() { m_wallet_create_error.clear(); Q_EMIT walletCreateErrorChanged(); }
+    Q_INVOKABLE void setOpenSelectedWalletLocationResult(const bool result, const QString& error = QString())
+    {
+        m_open_selected_wallet_location_result = result;
+        m_open_selected_wallet_location_error = error;
+    }
+    Q_INVOKABLE bool openSelectedWalletLocation()
+    {
+        ++m_open_selected_wallet_location_calls;
+        Q_EMIT openSelectedWalletLocationCallsChanged();
+        if (m_open_selected_wallet_location_result) {
+            clearWalletLocationOpenError();
+            return true;
+        }
+        m_wallet_location_open_error = m_open_selected_wallet_location_error.isEmpty()
+            ? QStringLiteral("Could not open wallet file location.")
+            : m_open_selected_wallet_location_error;
+        Q_EMIT walletLocationOpenErrorChanged();
+        return false;
+    }
+    Q_INVOKABLE void clearWalletLocationOpenError()
+    {
+        if (m_wallet_location_open_error.isEmpty()) return;
+        m_wallet_location_open_error.clear();
+        Q_EMIT walletLocationOpenErrorChanged();
+    }
 
 Q_SIGNALS:
     void initializedChanged();
@@ -1269,6 +1307,8 @@ Q_SIGNALS:
     void openReceiveRequestsChanged();
     void openReceiveRequested();
     void walletCreateSucceeded();
+    void walletLocationOpenErrorChanged();
+    void openSelectedWalletLocationCallsChanged();
 };
 
 class MockOptionsModel : public QObject

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -706,6 +706,19 @@ public:
         emitAggregateSignals();
     }
 
+    Q_INVOKABLE void reset()
+    {
+        bool changed{false};
+        for (CoinRow& row : m_rows) {
+            if (!row.selected) continue;
+            row.selected = false;
+            changed = true;
+        }
+        if (!changed) return;
+        Q_EMIT dataChanged(index(0, 0), index(rowCount() - 1, 0), {SelectedRole});
+        emitAggregateSignals();
+    }
+
     Q_INVOKABLE void update() {}
 
 Q_SIGNALS:
@@ -952,7 +965,11 @@ public:
         if (m_prepare_transaction_result) {
             setTransactionStatus({}, false);
         } else {
-            setTransactionStatus(QStringLiteral("Amount plus fee exceeds available balance"), false);
+            const bool selected_inputs_active{
+                m_coins_list_model && m_coins_list_model->property("selectedCoinsCount").toInt() > 0};
+            setTransactionStatus(selected_inputs_active
+                ? QStringLiteral("Selected inputs do not cover the amount plus fee")
+                : QStringLiteral("Amount plus fee exceeds available balance"), false);
         }
         return m_prepare_transaction_result;
     }

--- a/test/qml/tst_activitydetails.qml
+++ b/test/qml/tst_activitydetails.qml
@@ -38,6 +38,44 @@ TestCase {
         verify(banner !== null)
     }
 
+    function test_speedUpOverlay_prompts_for_password_when_bump_requires_unlock() {
+        testBumpModel.reset()
+        testBumpModel.requireUnlock = true
+
+        const page = createTemporaryObject(detailsComponent, this, {
+            txid: "bbbb",
+            canBump: true,
+            amount: "-0.00100000 BTC",
+            date: "2026-01-02",
+            depth: 0,
+            status: 0,
+            type: 3,
+            address: "bcrt1qsendaddress"
+        })
+        verify(page !== null)
+
+        const banner = findChild(page, "speedUpBanner")
+        verify(banner !== null)
+        const button = findChild(banner, "speedUpBannerPrimaryButton")
+        verify(button !== null)
+        banner.primaryClicked()
+
+        const overlay = findChild(page, "speedUpOverlay")
+        verify(overlay !== null)
+        tryCompare(overlay, "opened", true)
+
+        const updateButton = findChild(overlay, "updateTransactionButton")
+        verify(updateButton !== null)
+        tryCompare(updateButton, "enabled", true)
+        mouseClick(updateButton)
+
+        const popup = findChild(overlay, "speedUpPassphrasePopup")
+        verify(popup !== null)
+        tryCompare(popup, "opened", true)
+        compare(findChild(overlay, "speedUpPassphraseErrorText").text,
+                "Enter your wallet password to update this transaction.")
+    }
+
     function test_canBump_false_hides_speedUpBanner() {
         const page = createTemporaryObject(detailsComponent, this, {
             txid: "aaaa",

--- a/test/qml/tst_activitydetails.qml
+++ b/test/qml/tst_activitydetails.qml
@@ -72,8 +72,7 @@ TestCase {
         const popup = findChild(overlay, "speedUpPassphrasePopup")
         verify(popup !== null)
         tryCompare(popup, "opened", true)
-        compare(findChild(overlay, "speedUpPassphraseErrorText").text,
-                "Enter your wallet password to update this transaction.")
+        compare(findChild(overlay, "speedUpPassphraseErrorText").text, "")
     }
 
     function test_canBump_false_hides_speedUpBanner() {

--- a/test/qml/tst_createbackup.qml
+++ b/test/qml/tst_createbackup.qml
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/pages/wallet"
+
+TestCase {
+    name: "CreateBackup"
+    when: windowShown
+    width: 520
+    height: 720
+
+    Component {
+        id: createBackupComponent
+
+        CreateBackup {
+            width: 460
+            height: 680
+        }
+    }
+
+    function init() {
+        walletController.reset()
+    }
+
+    function createBackupPage() {
+        const page = createTemporaryObject(createBackupComponent, this)
+        verify(page !== null)
+        return page
+    }
+
+    function test_view_file_opens_wallet_location() {
+        const page = createBackupPage()
+        const viewFileButton = findChild(page, "createWalletBackupViewFileButton")
+        verify(viewFileButton !== null)
+        const errorText = findChild(page, "createWalletBackupErrorText")
+        verify(errorText !== null)
+
+        viewFileButton.clicked()
+
+        compare(walletController.openSelectedWalletLocationCalls, 1)
+        compare(errorText.text, "")
+    }
+
+    function test_view_file_shows_open_failure() {
+        const page = createBackupPage()
+        walletController.setOpenSelectedWalletLocationResult(false, "Could not open test wallet location.")
+        const viewFileButton = findChild(page, "createWalletBackupViewFileButton")
+        verify(viewFileButton !== null)
+        const errorText = findChild(page, "createWalletBackupErrorText")
+        verify(errorText !== null)
+
+        viewFileButton.clicked()
+
+        compare(walletController.openSelectedWalletLocationCalls, 1)
+        compare(errorText.text, "Could not open test wallet location.")
+    }
+
+    function test_view_file_shows_missing_wallet_location() {
+        const page = createBackupPage()
+        walletController.setOpenSelectedWalletLocationResult(false, "No wallet file is available to view.")
+        const viewFileButton = findChild(page, "createWalletBackupViewFileButton")
+        verify(viewFileButton !== null)
+        const errorText = findChild(page, "createWalletBackupErrorText")
+        verify(errorText !== null)
+
+        viewFileButton.clicked()
+
+        compare(walletController.openSelectedWalletLocationCalls, 1)
+        compare(errorText.text, "No wallet file is available to view.")
+    }
+}

--- a/test/qml/tst_navbutton.qml
+++ b/test/qml/tst_navbutton.qml
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/controls"
+
+TestCase {
+    name: "NavButton"
+    when: windowShown
+    width: 300
+    height: 200
+
+    Component {
+        id: iconTextButtonComponent
+
+        NavButton {
+            iconSource: "image://images/caret-left"
+            text: "Back"
+        }
+    }
+
+    function test_contentItemRespectsPadding() {
+        const button = createTemporaryObject(iconTextButtonComponent, this)
+        verify(button !== null)
+
+        compare(button.contentItem.x, button.leftPadding)
+        compare(button.contentItem.y, button.topPadding)
+        compare(button.contentItem.width, button.width - button.leftPadding - button.rightPadding)
+        compare(button.contentItem.height, button.height - button.topPadding - button.bottomPadding)
+    }
+}

--- a/test/qml/tst_requestpayment.qml
+++ b/test/qml/tst_requestpayment.qml
@@ -73,9 +73,9 @@ TestCase {
         id: btcValidatorComponent
         TextField {
             validator: RegularExpressionValidator {
-                regularExpression: /^(0|[1-9]\d{0,7})(\.\d{0,8})?$/
+                regularExpression: /^0*\d{0,8}(\.\d{0,8})?$/
             }
-            maximumLength: 17
+            maximumLength: 32
         }
     }
 
@@ -83,9 +83,9 @@ TestCase {
         id: satValidatorComponent
         TextField {
             validator: RegularExpressionValidator {
-                regularExpression: /^(0|[1-9]\d{0,15})$/
+                regularExpression: /^0*\d{0,16}$/
             }
-            maximumLength: 16
+            maximumLength: 32
         }
     }
 
@@ -104,19 +104,28 @@ TestCase {
 
         field.text = "0.00000001"
         compare(field.acceptableInput, true)
+
+        field.text = "01.00000000"
+        compare(field.acceptableInput, true)
+
+        field.text = "00000001.00000000"
+        compare(field.acceptableInput, true)
     }
 
     function test_btcValidator_rejects_invalid_amounts() {
         var field = createTemporaryObject(btcValidatorComponent, this)
         verify(field !== null)
 
-        field.text = "00"
-        compare(field.acceptableInput, false)
-
-        field.text = "1.000000001"
-        compare(field.acceptableInput, false)
-
         field.text = "-1"
+        compare(field.acceptableInput, false)
+
+        field.text = "1.2.3"
+        compare(field.acceptableInput, false)
+
+        field.text = "0.000000001"
+        compare(field.acceptableInput, false)
+
+        field.text = "100000000.00000000"
         compare(field.acceptableInput, false)
 
         field.text = "abc"
@@ -135,20 +144,113 @@ TestCase {
 
         field.text = "2100000000000000"
         compare(field.acceptableInput, true)
+
+        field.text = "00"
+        compare(field.acceptableInput, true)
+
+        field.text = "0002100000000000000"
+        compare(field.acceptableInput, true)
     }
 
     function test_satValidator_rejects_invalid_amounts() {
         var field = createTemporaryObject(satValidatorComponent, this)
         verify(field !== null)
 
-        field.text = "00"
-        compare(field.acceptableInput, false)
-
         field.text = "1.5"
         compare(field.acceptableInput, false)
 
         field.text = "-100"
         compare(field.acceptableInput, false)
+
+        field.text = "10000000000000000"
+        compare(field.acceptableInput, false)
+    }
+
+    function test_amountInput_keeps_user_draft_while_model_display_updates() {
+        const page = createTemporaryObject(requestPaymentComponent, this)
+        verify(page !== null)
+        page.wallet = testWalletModel
+        page.request = testPaymentRequest
+
+        const amountInput = findChild(page, "requestPaymentAmountInput")
+        verify(amountInput !== null)
+
+        amountInput.text = ""
+        amountInput.forceActiveFocus()
+        verify(amountInput.activeFocus)
+        keyClick("1")
+
+        compare(amountInput.text, "1")
+        compare(testPaymentRequest.amount.display, "1.00000000")
+    }
+
+    function test_amountInput_allows_editing_whole_part_before_decimal() {
+        const page = createTemporaryObject(requestPaymentComponent, this)
+        verify(page !== null)
+        page.wallet = testWalletModel
+        page.request = testPaymentRequest
+
+        const amountInput = findChild(page, "requestPaymentAmountInput")
+        verify(amountInput !== null)
+
+        amountInput.text = "0.00000000"
+        amountInput.cursorPosition = 1
+        amountInput.forceActiveFocus()
+        verify(amountInput.activeFocus)
+        keyClick("1")
+
+        compare(amountInput.text, "01.00000000")
+        compare(testPaymentRequest.amount.display, "1.00000000")
+
+        amountInput.focus = false
+        wait(0)
+        compare(amountInput.activeFocus, false)
+        compare(amountInput.text, "1.00000000")
+    }
+
+    function test_amountInput_rejects_extra_decimal_digits_while_editing() {
+        const page = createTemporaryObject(requestPaymentComponent, this)
+        verify(page !== null)
+        page.wallet = testWalletModel
+        page.request = testPaymentRequest
+
+        const amountInput = findChild(page, "requestPaymentAmountInput")
+        verify(amountInput !== null)
+
+        testPaymentRequest.amount.display = "0.12345678"
+        tryCompare(amountInput, "text", "0.12345678")
+        amountInput.cursorPosition = amountInput.text.length
+        amountInput.forceActiveFocus()
+        verify(amountInput.activeFocus)
+        keyClick("9")
+
+        compare(amountInput.text, "0.12345678")
+        compare(testPaymentRequest.amount.display, "0.12345678")
+
+        amountInput.focus = false
+        wait(0)
+        compare(amountInput.activeFocus, false)
+        compare(amountInput.text, "0.12345678")
+    }
+
+    function test_amountInput_rejects_extra_decimal_points_while_editing() {
+        const page = createTemporaryObject(requestPaymentComponent, this)
+        verify(page !== null)
+        page.wallet = testWalletModel
+        page.request = testPaymentRequest
+
+        const amountInput = findChild(page, "requestPaymentAmountInput")
+        verify(amountInput !== null)
+
+        testPaymentRequest.amount.display = "1.20000000"
+        amountInput.text = "1.2"
+        amountInput.cursorPosition = amountInput.text.length
+        amountInput.forceActiveFocus()
+        verify(amountInput.activeFocus)
+        keyClick(".")
+
+        compare(amountInput.text, "1.2")
+        compare(testPaymentRequest.amount.display, "1.20000000")
     }
 
     function test_addressTypeSelection_passes_selected_type_to_generation() {

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -150,10 +150,78 @@ TestCase {
         const amountInput = findChild(page, "sendAmountInput")
         verify(amountInput !== null)
 
+        amountInput.text = ""
+        amountInput.forceActiveFocus()
+        verify(amountInput.activeFocus)
         const callsBefore = testWalletModel.scheduleFeeEstimatesCalls
-        amountInput.text = "0.01000000"
+        keyClick("1")
 
         tryCompare(testWalletModel, "scheduleFeeEstimatesCalls", callsBefore + 1)
+        compare(amountInput.text, "1")
+        compare(testSendRecipient.amount.display, "1.00000000")
+    }
+
+    function test_send_amount_allows_editing_whole_part_before_decimal() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const amountInput = findChild(page, "sendAmountInput")
+        verify(amountInput !== null)
+
+        amountInput.text = "0.00000000"
+        amountInput.cursorPosition = 1
+        amountInput.forceActiveFocus()
+        verify(amountInput.activeFocus)
+        keyClick("1")
+
+        compare(amountInput.text, "01.00000000")
+        compare(testSendRecipient.amount.display, "1.00000000")
+
+        amountInput.focus = false
+        wait(0)
+        compare(amountInput.activeFocus, false)
+        compare(amountInput.text, "1.00000000")
+    }
+
+    function test_send_amount_rejects_extra_decimal_digits_while_editing() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const amountInput = findChild(page, "sendAmountInput")
+        verify(amountInput !== null)
+
+        testSendRecipient.amount.display = "0.12345678"
+        tryCompare(amountInput, "text", "0.12345678")
+        amountInput.cursorPosition = amountInput.text.length
+        amountInput.forceActiveFocus()
+        verify(amountInput.activeFocus)
+        keyClick("9")
+
+        compare(amountInput.text, "0.12345678")
+        compare(testSendRecipient.amount.display, "0.12345678")
+
+        amountInput.focus = false
+        wait(0)
+        compare(amountInput.activeFocus, false)
+        compare(amountInput.text, "0.12345678")
+    }
+
+    function test_send_amount_rejects_extra_decimal_points_while_editing() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const amountInput = findChild(page, "sendAmountInput")
+        verify(amountInput !== null)
+
+        testSendRecipient.amount.display = "1.20000000"
+        amountInput.text = "1.2"
+        amountInput.cursorPosition = amountInput.text.length
+        amountInput.forceActiveFocus()
+        verify(amountInput.activeFocus)
+        keyClick(".")
+
+        compare(amountInput.text, "1.2")
+        compare(testSendRecipient.amount.display, "1.20000000")
     }
 
     function test_send_shows_selected_estimated_fee() {

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -29,6 +29,8 @@ TestCase {
         testWalletModel.prepareTransactionResult = true
         testSendRecipient.subtractFeeFromAmount = false
         testSendRecipient.isValid = true
+        testRecipientsModel.allValid = true
+        testRecipientsModel.validationError = ""
     }
 
     function test_send_has_stable_selectors() {
@@ -57,11 +59,30 @@ TestCase {
         const continueButton = findChild(page, "sendReviewButton")
         verify(continueButton !== null)
 
-        testSendRecipient.isValid = false
+        testRecipientsModel.allValid = false
         tryCompare(continueButton, "enabled", false)
 
-        testSendRecipient.isValid = true
+        testRecipientsModel.allValid = true
         tryCompare(continueButton, "enabled", true)
+    }
+
+    function test_send_shows_recipient_validation_error() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const continueButton = findChild(page, "sendReviewButton")
+        const prepareError = findChild(page, "sendPrepareTransactionError")
+        const prepareErrorText = findChild(page, "sendPrepareTransactionErrorText")
+        verify(continueButton !== null)
+        verify(prepareError !== null)
+        verify(prepareErrorText !== null)
+
+        testRecipientsModel.allValid = false
+        testRecipientsModel.validationError = "Complete every recipient before continuing."
+
+        tryCompare(continueButton, "enabled", false)
+        tryCompare(page, "recipientValidationError", "Complete every recipient before continuing.")
+        tryCompare(prepareErrorText, "text", "Complete every recipient before continuing.")
     }
 
     function test_send_prepare_transaction_success_and_failure_paths() {

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -27,6 +27,7 @@ TestCase {
         testWalletModel.customFeeRate = ""
         testWalletModel.targetBlocks = 2
         testWalletModel.prepareTransactionResult = true
+        testWalletModel.sendAmountExhaustsBalance = false
         testSendRecipient.subtractFeeFromAmount = false
         testSendRecipient.isValid = true
         testRecipientsModel.allValid = true
@@ -64,6 +65,30 @@ TestCase {
 
         testRecipientsModel.allValid = true
         tryCompare(continueButton, "enabled", true)
+    }
+
+    function test_send_continue_button_requires_fee_buffer() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const continueButton = findChild(page, "sendReviewButton")
+        const prepareError = findChild(page, "sendPrepareTransactionError")
+        const prepareErrorText = findChild(page, "sendPrepareTransactionErrorText")
+        verify(continueButton !== null)
+        verify(prepareError !== null)
+        verify(prepareErrorText !== null)
+
+        testWalletModel.sendAmountExhaustsBalance = true
+
+        tryCompare(continueButton, "enabled", false)
+        tryCompare(page, "formErrorText", "Amount plus fee exceeds available balance")
+        compare(prepareErrorText.text, "Amount plus fee exceeds available balance")
+
+        testWalletModel.sendAmountExhaustsBalance = false
+
+        tryCompare(continueButton, "enabled", true)
+        tryCompare(page, "formErrorText", "")
+        compare(prepareErrorText.text, "")
     }
 
     function test_send_shows_recipient_validation_error() {

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -28,6 +28,9 @@ TestCase {
         testWalletModel.targetBlocks = 2
         testWalletModel.prepareTransactionResult = true
         testWalletModel.sendAmountExhaustsBalance = false
+        testSendRecipient.address.setAddress("bcrt1qsendtoaddress")
+        testSendRecipient.amount.display = "0.00000000"
+        testSendRecipient.label = ""
         testSendRecipient.subtractFeeFromAmount = false
         testSendRecipient.isValid = true
         testRecipientsModel.allValid = true
@@ -366,5 +369,29 @@ TestCase {
         compare(testSendRecipient.subtractFeeFromAmount, true)
         tryCompare(testWalletModel, "scheduleFeeEstimatesCalls", callsBefore + 1)
         compare(popup.visible, false)
+    }
+
+    function test_send_uri_import_schedules_fee_estimate() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const sendPage = findChild(page, "walletSendPage")
+        verify(sendPage !== null)
+
+        const callsBefore = testWalletModel.scheduleFeeEstimatesCalls
+        sendPage.applyPaymentRequestFromText(
+            "bitcoin:bcrt1qdavt4j2sd7dlhqsavtnfxvzppw6k7qy97tmnu9?amount=0.02000000&label=uri-label",
+            "clipboard"
+        )
+
+        // The mocked amount input still emits one schedule request when the
+        // imported amount updates the bound field. The explicit URI-import
+        // refresh added in Send.qml should contribute one more call.
+        tryCompare(testWalletModel, "scheduleFeeEstimatesCalls", callsBefore + 2)
+        compare(testSendRecipient.address.address, "bcrt1qdavt4j2sd7dlhqsavtnfxvzppw6k7qy97tmnu9")
+        compare(testSendRecipient.amount.display, "0.02000000")
+        compare(testSendRecipient.label, "uri-label")
+        compare(sendPage.paymentRequestStatus, "Payment request imported from clipboard.")
+        compare(sendPage.paymentRequestIsError, false)
     }
 }

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -32,6 +32,7 @@ TestCase {
         testSendRecipient.isValid = true
         testRecipientsModel.allValid = true
         testRecipientsModel.validationError = ""
+        testCoinsListModel.reset()
     }
 
     function test_send_has_stable_selectors() {
@@ -89,6 +90,13 @@ TestCase {
         tryCompare(continueButton, "enabled", true)
         tryCompare(page, "formErrorText", "")
         compare(prepareErrorText.text, "")
+
+        testCoinsListModel.toggleCoinSelection(0)
+        testWalletModel.sendAmountExhaustsBalance = true
+
+        tryCompare(continueButton, "enabled", false)
+        tryCompare(page, "formErrorText", "Selected inputs do not cover the amount plus fee")
+        compare(prepareErrorText.text, "Selected inputs do not cover the amount plus fee")
     }
 
     function test_send_shows_recipient_validation_error() {
@@ -137,9 +145,17 @@ TestCase {
         compare(page.prepareTransactionErrorText, "Amount plus fee exceeds available balance")
         compare(prepareErrorText.text, "Amount plus fee exceeds available balance")
 
-        testWalletModel.prepareTransactionResult = true
+        page.prepareTransactionErrorText = ""
+        testCoinsListModel.toggleCoinSelection(0)
         continueButton.clicked()
         compare(testWalletModel.prepareTransactionCalls, callsBefore + 2)
+        compare(transactionPreparedSpy.count, 0)
+        compare(page.prepareTransactionErrorText, "Selected inputs do not cover the amount plus fee")
+        compare(prepareErrorText.text, "Selected inputs do not cover the amount plus fee")
+
+        testWalletModel.prepareTransactionResult = true
+        continueButton.clicked()
+        compare(testWalletModel.prepareTransactionCalls, callsBefore + 3)
         compare(transactionPreparedSpy.count, 1)
         compare(transactionPreparedSpy.signalArguments[0][0], false)
         compare(page.prepareTransactionErrorText, "")

--- a/test/qml/tst_walletpasswordsettings.qml
+++ b/test/qml/tst_walletpasswordsettings.qml
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Window 2.15
+import QtTest 1.2
+import "../../qml/pages/wallet"
+
+TestCase {
+    name: "WalletPasswordSettings"
+    when: windowShown
+    width: 520
+    height: 720
+
+    Window {
+        id: testWindow
+        visible: true
+        width: 520
+        height: 720
+
+        Item {
+            id: testRoot
+            anchors.fill: parent
+            focus: true
+
+            Loader {
+                id: pageLoader
+                anchors.fill: parent
+            }
+        }
+    }
+
+    Component {
+        id: setPasswordComponent
+
+        WalletPasswordSettings {
+            updating: false
+            width: 460
+            height: 680
+        }
+    }
+
+    Component {
+        id: updatePasswordComponent
+
+        WalletPasswordSettings {
+            updating: true
+            width: 460
+            height: 680
+        }
+    }
+
+    function createWalletPasswordSettingsPage(component) {
+        pageLoader.sourceComponent = component
+        const page = pageLoader.item
+        verify(page !== null)
+        testWindow.requestActivate()
+        tryCompare(testWindow, "active", true)
+        testRoot.forceActiveFocus()
+        page.focusInitialPasswordField()
+        wait(0)
+        return page
+    }
+
+    function typeText(text) {
+        for (let i = 0; i < text.length; ++i) {
+            keyClick(text.charAt(i))
+        }
+    }
+
+    function test_set_password_focuses_new_password_field() {
+        const page = createWalletPasswordSettingsPage(setPasswordComponent)
+        const currentPassword = findChild(page, "walletPasswordCurrentField")
+        const newPassword = findChild(page, "walletPasswordNewField")
+        verify(currentPassword !== null)
+        verify(newPassword !== null)
+
+        compare(page.updating, false)
+        compare(currentPassword.focus, false)
+        compare(newPassword.focus, true)
+
+        typeText("newsecret")
+        compare(currentPassword.text, "")
+        compare(newPassword.text, "newsecret")
+    }
+
+    function test_update_password_focuses_current_password_field() {
+        const page = createWalletPasswordSettingsPage(updatePasswordComponent)
+        const currentPassword = findChild(page, "walletPasswordCurrentField")
+        const newPassword = findChild(page, "walletPasswordNewField")
+        verify(currentPassword !== null)
+        verify(newPassword !== null)
+
+        compare(page.updating, true)
+        compare(currentPassword.focus, true)
+        compare(newPassword.focus, false)
+
+        typeText("currentsecret")
+        compare(currentPassword.text, "currentsecret")
+        compare(newPassword.text, "")
+    }
+}

--- a/test/test_bitcoinuri.cpp
+++ b/test/test_bitcoinuri.cpp
@@ -110,7 +110,7 @@ void BitcoinUriTests::parse_rejects_invalid_amount()
 
     const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
     QVERIFY(!result.success);
-    QVERIFY(result.error.contains(QStringLiteral("Invalid bitcoin amount")));
+    QVERIFY(result.error.contains(QStringLiteral("Invalid Bitcoin amount")));
 }
 
 void BitcoinUriTests::parse_rejects_unknown_required_parameter()
@@ -183,7 +183,7 @@ void BitcoinUriTests::parse_rejects_comma_in_amount()
     const QString uri = QStringLiteral("bitcoin:%1?amount=1,000").arg(TEST_ADDRESS);
     const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
     QVERIFY(!result.success);
-    QVERIFY(result.error.contains(QStringLiteral("Invalid bitcoin amount")));
+    QVERIFY(result.error.contains(QStringLiteral("Invalid Bitcoin amount")));
 }
 
 void BitcoinUriTests::parse_duplicate_amount_last_wins()
@@ -204,7 +204,7 @@ void BitcoinUriTests::parse_rejects_invalid_duplicate_amount()
     const QString uri = QStringLiteral("bitcoin:%1?amount=1&amount=bad").arg(TEST_ADDRESS);
     const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
     QVERIFY(!result.success);
-    QVERIFY(result.error.contains(QStringLiteral("Invalid bitcoin amount")));
+    QVERIFY(result.error.contains(QStringLiteral("Invalid Bitcoin amount")));
 }
 
 // ---------------------------------------------------------------------------

--- a/test/test_bitcoinuri.cpp
+++ b/test/test_bitcoinuri.cpp
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <chainparams.h>
+#include <qml/models/bitcoinuri.h>
+#include <util/chaintype.h>
+
+// A known valid mainnet P2WPKH bech32 address used across most tests.
+static const QString TEST_ADDRESS = QStringLiteral("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+// A known valid mainnet P2PKH (legacy) address (from bitcoin/src/test/util_tests.cpp).
+static const QString P2PKH_ADDRESS = QStringLiteral("1KqbBpLy5FARmTPD4VZnDDpYjkUvkr82Pm");
+
+class BitcoinUriTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase();
+
+    void parse_valid_uri_with_amount_label_and_message();
+    void parse_valid_uri_address_only();
+    void parse_rejects_empty_input();
+    void parse_rejects_bitcoin_double_slash_scheme();
+    void parse_rejects_invalid_scheme();
+    void parse_rejects_invalid_amount();
+    void parse_rejects_unknown_required_parameter();
+    void parse_rejects_invalid_address();
+    void parse_ignores_unknown_optional_parameter();
+    void parse_valid_uri_with_zero_amount();
+    void parse_valid_uri_uppercase_scheme();
+    void parse_valid_uri_with_empty_amount_param();
+    void parse_valid_uri_legacy_p2pkh_address();
+
+    // Duplicate / invalid amount edge cases
+    void parse_rejects_comma_in_amount();
+    void parse_duplicate_amount_last_wins();
+    void parse_rejects_invalid_duplicate_amount();
+
+    // req- prefix on known parameters must succeed
+    void parse_known_required_label();
+    void parse_known_required_message();
+    void parse_known_required_amount();
+
+    // Percent-decoding behaviour (QUrl::FullyDecoded — more correct than Bitcoin Core Qt)
+    void parse_decodes_percent_encoded_label();
+};
+
+void BitcoinUriTests::initTestCase()
+{
+    SelectParams(ChainType::MAIN);
+}
+
+void BitcoinUriTests::parse_valid_uri_with_amount_label_and_message()
+{
+    const QString uri = QStringLiteral("bitcoin:%1?amount=0.12345678&label=Invoice%2019&message=Rent")
+        .arg(TEST_ADDRESS);
+
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QCOMPARE(result.address, TEST_ADDRESS);
+    QCOMPARE(result.amount_sats, CAmount{12345678});
+    QVERIFY(result.has_amount);
+    QVERIFY(result.has_label);
+    QCOMPARE(result.label, QStringLiteral("Invoice 19"));
+    QVERIFY(result.has_message);
+    QCOMPARE(result.message, QStringLiteral("Rent"));
+}
+
+void BitcoinUriTests::parse_valid_uri_address_only()
+{
+    const QString uri = QStringLiteral("bitcoin:%1").arg(TEST_ADDRESS);
+
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QCOMPARE(result.address, TEST_ADDRESS);
+    QVERIFY(!result.has_amount);
+    QVERIFY(!result.has_label);
+    QVERIFY(!result.has_message);
+}
+
+void BitcoinUriTests::parse_rejects_empty_input()
+{
+    const BitcoinUriParseResult result = BitcoinUri::Parse(QString());
+    QVERIFY(!result.success);
+    QVERIFY(!result.error.isEmpty());
+}
+
+void BitcoinUriTests::parse_rejects_bitcoin_double_slash_scheme()
+{
+    const QString uri = QStringLiteral("bitcoin://%1?amount=0.1").arg(TEST_ADDRESS);
+
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(!result.success);
+    QVERIFY(result.error.contains(QStringLiteral("bitcoin://")));
+}
+
+void BitcoinUriTests::parse_rejects_invalid_scheme()
+{
+    const BitcoinUriParseResult result = BitcoinUri::Parse(QStringLiteral("notbitcoin:addr?amount=0.1"));
+    QVERIFY(!result.success);
+}
+
+void BitcoinUriTests::parse_rejects_invalid_amount()
+{
+    // More than 8 decimal places is not a valid satoshi amount.
+    const QString uri = QStringLiteral("bitcoin:%1?amount=0.123456789").arg(TEST_ADDRESS);
+
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(!result.success);
+    QVERIFY(result.error.contains(QStringLiteral("Invalid bitcoin amount")));
+}
+
+void BitcoinUriTests::parse_rejects_unknown_required_parameter()
+{
+    const QString uri = QStringLiteral("bitcoin:%1?req-foo=1").arg(TEST_ADDRESS);
+
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(!result.success);
+    QVERIFY(result.error.contains(QStringLiteral("Unsupported required parameter")));
+}
+
+void BitcoinUriTests::parse_rejects_invalid_address()
+{
+    const BitcoinUriParseResult result = BitcoinUri::Parse(
+        QStringLiteral("bitcoin:not-a-valid-address?amount=0.1"));
+    QVERIFY(!result.success);
+}
+
+void BitcoinUriTests::parse_ignores_unknown_optional_parameter()
+{
+    const QString uri = QStringLiteral("bitcoin:%1?unknown=value").arg(TEST_ADDRESS);
+
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QCOMPARE(result.address, TEST_ADDRESS);
+}
+
+void BitcoinUriTests::parse_valid_uri_with_zero_amount()
+{
+    const QString uri = QStringLiteral("bitcoin:%1?amount=0").arg(TEST_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QVERIFY(result.has_amount);
+    QCOMPARE(result.amount_sats, CAmount{0});
+}
+
+void BitcoinUriTests::parse_valid_uri_uppercase_scheme()
+{
+    // BIP21 scheme matching must be case-insensitive.
+    const QString uri = QStringLiteral("BITCOIN:%1?amount=0.001").arg(TEST_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QCOMPARE(result.address, TEST_ADDRESS);
+}
+
+void BitcoinUriTests::parse_valid_uri_with_empty_amount_param()
+{
+    // An empty amount value must be treated as absent, not an error.
+    const QString uri = QStringLiteral("bitcoin:%1?amount=").arg(TEST_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QVERIFY(!result.has_amount);
+}
+
+void BitcoinUriTests::parse_valid_uri_legacy_p2pkh_address()
+{
+    const QString uri = QStringLiteral("bitcoin:%1").arg(P2PKH_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QCOMPARE(result.address, P2PKH_ADDRESS);
+}
+
+// ---------------------------------------------------------------------------
+// Duplicate / invalid amount edge cases
+// ---------------------------------------------------------------------------
+
+void BitcoinUriTests::parse_rejects_comma_in_amount()
+{
+    // ParseMoney only accepts digits and '.'; a comma must be rejected.
+    const QString uri = QStringLiteral("bitcoin:%1?amount=1,000").arg(TEST_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(!result.success);
+    QVERIFY(result.error.contains(QStringLiteral("Invalid bitcoin amount")));
+}
+
+void BitcoinUriTests::parse_duplicate_amount_last_wins()
+{
+    // When amount appears twice, the last valid value must win — matching
+    // the behaviour documented in Bitcoin Core's src/qt/test/uritests.cpp.
+    const QString uri = QStringLiteral("bitcoin:%1?amount=1&amount=2").arg(TEST_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QVERIFY(result.has_amount);
+    QCOMPARE(result.amount_sats, CAmount{200000000}); // 2 BTC
+}
+
+void BitcoinUriTests::parse_rejects_invalid_duplicate_amount()
+{
+    // A valid first amount followed by an invalid second amount must fail.
+    // Bitcoin Core documents the same behaviour.
+    const QString uri = QStringLiteral("bitcoin:%1?amount=1&amount=bad").arg(TEST_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(!result.success);
+    QVERIFY(result.error.contains(QStringLiteral("Invalid bitcoin amount")));
+}
+
+// ---------------------------------------------------------------------------
+// req- prefix on known parameters must succeed (BIP21 §req-* semantics)
+// ---------------------------------------------------------------------------
+
+void BitcoinUriTests::parse_known_required_label()
+{
+    const QString uri = QStringLiteral("bitcoin:%1?req-label=Merchant").arg(TEST_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QVERIFY(result.has_label);
+    QCOMPARE(result.label, QStringLiteral("Merchant"));
+}
+
+void BitcoinUriTests::parse_known_required_message()
+{
+    const QString uri = QStringLiteral("bitcoin:%1?req-message=Donation").arg(TEST_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QVERIFY(result.has_message);
+    QCOMPARE(result.message, QStringLiteral("Donation"));
+}
+
+void BitcoinUriTests::parse_known_required_amount()
+{
+    const QString uri = QStringLiteral("bitcoin:%1?req-amount=0.5").arg(TEST_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QVERIFY(result.has_amount);
+    QCOMPARE(result.amount_sats, CAmount{50000000}); // 0.5 BTC
+}
+
+// ---------------------------------------------------------------------------
+// Percent-decoding behaviour
+// ---------------------------------------------------------------------------
+
+void BitcoinUriTests::parse_decodes_percent_encoded_label()
+{
+    // gui-qml uses QUrl::FullyDecoded, so percent-encoded sequences in label
+    // and message are decoded before use. This is more correct per BIP21 /
+    // RFC 3986 than Bitcoin Core Qt, which leaves them encoded (documented
+    // there with the comment "Escape sequences are not supported").
+    const QString uri = QStringLiteral("bitcoin:%1?label=%3F%26test&message=hello%20world")
+        .arg(TEST_ADDRESS);
+    const BitcoinUriParseResult result = BitcoinUri::Parse(uri);
+    QVERIFY(result.success);
+    QCOMPARE(result.label,   QStringLiteral("?&test"));
+    QCOMPARE(result.message, QStringLiteral("hello world"));
+}
+
+#ifdef BITCOINQML_NO_TEST_MAIN
+#include <test/qt_test_registry.h>
+BITCOINQML_REGISTER_QT_TEST(BitcoinUriTests)
+#else
+QTEST_MAIN(BitcoinUriTests)
+#endif
+#include "test_bitcoinuri.moc"

--- a/test/test_nodemodel.cpp
+++ b/test/test_nodemodel.cpp
@@ -140,6 +140,9 @@ private Q_SLOTS:
     void banPeerRejectsInvalidInputs();
     void banPeerReturnsFalseWithoutDisconnectWhenBackendFails();
     void banPeerDisconnectsAddressAfterSuccessfulBan();
+    void requestShutdownEmitsOnlyOnce();
+    void initializationFailureRequestsShutdownWhenCoreWasInterrupted();
+    void initializationFailureWithoutCoreInterruptOnlySetsErrorState();
     void nodeNotificationHandlersUpdateModelThroughQueuedSignals();
     void blockTipUpdatesQueuedAcrossThreadsRetainPayloadValues();
     void blockSyncActiveFollowsInitializationAndBlockTipState();
@@ -344,6 +347,67 @@ void NodeModelTests::banPeerDisconnectsAddressAfterSuccessfulBan()
     EXPECT_CALL(node, disconnectByAddress(Truly(is_loopback))).Times(1).WillOnce(Return(true));
 
     QVERIFY(model.banPeer(QStringLiteral("127.0.0.1"), 3600));
+}
+
+void NodeModelTests::requestShutdownEmitsOnlyOnce()
+{
+    NiceMock<MockNode> node;
+    MempoolState mempool;
+    InstallDefaultHandlers(node);
+    InstallMempoolGetters(node, mempool);
+
+    NodeModel model{node};
+    WaitForInitialMempoolRefresh(mempool);
+
+    QSignalSpy shutdown_spy{&model, &NodeModel::requestedShutdown};
+    model.requestShutdown();
+    model.requestShutdown();
+
+    QCOMPARE(shutdown_spy.count(), 1);
+}
+
+void NodeModelTests::initializationFailureRequestsShutdownWhenCoreWasInterrupted()
+{
+    NiceMock<MockNode> node;
+    MempoolState mempool;
+    InstallDefaultHandlers(node);
+    InstallMempoolGetters(node, mempool);
+    ON_CALL(node, shutdownRequested()).WillByDefault(Return(true));
+
+    NodeModel model{node};
+    WaitForInitialMempoolRefresh(mempool);
+
+    QSignalSpy error_state_spy{&model, &NodeModel::errorStateChanged};
+    QSignalSpy shutdown_spy{&model, &NodeModel::requestedShutdown};
+    QSignalSpy initialized_spy{&model, &NodeModel::nodeInitialized};
+    model.initializeResult(false, {});
+
+    QCOMPARE(error_state_spy.count(), 1);
+    QVERIFY(model.errorState());
+    QCOMPARE(shutdown_spy.count(), 1);
+    QCOMPARE(initialized_spy.count(), 1);
+}
+
+void NodeModelTests::initializationFailureWithoutCoreInterruptOnlySetsErrorState()
+{
+    NiceMock<MockNode> node;
+    MempoolState mempool;
+    InstallDefaultHandlers(node);
+    InstallMempoolGetters(node, mempool);
+    ON_CALL(node, shutdownRequested()).WillByDefault(Return(false));
+
+    NodeModel model{node};
+    WaitForInitialMempoolRefresh(mempool);
+
+    QSignalSpy error_state_spy{&model, &NodeModel::errorStateChanged};
+    QSignalSpy shutdown_spy{&model, &NodeModel::requestedShutdown};
+    QSignalSpy initialized_spy{&model, &NodeModel::nodeInitialized};
+    model.initializeResult(false, {});
+
+    QCOMPARE(error_state_spy.count(), 1);
+    QVERIFY(model.errorState());
+    QCOMPARE(shutdown_spy.count(), 0);
+    QCOMPARE(initialized_spy.count(), 1);
 }
 
 void NodeModelTests::nodeNotificationHandlersUpdateModelThroughQueuedSignals()

--- a/test/test_nodemodel.cpp
+++ b/test/test_nodemodel.cpp
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <functional>
 #include <map>
+#include <memory>
 #include <thread>
 #include <vector>
 
@@ -143,6 +144,7 @@ private Q_SLOTS:
     void requestShutdownEmitsOnlyOnce();
     void initializationFailureRequestsShutdownWhenCoreWasInterrupted();
     void initializationFailureWithoutCoreInterruptOnlySetsErrorState();
+    void destructorUnsubscribesCoreSignalsBeforeStoppingPolling();
     void nodeNotificationHandlersUpdateModelThroughQueuedSignals();
     void blockTipUpdatesQueuedAcrossThreadsRetainPayloadValues();
     void blockSyncActiveFollowsInitializationAndBlockTipState();
@@ -408,6 +410,47 @@ void NodeModelTests::initializationFailureWithoutCoreInterruptOnlySetsErrorState
     QVERIFY(model.errorState());
     QCOMPARE(shutdown_spy.count(), 0);
     QCOMPARE(initialized_spy.count(), 1);
+}
+
+void NodeModelTests::destructorUnsubscribesCoreSignalsBeforeStoppingPolling()
+{
+    NiceMock<MockNode> node;
+    MempoolState mempool;
+    std::atomic<int> disconnected_handlers{0};
+
+    InstallMempoolGetters(node, mempool);
+    ON_CALL(node, handleNotifyBlockTip(testing::_))
+        .WillByDefault(Invoke([&](interfaces::Node::NotifyBlockTipFn) {
+            return interfaces::MakeCleanupHandler([&] { ++disconnected_handlers; });
+        }));
+    ON_CALL(node, handleNotifyNumConnectionsChanged(testing::_))
+        .WillByDefault(Invoke([&](interfaces::Node::NotifyNumConnectionsChangedFn) {
+            return interfaces::MakeCleanupHandler([&] { ++disconnected_handlers; });
+        }));
+    ON_CALL(node, handleBannedListChanged(testing::_))
+        .WillByDefault(Invoke([&](interfaces::Node::BannedListChangedFn) {
+            return interfaces::MakeCleanupHandler([&] { ++disconnected_handlers; });
+        }));
+
+    auto model{std::make_unique<NodeModel>(node)};
+    WaitForInitialMempoolRefresh(mempool);
+
+    const int refresh_calls = mempool.max_usage_calls.load();
+    model->setMempoolInfoPollingActive(true);
+    QTRY_VERIFY_WITH_TIMEOUT(mempool.max_usage_calls.load() > refresh_calls, ASYNC_TIMEOUT_MS);
+
+    bool checked_shutdown_order{false};
+    QObject::connect(model.get(), &NodeModel::mempoolInfoPollingActiveChanged, [&](bool active) {
+        if (!active) {
+            checked_shutdown_order = true;
+            QCOMPARE(disconnected_handlers.load(), 3);
+        }
+    });
+
+    model.reset();
+
+    QVERIFY(checked_shutdown_order);
+    QCOMPARE(disconnected_handlers.load(), 3);
 }
 
 void NodeModelTests::nodeNotificationHandlersUpdateModelThroughQueuedSignals()

--- a/test/test_nodemodel.cpp
+++ b/test/test_nodemodel.cpp
@@ -417,19 +417,42 @@ void NodeModelTests::destructorUnsubscribesCoreSignalsBeforeStoppingPolling()
     NiceMock<MockNode> node;
     MempoolState mempool;
     std::atomic<int> disconnected_handlers{0};
+    auto counted_handler = [&] {
+        return interfaces::MakeCleanupHandler([&] { ++disconnected_handlers; });
+    };
 
     InstallMempoolGetters(node, mempool);
     ON_CALL(node, handleNotifyBlockTip(testing::_))
         .WillByDefault(Invoke([&](interfaces::Node::NotifyBlockTipFn) {
-            return interfaces::MakeCleanupHandler([&] { ++disconnected_handlers; });
+            return counted_handler();
+        }));
+    ON_CALL(node, handleNotifyHeaderTip(testing::_))
+        .WillByDefault(Invoke([&](interfaces::Node::NotifyHeaderTipFn) {
+            return counted_handler();
         }));
     ON_CALL(node, handleNotifyNumConnectionsChanged(testing::_))
         .WillByDefault(Invoke([&](interfaces::Node::NotifyNumConnectionsChangedFn) {
-            return interfaces::MakeCleanupHandler([&] { ++disconnected_handlers; });
+            return counted_handler();
+        }));
+    ON_CALL(node, handleNotifyNetworkActiveChanged(testing::_))
+        .WillByDefault(Invoke([&](interfaces::Node::NotifyNetworkActiveChangedFn) {
+            return counted_handler();
+        }));
+    ON_CALL(node, handleNotifyAlertChanged(testing::_))
+        .WillByDefault(Invoke([&](interfaces::Node::NotifyAlertChangedFn) {
+            return counted_handler();
+        }));
+    ON_CALL(node, handleMessageBox(testing::_))
+        .WillByDefault(Invoke([&](interfaces::Node::MessageBoxFn) {
+            return counted_handler();
+        }));
+    ON_CALL(node, handleQuestion(testing::_))
+        .WillByDefault(Invoke([&](interfaces::Node::QuestionFn) {
+            return counted_handler();
         }));
     ON_CALL(node, handleBannedListChanged(testing::_))
         .WillByDefault(Invoke([&](interfaces::Node::BannedListChangedFn) {
-            return interfaces::MakeCleanupHandler([&] { ++disconnected_handlers; });
+            return counted_handler();
         }));
 
     auto model{std::make_unique<NodeModel>(node)};
@@ -443,14 +466,14 @@ void NodeModelTests::destructorUnsubscribesCoreSignalsBeforeStoppingPolling()
     QObject::connect(model.get(), &NodeModel::mempoolInfoPollingActiveChanged, [&](bool active) {
         if (!active) {
             checked_shutdown_order = true;
-            QCOMPARE(disconnected_handlers.load(), 3);
+            QCOMPARE(disconnected_handlers.load(), 8);
         }
     });
 
     model.reset();
 
     QVERIFY(checked_shutdown_order);
-    QCOMPARE(disconnected_handlers.load(), 3);
+    QCOMPARE(disconnected_handlers.load(), 8);
 }
 
 void NodeModelTests::nodeNotificationHandlersUpdateModelThroughQueuedSignals()

--- a/test/test_receiverequesthistorymodel.cpp
+++ b/test/test_receiverequesthistorymodel.cpp
@@ -35,6 +35,40 @@ QmlRecentRequestEntry MakeEntry(int64_t id, const std::string& address, CAmount 
     entry.recipient.noteSelf = note_self;
     return entry;
 }
+
+struct QtWidgetsSendCoinsRecipient
+{
+    static constexpr int CURRENT_VERSION{1};
+    int nVersion{CURRENT_VERSION};
+    std::string address;
+    std::string label;
+    CAmount amount{0};
+    std::string message;
+    std::string sPaymentRequest;
+    std::string authenticatedMerchant;
+
+    SERIALIZE_METHODS(QtWidgetsSendCoinsRecipient, obj)
+    {
+        READWRITE(obj.nVersion, obj.address, obj.label, obj.amount, obj.message, obj.sPaymentRequest, obj.authenticatedMerchant);
+    }
+};
+
+struct QtWidgetsRecentRequestEntry
+{
+    static constexpr int CURRENT_VERSION{1};
+    int nVersion{CURRENT_VERSION};
+    int64_t id{0};
+    QDateTime date;
+    QtWidgetsSendCoinsRecipient recipient;
+
+    SERIALIZE_METHODS(QtWidgetsRecentRequestEntry, obj)
+    {
+        unsigned int date_timet;
+        SER_WRITE(obj, date_timet = static_cast<unsigned int>(obj.date.toSecsSinceEpoch()));
+        READWRITE(obj.nVersion, obj.id, date_timet, obj.recipient);
+        SER_READ(obj, obj.date = QDateTime::fromSecsSinceEpoch(date_timet));
+    }
+};
 } // namespace
 
 class ReceiveRequestHistoryModelTests : public QObject
@@ -48,7 +82,9 @@ private Q_SLOTS:
     void buildUriWithAmountLabelMessage();
     void buildUriPreservesBech32Case();
     void buildUriUrlEncodesParams();
-    void serializeRoundTripV2();
+    void serializeRoundTripWithQmlExtension();
+    void serializeBaseEntryMatchesQtWidgetsFormat();
+    void serializeQmlExtensionDoesNotBreakQtWidgetsFormat();
     void deserializeSkipsMalformed();
     void modelRolesMatchEntry();
     void prependInsertsNewRow();
@@ -58,7 +94,7 @@ private Q_SLOTS:
     void maxIdReturnsHighest();
     void deserializeTruncatedBlob();
     void formatAmountBtcEdgeCases();
-    void deserializeV1RecipientBlob();
+    void deserializeQtWidgetsRecipientBlob();
 };
 
 void ReceiveRequestHistoryModelTests::initTestCase()
@@ -101,7 +137,7 @@ void ReceiveRequestHistoryModelTests::buildUriUrlEncodesParams()
     QVERIFY(uri.contains("message=hi%3Dhello%3Fx"));
 }
 
-void ReceiveRequestHistoryModelTests::serializeRoundTripV2()
+void ReceiveRequestHistoryModelTests::serializeRoundTripWithQmlExtension()
 {
     const auto entry_in = MakeEntry(7, "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2", 50000, "Alice", "lunch", "personal note");
     const std::string blob = ReceiveRequestHistoryModel::SerializeEntry(entry_in);
@@ -115,6 +151,55 @@ void ReceiveRequestHistoryModelTests::serializeRoundTripV2()
     QCOMPARE(out.recipient.message, std::string{"lunch"});
     QCOMPARE(out.recipient.noteSelf, std::string{"personal note"});
     QCOMPARE(out.date.toSecsSinceEpoch(), entry_in.date.toSecsSinceEpoch());
+}
+
+void ReceiveRequestHistoryModelTests::serializeBaseEntryMatchesQtWidgetsFormat()
+{
+    const auto entry_in = MakeEntry(8, "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2", 75000, "Alice", "lunch");
+    const std::string blob = ReceiveRequestHistoryModel::SerializeEntry(entry_in);
+
+    // The base record is the shared Qt Widgets contract and must not contain
+    // QML-only fields.
+    std::vector<uint8_t> data(blob.begin(), blob.end());
+    DataStream ss{data};
+    QtWidgetsRecentRequestEntry out;
+    ss >> out;
+
+    QVERIFY(ss.empty());
+    QCOMPARE(out.nVersion, QtWidgetsRecentRequestEntry::CURRENT_VERSION);
+    QCOMPARE(out.id, int64_t{8});
+    QCOMPARE(out.date.toSecsSinceEpoch(), entry_in.date.toSecsSinceEpoch());
+    QCOMPARE(out.recipient.nVersion, QtWidgetsSendCoinsRecipient::CURRENT_VERSION);
+    QCOMPARE(out.recipient.address, std::string{"1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2"});
+    QCOMPARE(out.recipient.amount, CAmount{75000});
+    QCOMPARE(out.recipient.label, std::string{"Alice"});
+    QCOMPARE(out.recipient.message, std::string{"lunch"});
+}
+
+void ReceiveRequestHistoryModelTests::serializeQmlExtensionDoesNotBreakQtWidgetsFormat()
+{
+    const auto entry_in = MakeEntry(9, "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2", 80000, "Alice", "lunch", "personal note");
+    const std::string blob = ReceiveRequestHistoryModel::SerializeEntry(entry_in);
+
+    // noteSelf is a QML-owned extension after the Qt Widgets prefix. Qt Widgets
+    // readers should be able to deserialize the prefix without consuming it.
+    std::vector<uint8_t> data(blob.begin(), blob.end());
+    DataStream ss{data};
+    QtWidgetsRecentRequestEntry out;
+    ss >> out;
+
+    QCOMPARE(out.id, int64_t{9});
+    QCOMPARE(out.date.toSecsSinceEpoch(), entry_in.date.toSecsSinceEpoch());
+    QCOMPARE(out.recipient.address, std::string{"1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2"});
+    QCOMPARE(out.recipient.amount, CAmount{80000});
+    QCOMPARE(out.recipient.label, std::string{"Alice"});
+    QCOMPARE(out.recipient.message, std::string{"lunch"});
+    QVERIFY(!ss.empty());
+
+    std::string note_self;
+    ss >> note_self;
+    QCOMPARE(note_self, std::string{"personal note"});
+    QVERIFY(ss.empty());
 }
 
 void ReceiveRequestHistoryModelTests::deserializeSkipsMalformed()
@@ -240,12 +325,11 @@ void ReceiveRequestHistoryModelTests::formatAmountBtcEdgeCases()
     QCOMPARE(ReceiveRequestHistoryModel::FormatAmountBtc(100000000), QStringLiteral("1.00000000"));
 }
 
-void ReceiveRequestHistoryModelTests::deserializeV1RecipientBlob()
+void ReceiveRequestHistoryModelTests::deserializeQtWidgetsRecipientBlob()
 {
-    QmlRecentRequestEntry entry;
+    QtWidgetsRecentRequestEntry entry;
     entry.id = 5;
     entry.date = QDateTime::fromSecsSinceEpoch(1'700'000'005);
-    entry.recipient.nVersion = 1;
     entry.recipient.address = "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2";
     entry.recipient.amount = 25000;
     entry.recipient.label = "v1label";

--- a/test/test_walletqmlcontroller.cpp
+++ b/test/test_walletqmlcontroller.cpp
@@ -17,7 +17,10 @@
 
 #include <gmock/gmock.h>
 
+#include <QDir>
+#include <QFileInfo>
 #include <QSemaphore>
+#include <QTemporaryDir>
 
 #ifndef BITCOINQML_NO_TEST_MAIN
 const TranslateFn G_TRANSLATION_FUN{nullptr};
@@ -61,6 +64,7 @@ public:
     int get_wallets_calls{0};
     int list_wallet_dir_calls{0};
     int load_wallet_calls{0};
+    std::string wallet_dir;
 
     std::function<util::Result<std::unique_ptr<interfaces::Wallet>>(const std::string&, const SecureString&, uint64_t, std::vector<bilingual_str>&)>
         create_wallet_fn = [](const std::string&, const SecureString&, uint64_t, std::vector<bilingual_str>&) {
@@ -104,7 +108,7 @@ public:
         ++load_wallet_calls;
         return load_wallet_fn(name, warnings);
     }
-    std::string getWalletDir() override { return {}; }
+    std::string getWalletDir() override { return wallet_dir; }
     util::Result<std::unique_ptr<interfaces::Wallet>> restoreWallet(const fs::path&, const std::string&, std::vector<bilingual_str>&) override
     {
         return util::Error{Untranslated("Unexpected restoreWallet call")};
@@ -319,6 +323,10 @@ private Q_SLOTS:
     void walletNameAvailabilityErrorRejectsEmptyAndWhitespace();
     void walletNameAvailabilityErrorRejectsExistingNameWithSurroundingWhitespace();
     void walletNameAvailabilityErrorReturnsEmptyForAvailableName();
+    void openSelectedWalletLocationOpensWalletDirectory();
+    void openSelectedWalletLocationReportsOpenFailure();
+    void openSelectedWalletLocationReportsMissingWalletPath();
+    void openSelectedWalletLocationReportsMissingSelectedWallet();
 };
 
 void WalletQmlControllerTests::initTestCase()
@@ -1275,6 +1283,112 @@ void WalletQmlControllerTests::walletNameAvailabilityErrorReturnsEmptyForAvailab
     controller.initialize();
 
     QCOMPARE(controller.walletNameAvailabilityError("brand_new_wallet"), QString{});
+}
+
+void WalletQmlControllerTests::openSelectedWalletLocationOpensWalletDirectory()
+{
+    using ::testing::StrictMock;
+
+    StrictMock<MockNode> node;
+    FakeWalletLoader loader;
+    QTemporaryDir wallet_dir;
+    QVERIFY(wallet_dir.isValid());
+    QVERIFY(QDir{wallet_dir.path()}.mkpath("created_wallet"));
+    loader.wallet_dir = wallet_dir.path().toStdString();
+    FakeWallet::State wallet_state;
+    loader.get_wallets_fn = [&]() {
+        std::vector<std::unique_ptr<interfaces::Wallet>> wallets;
+        wallets.emplace_back(std::make_unique<FakeWallet>("created_wallet", &wallet_state));
+        return wallets;
+    };
+    ExpectControllerInitialization(node, loader);
+
+    WalletQmlController controller(node);
+    controller.initialize();
+
+    QString opened_path;
+    controller.setOpenLocalPathFnForTesting([&](const QString& path) {
+        opened_path = path;
+        return true;
+    });
+
+    QVERIFY(controller.openSelectedWalletLocation());
+    QCOMPARE(opened_path, QFileInfo{wallet_dir.filePath("created_wallet")}.absoluteFilePath());
+    QVERIFY(controller.walletLocationOpenError().isEmpty());
+}
+
+void WalletQmlControllerTests::openSelectedWalletLocationReportsOpenFailure()
+{
+    using ::testing::StrictMock;
+
+    StrictMock<MockNode> node;
+    FakeWalletLoader loader;
+    QTemporaryDir wallet_dir;
+    QVERIFY(wallet_dir.isValid());
+    QVERIFY(QDir{wallet_dir.path()}.mkpath("created_wallet"));
+    loader.wallet_dir = wallet_dir.path().toStdString();
+    FakeWallet::State wallet_state;
+    loader.get_wallets_fn = [&]() {
+        std::vector<std::unique_ptr<interfaces::Wallet>> wallets;
+        wallets.emplace_back(std::make_unique<FakeWallet>("created_wallet", &wallet_state));
+        return wallets;
+    };
+    ExpectControllerInitialization(node, loader);
+
+    WalletQmlController controller(node);
+    controller.initialize();
+
+    QString opened_path;
+    controller.setOpenLocalPathFnForTesting([&](const QString& path) {
+        opened_path = path;
+        return false;
+    });
+
+    QVERIFY(!controller.openSelectedWalletLocation());
+    QCOMPARE(opened_path, QFileInfo{wallet_dir.filePath("created_wallet")}.absoluteFilePath());
+    QCOMPARE(controller.walletLocationOpenError(), QString{"Could not open wallet file location."});
+}
+
+void WalletQmlControllerTests::openSelectedWalletLocationReportsMissingWalletPath()
+{
+    using ::testing::StrictMock;
+
+    StrictMock<MockNode> node;
+    FakeWalletLoader loader;
+    QTemporaryDir wallet_dir;
+    QVERIFY(wallet_dir.isValid());
+    loader.wallet_dir = wallet_dir.path().toStdString();
+    FakeWallet::State wallet_state;
+    loader.get_wallets_fn = [&]() {
+        std::vector<std::unique_ptr<interfaces::Wallet>> wallets;
+        wallets.emplace_back(std::make_unique<FakeWallet>("missing_wallet", &wallet_state));
+        return wallets;
+    };
+    ExpectControllerInitialization(node, loader);
+
+    WalletQmlController controller(node);
+    controller.initialize();
+
+    bool opened{false};
+    controller.setOpenLocalPathFnForTesting([&](const QString&) {
+        opened = true;
+        return true;
+    });
+
+    QVERIFY(!controller.openSelectedWalletLocation());
+    QVERIFY(!opened);
+    QCOMPARE(controller.walletLocationOpenError(), QString{"Wallet file not found: %1"}.arg(QFileInfo{wallet_dir.filePath("missing_wallet")}.absoluteFilePath()));
+}
+
+void WalletQmlControllerTests::openSelectedWalletLocationReportsMissingSelectedWallet()
+{
+    using ::testing::StrictMock;
+
+    StrictMock<MockNode> node;
+    WalletQmlController controller(node);
+
+    QVERIFY(!controller.openSelectedWalletLocation());
+    QCOMPARE(controller.walletLocationOpenError(), QString{"No wallet file is available to view."});
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -4,6 +4,7 @@
 
 #include <QtTest/QtTest>
 
+#include <test/mocks/mocknode.h>
 #include <test/mocks/mockwallet.h>
 #include <qml/models/activitylistmodel.h>
 #include <qml/models/sendrecipient.h>
@@ -76,7 +77,7 @@ private:
     ChainType m_previous_chain_type;
 };
 
-std::unique_ptr<WalletQmlModel> MakeWalletModel(NiceMock<MockWallet>*& wallet_out)
+std::unique_ptr<WalletQmlModel> MakeWalletModel(NiceMock<MockWallet>*& wallet_out, interfaces::Node* node = nullptr)
 {
     auto wallet = std::make_unique<NiceMock<MockWallet>>();
     wallet_out = wallet.get();
@@ -93,7 +94,7 @@ std::unique_ptr<WalletQmlModel> MakeWalletModel(NiceMock<MockWallet>*& wallet_ou
         return DecodeDestination(VALID_MAINNET_ADDRESS.toStdString());
     }));
 
-    return std::make_unique<WalletQmlModel>(std::move(wallet));
+    return std::make_unique<WalletQmlModel>(std::move(wallet), node);
 }
 
 void SetValidRecipient(WalletQmlModel& model,
@@ -337,11 +338,11 @@ public:
     std::unique_ptr<interfaces::Handler> handleCanGetAddressesChanged(CanGetAddressesChangedFn) override { return MakeNoopHandler(); }
 };
 
-std::unique_ptr<WalletQmlModel> MakeWalletModel(FakePasswordWallet*& wallet_out)
+std::unique_ptr<WalletQmlModel> MakeWalletModel(FakePasswordWallet*& wallet_out, interfaces::Node* node = nullptr)
 {
     auto wallet = std::make_unique<FakePasswordWallet>();
     wallet_out = wallet.get();
-    return std::make_unique<WalletQmlModel>(std::move(wallet));
+    return std::make_unique<WalletQmlModel>(std::move(wallet), node);
 }
 
 void SetPasswordRecipient(WalletQmlModel& model, qint64 satoshis)
@@ -394,6 +395,7 @@ private Q_SLOTS:
     void prepareTransactionOnLockedWalletRequiresPassword();
     void prepareTransactionWithPrivateKeysDisabledDoesNotRequirePassword();
     void sendRecipientRejectsDustAmount();
+    void sendRecipientUsesNodeDustRelayFee();
     void prepareTransactionRejectsDuplicateRecipientsBeforeUnlock();
     void prepareTransactionWithPassphraseForwardsUtf8Bytes();
     void prepareTransactionWithPassphraseRelocksWhenRecipientsInvalid();
@@ -1347,6 +1349,23 @@ void WalletQmlModelTests::sendRecipientRejectsDustAmount()
 
     recipient->address()->setAddress(VALID_MAINNET_ADDRESS, 0);
     recipient->amount()->setSatoshi(1);
+
+    QVERIFY(!recipient->isValid());
+    QCOMPARE(recipient->amountError(), QStringLiteral("Amount is too small to send."));
+    QVERIFY(!model->sendRecipientList()->allValid());
+}
+
+void WalletQmlModelTests::sendRecipientUsesNodeDustRelayFee()
+{
+    FakePasswordWallet* wallet{nullptr};
+    NiceMock<MockNode> node;
+    EXPECT_CALL(node, getDustRelayFee()).Times(AtLeast(1)).WillRepeatedly(Return(CFeeRate{10'000}));
+    auto model = MakeWalletModel(wallet, &node);
+    auto* recipient = model->sendRecipientList()->currentRecipient();
+    QVERIFY(recipient != nullptr);
+
+    recipient->address()->setAddress(VALID_MAINNET_ADDRESS, 0);
+    recipient->amount()->setSatoshi(600);
 
     QVERIFY(!recipient->isValid());
     QCOMPARE(recipient->amountError(), QStringLiteral("Amount is too small to send."));

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -85,6 +85,7 @@ std::unique_ptr<WalletQmlModel> MakeWalletModel(NiceMock<MockWallet>*& wallet_ou
     ON_CALL(*wallet_out, getWalletTxs()).WillByDefault(Return(std::set<interfaces::WalletTx>{}));
     ON_CALL(*wallet_out, listCoins()).WillByDefault(Return(interfaces::Wallet::CoinsList{}));
     ON_CALL(*wallet_out, getBalance()).WillByDefault(Return(10 * COIN));
+    ON_CALL(*wallet_out, getAvailableBalance(testing::_)).WillByDefault(Return(10 * COIN));
     ON_CALL(*wallet_out, getRequiredFee(testing::_)).WillByDefault(Return(1000));
     ON_CALL(*wallet_out, getDefaultAddressType()).WillByDefault(Return(OutputType::BECH32));
     ON_CALL(*wallet_out, handleTransactionChanged(testing::_)).WillByDefault(Invoke([](interfaces::Wallet::TransactionChangedFn) {
@@ -381,6 +382,7 @@ private Q_SLOTS:
     void prepareTransaction_reassignsAmountWhenFeeIncluded();
     void walletQmlModelTransaction_reassignAmounts_excludesChangeOutput();
     void scheduleFeeEstimates_usesSelectedCoinsInCoinControl();
+    void prepareTransaction_disallowsOtherInputsWhenCoinsSelected();
     void scheduleFeeEstimates_debouncesRapidRestarts();
     void transactionChangedEmitsBalanceChanged();
     void setCurrentPaymentRequestAddressUsesAddressListLabel();
@@ -1064,6 +1066,7 @@ void WalletQmlModelTests::scheduleFeeEstimates_usesSelectedCoinsInCoinControl()
     std::atomic<int> create_transaction_calls{0};
     std::atomic<bool> saw_sign_true{false};
     std::atomic<bool> saw_missing_selection{false};
+    std::atomic<bool> saw_other_inputs_allowed{false};
     std::atomic<int> selected_count{-1};
     std::vector<unsigned int> selected_targets;
 
@@ -1075,6 +1078,7 @@ void WalletQmlModelTests::scheduleFeeEstimates_usesSelectedCoinsInCoinControl()
                                            CAmount& fee) -> util::Result<CTransactionRef> {
         if (sign) saw_sign_true = true;
         if (!coin_control.HasSelected() || !coin_control.IsSelected(selected_outpoint)) saw_missing_selection = true;
+        if (coin_control.m_allow_other_inputs) saw_other_inputs_allowed = true;
         const auto selected = coin_control.ListSelected();
         selected_count = static_cast<int>(selected.size());
         if (selected.size() != 1U || selected.front() != selected_outpoint) saw_missing_selection = true;
@@ -1091,11 +1095,53 @@ void WalletQmlModelTests::scheduleFeeEstimates_usesSelectedCoinsInCoinControl()
     QTRY_COMPARE_WITH_TIMEOUT(create_transaction_calls.load(), 3, FEE_ESTIMATE_TIMEOUT_MS);
     QVERIFY(!saw_sign_true.load());
     QVERIFY(!saw_missing_selection.load());
+    QVERIFY(!saw_other_inputs_allowed.load());
     QCOMPARE(selected_count.load(), 1);
     QCOMPARE(selected_targets.size(), 3U);
     QCOMPARE(selected_targets.at(0), 1U);
     QCOMPARE(selected_targets.at(1), 2U);
     QCOMPARE(selected_targets.at(2), 6U);
+}
+
+void WalletQmlModelTests::prepareTransaction_disallowsOtherInputsWhenCoinsSelected()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model);
+
+    const COutPoint selected_outpoint{Txid::FromUint256(uint256::ONE), 1};
+    std::optional<bool> available_balance_allow_other_inputs;
+    bool saw_selected_coin{false};
+    bool saw_other_inputs_allowed{true};
+    int create_transaction_calls{0};
+
+    EXPECT_CALL(*wallet, getAvailableBalance(testing::_))
+        .WillOnce(Invoke([&](const wallet::CCoinControl& coin_control) {
+            available_balance_allow_other_inputs = coin_control.m_allow_other_inputs;
+            return 10 * COIN;
+        }));
+
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        ++create_transaction_calls;
+        saw_selected_coin = coin_control.HasSelected() && coin_control.IsSelected(selected_outpoint);
+        saw_other_inputs_allowed = coin_control.m_allow_other_inputs;
+        change_pos = -1;
+        fee = 200;
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    model->selectCoin(selected_outpoint);
+
+    QVERIFY(model->prepareTransaction());
+    QCOMPARE(create_transaction_calls, 1);
+    QVERIFY(saw_selected_coin);
+    QVERIFY(available_balance_allow_other_inputs.has_value());
+    QVERIFY(!*available_balance_allow_other_inputs);
+    QVERIFY(!saw_other_inputs_allowed);
 }
 
 void WalletQmlModelTests::scheduleFeeEstimates_debouncesRapidRestarts()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -127,6 +127,9 @@ public:
     int unlock_calls{0};
     int lock_calls{0};
     int commit_calls{0};
+    int create_bump_calls{0};
+    int sign_bump_calls{0};
+    int commit_bump_calls{0};
     int get_new_destination_calls{0};
     int set_address_receive_request_calls{0};
     std::vector<std::string> unlock_passphrases;
@@ -140,6 +143,9 @@ public:
     std::string get_address_label;
     int sign_message_calls{0};
     std::string last_signed_message;
+    bool can_bump_transaction{true};
+    bool sign_bump_result{true};
+    bool commit_bump_result{true};
 
     std::function<util::Result<CTransactionRef>(const std::vector<wallet::CRecipient>&,
                                                 const wallet::CCoinControl&,
@@ -269,6 +275,31 @@ public:
     {
         ++commit_calls;
     }
+    bool transactionCanBeBumped(const Txid&) override { return can_bump_transaction; }
+    bool createBumpTransaction(const Txid& txid,
+                               const wallet::CCoinControl&,
+                               std::vector<bilingual_str>&,
+                               CAmount& old_fee,
+                               CAmount& new_fee,
+                               CMutableTransaction& mtx) override
+    {
+        ++create_bump_calls;
+        old_fee = 100;
+        new_fee = 200;
+        mtx.vin.emplace_back(COutPoint{txid, 0});
+        return true;
+    }
+    bool signBumpTransaction(CMutableTransaction&) override
+    {
+        ++sign_bump_calls;
+        return sign_bump_result;
+    }
+    bool commitBumpTransaction(const Txid&, CMutableTransaction&&, std::vector<bilingual_str>&, Txid& bumped_txid) override
+    {
+        ++commit_bump_calls;
+        bumped_txid = Txid::FromUint256(uint256::ONE);
+        return commit_bump_result;
+    }
     std::optional<common::PSBTError> fillPSBT(std::optional<int> sighash_type,
                                               bool sign,
                                               bool bip32derivs,
@@ -370,6 +401,9 @@ private Q_SLOTS:
     void sendTransactionClearsSelectedCoins();
     void clearingRecipientsClearsSelectedCoins();
     void sendTransactionWithPrivateKeysDisabledDoesNotCommit();
+    void bumpTransactionOnLockedWalletRequiresPassword();
+    void bumpTransactionWithPassphraseUnlocksCommitsAndRelocks();
+    void bumpTransactionWithWrongPassphraseDoesNotSign();
     void displayNameDefaultsToWalletName();
     void detailPropertiesReflectWalletCapabilities();
     void encryptWalletUpdatesSecurityState();
@@ -1374,6 +1408,71 @@ void WalletQmlModelTests::clearingRecipientsClearsSelectedCoins()
 
     model->sendRecipientList()->clear();
     QVERIFY(model->listSelectedCoins().empty());
+}
+
+void WalletQmlModelTests::bumpTransactionOnLockedWalletRequiresPassword()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    auto* bump_model = model->bumpModel();
+
+    bump_model->prepareFeeBump(QString::fromStdString(Txid::FromUint256(uint256::ONE).GetHex()), 1);
+    QCOMPARE(bump_model->state(), BumpTransactionModel::NeedsConfirmation);
+
+    QVERIFY(!bump_model->confirmFeeBump());
+    QCOMPARE(bump_model->state(), BumpTransactionModel::NeedsConfirmation);
+    QVERIFY(bump_model->needsUnlock());
+    QCOMPARE(bump_model->errorText(), QString("Enter your wallet password to update this transaction."));
+    QCOMPARE(wallet->unlock_calls, 0);
+    QCOMPARE(wallet->sign_bump_calls, 0);
+    QCOMPARE(wallet->commit_bump_calls, 0);
+}
+
+void WalletQmlModelTests::bumpTransactionWithPassphraseUnlocksCommitsAndRelocks()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    auto* bump_model = model->bumpModel();
+
+    bump_model->prepareFeeBump(QString::fromStdString(Txid::FromUint256(uint256::ONE).GetHex()), 1);
+    QCOMPARE(bump_model->state(), BumpTransactionModel::NeedsConfirmation);
+
+    QVERIFY(bump_model->confirmFeeBumpWithPassphrase(QStringLiteral("secret")));
+    QCOMPARE(bump_model->state(), BumpTransactionModel::Succeeded);
+    QVERIFY(!bump_model->newTxid().isEmpty());
+    QVERIFY(!bump_model->needsUnlock());
+    QCOMPARE(wallet->unlock_calls, 1);
+    QCOMPARE(wallet->unlock_passphrases.size(), size_t{1});
+    QCOMPARE(wallet->unlock_passphrases.front(), std::string{"secret"});
+    QCOMPARE(wallet->lock_calls, 1);
+    QCOMPARE(wallet->sign_bump_calls, 1);
+    QCOMPARE(wallet->commit_bump_calls, 1);
+    QVERIFY(wallet->locked);
+}
+
+void WalletQmlModelTests::bumpTransactionWithWrongPassphraseDoesNotSign()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->unlock_fn = [wallet](const SecureString& passphrase) {
+        ++wallet->unlock_calls;
+        wallet->unlock_passphrases.emplace_back(passphrase.begin(), passphrase.end());
+        return false;
+    };
+    auto* bump_model = model->bumpModel();
+
+    bump_model->prepareFeeBump(QString::fromStdString(Txid::FromUint256(uint256::ONE).GetHex()), 1);
+    QCOMPARE(bump_model->state(), BumpTransactionModel::NeedsConfirmation);
+
+    QVERIFY(!bump_model->confirmFeeBumpWithPassphrase(QStringLiteral("wrong")));
+    QCOMPARE(bump_model->state(), BumpTransactionModel::NeedsConfirmation);
+    QVERIFY(bump_model->needsUnlock());
+    QCOMPARE(bump_model->errorText(), QString("The wallet password you entered was incorrect."));
+    QCOMPARE(wallet->unlock_calls, 1);
+    QCOMPARE(wallet->lock_calls, 0);
+    QCOMPARE(wallet->sign_bump_calls, 0);
+    QCOMPARE(wallet->commit_bump_calls, 0);
+    QVERIFY(wallet->locked);
 }
 
 void WalletQmlModelTests::signVerifyMessageRejectsNonP2PKHAddress()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -340,6 +340,7 @@ private Q_SLOTS:
     void scheduleFeeEstimates_fallsBackWhenNetworkFeeEstimatesUnavailable();
     void scheduleFeeEstimates_usesStaticRegtestFeeOverride();
     void scheduleFeeEstimates_usesCustomFeeRateWhenEnabled();
+    void scheduleFeeEstimates_usesDummyPreviewChangeDestination();
     void prepareTransaction_usesStaticRegtestFeeOverride();
     void prepareTransaction_usesCustomFeeRateWithoutRegtestOverride();
     void prepareTransaction_reassignsAmountWhenFeeIncluded();
@@ -541,7 +542,7 @@ void WalletQmlModelTests::scheduleFeeEstimates_populatesFormattedEstimates()
     std::atomic<bool> saw_nonempty_feerate{false};
     std::vector<unsigned int> requested_targets;
 
-    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    EXPECT_CALL(*wallet, getNewDestinationValue(testing::_, testing::_)).Times(0);
     wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>& recipients,
                                            const wallet::CCoinControl& coin_control,
                                            bool sign,
@@ -594,7 +595,7 @@ void WalletQmlModelTests::scheduleFeeEstimates_fallsBackWhenNetworkFeeEstimatesU
     std::atomic<bool> saw_fallback_feerate{false};
     std::vector<CAmount> fallback_fee_rates;
 
-    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    EXPECT_CALL(*wallet, getNewDestinationValue(testing::_, testing::_)).Times(0);
     EXPECT_CALL(*wallet, getRequiredFee(1000)).Times(AtLeast(3)).WillRepeatedly(Return(1000));
     wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
                                            const wallet::CCoinControl& coin_control,
@@ -640,7 +641,7 @@ void WalletQmlModelTests::scheduleFeeEstimates_usesStaticRegtestFeeOverride()
     std::vector<unsigned int> requested_targets;
     std::vector<CAmount> requested_fee_rates;
 
-    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    EXPECT_CALL(*wallet, getNewDestinationValue(testing::_, testing::_)).Times(0);
     EXPECT_CALL(*wallet, getRequiredFee(1000)).Times(0);
     wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
                                            const wallet::CCoinControl& coin_control,
@@ -684,7 +685,7 @@ void WalletQmlModelTests::scheduleFeeEstimates_usesCustomFeeRateWhenEnabled()
     std::vector<unsigned int> requested_targets;
     std::vector<CAmount> requested_fee_rates;
 
-    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    EXPECT_CALL(*wallet, getNewDestinationValue(testing::_, testing::_)).Times(0);
     wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
                                            const wallet::CCoinControl& coin_control,
                                            bool,
@@ -711,6 +712,41 @@ void WalletQmlModelTests::scheduleFeeEstimates_usesCustomFeeRateWhenEnabled()
     QVERIFY(std::find(requested_targets.begin(), requested_targets.end(), 2U) != requested_targets.end());
     QVERIFY(std::find(requested_targets.begin(), requested_targets.end(), 6U) != requested_targets.end());
     QVERIFY(std::find(requested_targets.begin(), requested_targets.end(), 0U) != requested_targets.end());
+}
+
+void WalletQmlModelTests::scheduleFeeEstimates_usesDummyPreviewChangeDestination()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model);
+
+    std::atomic<int> create_transaction_calls{0};
+    std::atomic<bool> saw_missing_change{false};
+    std::atomic<bool> saw_wrong_change_type{false};
+
+    EXPECT_CALL(*wallet, getNewDestinationValue(testing::_, testing::_)).Times(0);
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        ++create_transaction_calls;
+        if (std::get_if<CNoDestination>(&coin_control.destChange)) {
+            saw_missing_change = true;
+        }
+        if (!std::get_if<WitnessV0KeyHash>(&coin_control.destChange)) {
+            saw_wrong_change_type = true;
+        }
+        change_pos = -1;
+        fee = coin_control.m_confirm_target.value_or(0) * 100;
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    model->scheduleFeeEstimates();
+
+    QTRY_COMPARE_WITH_TIMEOUT(create_transaction_calls.load(), 3, FEE_ESTIMATE_TIMEOUT_MS);
+    QVERIFY(!saw_missing_change.load());
+    QVERIFY(!saw_wrong_change_type.load());
 }
 
 void WalletQmlModelTests::prepareTransaction_usesStaticRegtestFeeOverride()
@@ -881,7 +917,7 @@ void WalletQmlModelTests::scheduleFeeEstimates_usesSelectedCoinsInCoinControl()
     std::atomic<int> selected_count{-1};
     std::vector<unsigned int> selected_targets;
 
-    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    EXPECT_CALL(*wallet, getNewDestinationValue(testing::_, testing::_)).Times(0);
     wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
                                            const wallet::CCoinControl& coin_control,
                                            bool sign,
@@ -920,7 +956,7 @@ void WalletQmlModelTests::scheduleFeeEstimates_debouncesRapidRestarts()
 
     std::atomic<int> create_transaction_calls{0};
 
-    EXPECT_CALL(*wallet, getNewDestinationValue(OutputType::BECH32, "qml-fee-preview")).Times(1);
+    EXPECT_CALL(*wallet, getNewDestinationValue(testing::_, testing::_)).Times(0);
     std::atomic<bool> saw_sign_true{false};
     wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
                                            const wallet::CCoinControl& coin_control,

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -385,6 +385,7 @@ private Q_SLOTS:
     void scheduleFeeEstimates_usesSelectedCoinsInCoinControl();
     void prepareTransaction_disallowsOtherInputsWhenCoinsSelected();
     void scheduleFeeEstimates_debouncesRapidRestarts();
+    void scheduleFeeEstimates_invalidatesStalePreviewState();
     void transactionChangedEmitsBalanceChanged();
     void setCurrentPaymentRequestAddressUsesAddressListLabel();
     void commitPaymentRequestUsesSelectedAddressType();
@@ -1238,6 +1239,72 @@ void WalletQmlModelTests::scheduleFeeEstimates_debouncesRapidRestarts()
     QCOMPARE(model->estimatedFeeForTarget(1), QStringLiteral("0.00000250 ₿"));
     QCOMPARE(model->estimatedFeeForTarget(2), QStringLiteral("0.00000500 ₿"));
     QCOMPARE(model->estimatedFeeForTarget(6), QStringLiteral("0.00001500 ₿"));
+}
+
+void WalletQmlModelTests::scheduleFeeEstimates_invalidatesStalePreviewState()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    ON_CALL(*wallet, getAvailableBalance(testing::_)).WillByDefault(Return(50'000));
+    SetValidRecipient(*model);
+
+    auto* recipient = model->sendRecipientList()->currentRecipient();
+    QVERIFY(recipient != nullptr);
+    recipient->amount()->setSatoshi(49'000);
+
+    std::atomic<int> create_transaction_calls{0};
+    std::atomic<bool> stale_request_started{false};
+    std::atomic<bool> fresh_request_started{false};
+    QSemaphore release_stale_request;
+    QSemaphore release_fresh_request;
+
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>& recipients,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        ++create_transaction_calls;
+        const CAmount total_amount = std::accumulate(recipients.begin(), recipients.end(), CAmount{0}, [](const CAmount total, const wallet::CRecipient& recipient) {
+            return total + recipient.nAmount;
+        });
+
+        if (total_amount == 49'000 && !stale_request_started.exchange(true)) {
+            release_stale_request.acquire();
+        }
+        if (total_amount == 49'900 && !fresh_request_started.exchange(true)) {
+            release_fresh_request.acquire();
+        }
+
+        change_pos = -1;
+        fee = total_amount == 49'900
+            ? coin_control.m_confirm_target.value_or(0) * 100
+            : 50;
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    model->scheduleFeeEstimates();
+    QTRY_VERIFY_WITH_TIMEOUT(stale_request_started.load(), FEE_ESTIMATE_TIMEOUT_MS);
+    const auto release_stale_on_exit{interfaces::MakeCleanupHandler([&] { release_stale_request.release(); })};
+    QVERIFY(model->feeEstimatePending());
+    QCOMPARE(model->estimatedFeeForTarget(2), QString());
+
+    recipient->amount()->setSatoshi(49'900);
+    model->scheduleFeeEstimates();
+    QCOMPARE(model->estimatedFeeForTarget(2), QString());
+    QVERIFY(model->feeEstimatePending());
+
+    release_stale_request.release();
+    QTRY_VERIFY_WITH_TIMEOUT(fresh_request_started.load(), FEE_ESTIMATE_TIMEOUT_MS);
+    const auto release_fresh_on_exit{interfaces::MakeCleanupHandler([&] { release_fresh_request.release(); })};
+    QCOMPARE(model->estimatedFeeForTarget(2), QString());
+    QVERIFY(model->feeEstimatePending());
+    QVERIFY(!model->sendAmountExhaustsBalance());
+
+    release_fresh_request.release();
+    QTRY_COMPARE_WITH_TIMEOUT(model->estimatedFeeForTarget(2), QStringLiteral("0.00000200 ₿"), FEE_ESTIMATE_TIMEOUT_MS);
+    QTRY_VERIFY_WITH_TIMEOUT(!model->feeEstimatePending(), FEE_ESTIMATE_TIMEOUT_MS);
+    QVERIFY(model->sendAmountExhaustsBalance());
+    QVERIFY(create_transaction_calls.load() >= 6);
 }
 
 void WalletQmlModelTests::transactionChangedEmitsBalanceChanged()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -376,6 +376,7 @@ private Q_SLOTS:
     void scheduleFeeEstimates_usesCustomFeeRateWhenEnabled();
     void scheduleFeeEstimates_estimatesWhenAmountWouldExceedBalanceWithFee();
     void sendAmountExhaustsBalance_requiresFeeBuffer();
+    void sendAmountExhaustsBalance_usesCoinControlAvailableBalance();
     void scheduleFeeEstimates_usesDummyPreviewChangeDestination();
     void prepareTransaction_usesStaticRegtestFeeOverride();
     void prepareTransaction_usesCustomFeeRateWithoutRegtestOverride();
@@ -762,6 +763,7 @@ void WalletQmlModelTests::scheduleFeeEstimates_estimatesWhenAmountWouldExceedBal
     NiceMock<MockWallet>* wallet{nullptr};
     auto model = MakeWalletModel(wallet);
     ON_CALL(*wallet, getBalance()).WillByDefault(Return(50'000));
+    ON_CALL(*wallet, getAvailableBalance(testing::_)).WillByDefault(Return(50'000));
     SetValidRecipient(*model);
     auto* recipient = model->sendRecipientList()->currentRecipient();
     QVERIFY(recipient != nullptr);
@@ -864,6 +866,66 @@ void WalletQmlModelTests::sendAmountExhaustsBalance_requiresFeeBuffer()
     QVERIFY(model->sendAmountExhaustsBalance());
     model->sendRecipientList()->remove();
     QVERIFY(!model->sendAmountExhaustsBalance());
+}
+
+void WalletQmlModelTests::sendAmountExhaustsBalance_usesCoinControlAvailableBalance()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetValidRecipient(*model);
+
+    const COutPoint selected_outpoint{Txid::FromUint256(uint256::ONE), 1};
+    bool create_transaction_called{false};
+
+    EXPECT_CALL(*wallet, getBalance()).Times(0);
+    EXPECT_CALL(*wallet, getAvailableBalance(testing::_))
+        .WillRepeatedly(Invoke([&](const wallet::CCoinControl& coin_control) {
+            if (coin_control.HasSelected()) {
+                EXPECT_TRUE(coin_control.IsSelected(selected_outpoint));
+                EXPECT_FALSE(coin_control.m_allow_other_inputs);
+                return CAmount{20'000};
+            }
+
+            EXPECT_TRUE(coin_control.m_allow_other_inputs);
+            return CAmount{100'000};
+        }));
+
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>&,
+                                           const wallet::CCoinControl&,
+                                           bool,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        create_transaction_called = true;
+        change_pos = -1;
+        fee = 200;
+        return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+    };
+
+    QVERIFY(!model->sendAmountExhaustsBalance());
+
+    QSignalSpy spy{model.get(), &WalletQmlModel::sendAmountExhaustsBalanceChanged};
+    model->selectCoin(selected_outpoint);
+    QCOMPARE(spy.count(), 1);
+    QVERIFY(model->sendAmountExhaustsBalance());
+    QVERIFY(!model->prepareTransaction());
+    QVERIFY(!create_transaction_called);
+    QCOMPARE(model->transactionError(), QStringLiteral("Selected inputs do not cover the amount plus fee"));
+
+    model->unselectCoin(selected_outpoint);
+    QCOMPARE(spy.count(), 2);
+    QVERIFY(!model->sendAmountExhaustsBalance());
+    QVERIFY(model->prepareTransaction());
+    QVERIFY(create_transaction_called);
+
+    model->selectCoin(selected_outpoint);
+    QCOMPARE(spy.count(), 3);
+    QVERIFY(model->sendAmountExhaustsBalance());
+    model->clearSelectedCoins();
+    QCOMPARE(spy.count(), 4);
+    QVERIFY(!model->sendAmountExhaustsBalance());
+
+    model->clearSelectedCoins();
+    QCOMPARE(spy.count(), 4);
 }
 
 void WalletQmlModelTests::scheduleFeeEstimates_usesDummyPreviewChangeDestination()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -35,6 +35,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <string>
 #include <vector>
@@ -371,6 +372,8 @@ private Q_SLOTS:
     void scheduleFeeEstimates_fallsBackWhenNetworkFeeEstimatesUnavailable();
     void scheduleFeeEstimates_usesStaticRegtestFeeOverride();
     void scheduleFeeEstimates_usesCustomFeeRateWhenEnabled();
+    void scheduleFeeEstimates_estimatesWhenAmountWouldExceedBalanceWithFee();
+    void sendAmountExhaustsBalance_requiresFeeBuffer();
     void scheduleFeeEstimates_usesDummyPreviewChangeDestination();
     void prepareTransaction_usesStaticRegtestFeeOverride();
     void prepareTransaction_usesCustomFeeRateWithoutRegtestOverride();
@@ -748,6 +751,115 @@ void WalletQmlModelTests::scheduleFeeEstimates_usesCustomFeeRateWhenEnabled()
     QVERIFY(std::find(requested_targets.begin(), requested_targets.end(), 2U) != requested_targets.end());
     QVERIFY(std::find(requested_targets.begin(), requested_targets.end(), 6U) != requested_targets.end());
     QVERIFY(std::find(requested_targets.begin(), requested_targets.end(), 0U) != requested_targets.end());
+}
+
+void WalletQmlModelTests::scheduleFeeEstimates_estimatesWhenAmountWouldExceedBalanceWithFee()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    ON_CALL(*wallet, getBalance()).WillByDefault(Return(50'000));
+    SetValidRecipient(*model);
+    auto* recipient = model->sendRecipientList()->currentRecipient();
+    QVERIFY(recipient != nullptr);
+    recipient->amount()->setSatoshi(49'850);
+    QVERIFY(!model->sendAmountExhaustsBalance());
+    QSignalSpy balance_exhausted_spy{model.get(), &WalletQmlModel::sendAmountExhaustsBalanceChanged};
+
+    bool saw_regular_recipient{false};
+    bool saw_fee_subtracted_recipient{false};
+    std::vector<unsigned int> requested_targets;
+
+    EXPECT_CALL(*wallet, getRequiredFee(testing::_)).Times(0);
+    wallet->createTransactionHandler = [&](const std::vector<wallet::CRecipient>& recipients,
+                                           const wallet::CCoinControl& coin_control,
+                                           bool,
+                                           int& change_pos,
+                                           CAmount& fee) -> util::Result<CTransactionRef> {
+        requested_targets.push_back(coin_control.m_confirm_target.value_or(0));
+        change_pos = -1;
+        fee = coin_control.m_feerate.has_value()
+            ? 50
+            : coin_control.m_confirm_target.value_or(0) * 100;
+
+        const CAmount total_amount = std::accumulate(recipients.begin(), recipients.end(), CAmount{0}, [](const CAmount total, const wallet::CRecipient& recipient) {
+            return total + recipient.nAmount;
+        });
+        const bool subtracts_fee = std::any_of(recipients.begin(), recipients.end(), [](const wallet::CRecipient& recipient) {
+            return recipient.fSubtractFeeFromAmount;
+        });
+
+        if (subtracts_fee) {
+            saw_fee_subtracted_recipient = true;
+            return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+        }
+
+        saw_regular_recipient = true;
+        if (total_amount + fee <= 50'000) {
+            return util::Result<CTransactionRef>{MakeTransactionRef(CMutableTransaction{})};
+        }
+        return util::Error{Untranslated("amount plus fee exceeds balance")};
+    };
+
+    model->scheduleFeeEstimates();
+
+    QTRY_COMPARE_WITH_TIMEOUT(model->estimatedFeeForTarget(2), QStringLiteral("0.00000200 ₿"), FEE_ESTIMATE_TIMEOUT_MS);
+    QTRY_VERIFY_WITH_TIMEOUT(model->sendAmountExhaustsBalance(), FEE_ESTIMATE_TIMEOUT_MS);
+    QVERIFY(model->sendAmountExhaustsBalance());
+    QVERIFY(balance_exhausted_spy.count() > 0);
+    QVERIFY(saw_regular_recipient);
+    QVERIFY(saw_fee_subtracted_recipient);
+    QVERIFY(requested_targets.size() >= 5);
+    QCOMPARE(model->sendRecipientList()->currentRecipient()->subtractFeeFromAmount(), false);
+    QCOMPARE(model->estimatedFeeForTarget(1), QStringLiteral("0.00000100 ₿"));
+    QCOMPARE(model->estimatedFeeForTarget(2), QStringLiteral("0.00000200 ₿"));
+    QCOMPARE(model->estimatedFeeForTarget(6), QStringLiteral("0.00000600 ₿"));
+
+    model->setFeeTargetBlocks(1);
+    QCOMPARE(model->estimatedFee(), QStringLiteral("0.00000100 ₿"));
+    QVERIFY(!model->sendAmountExhaustsBalance());
+
+    model->setFeeTargetBlocks(6);
+    QCOMPARE(model->estimatedFee(), QStringLiteral("0.00000600 ₿"));
+    QVERIFY(model->sendAmountExhaustsBalance());
+
+    model->setCustomFeeEnabled(true);
+    model->setCustomFeeRate(QStringLiteral("1"));
+    QTRY_COMPARE_WITH_TIMEOUT(model->estimatedFee(), QStringLiteral("0.00000050 ₿"), FEE_ESTIMATE_TIMEOUT_MS);
+    QVERIFY(!model->sendAmountExhaustsBalance());
+}
+
+void WalletQmlModelTests::sendAmountExhaustsBalance_requiresFeeBuffer()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    wallet->balance = 50'000;
+    SetPasswordRecipient(*model, 50'000);
+
+    QVERIFY(model->sendAmountExhaustsBalance());
+
+    auto* recipient = model->sendRecipientList()->currentRecipient();
+    QVERIFY(recipient != nullptr);
+    QSignalSpy spy{model.get(), &WalletQmlModel::sendAmountExhaustsBalanceChanged};
+    recipient->amount()->setSatoshi(49'999);
+    QVERIFY(!model->sendAmountExhaustsBalance());
+    QVERIFY(spy.count() > 0);
+
+    recipient->amount()->setSatoshi(50'000);
+    QVERIFY(model->sendAmountExhaustsBalance());
+    recipient->setSubtractFeeFromAmount(true);
+    QVERIFY(!model->sendAmountExhaustsBalance());
+
+    recipient->setSubtractFeeFromAmount(false);
+    recipient->amount()->setSatoshi(49'000);
+    QVERIFY(!model->sendAmountExhaustsBalance());
+    model->sendRecipientList()->add();
+    auto* second_recipient = model->sendRecipientList()->currentRecipient();
+    QVERIFY(second_recipient != nullptr);
+    second_recipient->address()->setAddress(VALID_MAINNET_P2SH_ADDRESS, 0);
+    second_recipient->amount()->setSatoshi(1'000);
+    QVERIFY(model->sendAmountExhaustsBalance());
+    model->sendRecipientList()->remove();
+    QVERIFY(!model->sendAmountExhaustsBalance());
 }
 
 void WalletQmlModelTests::scheduleFeeEstimates_usesDummyPreviewChangeDestination()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -358,8 +358,11 @@ private Q_SLOTS:
     void removeReceiveRequestRemovesPendingActivityRow();
     void prepareTransactionOnLockedWalletRequiresPassword();
     void prepareTransactionWithPrivateKeysDisabledDoesNotRequirePassword();
+    void sendRecipientRejectsDustAmount();
+    void prepareTransactionRejectsDuplicateRecipientsBeforeUnlock();
     void prepareTransactionWithPassphraseForwardsUtf8Bytes();
     void prepareTransactionWithPassphraseRelocksWhenRecipientsInvalid();
+    void prepareTransactionWithPassphraseRequiresCompleteMultiRecipient();
     void prepareTransactionWithPassphraseRelocksWhenCustomFeeInvalid();
     void prepareTransactionWithPassphraseReportsCreateErrorAndRelocks();
     void sendTransactionCommitsPreparedTransactionWithoutUnlockingAgain();
@@ -1151,6 +1154,44 @@ void WalletQmlModelTests::prepareTransactionWithPrivateKeysDisabledDoesNotRequir
     QCOMPARE(wallet->lock_calls, 0);
 }
 
+void WalletQmlModelTests::sendRecipientRejectsDustAmount()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    auto* recipient = model->sendRecipientList()->currentRecipient();
+    QVERIFY(recipient != nullptr);
+
+    recipient->address()->setAddress(VALID_MAINNET_ADDRESS, 0);
+    recipient->amount()->setSatoshi(1);
+
+    QVERIFY(!recipient->isValid());
+    QCOMPARE(recipient->amountError(), QStringLiteral("Amount is too small to send."));
+    QVERIFY(!model->sendRecipientList()->allValid());
+}
+
+void WalletQmlModelTests::prepareTransactionRejectsDuplicateRecipientsBeforeUnlock()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetPasswordRecipient(*model, 1'000);
+
+    model->sendRecipientList()->add();
+    auto* second = model->sendRecipientList()->currentRecipient();
+    QVERIFY(second != nullptr);
+    second->address()->setAddress(VALID_MAINNET_ADDRESS, 0);
+    second->amount()->setSatoshi(2'000);
+    QVERIFY(second->isValid());
+
+    QVERIFY(!model->sendRecipientList()->allValid());
+    QCOMPARE(model->sendRecipientList()->validationError(), QString("Recipient addresses must be unique."));
+
+    QVERIFY(!model->prepareTransactionWithPassphrase("secret"));
+    QCOMPARE(model->transactionError(), QString("Recipient addresses must be unique."));
+    QCOMPARE(wallet->unlock_calls, 0);
+    QCOMPARE(wallet->lock_calls, 0);
+    QVERIFY(wallet->create_transaction_sign_args.empty());
+}
+
 void WalletQmlModelTests::prepareTransactionWithPassphraseForwardsUtf8Bytes()
 {
     FakePasswordWallet* wallet{nullptr};
@@ -1176,10 +1217,36 @@ void WalletQmlModelTests::prepareTransactionWithPassphraseRelocksWhenRecipientsI
     recipient->amount()->setSatoshi(1'000);
     QVERIFY(!recipient->isValid());
 
+    QVERIFY(!model->sendRecipientList()->allValid());
+    QVERIFY(model->sendRecipientList()->validationError().isEmpty());
+
     QVERIFY(!model->prepareTransactionWithPassphrase("secret"));
     QVERIFY(wallet->locked);
-    QCOMPARE(wallet->unlock_calls, 1);
-    QCOMPARE(wallet->lock_calls, 1);
+    QVERIFY(model->transactionError().isEmpty());
+    QCOMPARE(wallet->unlock_calls, 0);
+    QCOMPARE(wallet->lock_calls, 0);
+    QVERIFY(wallet->create_transaction_sign_args.empty());
+}
+
+void WalletQmlModelTests::prepareTransactionWithPassphraseRequiresCompleteMultiRecipient()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetPasswordRecipient(*model, 1'000);
+
+    model->sendRecipientList()->add();
+    auto* second = model->sendRecipientList()->currentRecipient();
+    QVERIFY(second != nullptr);
+    QVERIFY(!second->isValid());
+
+    QVERIFY(!model->sendRecipientList()->allValid());
+    QCOMPARE(model->sendRecipientList()->validationError(), QString("Complete every recipient before continuing."));
+
+    QVERIFY(!model->prepareTransactionWithPassphrase("secret"));
+    QVERIFY(wallet->locked);
+    QCOMPARE(model->transactionError(), QString("Complete every recipient before continuing."));
+    QCOMPARE(wallet->unlock_calls, 0);
+    QCOMPARE(wallet->lock_calls, 0);
     QVERIFY(wallet->create_transaction_sign_args.empty());
 }
 

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -367,6 +367,8 @@ private Q_SLOTS:
     void prepareTransactionWithPassphraseRelocksWhenCustomFeeInvalid();
     void prepareTransactionWithPassphraseReportsCreateErrorAndRelocks();
     void sendTransactionCommitsPreparedTransactionWithoutUnlockingAgain();
+    void sendTransactionClearsSelectedCoins();
+    void clearingRecipientsClearsSelectedCoins();
     void sendTransactionWithPrivateKeysDisabledDoesNotCommit();
     void displayNameDefaultsToWalletName();
     void detailPropertiesReflectWalletCapabilities();
@@ -1344,6 +1346,34 @@ void WalletQmlModelTests::sendTransactionCommitsPreparedTransactionWithoutUnlock
     QVERIFY(wallet->fill_psbt_sign_args.empty());
     QVERIFY(model->transactionError().isEmpty());
     QVERIFY(!model->transactionNeedsUnlock());
+}
+
+void WalletQmlModelTests::sendTransactionClearsSelectedCoins()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    SetPasswordRecipient(*model, 1'000);
+    const COutPoint selected_outpoint{Txid::FromUint256(uint256::ONE), 1};
+
+    model->selectCoin(selected_outpoint);
+    QCOMPARE(model->listSelectedCoins().size(), size_t{1});
+
+    QVERIFY(model->prepareTransactionWithPassphrase("secret"));
+    QVERIFY(model->sendTransaction());
+    QVERIFY(model->listSelectedCoins().empty());
+}
+
+void WalletQmlModelTests::clearingRecipientsClearsSelectedCoins()
+{
+    FakePasswordWallet* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    const COutPoint selected_outpoint{Txid::FromUint256(uint256::ONE), 1};
+
+    model->selectCoin(selected_outpoint);
+    QCOMPARE(model->listSelectedCoins().size(), size_t{1});
+
+    model->sendRecipientList()->clear();
+    QVERIFY(model->listSelectedCoins().empty());
 }
 
 void WalletQmlModelTests::signVerifyMessageRejectsNonP2PKHAddress()


### PR DESCRIPTION
This PR groups Preview-targeted fixes around Send correctness, fee preview behavior, wallet shutdown/lifecycle handling, receive-request compatibility, and small wallet UI polish.

## Issues
Fixes #467 - Send amount validation accounts for the selected fee estimate before allowing review.
Fixes #624 - Create-backup `View file` opens the selected wallet location and reports failures.
Fixes #636 - Fee bump confirmation prompts to unlock encrypted wallets and relocks after signing.
Fixes #692 - RBF speed-up prompts to unlock encrypted wallets before confirming and is covered by the encrypted-wallet RBF functional test.
Fixes #659 - Send validation rejects duplicate recipients and dust outputs before review.
Fixes #665 - Coin control selections are cleared after send and when clearing recipients.
Fixes #739 - QML coin control treats manually selected coins as exclusive during fee preview and transaction preparation.
Fixes #705 - Send review stays disabled when any visible multi-recipient row is incomplete, with a clear validation error.
Fixes #712 - Update-password mode focuses the current-password field first.
Fixes #715 - Fee previews no longer create persistent `qml-fee-preview` wallet addresses.
Fixes #721 - Receive request serialization stays compatible with bitcoin-qt and is covered by a bitcoin-qt v31.0 regression workflow.
Fixes #728 - Navigation button content padding is restored.
Fixes #730 - `NodeModel` unsubscribes from core signals during destruction.
Fixes #731 - SIGINT/Ctrl+C during interrupted initialization exits cleanly instead of hanging.

Refs #582
Refs #577
Refs #579