### PR TITLE
qml: Render OP_RETURN outputs in imported PSBT review

### DIFF
--- a/qml/components/MultipleRecipientsSummary.qml
+++ b/qml/components/MultipleRecipientsSummary.qml
@@ -42,18 +42,26 @@ ColumnLayout {
             required property string amount;
             required property string formattedAddress;
             required property string amountUnitLabel;
+            required property bool isDataOutput;
+            required property string dataHex;
             property bool expanded: false
             readonly property bool expandable: formattedAddress.length > 0
             readonly property string amountText: amountUnitLabel.length > 0 ? amount + " " + amountUnitLabel : amount
-            readonly property string primaryText: label.length > 0 ? label : address
-            readonly property string secondaryText: expanded ? formattedAddress : (label.length > 0 ? address : "")
+            readonly property string primaryText: isDataOutput ? qsTr("Data output") : (label.length > 0 ? label : address)
+            readonly property string secondaryText: {
+                if (isDataOutput) return dataHex
+                if (expanded) return formattedAddress
+                return label.length > 0 ? address : ""
+            }
             readonly property bool secondaryVisible: secondaryText.length > 0
 
             activeFocusOnTab: expandable
             Accessible.role: Accessible.Button
-            Accessible.name: label.length > 0
-                ? qsTr("%1, address %2, amount %3").arg(label).arg(formattedAddress).arg(amountText)
-                : qsTr("Address %1, amount %2").arg(formattedAddress).arg(amountText)
+            Accessible.name: isDataOutput
+                ? qsTr("Data output %1, amount %2").arg(dataHex).arg(amountText)
+                : label.length > 0
+                    ? qsTr("%1, address %2, amount %3").arg(label).arg(formattedAddress).arg(amountText)
+                    : qsTr("Address %1, amount %2").arg(formattedAddress).arg(amountText)
             Accessible.description: expanded ? qsTr("Hide full address") : qsTr("Show full address")
             Accessible.onPressAction: click()
 

--- a/qml/models/sendrecipient.cpp
+++ b/qml/models/sendrecipient.cpp
@@ -109,6 +109,31 @@ CAmount SendRecipient::cAmount() const
     return m_amount->satoshi();
 }
 
+bool SendRecipient::isDataOutput() const
+{
+    return m_isDataOutput;
+}
+
+QString SendRecipient::dataHex() const
+{
+    return m_dataHex;
+}
+
+void SendRecipient::setDataOutput(const QString& hex)
+{
+    if (!m_isDataOutput) {
+        m_isDataOutput = true;
+        Q_EMIT isDataOutputChanged();
+    }
+    if (m_dataHex != hex) {
+        m_dataHex = hex;
+        Q_EMIT dataHexChanged();
+    }
+    setAddressError("");
+    setAmountError("");
+    Q_EMIT isValidChanged();
+}
+
 void SendRecipient::clear()
 {
     m_label = "";
@@ -116,6 +141,14 @@ void SendRecipient::clear()
     setSubtractFeeFromAmount(false);
     m_address->setAddress("", 0);
     m_amount->clear();
+    if (m_isDataOutput) {
+        m_isDataOutput = false;
+        Q_EMIT isDataOutputChanged();
+    }
+    if (!m_dataHex.isEmpty()) {
+        m_dataHex = "";
+        Q_EMIT dataHexChanged();
+    }
     Q_EMIT addressChanged();
     Q_EMIT labelChanged();
     Q_EMIT messageChanged();
@@ -140,6 +173,11 @@ void SendRecipient::validateAddress()
 
 void SendRecipient::validateAmount()
 {
+    if (m_isDataOutput) {
+        setAmountError("");
+        Q_EMIT isValidChanged();
+        return;
+    }
     if (m_amount->isSet()) {
         if (m_amount->satoshi() <= 0) {
             setAmountError(tr("Amount must be greater than zero"));
@@ -163,5 +201,6 @@ void SendRecipient::validateAmount()
 
 bool SendRecipient::isValid() const
 {
+    if (m_isDataOutput) return true;
     return m_addressError.isEmpty() && m_amountError.isEmpty() && m_amount->satoshi() > 0 && !m_address->isEmpty();
 }

--- a/qml/models/sendrecipient.h
+++ b/qml/models/sendrecipient.h
@@ -25,6 +25,8 @@ class SendRecipient : public QObject
     Q_PROPERTY(QString addressError READ addressError NOTIFY addressErrorChanged)
     Q_PROPERTY(QString amountError READ amountError NOTIFY amountErrorChanged)
     Q_PROPERTY(bool isValid READ isValid NOTIFY isValidChanged)
+    Q_PROPERTY(bool isDataOutput READ isDataOutput NOTIFY isDataOutputChanged)
+    Q_PROPERTY(QString dataHex READ dataHex NOTIFY dataHexChanged)
 
 public:
     explicit SendRecipient(WalletQmlModel* wallet, QObject* parent = nullptr);
@@ -52,6 +54,10 @@ public:
 
     bool isValid() const;
 
+    bool isDataOutput() const;
+    QString dataHex() const;
+    void setDataOutput(const QString& hex);
+
     Q_INVOKABLE void clear();
 
 Q_SIGNALS:
@@ -62,6 +68,8 @@ Q_SIGNALS:
     void messageChanged();
     void subtractFeeFromAmountChanged();
     void isValidChanged();
+    void isDataOutputChanged();
+    void dataHexChanged();
 
 private:
     void validateAddress();
@@ -75,6 +83,8 @@ private:
     BitcoinAmount* m_amount;
     QString m_amountError{""};
     bool m_subtractFeeFromAmount{false};
+    bool m_isDataOutput{false};
+    QString m_dataHex{""};
 };
 
 #endif // BITCOIN_QML_MODELS_SENDRECIPIENT_H

--- a/qml/models/sendrecipientslistmodel.cpp
+++ b/qml/models/sendrecipientslistmodel.cpp
@@ -39,6 +39,8 @@ QVariant SendRecipientsListModel::data(const QModelIndex& index, int role) const
     case MessageRole: return r->message();
     case FormattedAddressRole: return r->address()->formattedAddress();
     case AmountUnitLabelRole: return r->amount()->unitLabel();
+    case IsDataOutputRole: return r->isDataOutput();
+    case DataHexRole: return r->dataHex();
     default: return {};
     }
     return {};
@@ -53,6 +55,8 @@ QHash<int, QByteArray> SendRecipientsListModel::roleNames() const
         {MessageRole, "message"},
         {FormattedAddressRole, "formattedAddress"},
         {AmountUnitLabelRole, "amountUnitLabel"},
+        {IsDataOutputRole, "isDataOutput"},
+        {DataHexRole, "dataHex"},
     };
 }
 
