### PR TITLE
qml: Add default member initializers to `QmlCoreSettings::Values` strings

### DIFF
--- a/qml/core_settings.h
+++ b/qml/core_settings.h
@@ -28,9 +28,9 @@ struct Values {
     bool natpmp{false};
     bool server{false};
     bool proxy_enabled{false};
-    QString proxy_address;
+    QString proxy_address{};
     bool tor_enabled{false};
-    QString tor_address;
+    QString tor_address{};
 };
 
 struct Change {


### PR DESCRIPTION
Silences GCC's `-Wmissing-field-initializers` at designated-initializer call sites in `test_options_model.cpp`, where only `proxy_address` and `tor_address` were flagged as they were the only members without a default member initializer.

Fixes https://github.com/bitcoin-core/gui-qml/issues/779.