### PR TITLE
fix: Deprecated `Settings` from `Qt.labs.settings`

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, ubuntu-24.04]
+        os: [macos-15, ubuntu-26.04]
 
     steps:
       - name: Checkout
@@ -47,7 +47,7 @@ jobs:
             build-essential ccache cmake pkgconf \
             libevent-dev libboost-dev libsqlite3-dev libgl-dev libqrencode-dev \
             qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools \
-            qt6-declarative-dev qml6-module-qt-labs-settings qml6-module-qtquick qml6-module-qtquick-controls qml6-module-qtquick-dialogs qml6-module-qtquick-layouts qml6-module-qtquick-templates qml6-module-qtqml
+            qt6-declarative-dev qml6-module-qtcore qml6-module-qtquick qml6-module-qtquick-controls qml6-module-qtquick-dialogs qml6-module-qtquick-layouts qml6-module-qtquick-templates qml6-module-qtqml
           if [ "${BUILD_APP_TESTS}" = "ON" ]; then
             sudo apt-get install -y libgtest-dev libgmock-dev
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       BUILD_APP_TESTS: ON
     steps:
@@ -35,7 +35,7 @@ jobs:
             qt6-l10n-tools \
             qt6-tools-dev-tools \
             qt6-declarative-dev \
-            qml6-module-qt-labs-settings \
+            qml6-module-qtcore \
             qml6-module-qtquick \
             qml6-module-qtquick-controls \
             qml6-module-qtquick-dialogs \

--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   qml-functional-tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       LEGACY_BITCOIND_VERSION: "28.0"
       QT_COMPAT_VERSION: "31.0"
@@ -36,7 +36,7 @@ jobs:
             qt6-qpa-plugins \
             qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools \
             qt6-declarative-dev \
-            qml6-module-qtqml qml6-module-qtqml-models qml6-module-qtqml-workerscript qml6-module-qt-labs-settings \
+            qml6-module-qtqml qml6-module-qtqml-models qml6-module-qtqml-workerscript qml6-module-qtcore \
             qml6-module-qtquick qml6-module-qtquick-window \
             qml6-module-qtquick-layouts qml6-module-qtquick-controls \
             qml6-module-qtquick-dialogs qml6-module-qtquick-templates

--- a/qml/components/BlockClock.qml
+++ b/qml/components/BlockClock.qml
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import QtCore
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import Qt.labs.settings 1.0
 
 import org.bitcoincore.qt 1.0
 

--- a/qml/components/ThemeSettings.qml
+++ b/qml/components/ThemeSettings.qml
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import QtCore
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import Qt.labs.settings 1.0
 import org.bitcoincore.qt 1.0
 import "../controls"
 

--- a/qml/controls/Theme.qml
+++ b/qml/controls/Theme.qml
@@ -1,7 +1,7 @@
 pragma Singleton
+import QtCore
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import Qt.labs.settings 1.0
 
 Control {
     id: root

--- a/qml/pages/MainWindow.qml
+++ b/qml/pages/MainWindow.qml
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import QtCore
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import Qt.labs.settings 1.0
 import org.bitcoincore.qt 1.0
 import "../components"
 import "../controls"

--- a/qml/pages/node/NetworkTraffic.qml
+++ b/qml/pages/node/NetworkTraffic.qml
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import QtCore
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import Qt.labs.settings 1.0
 import "../../controls"
 import "../../components"
 

--- a/qml/pages/node/Peers.qml
+++ b/qml/pages/node/Peers.qml
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import QtCore
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import Qt.labs.settings 1.0
 import org.bitcoincore.qt 1.0
 import "../../controls"
 import "../../components"

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import QtCore
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Dialogs
 import QtQuick.Layouts 1.15
-import Qt.labs.settings 1.0
 import org.bitcoincore.qt 1.0
 
 import "../../controls"

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import QtCore
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import Qt.labs.settings 1.0
 import org.bitcoincore.qt 1.0
 
 import "../../controls"

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import QtCore
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Dialogs
-import Qt.labs.settings 1.0
 import org.bitcoincore.qt 1.0
 
 import "../../controls"


### PR DESCRIPTION
use `QtCore` instead of `Qt.labs.settings` for `Settings` because it's deprecated and would be removed later

fix #780