@@ -145,6 +149,12 @@ void SendRecipientsListModel::connectRecipientSignals(SendRecipient* recipient)
     });
     connect(recipient, &SendRecipient::messageChanged, this, [emit_roles_changed] {
         emit_roles_changed({MessageRole});
+    });
+    connect(recipient, &SendRecipient::isDataOutputChanged, this, [emit_roles_changed] {
+        emit_roles_changed({IsDataOutputRole});
+    });
+    connect(recipient, &SendRecipient::dataHexChanged, this, [emit_roles_changed] {
+        emit_roles_changed({DataHexRole});
     });
     connect(recipient->address(), &BitcoinAddress::formattedAddressChanged, this, [emit_roles_changed] {
         emit_roles_changed({AddressRole, FormattedAddressRole});

--- a/qml/models/sendrecipientslistmodel.h
+++ b/qml/models/sendrecipientslistmodel.h
@@ -29,6 +29,8 @@ public:
         MessageRole,
         FormattedAddressRole,
         AmountUnitLabelRole,
+        IsDataOutputRole,
+        DataHexRole,
     };
 
     explicit SendRecipientsListModel(QObject* parent = nullptr);

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -39,6 +39,7 @@
 #include <script/solver.h>
 #include <support/allocators/secure.h>
 #include <util/result.h>
+#include <util/strencodings.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
@@ -2004,6 +2005,8 @@ bool WalletQmlModel::tryImportPsbtToReview(const PartiallySignedTransaction& psb
         QString address;
         QString label;
         CAmount amount;
+        bool is_data_output{false};
+        QString data_hex{};
     };
     std::vector<DraftRecipient> draft_recipients;
     CAmount recipient_total{0};
@@ -2011,6 +2014,9 @@ bool WalletQmlModel::tryImportPsbtToReview(const PartiallySignedTransaction& psb
         CTxDestination destination;
         if (!ExtractDestination(output.scriptPubKey, destination)) {
             if (output.nValue == 0 && output.scriptPubKey.IsUnspendable()) {
+                draft_recipients.push_back({QString{}, QString{}, output.nValue,
+                                            /*is_data_output=*/true,
+                                            QString::fromStdString(HexStr(output.scriptPubKey))});
                 continue;
             }
             reason = tr("Only PSBTs with standard address outputs are supported right now.");
@@ -2043,8 +2049,12 @@ bool WalletQmlModel::tryImportPsbtToReview(const PartiallySignedTransaction& psb
             m_send_recipients->add();
         }
         SendRecipient* recipient{m_send_recipients->currentRecipient()};
-        recipient->setAddress(draft_recipients[i].address);
-        recipient->setLabel(draft_recipients[i].label);
+        if (draft_recipients[i].is_data_output) {
+            recipient->setDataOutput(draft_recipients[i].data_hex);
+        } else {
+            recipient->setAddress(draft_recipients[i].address);
+            recipient->setLabel(draft_recipients[i].label);
+        }
         recipient->amount()->setSatoshi(draft_recipients[i].amount);
         recipient->setMessage(QString());
     }

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -468,7 +468,7 @@ private Q_SLOTS:
     void importPsbtFromFile_opensForeignUnsignedPsbtForReviewOnly();
     void importPsbtFromFile_broadcastsCompleteForeignMultisigPsbt();
     void saveCompleteBroadcastableImportedPsbt_preservesOriginalPsbt();
-    void importPsbtFromFile_skipsZeroValueOpReturnOutputs();
+    void importPsbtFromFile_showsOpReturnAsDataOutput();
     void importPsbtFromFile_opensUnsignedMultisigPsbtForReviewOnly();
     void importPsbtFromFile_blocksBroadcastWhenFeeIsInvalid();
     void importPsbtFromFile_returnsTransactionAlreadyKnownWhenTxIsInWallet();
@@ -2411,7 +2411,7 @@ void WalletQmlModelTests::saveCompleteBroadcastableImportedPsbt_preservesOrigina
     QCOMPARE(PsbtQmlModel::SerializePsbtRaw(saved), PsbtQmlModel::SerializePsbtRaw(psbt));
 }
 
-void WalletQmlModelTests::importPsbtFromFile_skipsZeroValueOpReturnOutputs()
+void WalletQmlModelTests::importPsbtFromFile_showsOpReturnAsDataOutput()
 {
     FakePasswordWallet* wallet{nullptr};
     auto model = MakeWalletModel(wallet);
@@ -2444,9 +2444,16 @@ void WalletQmlModelTests::importPsbtFromFile_skipsZeroValueOpReturnOutputs()
     QCOMPARE(model->importPsbtFromFile(source_path), WalletQmlModel::PsbtImportResult::WalletCannotSign);
     QVERIFY(model->currentTransaction() != nullptr);
     QVERIFY(model->currentTransactionCanBroadcast());
-    QCOMPARE(model->sendRecipientList()->count(), 1);
+    QCOMPARE(model->sendRecipientList()->count(), 2);
     QCOMPARE(model->sendRecipientList()->currentRecipient()->address()->address(), VALID_MAINNET_ADDRESS);
     QCOMPARE(model->sendRecipientList()->currentRecipient()->amount()->satoshi(), CAmount{1'500});
+
+    SendRecipient* data_output{model->sendRecipientList()->recipients().at(1)};
+    QVERIFY(data_output->isDataOutput());
+    QCOMPARE(data_output->dataHex(), QStringLiteral("6a020102"));
+    QCOMPARE(data_output->amount()->satoshi(), CAmount{0});
+    QVERIFY(data_output->isValid());
+    QVERIFY(data_output->address()->address().isEmpty());
 
     const QString saved_path{temp_dir.filePath(QStringLiteral("op-return-saved.psbt"))};
     QCOMPARE(model->saveCurrentTransactionAsPsbt(saved_path), QString{});


### PR DESCRIPTION
Fixes #756. Follow-up to #750.

While learning the imported PSBT flow I reproduced the OP_RETURN skip on regtest: a PSBT with a recipient plus a `data` output imports fine, signs, broadcasts, and the OP_RETURN lands on-chain,  but the review screen never shows it. This implements what #756 (and the #750 review discussion) asked for: render it as a read-only "Data output" row with the amount and output script hex, so it stops being invisible "without becoming a scary failure."

## screenshot

<img width="1022" height="701" alt="Screenshot 2026-07-05 at 15 31 48" src="https://github.com/user-attachments/assets/63c6b36d-520b-41da-a5da-faae803f5413" />


## Approach

I read through the #750 review thread before writing this, so to be upfront about the design tension: @jarolrod's comments there argue imported PSBT review should eventually stop depending on the editable `SendRecipient` model entirely (#757, #762). I agree,  but since #750 merged with the reduced-scope recipient projection, this PR stays inside that mechanism and just fixes the OP_RETURN rendering for now. 

- `SendRecipient` gains `isDataOutput` / `dataHex`. Data outputs always report valid, so they never block the flow.
- `SendRecipientsListModel` exposes both as roles.
- `tryImportPsbtToReview()` projects zero-value unspendable outputs into data rows instead of moving past them. Since the guard only admits zero-value scripts, the positive-amount check (`recipient_total`) behaves exactly as before.
- `MultipleRecipientsSummary` renders data rows read-only ("Data output" + script hex). `SingleRecipientSummary` is untouched, a lone data output implies a data-only PSBT, which is still rejected (that's #759's territory).

The state is intentionally a thin flag, so when the read-only output model (#757) / imported session state (#762) land, this rendering maps onto them one-to-one. If you'd rather I do those first and have me rebase this on top, or I build the output-row model here instead adding it to this PR, that still works. 

## Testing

- Rewrote `importPsbtFromFile_skipsZeroValueOpReturnOutputs` as `importPsbtFromFile_showsOpReturnAsDataOutput`: asserts the data row's flag, script hex, zero amount and validity, and keeps the existing checks that the PSBT stays broadcastable and the saved PSBT is byte-identical to the imported one.

## Things I hit but left alone (tracked elsewhere)

- Data-only PSBTs still rejected → #759
- Positive-value unknown scripts still rejected (rather than warn) → #760
- Back-navigation from review exposes imported rows as editable drafts, including the data output as a blank entry → #762. it's the draft-vs-session confusion your review described.
- Two small ones that seem unfiled — the review header counts data outputs as recipients ("There are 2 recipients."), and Activity renders OP_RETURN as a blank zero-amount row.