### PR TITLE
Quiet runtime debug log warnings

### DIFF
--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -97,6 +97,16 @@ Q_IMPORT_PLUGIN(QtQuickControls2Plugin)
 Q_IMPORT_PLUGIN(QtQuickTemplates2Plugin)
 #endif
 
+// Qt emits "OpenType support missing for ..." warnings when BitcoinCoreSans
+// lacks glyphs for a script and Qt falls back to another font. These are
+// harmless and noisy, so treat them like debug output rather than printing
+// them unconditionally. Defined at global scope (not in the anonymous
+// namespace below) so the classification can be unit tested.
+bool IsBenignQtFontWarning(const QString& msg)
+{
+    return msg.startsWith(QLatin1String("OpenType support missing for"));
+}
+
 namespace {
 void SetupUIArgs(ArgsManager& argsman)
 {
@@ -161,7 +171,7 @@ void RecordStartupWarning(QStringList& startup_warnings, const bilingual_str& me
 void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg)
 {
     Q_UNUSED(context);
-    if (type == QtDebugMsg) {
+    if (type == QtDebugMsg || (type == QtWarningMsg && IsBenignQtFontWarning(msg))) {
         LogDebug(BCLog::QT, "GUI: %s\n", msg.toStdString());
     } else {
         LogPrintf("GUI: %s\n", msg.toStdString());

--- a/qml/bitcoin.h
+++ b/qml/bitcoin.h
@@ -1,10 +1,16 @@
-// Copyright (c) 2021 The Bitcoin Core developers
+// Copyright (c) 2021-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_QML_BITCOIN_H
 #define BITCOIN_QML_BITCOIN_H
 
+class QString;
+
 int QmlGuiMain(int argc, char* argv[]);
+
+//! Returns true for benign Qt font fallback warnings ("OpenType support
+//! missing for ...") that should be logged at debug level rather than printed.
+bool IsBenignQtFontWarning(const QString& msg);
 
 #endif // BITCOIN_QML_BITCOIN_H

--- a/qml/controls/PageStack.qml
+++ b/qml/controls/PageStack.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Bitcoin Core developers
+// Copyright (c) 2024-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -18,7 +18,7 @@ StackView {
     pushEnter: Transition {
         NumberAnimation {
             property: vertical ? "y" : "x"
-            from: vertical ? parent.height : parent.width
+            from: parent ? (vertical ? parent.height : parent.width) : 0
             to: 0
             duration: 500
             easing.type: Easing.InOutCubic
@@ -28,7 +28,7 @@ StackView {
         NumberAnimation {
             property: vertical ? "y" : "x"
             from: 0
-            to: vertical ? -parent.height : -parent.width
+            to: parent ? (vertical ? -parent.height : -parent.width) : 0
             duration: 500
             easing.type: Easing.InOutCubic
         }
@@ -36,7 +36,7 @@ StackView {
     popEnter: Transition {
         NumberAnimation {
             property: vertical ? "y" : "x"
-            from: vertical ? -parent.height : -parent.width
+            from: parent ? (vertical ? -parent.height : -parent.width) : 0
             to: 0
             duration: 500
             easing.type: Easing.InOutCubic
@@ -46,7 +46,7 @@ StackView {
         NumberAnimation {
             property: vertical ? "y" : "x"
             from: 0
-            to: vertical ? parent.height : parent.width
+            to: parent ? (vertical ? parent.height : parent.width) : 0
             duration: 500
             easing.type: Easing.InOutCubic
         }

--- a/qml/pages/settings/SettingsDebugLog.qml
+++ b/qml/pages/settings/SettingsDebugLog.qml
@@ -287,7 +287,7 @@ Page {
             // DebugLogModel renders newest-first at the top, so y > 0 means
             // "scrolled away from the newest entries" — which is exactly when
             // the "N new entries" pill should be offered.
-            onScrolled: {
+            onScrolled: function(y) {
                 root.userIsScrolled = (y > 0)
                 if (logView.atTop && root.pendingNewLines > 0) {
                     root.pendingNewLines = 0

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(bitcoinqml_unit_tests
   test_receiverequesthistorymodel.cpp
   test_transaction.cpp
   test_activityfilterproxymodel.cpp
+  test_qtmessagefilter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/bitcoinuri.cpp
 )

--- a/test/test_qtmessagefilter.cpp
+++ b/test/test_qtmessagefilter.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <qml/bitcoin.h>
+
+class QtMessageFilterTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void benignFontWarning_matches();
+    void benignFontWarning_rejectsOther();
+};
+
+void QtMessageFilterTests::benignFontWarning_matches()
+{
+    QVERIFY(IsBenignQtFontWarning(QStringLiteral("OpenType support missing for \"BitcoinCoreSans\", script 18")));
+    // The prefix alone is enough; the trailing script details vary.
+    QVERIFY(IsBenignQtFontWarning(QStringLiteral("OpenType support missing for")));
+}
+
+void QtMessageFilterTests::benignFontWarning_rejectsOther()
+{
+    QVERIFY(!IsBenignQtFontWarning(QString()));
+    QVERIFY(!IsBenignQtFontWarning(QStringLiteral("Some unrelated Qt warning")));
+    // Match is case sensitive, mirroring the exact text Qt emits.
+    QVERIFY(!IsBenignQtFontWarning(QStringLiteral("opentype support missing for")));
+}
+
+#ifdef BITCOINQML_NO_TEST_MAIN
+#include <test/qt_test_registry.h>
+BITCOINQML_REGISTER_QT_TEST(QtMessageFilterTests)
+#else
+QTEST_MAIN(QtMessageFilterTests)
+#endif
+#include "test_qtmessagefilter.moc"


### PR DESCRIPTION
Fixed multiple instances of false debug log warnings:
- The debug log page's scroll used a deprecated implicit injection of the signal parameter, leading to logging a warning. Parameter is now declared explicitly, behavior unchanged. Fixes #701.

- When transitioning between pages the animated item's parent is briefly null, leading to TypeError log. Guards the transitions, visible behavior unchanged. Fixes #702.

- Fallback font warning logs are now gated behind the debug=qt flag. Also added unit test for new behavior. Fixes #703.
