### PR TITLE
Improve block clock rendering and sync state

### DIFF
--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -40,6 +40,7 @@
 #include <qml/models/banlistmodel.h>
 #include <qml/models/bitcoinaddress.h>
 #include <qml/models/bitcoinurimodel.h>
+#include <qml/models/blockclockmodel.h>
 #include <qml/models/bumptransactionmodel.h>
 #include <qml/models/chainmodel.h>
 #include <qml/models/debuglogmodel.h>
@@ -602,9 +603,11 @@ int QmlGuiMain(int argc, char* argv[])
     AndroidNotifier android_notifier{node_model};
 #endif
 
-    ChainModel chain_model{*chain};
-    chain_model.setCurrentNetworkName(QString::fromStdString(gArgs.GetChainTypeString()));
-    setupChainQSettings(&app, chain_model.currentNetworkName());
+    ChainModel chain_model{QString::fromStdString(gArgs.GetChainTypeString())};
+    BlockClockModel block_clock_model{[chain = chain.get()](qint64 period_start, qint64 period_end) {
+        return LoadBlockClockHistory(*chain, period_start, period_end);
+    }};
+    setupChainQSettings(&app, chain_model.networkName());
     // Settings reset must happen before model instantiation so the models
     // read clean defaults from QSettings.
     if (gArgs.IsArgSet("-resetguisettings")) {
@@ -614,8 +617,8 @@ int QmlGuiMain(int argc, char* argv[])
         settings.remove(QStringLiteral("fMinimizeOnClose"));
     }
 
-    QObject::connect(&node_model, &NodeModel::setTimeRatioList, &chain_model, &ChainModel::setTimeRatioList);
-    QObject::connect(&node_model, &NodeModel::setTimeRatioListInitial, &chain_model, &ChainModel::setTimeRatioListInitial);
+    QObject::connect(&node_model, &NodeModel::blockTipTimeChanged, &block_clock_model, &BlockClockModel::recordBlockTime);
+    QObject::connect(&node_model, &NodeModel::chainStateReady, &block_clock_model, &BlockClockModel::initializeHistory);
 
 
     DesktopWindowBehaviorModel desktop_window_behavior_model;
@@ -649,6 +652,7 @@ int QmlGuiMain(int argc, char* argv[])
     engine->rootContext()->setContextProperty("networkStatusModel", &network_status_model);
     engine->rootContext()->setContextProperty("nodeModel", &node_model);
     engine->rootContext()->setContextProperty("chainModel", &chain_model);
+    engine->rootContext()->setContextProperty("blockClockModel", &block_clock_model);
     engine->rootContext()->setContextProperty("peerTableModel", &peer_model);
     engine->rootContext()->setContextProperty("peerListModelProxy", &peer_model_sort_proxy);
     engine->rootContext()->setContextProperty("banListModel", &ban_list_model);

--- a/qml/components/BlockClock.qml
+++ b/qml/components/BlockClock.qml
@@ -30,10 +30,15 @@ Item {
     property alias header: mainText.text
     property alias headerSize: mainText.font.pixelSize
     property alias subText: subText.text
-    property bool connected: root.nodeModelRef !== null && root.nodeModelRef.numPeers > 0
-    property bool synced: root.nodeModelRef !== null && root.nodeModelRef.verificationProgress > 0.999
-    property bool headerSyncActive: root.nodeModelRef !== null && root.nodeModelRef.headerSyncActive
-    property string syncProgress: formatProgressPercentage((root.headerSyncActive ? root.nodeModelRef.headerSyncProgress : (root.nodeModelRef !== null ? root.nodeModelRef.verificationProgress : 0)) * 100)
+    readonly property bool connected: root.nodeModelRef !== null && root.nodeModelRef.numPeers > 0
+    // Completion is latched after Core leaves IBD and the active chain catches
+    // the best known header. verificationProgress only renders ongoing sync.
+    readonly property bool synced: root.nodeModelRef !== null && root.nodeModelRef.initialSyncComplete
+    readonly property bool headerSyncActive: root.nodeModelRef !== null && root.nodeModelRef.headerSyncActive
+    readonly property real syncProgressFraction: root.headerSyncActive
+        ? root.nodeModelRef.headerSyncProgress
+        : (root.nodeModelRef !== null ? root.nodeModelRef.verificationProgress : 0)
+    readonly property string syncProgress: formatProgressPercentage(root.syncProgressFraction * 100, root.synced)
     property bool paused: root.nodeModelRef !== null && root.nodeModelRef.pause
     property var syncState: Utils.formatRemainingSyncTime(root.nodeModelRef !== null ? root.nodeModelRef.remainingSyncTime : 0)
     property string syncTime: syncState.text
@@ -59,7 +64,7 @@ Item {
         penWidth: dial.width / 50
         currentTimeFraction: root.blockClockModelRef !== null ? root.blockClockModelRef.currentTimeFraction : 0
         blockTimeFractions: root.blockClockModelRef !== null ? root.blockClockModelRef.blockTimeFractions : []
-        verificationProgress: root.nodeModelRef !== null ? root.nodeModelRef.verificationProgress : 0
+        syncProgress: root.syncProgressFraction
         paused: root.paused || root.faulted || root.offline
         connected: root.connected && !root.offline
         synced: root.synced
@@ -105,12 +110,17 @@ Item {
 
     Label {
         id: subText
+        objectName: "blockClockSubText"
         anchors.top: mainText.bottom
         property bool estimating: root.estimating
         anchors.horizontalCenter: root.horizontalCenter
+        width: dial.width * (4/5)
+        horizontalAlignment: Text.AlignHCenter
         font.family: "BitcoinCoreSans"
         font.styleName: "Semi Bold"
         font.pixelSize: dial.width * (9/100)
+        fontSizeMode: Text.HorizontalFit
+        minimumPixelSize: dial.width * (3/50)
         color: Theme.color.neutral4
 
         Behavior on color {
@@ -262,7 +272,14 @@ Item {
     ]
 
 
-    function formatProgressPercentage(progress) {
+    function formatProgressPercentage(progress, complete) {
+        if (complete === true) {
+            return "100%"
+        }
+        // Never present an estimate as complete while initial sync is pending.
+        if (progress >= 99.9) {
+            return "99.9%"
+        }
         if (progress >= 1) {
             return Math.round(progress) + "%"
         } else if (progress >= 0.1) {

--- a/qml/components/BlockClock.qml
+++ b/qml/components/BlockClock.qml
@@ -17,8 +17,11 @@ Item {
     property real parentWidth: 600
     property real parentHeight: 600
     property bool showNetworkIndicator: true
+    // Backing models remain current while false; only presentation work stops.
+    property bool renderingActive: true
     property var nodeModelRef: typeof nodeModel !== "undefined" ? nodeModel : null
     property var chainModelRef: typeof chainModel !== "undefined" ? chainModel : null
+    property var blockClockModelRef: typeof blockClockModel !== "undefined" ? blockClockModel : null
     property var networkStatusModelRef: typeof networkStatusModel !== "undefined" ? networkStatusModel : null
 
     width: dial.width
@@ -47,13 +50,15 @@ Item {
 
     BlockClockDial {
         id: dial
+        objectName: "blockClockDial"
         anchors.horizontalCenter: root.horizontalCenter
         scale: Theme.blockclocksize
         width: {Math.max(Math.min(200, Math.min(root.parentWidth - 30, root.parentHeight - 30)), 
                 Math.min((root.parentWidth * dial.scale), (root.parentHeight * dial.scale)))}
         height: dial.width
         penWidth: dial.width / 50
-        timeRatioList: root.chainModelRef !== null ? root.chainModelRef.timeRatioList : []
+        currentTimeFraction: root.blockClockModelRef !== null ? root.blockClockModelRef.currentTimeFraction : 0
+        blockTimeFractions: root.blockClockModelRef !== null ? root.blockClockModelRef.blockTimeFractions : []
         verificationProgress: root.nodeModelRef !== null ? root.nodeModelRef.verificationProgress : 0
         paused: root.paused || root.faulted || root.offline
         connected: root.connected && !root.offline
@@ -61,6 +66,7 @@ Item {
         backgroundColor: Theme.color.neutral2
         timeTickColor: Theme.color.neutral5
         confirmationColors: Theme.color.confirmationColors
+        renderingActive: root.renderingActive
 
         Behavior on backgroundColor {
             ColorAnimation { duration: 150 }
@@ -107,40 +113,24 @@ Item {
         font.pixelSize: dial.width * (9/100)
         color: Theme.color.neutral4
 
-        Component.onCompleted: {
-            colorChanged.connect(function() {
-                if (!subText.estimating) {
-                    themeChange.restart();
-                }
-            });
-
-            estimatingChanged.connect(function() {
-                if (subText.estimating) {
-                    estimatingTime.start();
-                } else {
-                    estimatingTime.stop();
-                }
-            });
-
-            subText.estimatingChanged();
-        }
-
-        ColorAnimation on color{
-            id: themeChange
-            target: subText
-            duration: 150
+        Behavior on color {
+            enabled: !subText.estimating
+            ColorAnimation { duration: 150 }
         }
 
         SequentialAnimation {
             id: estimatingTime
+            objectName: "blockClockEstimatingAnimation"
+            running: root.renderingActive && subText.estimating
             loops: Animation.Infinite
-            ColorAnimation { target: subText; property: "color"; from: subText.color; to: Theme.color.neutral6; duration: 1000 }
-            ColorAnimation { target: subText; property: "color"; from: Theme.color.neutral6; to: subText.color; duration: 1000 }
+            ColorAnimation { target: subText; property: "color"; from: Theme.color.neutral4; to: Theme.color.neutral6; duration: 1000 }
+            ColorAnimation { target: subText; property: "color"; from: Theme.color.neutral6; to: Theme.color.neutral4; duration: 1000 }
         }
 
     }
 
     PeersIndicator {
+        objectName: "blockClockPeersIndicator"
         anchors.top: subText.bottom
         anchors.topMargin: dial.width / 10
         anchors.horizontalCenter: root.horizontalCenter
@@ -149,6 +139,7 @@ Item {
         indicatorDimensions: dial.width * (3/200)
         indicatorSpacing: dial.width / 40
         paused: root.paused || root.faulted
+        active: root.renderingActive
     }
 
     NetworkIndicator {

--- a/qml/components/BlockClock.qml
+++ b/qml/components/BlockClock.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 
 import org.bitcoincore.qt 1.0
 
@@ -23,6 +24,11 @@ Item {
     property var chainModelRef: typeof chainModel !== "undefined" ? chainModel : null
     property var blockClockModelRef: typeof blockClockModel !== "undefined" ? blockClockModel : null
     property var networkStatusModelRef: typeof networkStatusModel !== "undefined" ? networkStatusModel : null
+    readonly property bool windowVisible: root.Window.window !== null &&
+        root.Window.window.visible &&
+        root.Window.window.visibility !== Window.Hidden &&
+        root.Window.window.visibility !== Window.Minimized
+    readonly property bool presentationActive: root.renderingActive && root.visible && root.windowVisible
 
     width: dial.width
     height: dial.height + (networkIndicator.visible ? networkIndicator.height + networkIndicator.anchors.topMargin : 0)
@@ -71,7 +77,7 @@ Item {
         backgroundColor: Theme.color.neutral2
         timeTickColor: Theme.color.neutral5
         confirmationColors: Theme.color.confirmationColors
-        renderingActive: root.renderingActive
+        renderingActive: root.presentationActive
 
         Behavior on backgroundColor {
             ColorAnimation { duration: 150 }
@@ -108,6 +114,14 @@ Item {
         }
     }
 
+    TextMetrics {
+        id: subTextMetrics
+        font.family: "BitcoinCoreSans"
+        font.styleName: "Semi Bold"
+        font.pixelSize: Math.max(1, Math.round(dial.width * (9/100)))
+        text: subText.text
+    }
+
     Label {
         id: subText
         objectName: "blockClockSubText"
@@ -118,9 +132,12 @@ Item {
         horizontalAlignment: Text.AlignHCenter
         font.family: "BitcoinCoreSans"
         font.styleName: "Semi Bold"
-        font.pixelSize: dial.width * (9/100)
-        fontSizeMode: Text.HorizontalFit
-        minimumPixelSize: dial.width * (3/50)
+        readonly property int desiredPixelSize: subTextMetrics.font.pixelSize
+        readonly property real desiredTextWidth: Math.max(subTextMetrics.width, subTextMetrics.advanceWidth)
+        font.pixelSize: subText.desiredTextWidth > subText.width
+            ? Math.max(1, Math.floor(subText.desiredPixelSize * (subText.width - 2) / subText.desiredTextWidth))
+            : subText.desiredPixelSize
+        elide: Text.ElideRight
         color: Theme.color.neutral4
 
         Behavior on color {
@@ -131,7 +148,7 @@ Item {
         SequentialAnimation {
             id: estimatingTime
             objectName: "blockClockEstimatingAnimation"
-            running: root.renderingActive && subText.estimating
+            running: root.presentationActive && subText.estimating
             loops: Animation.Infinite
             ColorAnimation { target: subText; property: "color"; from: Theme.color.neutral4; to: Theme.color.neutral6; duration: 1000 }
             ColorAnimation { target: subText; property: "color"; from: Theme.color.neutral6; to: Theme.color.neutral4; duration: 1000 }
@@ -149,7 +166,7 @@ Item {
         indicatorDimensions: dial.width * (3/200)
         indicatorSpacing: dial.width / 40
         paused: root.paused || root.faulted
-        active: root.renderingActive
+        active: root.presentationActive
     }
 
     NetworkIndicator {

--- a/qml/components/MiniBlockClock.qml
+++ b/qml/components/MiniBlockClock.qml
@@ -15,10 +15,11 @@ Item {
     property real iconSize: 18
     property bool pageSelected: false
     property bool renderingActive: true
-    property bool connected: nodeModel.numPeers > 0
-    property bool synced: nodeModel.verificationProgress > 0.999
-    property bool paused: nodeModel.pause
-    property bool faulted: nodeModel.faulted
+    property var nodeModelRef: typeof nodeModel !== "undefined" ? nodeModel : null
+    readonly property bool connected: root.nodeModelRef !== null && root.nodeModelRef.numPeers > 0
+    readonly property bool synced: root.nodeModelRef !== null && root.nodeModelRef.initialSyncComplete
+    property bool paused: root.nodeModelRef !== null && root.nodeModelRef.pause
+    property bool faulted: root.nodeModelRef !== null && root.nodeModelRef.faulted
     property var networkStatusModelRef: typeof networkStatusModel !== "undefined" ? networkStatusModel : null
     property var blockClockModelRef: typeof blockClockModel !== "undefined" ? blockClockModel : null
     property bool offline: networkStatusModelRef !== null && networkStatusModelRef.networkOffline
@@ -44,13 +45,14 @@ Item {
 
     BlockClockDial {
         id: dial
+        objectName: "miniBlockClockDial"
         visible: root.showConnectingState || root.showIbdState || root.showClockState
         anchors.fill: parent
         penWidth: root.strokeWidth
         connectingAnimationDelayMs: 0
         currentTimeFraction: root.pageSelected ? 1.0 : (root.blockClockModelRef !== null ? root.blockClockModelRef.currentTimeFraction : 0)
         blockTimeFractions: []
-        verificationProgress: root.pageSelected ? 1.0 : nodeModel.verificationProgress
+        syncProgress: root.pageSelected ? 1.0 : (root.nodeModelRef !== null ? root.nodeModelRef.verificationProgress : 0)
         connected: root.pageSelected || root.connected
         synced: root.pageSelected || root.synced
         paused: false

--- a/qml/components/MiniBlockClock.qml
+++ b/qml/components/MiniBlockClock.qml
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import QtQuick 2.15
+import QtQuick.Window 2.15
 
 import org.bitcoincore.qt 1.0
 
@@ -23,6 +24,11 @@ Item {
     property var networkStatusModelRef: typeof networkStatusModel !== "undefined" ? networkStatusModel : null
     property var blockClockModelRef: typeof blockClockModel !== "undefined" ? blockClockModel : null
     property bool offline: networkStatusModelRef !== null && networkStatusModelRef.networkOffline
+    readonly property bool windowVisible: root.Window.window !== null &&
+        root.Window.window.visible &&
+        root.Window.window.visibility !== Window.Hidden &&
+        root.Window.window.visibility !== Window.Minimized
+    readonly property bool presentationActive: root.renderingActive && root.visible && root.windowVisible
 
     readonly property bool showOfflineState: !root.faulted && root.offline
     readonly property bool showPausedState: root.paused && !root.faulted && !root.offline
@@ -63,7 +69,7 @@ Item {
         backgroundColor: Theme.color.neutral3
         timeTickColor: "transparent"
         confirmationColors: Theme.color.confirmationColors
-        renderingActive: root.renderingActive
+        renderingActive: root.presentationActive
     }
 
     Item {

--- a/qml/components/MiniBlockClock.qml
+++ b/qml/components/MiniBlockClock.qml
@@ -14,11 +14,13 @@ Item {
 
     property real iconSize: 18
     property bool pageSelected: false
+    property bool renderingActive: true
     property bool connected: nodeModel.numPeers > 0
     property bool synced: nodeModel.verificationProgress > 0.999
     property bool paused: nodeModel.pause
     property bool faulted: nodeModel.faulted
     property var networkStatusModelRef: typeof networkStatusModel !== "undefined" ? networkStatusModel : null
+    property var blockClockModelRef: typeof blockClockModel !== "undefined" ? blockClockModel : null
     property bool offline: networkStatusModelRef !== null && networkStatusModelRef.networkOffline
 
     readonly property bool showOfflineState: !root.faulted && root.offline
@@ -40,15 +42,14 @@ Item {
     width: implicitWidth
     height: implicitHeight
 
-    readonly property var fullDialTimeRatioList: [1.0, 0.0]
-
     BlockClockDial {
         id: dial
         visible: root.showConnectingState || root.showIbdState || root.showClockState
         anchors.fill: parent
         penWidth: root.strokeWidth
         connectingAnimationDelayMs: 0
-        timeRatioList: root.pageSelected ? root.fullDialTimeRatioList : chainModel.timeRatioList
+        currentTimeFraction: root.pageSelected ? 1.0 : (root.blockClockModelRef !== null ? root.blockClockModelRef.currentTimeFraction : 0)
+        blockTimeFractions: []
         verificationProgress: root.pageSelected ? 1.0 : nodeModel.verificationProgress
         connected: root.pageSelected || root.connected
         synced: root.pageSelected || root.synced
@@ -60,6 +61,7 @@ Item {
         backgroundColor: Theme.color.neutral3
         timeTickColor: "transparent"
         confirmationColors: Theme.color.confirmationColors
+        renderingActive: root.renderingActive
     }
 
     Item {

--- a/qml/components/NetworkIndicator.qml
+++ b/qml/components/NetworkIndicator.qml
@@ -20,7 +20,7 @@ Button {
     bottomPadding: 2
     leftPadding: 7
     rightPadding: 7
-    state: show && root.chainModelRef !== null ? root.chainModelRef.currentNetworkName : "MAIN"
+    state: show && root.chainModelRef !== null ? root.chainModelRef.networkName : "MAIN"
     contentItem: CoreText {
         text: root.text
         font.pixelSize: root.textSize

--- a/qml/components/PeersIndicator.qml
+++ b/qml/components/PeersIndicator.qml
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import QtQuick 2.15
+import QtQuick.Window 2.15
 import "../controls"
 
 Row {
@@ -11,6 +12,11 @@ Row {
     required property int maxNumOutboundPeers
     required property bool paused
     required property bool active
+    readonly property bool windowVisible: root.Window.window !== null &&
+        root.Window.window.visible &&
+        root.Window.window.visibility !== Window.Hidden &&
+        root.Window.window.visibility !== Window.Minimized
+    readonly property bool presentationActive: root.active && root.visible && root.windowVisible
     property int size: 5
     property real indicatorDimensions: 3
     property real indicatorSpacing: 5
@@ -29,7 +35,7 @@ Row {
             Behavior on opacity { OpacityAnimator { duration: 150 } }
             SequentialAnimation on opacity {
                 loops: Animation.Infinite
-                running: root.active && numOutboundPeers === 0 && index === 0 && !root.paused
+                running: root.presentationActive && numOutboundPeers === 0 && index === 0 && !root.paused
                 SmoothedAnimation { to: 0; velocity: 2.2 }
                 SmoothedAnimation { to: 1; velocity: 2.2 }
             }

--- a/qml/components/PeersIndicator.qml
+++ b/qml/components/PeersIndicator.qml
@@ -10,6 +10,7 @@ Row {
     required property int numOutboundPeers
     required property int maxNumOutboundPeers
     required property bool paused
+    required property bool active
     property int size: 5
     property real indicatorDimensions: 3
     property real indicatorSpacing: 5
@@ -28,7 +29,7 @@ Row {
             Behavior on opacity { OpacityAnimator { duration: 150 } }
             SequentialAnimation on opacity {
                 loops: Animation.Infinite
-                running: numOutboundPeers === 0 && index === 0 && !root.paused
+                running: root.active && numOutboundPeers === 0 && index === 0 && !root.paused
                 SmoothedAnimation { to: 0; velocity: 2.2 }
                 SmoothedAnimation { to: 1; velocity: 2.2 }
             }

--- a/qml/components/blockclockdial.cpp
+++ b/qml/components/blockclockdial.cpp
@@ -5,6 +5,7 @@
 #include <qml/components/blockclockdial.h>
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 #include <QBrush>
@@ -381,39 +382,61 @@ void BlockClockDial::paintBlocks(QPainter * painter)
 
     QPen pen(m_confirmation_colors.constLast());
     pen.setWidthF(m_pen_width);
-    pen.setCapStyle(Qt::FlatCap);
+    pen.setCapStyle(Qt::RoundCap);
     const QRectF bounds = getBoundsForPen(pen);
     painter->setPen(pen);
 
-    // Boundaries are explicit: the period starts at zero, each block closes
-    // one confirmation segment, and the current time closes the newest one.
-    QList<qreal> boundaries;
-    boundaries.reserve(m_block_time_fractions.size() + 2);
-    boundaries.push_back(0.0);
-    boundaries.append(m_block_time_fractions);
-    boundaries.push_back(m_current_time_fraction);
-
-    const qreal gap{degreesPerPixel()};
-    const qsizetype segment_count{boundaries.size() - 1};
-    for (qsizetype segment{0}; segment < segment_count; ++segment) {
-        const qsizetype color_index{qMin<qsizetype>(5, segment_count - segment - 1)};
-        pen.setColor(m_confirmation_colors.at(color_index));
-        painter->setPen(pen);
-
-        const qreal startAngle{90 - 360 * boundaries.at(segment)};
-        qreal nextAngle{90 - 360 * boundaries.at(segment + 1)};
-
-        QPainterPath path;
-        path.arcMoveTo(bounds, startAngle);
-
-        if (-1 * nextAngle + 90 > m_animating_max_angle) {
-            nextAngle = -1 * m_animating_max_angle + 90;
-            segment = segment_count;
+    // Rounded caps extend half a stroke beyond each path endpoint. Separate
+    // their center lines by one stroke plus a small visible gap so neighboring
+    // confirmation segments retain the pill-shaped spacing from the design.
+    const QList<BlockSegment> segments{coalescedBlockSegments(bounds)};
+    const qreal boundary_gap_degrees{
+        degreesForArcPixels(m_pen_width + blockSegmentGapPixels(), bounds)};
+    const qreal half_boundary_gap{boundary_gap_degrees / 2.0};
+    const qreal animated_fraction{qBound<qreal>(0.0, m_animating_max_angle / 360.0, 1.0)};
+    for (const BlockSegment& segment : segments) {
+        const qreal painted_end{qMin(segment.end_fraction, animated_fraction)};
+        const qreal available_degrees{(painted_end - segment.start_fraction) * 360.0};
+        if (available_degrees <= boundary_gap_degrees) {
+            if (segment.end_fraction > animated_fraction) break;
+            continue;
         }
 
-        const qreal spanAngle = -1 * (startAngle - nextAngle) + gap;
-        path.arcTo(bounds, startAngle, spanAngle);
+        const qsizetype confirmation_steps{segment.start_confirmations - segment.end_confirmations};
+        const qsizetype start_color_index{qMin<qsizetype>(5, segment.start_confirmations)};
+        const qsizetype end_color_index{qMin<qsizetype>(5, segment.end_confirmations)};
+        if (confirmation_steps > 1 && start_color_index != end_color_index) {
+            // Conical gradients run counter-clockwise, so anchor the first stop
+            // at the newer end and interpolate back toward the segment start.
+            const qreal gradient_angle{
+                std::fmod(450.0 - 360.0 * segment.end_fraction, 360.0)};
+            const qreal gradient_span{segment.end_fraction - segment.start_fraction};
+            QConicalGradient gradient{bounds.center(), gradient_angle};
+            gradient.setColorAt(0.0, m_confirmation_colors.at(end_color_index));
+            for (qsizetype confirmations{segment.end_confirmations + 1};
+                 confirmations <= start_color_index;
+                 ++confirmations) {
+                const qreal stop{
+                    gradient_span * (confirmations - segment.end_confirmations) /
+                    confirmation_steps};
+                gradient.setColorAt(stop, m_confirmation_colors.at(confirmations));
+            }
+            gradient.setColorAt(gradient_span, m_confirmation_colors.at(start_color_index));
+            pen.setBrush(QBrush{gradient});
+        } else {
+            pen.setColor(m_confirmation_colors.at(start_color_index));
+        }
+        painter->setPen(pen);
+
+        const qreal start_angle{90 - 360 * segment.start_fraction - half_boundary_gap};
+        const qreal end_angle{90 - 360 * painted_end + half_boundary_gap};
+
+        QPainterPath path;
+        path.arcMoveTo(bounds, start_angle);
+        path.arcTo(bounds, start_angle, end_angle - start_angle);
         painter->drawPath(path);
+
+        if (segment.end_fraction > animated_fraction) break;
     }
 }
 
@@ -510,6 +533,77 @@ double BlockClockDial::degreesPerPixel()
 {
     double circumference = width() * 3.1415926;
     return 360 / circumference;
+}
+
+qreal BlockClockDial::degreesForArcPixels(qreal pixels, const QRectF& bounds) const
+{
+    const qreal radius{qMin(bounds.width(), bounds.height()) / 2.0};
+    if (radius <= 0.0) return 360.0;
+    return qRadiansToDegrees(pixels / radius);
+}
+
+qreal BlockClockDial::blockSegmentGapPixels() const
+{
+    // The Figma dial uses a gap around half the stroke width, with one device
+    // pixel as the lower bound for small miniatures.
+    return qMax<qreal>(1.0, m_pen_width / 2.0);
+}
+
+QList<BlockClockDial::BlockSegment> BlockClockDial::coalescedBlockSegments(
+    const QRectF& bounds) const
+{
+    const qreal current_fraction{qBound<qreal>(0.0, m_current_time_fraction, 1.0)};
+    if (current_fraction <= 0.0) return {};
+
+    // A rounded segment needs room for both half-caps, the visual gap, and at
+    // least one pixel of center line. Each visual boundary retains the number
+    // of blocks in its cluster so painting can preserve confirmation depth.
+    const qreal minimum_interval_fraction{
+        degreesForArcPixels(m_pen_width + blockSegmentGapPixels() + 1.0, bounds) / 360.0};
+
+    struct Boundary
+    {
+        qreal fraction;
+        qsizetype block_count;
+    };
+    QList<Boundary> descending_boundaries{{current_fraction, 0}};
+    qreal next_boundary{current_fraction};
+    // Walk backward so an unrenderable block joins the newer visual boundary.
+    // The current-time boundary can therefore carry recently mined blocks too.
+    for (auto it{m_block_time_fractions.crbegin()}; it != m_block_time_fractions.crend(); ++it) {
+        const qreal boundary{*it};
+        if (boundary <= 0.0 || boundary >= current_fraction) continue;
+        if (next_boundary - boundary < minimum_interval_fraction) {
+            ++descending_boundaries.last().block_count;
+            continue;
+        }
+
+        descending_boundaries.push_back({boundary, 1});
+        next_boundary = boundary;
+    }
+
+    // Do not leave an undersized first segment against the period boundary.
+    if (descending_boundaries.size() > 1 &&
+        descending_boundaries.constLast().fraction < minimum_interval_fraction) {
+        descending_boundaries.removeLast();
+    }
+    std::reverse(descending_boundaries.begin(), descending_boundaries.end());
+
+    // Convert weighted visual boundaries into chronological paint segments.
+    // Crossing a boundary removes every confirmation represented by its cluster.
+    qsizetype confirmations{0};
+    for (const Boundary& boundary : descending_boundaries) confirmations += boundary.block_count;
+
+    QList<BlockSegment> segments;
+    segments.reserve(descending_boundaries.size());
+    qreal segment_start{0.0};
+    for (const Boundary& boundary : descending_boundaries) {
+        const qsizetype next_confirmations{confirmations - boundary.block_count};
+        segments.push_back({segment_start, boundary.fraction, confirmations, next_confirmations});
+        segment_start = boundary.fraction;
+        confirmations = next_confirmations;
+    }
+    return segments;
 }
 
 void BlockClockDial::paintTimeTicks(QPainter * painter)

--- a/qml/components/blockclockdial.cpp
+++ b/qml/components/blockclockdial.cpp
@@ -69,13 +69,16 @@ void BlockClockDial::setupSyncedGradient(const QRectF& bounds)
     m_synced_gradient_bounds = bounds;
     m_synced_gradient.setCenter(bounds.center());
     m_synced_gradient.setAngle(90);
-    m_synced_gradient.setColorAt(0, m_confirmation_colors[5]);
-    m_synced_gradient.setColorAt(0.16, m_confirmation_colors[5]);
-    m_synced_gradient.setColorAt(0.32, m_confirmation_colors[4]);
-    m_synced_gradient.setColorAt(0.48, m_confirmation_colors[3]);
-    m_synced_gradient.setColorAt(0.64, m_confirmation_colors[2]);
-    m_synced_gradient.setColorAt(0.8, m_confirmation_colors[1]);
-    m_synced_gradient.setColorAt(1, m_confirmation_colors[0]);
+    // The dial advances clockwise while conical gradients advance
+    // counter-clockwise. Mirror the stops so older time is more confirmed and
+    // the color moves toward zero confirmations as the dial advances.
+    m_synced_gradient.setColorAt(0, m_confirmation_colors[0]);
+    m_synced_gradient.setColorAt(0.2, m_confirmation_colors[1]);
+    m_synced_gradient.setColorAt(0.36, m_confirmation_colors[2]);
+    m_synced_gradient.setColorAt(0.52, m_confirmation_colors[3]);
+    m_synced_gradient.setColorAt(0.68, m_confirmation_colors[4]);
+    m_synced_gradient.setColorAt(0.84, m_confirmation_colors[5]);
+    m_synced_gradient.setColorAt(1, m_confirmation_colors[5]);
     m_synced_gradient_needs_update = false;
 }
 

--- a/qml/components/blockclockdial.cpp
+++ b/qml/components/blockclockdial.cpp
@@ -97,7 +97,7 @@ qreal BlockClockDial::getTargetAnimationAngle() const
     if (connected() && synced()) {
         return m_current_time_fraction * 360;
     } else if (connected()) {
-        return verificationProgress() * 360;
+        return syncProgress() * 360;
     } else {
         return 360;
     }
@@ -212,10 +212,11 @@ void BlockClockDial::setBlockTimeFractions(QList<qreal> fractions)
     requestRepaint();
 }
 
-void BlockClockDial::setVerificationProgress(double progress)
+void BlockClockDial::setSyncProgress(double progress)
 {
-    if (qFuzzyCompare(m_verification_progress + 1.0, progress + 1.0)) return;
-    m_verification_progress = progress;
+    progress = qBound(0.0, progress, 1.0);
+    if (qFuzzyCompare(m_sync_progress + 1.0, progress + 1.0)) return;
+    m_sync_progress = progress;
     syncAnimationState();
     requestRepaint();
 }
@@ -430,10 +431,10 @@ void BlockClockDial::paintProgress(QPainter * painter)
     // QPainter's is 3 o'clock, hence - 90.
     const qreal startAngle = 90;
     qreal spanAngle;
-    if (verificationProgress() * 360 > m_animating_max_angle) {
+    if (syncProgress() * 360 > m_animating_max_angle) {
         spanAngle = m_animating_max_angle * -1;
     } else {
-        spanAngle = verificationProgress() * -360;
+        spanAngle = syncProgress() * -360;
     }
 
     // QPainter::drawArc parameters are 1/16 of a degree

--- a/qml/components/blockclockdial.cpp
+++ b/qml/components/blockclockdial.cpp
@@ -4,36 +4,48 @@
 
 #include <qml/components/blockclockdial.h>
 
+#include <algorithm>
+#include <utility>
+
 #include <QBrush>
 #include <QColor>
 #include <QPainterPath>
 #include <QConicalGradient>
 #include <QPen>
+#include <QQuickWindow>
 #include <QtMath>
 #include <QtGlobal>
 
 BlockClockDial::BlockClockDial(QQuickItem *parent)
-    : QQuickPaintedItem(parent)
+    : QQuickPaintedItem(parent),
+      m_animation_timer{this},
+      m_delay_timer{this}
 {
     m_animation_timer.setTimerType(Qt::PreciseTimer);
     m_animation_timer.setInterval(16);
     m_delay_timer.setSingleShot(true);
     m_delay_timer.setInterval(m_connecting_animation_delay_ms);
     connect(&m_delay_timer, &QTimer::timeout,
-            this, [this]() { this->m_animation_timer.start(); });
-    connect(&m_animation_timer, &QTimer::timeout,
-            this, [=, this]() {
-                if (m_is_connected
-                    && getTargetAnimationAngle() - m_animating_max_angle < 1) {
-                    m_animation_timer.stop();
+            this, [this] {
+                if (presentationActive() && m_animate_dial && !m_is_paused) {
+                    m_animation_timer.start();
                 }
-                this->update();
             });
-    if (m_connecting_animation_delay_ms == 0) {
-        m_animation_timer.start();
-    } else {
-        m_delay_timer.start();
-    }
+    connect(&m_animation_timer, &QTimer::timeout,
+            this, &BlockClockDial::advanceAnimation);
+    connect(this, &QQuickItem::visibleChanged, this, &BlockClockDial::syncAnimationState);
+    connect(this, &QQuickItem::windowChanged, this, [this] {
+        connectWindowVisibility();
+        syncAnimationState();
+    });
+}
+
+void BlockClockDial::componentComplete()
+{
+    QQuickPaintedItem::componentComplete();
+    m_component_complete = true;
+    connectWindowVisibility();
+    syncAnimationState();
 }
 
 void BlockClockDial::setupConnectingGradient(const QPen & pen)
@@ -71,7 +83,7 @@ void BlockClockDial::invalidateSyncedGradient()
     m_synced_gradient_needs_update = true;
 }
 
-qreal BlockClockDial::decrementGradientAngle(qreal angle)
+qreal BlockClockDial::decrementGradientAngle(qreal angle) const
 {
     if (angle == -360) {
         return 0;
@@ -80,14 +92,10 @@ qreal BlockClockDial::decrementGradientAngle(qreal angle)
     }
 }
 
-qreal BlockClockDial::getTargetAnimationAngle()
+qreal BlockClockDial::getTargetAnimationAngle() const
 {
-    if (m_time_ratio_list.isEmpty()) {
-        return connected() ? verificationProgress() * 360 : 360;
-    }
-
     if (connected() && synced()) {
-        return m_time_ratio_list[0].toDouble() * 360;
+        return m_current_time_fraction * 360;
     } else if (connected()) {
         return verificationProgress() * 360;
     } else {
@@ -95,36 +103,121 @@ qreal BlockClockDial::getTargetAnimationAngle()
     }
 }
 
-qreal BlockClockDial::incrementAnimatingMaxAngle(qreal angle)
+bool BlockClockDial::presentationActive() const
 {
+    if (!m_component_complete || !m_rendering_active || !isVisible()) return false;
+    if (!window()) return true;
+
+    const QWindow::Visibility visibility{window()->visibility()};
+    return window()->isVisible() &&
+           visibility != QWindow::Hidden &&
+           visibility != QWindow::Minimized;
+}
+
+void BlockClockDial::requestRepaint()
+{
+    if (presentationActive()) update();
+}
+
+void BlockClockDial::advanceAnimation()
+{
+    if (!presentationActive() || !m_animate_dial || m_is_paused) {
+        m_animation_timer.stop();
+        return;
+    }
+
     if (connected()) {
-        return angle += (getTargetAnimationAngle() - angle) * 0.05;
-    } else {
-        // Use linear growth for the "Connecting" animation
-        if (angle >= 360) {
-            return 360;
-        } else {
-            return angle += 4;
+        const qreal target{getTargetAnimationAngle()};
+        m_animating_max_angle += (target - m_animating_max_angle) * 0.05;
+        if (qAbs(target - m_animating_max_angle) < 1.0) {
+            m_animating_max_angle = target;
+            m_animation_timer.stop();
         }
+    } else {
+        m_animating_max_angle = qMin<qreal>(360.0, m_animating_max_angle + 4.0);
+        if (m_animating_max_angle >= m_connecting_end_angle * -1) {
+            m_connecting_start_angle = decrementGradientAngle(m_connecting_start_angle);
+        }
+    }
+
+    requestRepaint();
+}
+
+void BlockClockDial::syncAnimationState()
+{
+    const bool active{presentationActive()};
+    const bool becoming_active{active && !m_presentation_was_active};
+    m_presentation_was_active = active;
+
+    if (!active || !m_animate_dial || m_is_paused) {
+        m_animation_timer.stop();
+        m_delay_timer.stop();
+        if (!m_animate_dial) m_animating_max_angle = getTargetAnimationAngle();
+        return;
+    }
+
+    if (becoming_active) {
+        // Backing models continued to advance while hidden. Connected clocks
+        // resume at the latest value rather than replaying stale animation.
+        m_animating_max_angle = connected() ? getTargetAnimationAngle() : 0.0;
+        if (!connected()) m_connecting_start_angle = 90.0;
+        requestRepaint();
+    }
+
+    if (!connected()) {
+        if (m_animation_timer.isActive() || m_delay_timer.isActive()) return;
+        if (m_connecting_animation_delay_ms == 0) {
+            m_animation_timer.start();
+        } else {
+            m_delay_timer.start(m_connecting_animation_delay_ms);
+        }
+        return;
+    }
+
+    m_delay_timer.stop();
+    const qreal target{getTargetAnimationAngle()};
+    if (qAbs(target - m_animating_max_angle) < 1.0) {
+        m_animating_max_angle = target;
+        m_animation_timer.stop();
+    } else if (!m_animation_timer.isActive()) {
+        m_animation_timer.start();
     }
 }
 
-void BlockClockDial::setTimeRatioList(QVariantList new_list)
+void BlockClockDial::connectWindowVisibility()
 {
-    m_time_ratio_list = new_list;
-    if (!m_animate_dial) {
-        m_animating_max_angle = getTargetAnimationAngle();
-    }
-    update();
+    disconnect(m_window_visibility_connection);
+    if (!window()) return;
+    m_window_visibility_connection = connect(window(), &QWindow::visibilityChanged, this, [this] {
+        syncAnimationState();
+    });
+}
+
+void BlockClockDial::setCurrentTimeFraction(qreal fraction)
+{
+    fraction = qBound<qreal>(0.0, fraction, 1.0);
+    if (qFuzzyCompare(m_current_time_fraction + 1.0, fraction + 1.0)) return;
+    m_current_time_fraction = fraction;
+    syncAnimationState();
+    requestRepaint();
+}
+
+void BlockClockDial::setBlockTimeFractions(QList<qreal> fractions)
+{
+    for (qreal& fraction : fractions) fraction = qBound<qreal>(0.0, fraction, 1.0);
+    std::sort(fractions.begin(), fractions.end());
+    fractions.erase(std::unique(fractions.begin(), fractions.end()), fractions.end());
+    if (m_block_time_fractions == fractions) return;
+    m_block_time_fractions = std::move(fractions);
+    requestRepaint();
 }
 
 void BlockClockDial::setVerificationProgress(double progress)
 {
+    if (qFuzzyCompare(m_verification_progress + 1.0, progress + 1.0)) return;
     m_verification_progress = progress;
-    if (!m_animate_dial) {
-        m_animating_max_angle = getTargetAnimationAngle();
-    }
-    update();
+    syncAnimationState();
+    requestRepaint();
 }
 
 void BlockClockDial::setConnected(bool connected)
@@ -132,23 +225,9 @@ void BlockClockDial::setConnected(bool connected)
     if (m_is_connected != connected) {
         m_is_connected = connected;
         m_animating_max_angle = 0;
-        if (!m_animate_dial) {
-            m_animation_timer.stop();
-            m_delay_timer.stop();
-            m_animating_max_angle = getTargetAnimationAngle();
-        } else if (m_is_connected) {
-            m_delay_timer.stop();
-            m_animation_timer.start();
-        } else {
-            m_animation_timer.stop();
-            if (m_connecting_animation_delay_ms == 0) {
-                m_delay_timer.stop();
-                m_animation_timer.start();
-            } else {
-                m_delay_timer.start();
-            }
-        }
-        update();
+        if (!m_is_connected) m_connecting_start_angle = 90.0;
+        syncAnimationState();
+        requestRepaint();
     }
 }
 
@@ -157,14 +236,8 @@ void BlockClockDial::setSynced(bool is_synced)
     if (m_is_synced != is_synced) {
         m_is_synced = is_synced;
         m_animating_max_angle = 0;
-        if (!m_animate_dial) {
-            m_animation_timer.stop();
-            m_delay_timer.stop();
-            m_animating_max_angle = getTargetAnimationAngle();
-        } else if (m_is_synced && connected()) {
-            m_animation_timer.start();
-        }
-        update();
+        syncAnimationState();
+        requestRepaint();
     }
 }
 
@@ -172,11 +245,8 @@ void BlockClockDial::setPaused(bool paused)
 {
     if (m_is_paused != paused) {
         m_is_paused = paused;
-        if (m_is_paused) {
-            m_animation_timer.stop();
-        }
-        m_animating_max_angle = 0;
-        update();
+        syncAnimationState();
+        requestRepaint();
     }
 }
 
@@ -184,21 +254,18 @@ void BlockClockDial::setAnimateDial(bool animate_dial)
 {
     if (m_animate_dial != animate_dial) {
         m_animate_dial = animate_dial;
-        if (m_animate_dial) {
-            m_animating_max_angle = 0;
-            if (m_is_connected) {
-                m_animation_timer.start();
-            } else {
-                m_animation_timer.stop();
-                m_delay_timer.start();
-            }
-        } else {
-            m_animation_timer.stop();
-            m_delay_timer.stop();
-            m_animating_max_angle = getTargetAnimationAngle();
-        }
-        update();
+        if (m_animate_dial) m_animating_max_angle = 0;
+        syncAnimationState();
+        requestRepaint();
     }
+}
+
+void BlockClockDial::setRenderingActive(bool active)
+{
+    if (m_rendering_active == active) return;
+    m_rendering_active = active;
+    Q_EMIT renderingActiveChanged();
+    syncAnimationState();
 }
 
 void BlockClockDial::setConnectingAnimationDelayMs(int connecting_animation_delay_ms)
@@ -207,14 +274,11 @@ void BlockClockDial::setConnectingAnimationDelayMs(int connecting_animation_dela
     if (m_connecting_animation_delay_ms != connecting_animation_delay_ms) {
         m_connecting_animation_delay_ms = connecting_animation_delay_ms;
         m_delay_timer.setInterval(m_connecting_animation_delay_ms);
-        if (!m_is_connected && m_animate_dial) {
-            if (m_connecting_animation_delay_ms == 0) {
-                m_delay_timer.stop();
-                m_animation_timer.start();
-            } else if (!m_animation_timer.isActive()) {
-                m_delay_timer.start();
-            }
+        if (!m_is_connected) {
+            m_animation_timer.stop();
+            m_delay_timer.stop();
         }
+        syncAnimationState();
     }
 }
 
@@ -222,7 +286,7 @@ void BlockClockDial::setShowTimeTicks(bool show_time_ticks)
 {
     if (m_show_time_ticks != show_time_ticks) {
         m_show_time_ticks = show_time_ticks;
-        update();
+        requestRepaint();
     }
 }
 
@@ -230,7 +294,7 @@ void BlockClockDial::setShowBlockSegments(bool show_block_segments)
 {
     if (m_show_block_segments != show_block_segments) {
         m_show_block_segments = show_block_segments;
-        update();
+        requestRepaint();
     }
 }
 
@@ -238,7 +302,7 @@ void BlockClockDial::setUseGradientArcWhenSynced(bool use_gradient_arc_when_sync
 {
     if (m_use_gradient_arc_when_synced != use_gradient_arc_when_synced) {
         m_use_gradient_arc_when_synced = use_gradient_arc_when_synced;
-        update();
+        requestRepaint();
     }
 }
 
@@ -247,7 +311,7 @@ void BlockClockDial::setPenWidth(qreal width)
     if (m_pen_width != width) {
         m_pen_width = width;
         invalidateSyncedGradient();
-        update();
+        requestRepaint();
     }
 }
 
@@ -256,7 +320,7 @@ void BlockClockDial::setScale(qreal scale)
     if (m_scale != scale) {
         m_scale = scale;
         invalidateSyncedGradient();
-        update();
+        requestRepaint();
 
         Q_EMIT scaleChanged();
     }
@@ -264,8 +328,9 @@ void BlockClockDial::setScale(qreal scale)
 
 void BlockClockDial::setBackgroundColor(QColor color)
 {
+    if (m_background_color == color) return;
     m_background_color = color;
-    update();
+    requestRepaint();
 }
 
 void BlockClockDial::setConfirmationColors(QList<QColor> colorList)
@@ -273,14 +338,15 @@ void BlockClockDial::setConfirmationColors(QList<QColor> colorList)
     if (m_confirmation_colors != colorList) {
         m_confirmation_colors = colorList;
         invalidateSyncedGradient();
-        update();
+        requestRepaint();
     }
 }
 
 void BlockClockDial::setTimeTickColor(QColor color)
 {
+    if (m_time_tick_color == color) return;
     m_time_tick_color = color;
-    update();
+    requestRepaint();
 }
 
 QRectF BlockClockDial::getBoundsForPen(const QPen & pen)
@@ -310,45 +376,38 @@ QRectF BlockClockDial::getBoundsForPen(const QPen & pen)
 
 void BlockClockDial::paintBlocks(QPainter * painter)
 {
-    int numberOfBlocks = m_time_ratio_list.length();
-    if (numberOfBlocks < 2) {
-        return;
-    }
+    if (m_confirmation_colors.size() < 6) return;
 
-    QPen pen(m_confirmation_colors[5]);
+    QPen pen(m_confirmation_colors.constLast());
     pen.setWidthF(m_pen_width);
     pen.setCapStyle(Qt::FlatCap);
     const QRectF bounds = getBoundsForPen(pen);
     painter->setPen(pen);
 
-    // The gap is calculated here and is used to create a
-    // one pixel spacing between each block
-    double gap = degreesPerPixel();
+    // Boundaries are explicit: the period starts at zero, each block closes
+    // one confirmation segment, and the current time closes the newest one.
+    QList<qreal> boundaries;
+    boundaries.reserve(m_block_time_fractions.size() + 2);
+    boundaries.push_back(0.0);
+    boundaries.append(m_block_time_fractions);
+    boundaries.push_back(m_current_time_fraction);
 
-    // Paint blocks
-    for (int i = 1; i < numberOfBlocks; i++) {
-        if (numberOfBlocks - i <= 6) {
-            QPen pen(m_confirmation_colors[numberOfBlocks - i - 1]);
-            pen.setWidthF(m_pen_width);
-            pen.setCapStyle(Qt::FlatCap);
-            painter->setPen(pen);
-        }
+    const qreal gap{degreesPerPixel()};
+    const qsizetype segment_count{boundaries.size() - 1};
+    for (qsizetype segment{0}; segment < segment_count; ++segment) {
+        const qsizetype color_index{qMin<qsizetype>(5, segment_count - segment - 1)};
+        pen.setColor(m_confirmation_colors.at(color_index));
+        painter->setPen(pen);
 
-        const qreal startAngle = 90 + (-360 * m_time_ratio_list[i].toDouble());
-        qreal nextAngle;
-        if (i == numberOfBlocks - 1) {
-            nextAngle = 90 + (-360 * m_time_ratio_list[0].toDouble());
-        } else {
-            nextAngle = 90 + (-360 * m_time_ratio_list[i+1].toDouble());
-        }
+        const qreal startAngle{90 - 360 * boundaries.at(segment)};
+        qreal nextAngle{90 - 360 * boundaries.at(segment + 1)};
 
         QPainterPath path;
         path.arcMoveTo(bounds, startAngle);
 
         if (-1 * nextAngle + 90 > m_animating_max_angle) {
             nextAngle = -1 * m_animating_max_angle + 90;
-            // end the loop early
-            i = numberOfBlocks;
+            segment = segment_count;
         }
 
         const qreal spanAngle = -1 * (startAngle - nextAngle) + gap;
@@ -359,6 +418,7 @@ void BlockClockDial::paintBlocks(QPainter * painter)
 
 void BlockClockDial::paintProgress(QPainter * painter)
 {
+    if (m_confirmation_colors.size() < 6) return;
     QPen pen(m_confirmation_colors[5]);
     pen.setWidthF(m_pen_width);
     pen.setCapStyle(Qt::RoundCap);
@@ -382,9 +442,7 @@ void BlockClockDial::paintProgress(QPainter * painter)
 
 void BlockClockDial::paintCurrentTimeArc(QPainter* painter)
 {
-    if (m_time_ratio_list.isEmpty()) {
-        return;
-    }
+    if (m_confirmation_colors.size() < 6) return;
 
     QPen pen(m_confirmation_colors[5]);
     pen.setWidthF(m_pen_width);
@@ -393,14 +451,14 @@ void BlockClockDial::paintCurrentTimeArc(QPainter* painter)
     painter->setPen(pen);
 
     const qreal start_angle = 90;
-    const qreal time_angle = m_time_ratio_list[0].toDouble() * 360;
+    const qreal time_angle = m_current_time_fraction * 360;
     const qreal span_angle = -1 * qMin(time_angle, m_animating_max_angle);
     painter->drawArc(bounds, start_angle * 16, span_angle * 16);
 }
 
 void BlockClockDial::paintSyncedGradientArc(QPainter* painter)
 {
-    if (m_confirmation_colors.size() < 6 || m_time_ratio_list.isEmpty()) {
+    if (m_confirmation_colors.size() < 6) {
         paintCurrentTimeArc(painter);
         return;
     }
@@ -414,13 +472,15 @@ void BlockClockDial::paintSyncedGradientArc(QPainter* painter)
     painter->setPen(pen);
 
     const qreal start_angle = 90;
-    const qreal time_angle = m_time_ratio_list[0].toDouble() * 360;
+    const qreal time_angle = m_current_time_fraction * 360;
     const qreal span_angle = -1 * qMin(time_angle, m_animating_max_angle);
     painter->drawArc(bounds, start_angle * 16, span_angle * 16);
 }
 
 void BlockClockDial::paintConnectingAnimation(QPainter * painter)
 {
+    if (m_confirmation_colors.size() < 6) return;
+
     QPen pen;
     pen.setWidthF(m_pen_width);
     setupConnectingGradient(pen);
@@ -432,7 +492,6 @@ void BlockClockDial::paintConnectingAnimation(QPainter * painter)
         painter->drawArc(bounds, m_connecting_start_angle * 16, m_animating_max_angle * -16);
     } else {
         painter->drawArc(bounds, m_connecting_start_angle * 16, m_connecting_end_angle * 16);
-        m_connecting_start_angle = decrementGradientAngle(m_connecting_start_angle);
     }
 }
 
@@ -497,8 +556,5 @@ void BlockClockDial::paint(QPainter * painter)
         paintProgress(painter);
     } else if (m_animation_timer.isActive()) {
         paintConnectingAnimation(painter);
-    }
-    if (m_animate_dial) {
-        m_animating_max_angle = incrementAnimatingMaxAngle(m_animating_max_angle);
     }
 }

--- a/qml/components/blockclockdial.h
+++ b/qml/components/blockclockdial.h
@@ -7,6 +7,7 @@
 
 #include <QQuickPaintedItem>
 #include <QConicalGradient>
+#include <QMetaObject>
 #include <QPainter>
 #include <QTimer>
 #include <QtGlobal>
@@ -14,12 +15,16 @@
 class BlockClockDial : public QQuickPaintedItem
 {
     Q_OBJECT
-    Q_PROPERTY(QVariantList timeRatioList READ timeRatioList WRITE setTimeRatioList)
+    /** Current position through the local twelve-hour period, in [0, 1]. */
+    Q_PROPERTY(qreal currentTimeFraction READ currentTimeFraction WRITE setCurrentTimeFraction)
+    /** Sorted block positions through the same period, each in [0, 1]. */
+    Q_PROPERTY(QList<qreal> blockTimeFractions READ blockTimeFractions WRITE setBlockTimeFractions)
     Q_PROPERTY(double verificationProgress READ verificationProgress WRITE setVerificationProgress)
     Q_PROPERTY(bool connected READ connected WRITE setConnected)
     Q_PROPERTY(bool synced READ synced WRITE setSynced)
     Q_PROPERTY(bool paused READ paused WRITE setPaused)
     Q_PROPERTY(bool animateDial READ animateDial WRITE setAnimateDial)
+    Q_PROPERTY(bool renderingActive READ renderingActive WRITE setRenderingActive NOTIFY renderingActiveChanged)
     Q_PROPERTY(int connectingAnimationDelayMs READ connectingAnimationDelayMs WRITE setConnectingAnimationDelayMs)
     Q_PROPERTY(bool showTimeTicks READ showTimeTicks WRITE setShowTimeTicks)
     Q_PROPERTY(bool showBlockSegments READ showBlockSegments WRITE setShowBlockSegments)
@@ -34,12 +39,14 @@ public:
     explicit BlockClockDial(QQuickItem * parent = nullptr);
     void paint(QPainter * painter) override;
 
-    QVariantList timeRatioList() const { return m_time_ratio_list; };
+    qreal currentTimeFraction() const { return m_current_time_fraction; }
+    QList<qreal> blockTimeFractions() const { return m_block_time_fractions; }
     double verificationProgress() const { return m_verification_progress; };
     bool connected() const { return m_is_connected; };
     bool synced() const { return m_is_synced; };
     bool paused() const { return m_is_paused; };
     bool animateDial() const { return m_animate_dial; };
+    bool renderingActive() const { return m_rendering_active; }
     int connectingAnimationDelayMs() const { return m_connecting_animation_delay_ms; };
     bool showTimeTicks() const { return m_show_time_ticks; };
     bool showBlockSegments() const { return m_show_block_segments; };
@@ -51,12 +58,14 @@ public:
     QColor timeTickColor() const { return m_time_tick_color; };
 
 public Q_SLOTS:
-    void setTimeRatioList(QVariantList new_time);
+    void setCurrentTimeFraction(qreal fraction);
+    void setBlockTimeFractions(QList<qreal> fractions);
     void setVerificationProgress(double progress);
     void setConnected(bool connected);
     void setSynced(bool synced);
     void setPaused(bool paused);
     void setAnimateDial(bool animate_dial);
+    void setRenderingActive(bool active);
     void setConnectingAnimationDelayMs(int connecting_animation_delay_ms);
     void setShowTimeTicks(bool show_time_ticks);
     void setShowBlockSegments(bool show_block_segments);
@@ -69,6 +78,10 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void scaleChanged();
+    void renderingActiveChanged();
+
+protected:
+    void componentComplete() override;
 
 private:
     void paintConnectingAnimation(QPainter * painter);
@@ -83,16 +96,24 @@ private:
     void setupConnectingGradient(const QPen & pen);
     void setupSyncedGradient(const QRectF& bounds);
     void invalidateSyncedGradient();
-    qreal decrementGradientAngle(qreal angle);
-    qreal incrementAnimatingMaxAngle(qreal angle);
-    qreal getTargetAnimationAngle();
+    qreal decrementGradientAngle(qreal angle) const;
+    qreal getTargetAnimationAngle() const;
+    bool presentationActive() const;
+    void requestRepaint();
+    void advanceAnimation();
+    void syncAnimationState();
+    void connectWindowVisibility();
 
-    QVariantList m_time_ratio_list{0.0};
+    qreal m_current_time_fraction{0.0};
+    QList<qreal> m_block_time_fractions;
     double m_verification_progress{0.0};
     bool m_is_connected{false};
     bool m_is_synced{false};
     bool m_is_paused{false};
     bool m_animate_dial{true};
+    bool m_rendering_active{true};
+    bool m_component_complete{false};
+    bool m_presentation_was_active{false};
     int m_connecting_animation_delay_ms{5000};
     bool m_show_time_ticks{true};
     bool m_show_block_segments{true};
@@ -108,8 +129,9 @@ private:
     const qreal m_connecting_end_angle = -180;
     QList<QColor> m_confirmation_colors{};
     QColor m_time_tick_color{"#000000"};
-    QTimer m_animation_timer{this};
+    QTimer m_animation_timer;
     QTimer m_delay_timer;
+    QMetaObject::Connection m_window_visibility_connection;
     qreal m_animating_max_angle = 0;
 };
 

--- a/qml/components/blockclockdial.h
+++ b/qml/components/blockclockdial.h
@@ -19,7 +19,8 @@ class BlockClockDial : public QQuickPaintedItem
     Q_PROPERTY(qreal currentTimeFraction READ currentTimeFraction WRITE setCurrentTimeFraction)
     /** Sorted block positions through the same period, each in [0, 1]. */
     Q_PROPERTY(QList<qreal> blockTimeFractions READ blockTimeFractions WRITE setBlockTimeFractions)
-    Q_PROPERTY(double verificationProgress READ verificationProgress WRITE setVerificationProgress)
+    /** Progress of the synchronization phase currently presented by the dial. */
+    Q_PROPERTY(double syncProgress READ syncProgress WRITE setSyncProgress)
     Q_PROPERTY(bool connected READ connected WRITE setConnected)
     Q_PROPERTY(bool synced READ synced WRITE setSynced)
     Q_PROPERTY(bool paused READ paused WRITE setPaused)
@@ -41,7 +42,7 @@ public:
 
     qreal currentTimeFraction() const { return m_current_time_fraction; }
     QList<qreal> blockTimeFractions() const { return m_block_time_fractions; }
-    double verificationProgress() const { return m_verification_progress; };
+    double syncProgress() const { return m_sync_progress; };
     bool connected() const { return m_is_connected; };
     bool synced() const { return m_is_synced; };
     bool paused() const { return m_is_paused; };
@@ -60,7 +61,7 @@ public:
 public Q_SLOTS:
     void setCurrentTimeFraction(qreal fraction);
     void setBlockTimeFractions(QList<qreal> fractions);
-    void setVerificationProgress(double progress);
+    void setSyncProgress(double progress);
     void setConnected(bool connected);
     void setSynced(bool synced);
     void setPaused(bool paused);
@@ -106,7 +107,7 @@ private:
 
     qreal m_current_time_fraction{0.0};
     QList<qreal> m_block_time_fractions;
-    double m_verification_progress{0.0};
+    double m_sync_progress{0.0};
     bool m_is_connected{false};
     bool m_is_synced{false};
     bool m_is_paused{false};

--- a/qml/components/blockclockdial.h
+++ b/qml/components/blockclockdial.h
@@ -12,6 +12,16 @@
 #include <QTimer>
 #include <QtGlobal>
 
+/**
+ * Paints the current twelve-hour block timeline clockwise from midnight or noon.
+ *
+ * A point on the dial has one confirmation for each later block boundary. The
+ * newest interval therefore has zero confirmations, while older intervals move
+ * through the confirmation color palette. Boundaries too close to render as
+ * separate rounded segments are coalesced without losing their block count;
+ * the resulting segment records both confirmation depths and paints the skipped
+ * transitions as a continuous gradient.
+ */
 class BlockClockDial : public QQuickPaintedItem
 {
     Q_OBJECT
@@ -85,6 +95,15 @@ protected:
     void componentComplete() override;
 
 private:
+    /** Drawable interval and confirmation depths around its ending block cluster. */
+    struct BlockSegment
+    {
+        qreal start_fraction;
+        qreal end_fraction;
+        qsizetype start_confirmations;
+        qsizetype end_confirmations;
+    };
+
     void paintConnectingAnimation(QPainter * painter);
     void paintProgress(QPainter * painter);
     void paintCurrentTimeArc(QPainter* painter);
@@ -94,6 +113,9 @@ private:
     void paintTimeTicks(QPainter * painter);
     QRectF getBoundsForPen(const QPen & pen);
     double degreesPerPixel();
+    qreal degreesForArcPixels(qreal pixels, const QRectF& bounds) const;
+    qreal blockSegmentGapPixels() const;
+    QList<BlockSegment> coalescedBlockSegments(const QRectF& bounds) const;
     void setupConnectingGradient(const QPen & pen);
     void setupSyncedGradient(const QRectF& bounds);
     void invalidateSyncedGradient();

--- a/qml/models/blockclockmodel.cpp
+++ b/qml/models/blockclockmodel.cpp
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/blockclockmodel.h>
+
+#include <interfaces/chain.h>
+
+#include <algorithm>
+#include <optional>
+#include <utility>
+
+#include <QTime>
+
+BlockClockModel::BlockClockModel(HistoryLoader history_loader, bool start_timer, QObject* parent)
+    : QObject{parent},
+      m_history_loader{std::move(history_loader)},
+      m_clock_timer{this}
+{
+    m_clock_timer.setInterval(1000);
+    connect(&m_clock_timer, &QTimer::timeout, this, [this] {
+        updateCurrentTime(QDateTime::currentDateTime());
+    });
+
+    updateCurrentTime(QDateTime::currentDateTime());
+    if (start_timer) m_clock_timer.start();
+}
+
+qint64 BlockClockModel::PeriodStartFor(const QDateTime& current_time)
+{
+    const qint64 seconds_since_midnight{current_time.time().msecsSinceStartOfDay() / 1000};
+    return current_time.toSecsSinceEpoch() - (seconds_since_midnight % PERIOD_SECONDS);
+}
+
+void BlockClockModel::updateCurrentTime(const QDateTime& current_time)
+{
+    const qint64 period_start{PeriodStartFor(current_time)};
+    if (m_timeline.period_start != period_start) {
+        m_timeline.period_start = period_start;
+        Q_EMIT periodChanged();
+
+        if (m_history_initialized) {
+            loadHistory();
+        } else {
+            replaceBlockHistory({});
+        }
+    }
+
+    const qreal fraction{fractionForTimestamp(current_time.toSecsSinceEpoch())};
+    if (!qFuzzyCompare(m_current_time_fraction + 1.0, fraction + 1.0)) {
+        m_current_time_fraction = fraction;
+        Q_EMIT currentTimeFractionChanged();
+    }
+}
+
+void BlockClockModel::initializeHistory()
+{
+    m_history_initialized = true;
+    loadHistory();
+}
+
+void BlockClockModel::recordBlockTime(qint64 block_timestamp)
+{
+    const qint64 period_end{m_timeline.period_start + PERIOD_SECONDS};
+    if (block_timestamp < m_timeline.period_start || block_timestamp >= period_end) return;
+
+    auto insert_position{std::lower_bound(m_timeline.block_timestamps.begin(), m_timeline.block_timestamps.end(), block_timestamp)};
+    if (insert_position != m_timeline.block_timestamps.end() && *insert_position == block_timestamp) return;
+
+    m_timeline.block_timestamps.insert(insert_position, block_timestamp);
+    rebuildBlockTimeFractions();
+    Q_EMIT blockTimeFractionsChanged();
+}
+
+void BlockClockModel::loadHistory()
+{
+    if (!m_history_loader) {
+        replaceBlockHistory({});
+        return;
+    }
+
+    replaceBlockHistory(m_history_loader(m_timeline.period_start, m_timeline.period_start + PERIOD_SECONDS));
+}
+
+void BlockClockModel::replaceBlockHistory(QList<qint64> block_timestamps)
+{
+    const qint64 period_end{m_timeline.period_start + PERIOD_SECONDS};
+    std::sort(block_timestamps.begin(), block_timestamps.end());
+    block_timestamps.erase(std::remove_if(block_timestamps.begin(), block_timestamps.end(), [this, period_end](qint64 timestamp) {
+        return timestamp < m_timeline.period_start || timestamp >= period_end;
+    }), block_timestamps.end());
+    block_timestamps.erase(std::unique(block_timestamps.begin(), block_timestamps.end()), block_timestamps.end());
+
+    if (m_timeline.block_timestamps == block_timestamps) return;
+    m_timeline.block_timestamps = std::move(block_timestamps);
+    rebuildBlockTimeFractions();
+    Q_EMIT blockTimeFractionsChanged();
+}
+
+void BlockClockModel::rebuildBlockTimeFractions()
+{
+    m_block_time_fractions.clear();
+    m_block_time_fractions.reserve(m_timeline.block_timestamps.size());
+    for (qint64 timestamp : m_timeline.block_timestamps) {
+        m_block_time_fractions.push_back(fractionForTimestamp(timestamp));
+    }
+}
+
+qreal BlockClockModel::fractionForTimestamp(qint64 timestamp) const
+{
+    if (m_timeline.period_start == 0) return 0.0;
+    return std::clamp<qreal>(
+        static_cast<qreal>(timestamp - m_timeline.period_start) / PERIOD_SECONDS,
+        0.0,
+        1.0);
+}
+
+QList<qint64> LoadBlockClockHistory(interfaces::Chain& chain, qint64 period_start, qint64 period_end)
+{
+    QList<qint64> block_timestamps;
+    const std::optional<int> active_height{chain.getHeight()};
+    if (!active_height) return block_timestamps;
+
+    int first_height{0};
+    if (!chain.findFirstBlockWithTimeAndHeight(period_start, /*min_height=*/0, interfaces::FoundBlock{}.height(first_height))) {
+        return block_timestamps;
+    }
+
+    for (int height{first_height}; height <= *active_height; ++height) {
+        const uint256 block_hash{chain.getBlockHash(height)};
+        int64_t block_time{0};
+        if (!chain.findBlock(block_hash, interfaces::FoundBlock{}.time(block_time))) continue;
+        if (block_time >= period_start && block_time < period_end) block_timestamps.push_back(block_time);
+    }
+    return block_timestamps;
+}

--- a/qml/models/blockclockmodel.cpp
+++ b/qml/models/blockclockmodel.cpp
@@ -12,18 +12,28 @@
 
 #include <QTime>
 
-BlockClockModel::BlockClockModel(HistoryLoader history_loader, bool start_timer, QObject* parent)
+BlockClockModel::BlockClockModel(HistoryLoader history_loader, bool start_timer,
+                                 CurrentTimeProvider current_time_provider, QObject* parent)
     : QObject{parent},
       m_history_loader{std::move(history_loader)},
+      m_current_time_provider{std::move(current_time_provider)},
       m_clock_timer{this}
 {
-    m_clock_timer.setInterval(1000);
+    if (!m_current_time_provider) {
+        m_current_time_provider = [] { return QDateTime::currentDateTime(); };
+    }
+
+    m_clock_timer.setSingleShot(true);
+    m_clock_timer.setTimerType(Qt::PreciseTimer);
     connect(&m_clock_timer, &QTimer::timeout, this, [this] {
-        updateCurrentTime(QDateTime::currentDateTime());
+        const QDateTime current_time{m_current_time_provider()};
+        updateCurrentTime(current_time);
+        scheduleNextClockUpdate(current_time);
     });
 
-    updateCurrentTime(QDateTime::currentDateTime());
-    if (start_timer) m_clock_timer.start();
+    const QDateTime current_time{m_current_time_provider()};
+    updateCurrentTime(current_time);
+    if (start_timer) scheduleNextClockUpdate(current_time);
 }
 
 qint64 BlockClockModel::PeriodStartFor(const QDateTime& current_time)
@@ -53,6 +63,13 @@ void BlockClockModel::updateCurrentTime(const QDateTime& current_time)
     }
 }
 
+void BlockClockModel::scheduleNextClockUpdate(const QDateTime& current_time)
+{
+    const QTime time{current_time.time()};
+    const int milliseconds_into_minute{time.second() * 1000 + time.msec()};
+    m_clock_timer.start(CLOCK_UPDATE_INTERVAL_MS - milliseconds_into_minute);
+}
+
 void BlockClockModel::initializeHistory()
 {
     m_history_initialized = true;
@@ -61,6 +78,8 @@ void BlockClockModel::initializeHistory()
 
 void BlockClockModel::recordBlockTime(qint64 block_timestamp)
 {
+    updateCurrentTime(m_current_time_provider());
+
     const qint64 period_end{m_timeline.period_start + PERIOD_SECONDS};
     if (block_timestamp < m_timeline.period_start || block_timestamp >= period_end) return;
 

--- a/qml/models/blockclockmodel.h
+++ b/qml/models/blockclockmodel.h
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_BLOCKCLOCKMODEL_H
+#define BITCOIN_QML_MODELS_BLOCKCLOCKMODEL_H
+
+#include <functional>
+
+#include <QDateTime>
+#include <QList>
+#include <QObject>
+#include <QTimer>
+
+namespace interfaces {
+class Chain;
+}
+
+/**
+ * Raw data represented by the block clock.
+ *
+ * The dial covers one local twelve-hour period, beginning at midnight or
+ * noon. Timestamps are Unix seconds. Block timestamps are sorted, unique, and
+ * restricted to [period_start, period_start + PERIOD_SECONDS).
+ */
+struct BlockClockTimeline
+{
+    qint64 period_start{0};
+    QList<qint64> block_timestamps;
+};
+
+/**
+ * Maintains block-clock time and history independently of its presentation.
+ *
+ * This model remains current while the dial is hidden. The once-per-second
+ * currentTimeFraction signal is separate from blockTimeFractions so a clock
+ * tick never republishes the full block history. Fractions are normalized to
+ * the current twelve-hour period and are always in the range [0, 1].
+ *
+ * All methods and the owned timer run on this object's thread (the GUI thread
+ * in production). History loading is infrequent: once after node
+ * initialization and once when the local clock crosses midnight or noon.
+ */
+class BlockClockModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(qint64 periodStart READ periodStart NOTIFY periodChanged)
+    Q_PROPERTY(qreal currentTimeFraction READ currentTimeFraction NOTIFY currentTimeFractionChanged)
+    Q_PROPERTY(QList<qreal> blockTimeFractions READ blockTimeFractions NOTIFY blockTimeFractionsChanged)
+
+public:
+    static constexpr qint64 PERIOD_SECONDS{12 * 60 * 60};
+    using HistoryLoader = std::function<QList<qint64>(qint64 period_start, qint64 period_end)>;
+
+    explicit BlockClockModel(HistoryLoader history_loader = {}, bool start_timer = true, QObject* parent = nullptr);
+
+    qint64 periodStart() const { return m_timeline.period_start; }
+    qreal currentTimeFraction() const { return m_current_time_fraction; }
+    QList<qreal> blockTimeFractions() const { return m_block_time_fractions; }
+    bool timerActive() const { return m_clock_timer.isActive(); }
+
+    /** Return the midnight/noon boundary containing @p current_time. */
+    static qint64 PeriodStartFor(const QDateTime& current_time);
+
+    /** Update the scalar clock position. Public to allow deterministic tests. */
+    void updateCurrentTime(const QDateTime& current_time);
+
+public Q_SLOTS:
+    /** Load the current period's active-chain block history. */
+    void initializeHistory();
+
+    /** Record a new active-chain block timestamp, if it belongs on this dial. */
+    void recordBlockTime(qint64 block_timestamp);
+
+Q_SIGNALS:
+    void periodChanged();
+    void currentTimeFractionChanged();
+    void blockTimeFractionsChanged();
+
+private:
+    void loadHistory();
+    void replaceBlockHistory(QList<qint64> block_timestamps);
+    void rebuildBlockTimeFractions();
+    qreal fractionForTimestamp(qint64 timestamp) const;
+
+    HistoryLoader m_history_loader;
+    QTimer m_clock_timer;
+    BlockClockTimeline m_timeline;
+    qreal m_current_time_fraction{0.0};
+    QList<qreal> m_block_time_fractions;
+    bool m_history_initialized{false};
+};
+
+/** Read active-chain block timestamps belonging to the requested dial period. */
+QList<qint64> LoadBlockClockHistory(interfaces::Chain& chain, qint64 period_start, qint64 period_end);
+
+#endif // BITCOIN_QML_MODELS_BLOCKCLOCKMODEL_H

--- a/qml/models/blockclockmodel.h
+++ b/qml/models/blockclockmodel.h
@@ -35,7 +35,10 @@ struct BlockClockTimeline
  * This model remains current while the dial is hidden. The once-per-second
  * currentTimeFraction signal is separate from blockTimeFractions so a clock
  * tick never republishes the full block history. Fractions are normalized to
- * the current twelve-hour period and are always in the range [0, 1].
+ * the current twelve-hour period and are always in the range [0, 1]. An empty
+ * blockTimeFractions list is valid: it means the active chain contains no
+ * blocks timestamped in the displayed period, not that synchronization is
+ * incomplete. Initial-sync state belongs to NodeModel.
  *
  * All methods and the owned timer run on this object's thread (the GUI thread
  * in production). History loading is infrequent: once after node

--- a/qml/models/blockclockmodel.h
+++ b/qml/models/blockclockmodel.h
@@ -32,13 +32,14 @@ struct BlockClockTimeline
 /**
  * Maintains block-clock time and history independently of its presentation.
  *
- * This model remains current while the dial is hidden. The once-per-second
- * currentTimeFraction signal is separate from blockTimeFractions so a clock
- * tick never republishes the full block history. Fractions are normalized to
- * the current twelve-hour period and are always in the range [0, 1]. An empty
- * blockTimeFractions list is valid: it means the active chain contains no
- * blocks timestamped in the displayed period, not that synchronization is
- * incomplete. Initial-sync state belongs to NodeModel.
+ * This model remains current while the dial is hidden. currentTimeFraction is
+ * refreshed at minute boundaries and when a block arrives. It is separate
+ * from blockTimeFractions so a clock tick never republishes the full block
+ * history. Fractions are normalized to the current twelve-hour period and are
+ * always in the range [0, 1]. An empty blockTimeFractions list is valid: it
+ * means the active chain contains no blocks timestamped in the displayed
+ * period, not that synchronization is incomplete. Initial-sync state belongs
+ * to NodeModel.
  *
  * All methods and the owned timer run on this object's thread (the GUI thread
  * in production). History loading is infrequent: once after node
@@ -53,9 +54,12 @@ class BlockClockModel : public QObject
 
 public:
     static constexpr qint64 PERIOD_SECONDS{12 * 60 * 60};
+    static constexpr int CLOCK_UPDATE_INTERVAL_MS{60 * 1000};
     using HistoryLoader = std::function<QList<qint64>(qint64 period_start, qint64 period_end)>;
+    using CurrentTimeProvider = std::function<QDateTime()>;
 
-    explicit BlockClockModel(HistoryLoader history_loader = {}, bool start_timer = true, QObject* parent = nullptr);
+    explicit BlockClockModel(HistoryLoader history_loader = {}, bool start_timer = true,
+                             CurrentTimeProvider current_time_provider = {}, QObject* parent = nullptr);
 
     qint64 periodStart() const { return m_timeline.period_start; }
     qreal currentTimeFraction() const { return m_current_time_fraction; }
@@ -81,12 +85,14 @@ Q_SIGNALS:
     void blockTimeFractionsChanged();
 
 private:
+    void scheduleNextClockUpdate(const QDateTime& current_time);
     void loadHistory();
     void replaceBlockHistory(QList<qint64> block_timestamps);
     void rebuildBlockTimeFractions();
     qreal fractionForTimestamp(qint64 timestamp) const;
 
     HistoryLoader m_history_loader;
+    CurrentTimeProvider m_current_time_provider;
     QTimer m_clock_timer;
     BlockClockTimeline m_timeline;
     qreal m_current_time_fraction{0.0};

--- a/qml/models/chainmodel.cpp
+++ b/qml/models/chainmodel.cpp
@@ -1,112 +1,15 @@
-// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2022-2026 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <qml/models/chainmodel.h>
 
 #include <chainparams.h>
-#include <interfaces/chain.h>
 
-#include <QDateTime>
-#include <QString>
-#include <QThread>
-#include <QTime>
-
-using interfaces::FoundBlock;
-
-ChainModel::ChainModel(interfaces::Chain& chain)
-    : m_assumed_blockchain_size{Params().AssumedBlockchainSize()},
-      m_assumed_chainstate_size{Params().AssumedChainStateSize()},
-      m_chain{chain}
+ChainModel::ChainModel(QString network_name, QObject* parent)
+    : QObject{parent},
+      m_network_name{network_name.toUpper()},
+      m_assumed_blockchain_size{Params().AssumedBlockchainSize()},
+      m_assumed_chainstate_size{Params().AssumedChainStateSize()}
 {
-    QTimer* timer = new QTimer();
-    connect(timer, &QTimer::timeout, this, &ChainModel::setCurrentTimeRatio);
-    timer->start(1000);
-
-    QThread* timer_thread = new QThread;
-    timer->moveToThread(timer_thread);
-    timer_thread->start();
-}
-
-void ChainModel::setCurrentNetworkName(QString network_name)
-{
-    m_current_network_name = network_name.toUpper();
-    Q_EMIT currentNetworkNameChanged();
-}
-
-void ChainModel::setTimeRatioList(int new_time)
-{
-    if (m_time_ratio_list.isEmpty()) {
-        setTimeRatioListInitial();
-    }
-    int time_at_meridian = timestampAtMeridian();
-
-    if (new_time < time_at_meridian) {
-        return;
-    }
-    m_time_ratio_list.push_back(double(new_time - time_at_meridian) / SECS_IN_12_HOURS);
-
-    Q_EMIT timeRatioListChanged();
-}
-
-int ChainModel::timestampAtMeridian()
-{
-    int secs_since_meridian = (QTime::currentTime().msecsSinceStartOfDay() / 1000) % SECS_IN_12_HOURS;
-    int current_timestamp = QDateTime::currentSecsSinceEpoch();
-
-    return current_timestamp - secs_since_meridian;
-}
-
-void ChainModel::setTimeRatioListInitial()
-{
-    int time_at_meridian = timestampAtMeridian();
-    m_time_ratio_list.clear();
-    /* m_time_ratio_list[0] = current_time_ratio
-     * m_time_ratio_list[1] = 0
-     * These two positions remain fixed for these
-     * values in m_time_ratio_list */
-    m_time_ratio_list.push_back(double(QDateTime::currentSecsSinceEpoch() - time_at_meridian) / SECS_IN_12_HOURS);
-    m_time_ratio_list.push_back(0);
-
-    if (!m_chain.getHeight()) {
-        Q_EMIT timeRatioListChanged();
-        return;
-    }
-
-    int first_block_height;
-    int active_chain_height = m_chain.getHeight().value();
-    bool success = m_chain.findFirstBlockWithTimeAndHeight(/*min_time=*/time_at_meridian, /*min_height=*/0, interfaces::FoundBlock().height(first_block_height));
-
-    if (!success) {
-        Q_EMIT timeRatioListChanged();
-        return;
-    }
-
-    for (int height = first_block_height; height < active_chain_height + 1; height++) {
-        uint256 block_hash{m_chain.getBlockHash(height)};
-        int64_t block_time;
-        m_chain.findBlock(block_hash, FoundBlock().time(block_time));
-        m_time_ratio_list.push_back(double(block_time - time_at_meridian) / SECS_IN_12_HOURS);
-    }
-
-    Q_EMIT timeRatioListChanged();
-}
-
-void ChainModel::setCurrentTimeRatio()
-{
-    int secs_since_meridian = (QTime::currentTime().msecsSinceStartOfDay() / 1000) % SECS_IN_12_HOURS;
-    double current_time_ratio = double(secs_since_meridian) / SECS_IN_12_HOURS;
-
-    if (current_time_ratio < m_time_ratio_list[0].toDouble()) { // That means time has crossed a meridian
-        m_time_ratio_list.clear();
-    }
-
-    if (m_time_ratio_list.isEmpty()) {
-        m_time_ratio_list.push_back(current_time_ratio);
-        m_time_ratio_list.push_back(0);
-    } else {
-        m_time_ratio_list[0] = current_time_ratio;
-    }
-
-    Q_EMIT timeRatioListChanged();
 }

--- a/qml/models/chainmodel.h
+++ b/qml/models/chainmodel.h
@@ -7,58 +7,35 @@
 
 #include <QObject>
 #include <QString>
-#include <QTimer>
-#include <QVariant>
 
-namespace interfaces {
-class FoundBlock;
-class Chain;
-} // namespace interfaces
-
-static const int SECS_IN_12_HOURS = 43200;
-
+/**
+ * Immutable chain metadata shared by the application UI.
+ *
+ * Dynamic block-clock state deliberately lives in BlockClockModel. Keeping
+ * this model limited to configuration values makes its ownership and update
+ * behavior explicit.
+ */
 class ChainModel : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QString currentNetworkName READ currentNetworkName WRITE setCurrentNetworkName NOTIFY currentNetworkNameChanged)
+    Q_PROPERTY(QString networkName READ networkName CONSTANT)
     Q_PROPERTY(quint64 assumedBlockchainSize READ assumedBlockchainSize CONSTANT)
     Q_PROPERTY(quint64 assumedChainstateSize READ assumedChainstateSize CONSTANT)
-    Q_PROPERTY(QVariantList timeRatioList READ timeRatioList NOTIFY timeRatioListChanged)
 
 public:
-    explicit ChainModel(interfaces::Chain& chain);
+    explicit ChainModel(QString network_name, QObject* parent = nullptr);
 
-    QString currentNetworkName() const { return m_current_network_name; };
-    void setCurrentNetworkName(QString network_name);
-    quint64 assumedBlockchainSize() const { return m_assumed_blockchain_size; };
-    quint64 assumedChainstateSize() const { return m_assumed_chainstate_size; };
-    QVariantList timeRatioList() const { return m_time_ratio_list; };
-
-    int timestampAtMeridian();
-
-    void setCurrentTimeRatio();
-
-public Q_SLOTS:
-    void setTimeRatioList(int new_time);
-    void setTimeRatioListInitial();
-
-Q_SIGNALS:
-    void timeRatioListChanged();
-    void currentNetworkNameChanged();
+    QString networkName() const { return m_network_name; }
+    quint64 assumedBlockchainSize() const { return m_assumed_blockchain_size; }
+    quint64 assumedChainstateSize() const { return m_assumed_chainstate_size; }
 
 private:
-    QString m_current_network_name;
+    /** Uppercase chain identifier used by network badges and settings scope. */
+    const QString m_network_name;
+    /** Estimated disk space, in GiB, shown during initial setup. */
     quint64 m_assumed_blockchain_size;
+    /** Estimated chainstate disk space, in GiB, shown during initial setup. */
     quint64 m_assumed_chainstate_size;
-    /* time_ratio: Ratio between the time at which an event
-     * happened and 12 hours. So, for example, if a block is
-     * found at 4 am or pm, the time_ratio would be 0.3.
-     * The m_time_ratio_list stores the time ratio value for
-     * the current_time and the time at which the blocks in
-     * the last 12 hours were mined. */
-    QVariantList m_time_ratio_list{0.0};
-
-    interfaces::Chain& m_chain;
 };
 
 #endif // BITCOIN_QML_MODELS_CHAINMODEL_H

--- a/qml/models/nodemodel.cpp
+++ b/qml/models/nodemodel.cpp
@@ -127,6 +127,7 @@ void NodeModel::setBlockTipHeight(int new_height)
     if (new_height != m_block_tip_height) {
         m_block_tip_height = new_height;
         Q_EMIT blockTipHeightChanged();
+        maybeCompleteInitialSync();
     }
 }
 
@@ -278,6 +279,14 @@ void NodeModel::setVerificationProgress(double new_progress)
     }
 }
 
+void NodeModel::setNodeReady(bool ready)
+{
+    if (m_node_ready == ready) return;
+
+    m_node_ready = ready;
+    maybeCompleteInitialSync();
+}
+
 void NodeModel::setBlockSyncActive(bool active)
 {
     if (m_block_sync_active == active) {
@@ -286,6 +295,7 @@ void NodeModel::setBlockSyncActive(bool active)
 
     m_block_sync_active = active;
     Q_EMIT blockSyncActiveChanged();
+    maybeCompleteInitialSync();
 }
 
 void NodeModel::setHeaderSyncState(int height, int64_t block_time, bool presync)
@@ -297,16 +307,33 @@ void NodeModel::setHeaderSyncState(int height, int64_t block_time, bool presync)
     const bool active{height > 0 && estimate_headers_left > HEADER_HEIGHT_DELTA_SYNC};
     const double progress{active ? 1.0 * height / (height + estimate_headers_left) : 0.0};
 
-    if (m_header_sync_active == active &&
-        m_header_presync == presync &&
-        m_header_sync_progress == progress) {
+    if (m_header_sync_active != active ||
+        m_header_presync != presync ||
+        m_header_sync_progress != progress) {
+        m_header_sync_active = active;
+        m_header_presync = presync;
+        m_header_sync_progress = progress;
+        Q_EMIT headerSyncChanged();
+    }
+    maybeCompleteInitialSync();
+}
+
+void NodeModel::maybeCompleteInitialSync()
+{
+    if (m_initial_sync_complete ||
+        !m_node_ready ||
+        m_block_sync_active ||
+        m_header_sync_active ||
+        m_header_presync ||
+        m_block_tip_height < m_header_tip_height) {
         return;
     }
 
-    m_header_sync_active = active;
-    m_header_presync = presync;
-    m_header_sync_progress = progress;
-    Q_EMIT headerSyncChanged();
+    // Completion is a startup transition. Once the active chain has caught up
+    // to the best known header, a subsequently announced block must not return
+    // the clock to its initial-sync presentation while that block is fetched.
+    m_initial_sync_complete = true;
+    Q_EMIT initialSyncCompleteChanged();
 }
 
 void NodeModel::setPause(bool new_pause)
@@ -434,14 +461,16 @@ void NodeModel::initializeResult(bool success, interfaces::BlockAndHeaderTipInfo
         }
     } else {
         m_startup_error_messages.clear();
-        m_node_ready = true;
         m_runtime_dialogs_enabled = true;
         refreshWarnings();
         showStartupWarnings();
         setBlockTipHeight(tip_info.block_height);
         setVerificationProgress(tip_info.verification_progress);
-        setBlockSyncActive(tip_info.block_height > 0 && m_node.isInitialBlockDownload());
+        // Core's IBD result is authoritative. Verification progress remains an
+        // estimate for display and must not decide when initial sync completes.
+        setBlockSyncActive(m_node.isInitialBlockDownload());
         setHeaderSyncState(tip_info.header_height, tip_info.header_time, /*presync=*/false);
+        setNodeReady(true);
         refreshMempoolInfo();
         Q_EMIT chainStateReady();
     }
@@ -490,7 +519,7 @@ void NodeModel::ConnectToBlockTipSignal()
             QMetaObject::invokeMethod(this, [this, state, block_height = tip.block_height, block_time = tip.block_time, verification_progress] {
                 setBlockTipHeight(block_height);
                 setVerificationProgress(verification_progress);
-                setBlockSyncActive(block_height > 0 && state != SynchronizationState::POST_INIT);
+                setBlockSyncActive(state != SynchronizationState::POST_INIT);
 
                 Q_EMIT blockTipTimeChanged(block_time);
             }, Qt::QueuedConnection);

--- a/qml/models/nodemodel.cpp
+++ b/qml/models/nodemodel.cpp
@@ -97,6 +97,7 @@ QVariant InformationRow(const QString& label, const QString& value)
 NodeModel::NodeModel(interfaces::Node& node)
     : m_node{node}
 {
+    m_sync_progress_clock.start();
     m_mempool_information_available = !gArgs.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY);
     initializeMempoolInfoPolling();
     refreshPeerCounts();
@@ -251,38 +252,21 @@ void NodeModel::applyMempoolInfo(const MempoolInfo& info)
 
 void NodeModel::setRemainingSyncTime(double new_progress)
 {
-    int currentTime = QDateTime::currentDateTime().toMSecsSinceEpoch();
-
-    // keep a vector of samples of verification progress at height
-    m_block_process_time.push_front(qMakePair(currentTime, new_progress));
-
-    // show progress speed if we have more than one sample
-    if (m_block_process_time.size() >= 2) {
-        double progressDelta = 0;
-        int timeDelta = 0;
-        int remainingMSecs = 0;
-        double remainingProgress = 1.0 - new_progress;
-        for (int i = 1; i < m_block_process_time.size(); i++) {
-            QPair<int, double> sample = m_block_process_time[i];
-
-            // take first sample after 500 seconds or last available one
-            if (sample.first < (currentTime - 500 * 1000) || i == m_block_process_time.size() - 1) {
-                progressDelta = m_block_process_time[0].second - sample.second;
-                timeDelta = m_block_process_time[0].first - sample.first;
-                remainingMSecs = (progressDelta > 0) ? remainingProgress / progressDelta * timeDelta : -1;
-                break;
-            }
-        }
-        if (remainingMSecs > 0 && m_block_process_time.count() % 1000 == 0) {
-            m_remaining_sync_time = remainingMSecs;
-
+    if (new_progress >= 1.0) {
+        m_sync_progress_tracker.reset();
+        if (m_remaining_sync_time != 0) {
+            m_remaining_sync_time = 0;
             Q_EMIT remainingSyncTimeChanged();
         }
-        static const int MAX_SAMPLES = 5000;
-        if (m_block_process_time.count() > MAX_SAMPLES) {
-            m_block_process_time.remove(1, m_block_process_time.count() - 1);
-        }
+        return;
     }
+
+    const std::optional<int64_t> estimate{
+        m_sync_progress_tracker.addSample(m_sync_progress_clock.elapsed(), new_progress)};
+    if (!estimate || *estimate == m_remaining_sync_time) return;
+
+    m_remaining_sync_time = *estimate;
+    Q_EMIT remainingSyncTimeChanged();
 }
 void NodeModel::setVerificationProgress(double new_progress)
 {
@@ -459,7 +443,7 @@ void NodeModel::initializeResult(bool success, interfaces::BlockAndHeaderTipInfo
         setBlockSyncActive(tip_info.block_height > 0 && m_node.isInitialBlockDownload());
         setHeaderSyncState(tip_info.header_height, tip_info.header_time, /*presync=*/false);
         refreshMempoolInfo();
-        Q_EMIT setTimeRatioListInitial();
+        Q_EMIT chainStateReady();
     }
     Q_EMIT nodeInitialized();
 }
@@ -508,7 +492,7 @@ void NodeModel::ConnectToBlockTipSignal()
                 setVerificationProgress(verification_progress);
                 setBlockSyncActive(block_height > 0 && state != SynchronizationState::POST_INIT);
 
-                Q_EMIT setTimeRatioList(block_time);
+                Q_EMIT blockTipTimeChanged(block_time);
             }, Qt::QueuedConnection);
         });
 }

--- a/qml/models/nodemodel.h
+++ b/qml/models/nodemodel.h
@@ -8,11 +8,13 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <clientversion.h>
+#include <qml/models/syncprogresstracker.h>
 
 #include <deque>
 #include <memory>
 
 #include <QObject>
+#include <QElapsedTimer>
 #include <QStringList>
 #include <QString>
 #include <QVariantList>
@@ -46,7 +48,7 @@ class NodeModel : public QObject
     Q_PROPERTY(double mempoolMaxUsageMB READ mempoolMaxUsageMB NOTIFY mempoolInfoChanged)
     Q_PROPERTY(bool mempoolInfoPollingActive READ mempoolInfoPollingActive WRITE setMempoolInfoPollingActive NOTIFY mempoolInfoPollingActiveChanged)
     Q_PROPERTY(bool mempoolInformationAvailable READ mempoolInformationAvailable CONSTANT)
-    Q_PROPERTY(int remainingSyncTime READ remainingSyncTime NOTIFY remainingSyncTimeChanged)
+    Q_PROPERTY(qint64 remainingSyncTime READ remainingSyncTime NOTIFY remainingSyncTimeChanged)
     Q_PROPERTY(double verificationProgress READ verificationProgress NOTIFY verificationProgressChanged)
     Q_PROPERTY(bool blockSyncActive READ blockSyncActive NOTIFY blockSyncActiveChanged)
     Q_PROPERTY(bool headerSyncActive READ headerSyncActive NOTIFY headerSyncChanged)
@@ -85,7 +87,7 @@ public:
     bool mempoolInfoPollingActive() const { return m_mempool_info_polling_active; }
     void setMempoolInfoPollingActive(bool active);
     bool mempoolInformationAvailable() const { return m_mempool_information_available; }
-    int remainingSyncTime() const { return m_remaining_sync_time; }
+    qint64 remainingSyncTime() const { return m_remaining_sync_time; }
     void setRemainingSyncTime(double new_progress);
     double verificationProgress() const { return m_verification_progress; }
     void setVerificationProgress(double new_progress);
@@ -153,8 +155,10 @@ Q_SIGNALS:
     void warningsChanged();
     void runtimeDialogChanged();
 
-    void setTimeRatioList(int new_time);
-    void setTimeRatioListInitial();
+    /** Active-chain block timestamp changed; consumers may update timelines. */
+    void blockTipTimeChanged(qint64 block_time);
+    /** Chain initialization succeeded and history-dependent models may load. */
+    void chainStateReady();
     void nodeInitialized();
     void bannedListChanged();
 
@@ -189,7 +193,7 @@ private:
     double m_mempool_max_usage_mb{0.0};
     bool m_mempool_info_polling_active{false};
     bool m_mempool_information_available{true};
-    int m_remaining_sync_time{0};
+    qint64 m_remaining_sync_time{0};
     double m_verification_progress{0.0};
     bool m_block_sync_active{false};
     bool m_pause{false};
@@ -220,7 +224,8 @@ private:
 
     int m_shutdown_polling_timer_id{0};
 
-    QVector<QPair<int, double>> m_block_process_time;
+    SyncProgressTracker m_sync_progress_tracker;
+    QElapsedTimer m_sync_progress_clock;
 
     interfaces::Node& m_node;
     QObject* m_mempool_info_worker{nullptr};

--- a/qml/models/nodemodel.h
+++ b/qml/models/nodemodel.h
@@ -49,7 +49,11 @@ class NodeModel : public QObject
     Q_PROPERTY(bool mempoolInfoPollingActive READ mempoolInfoPollingActive WRITE setMempoolInfoPollingActive NOTIFY mempoolInfoPollingActiveChanged)
     Q_PROPERTY(bool mempoolInformationAvailable READ mempoolInformationAvailable CONSTANT)
     Q_PROPERTY(qint64 remainingSyncTime READ remainingSyncTime NOTIFY remainingSyncTimeChanged)
+    /** Estimated chain-verification progress used only for progress presentation. */
     Q_PROPERTY(double verificationProgress READ verificationProgress NOTIFY verificationProgressChanged)
+    /** True once startup synchronization completes; remains true for this node session. */
+    Q_PROPERTY(bool initialSyncComplete READ initialSyncComplete NOTIFY initialSyncCompleteChanged)
+    /** True while Core reports initial block download through initialization or tip notifications. */
     Q_PROPERTY(bool blockSyncActive READ blockSyncActive NOTIFY blockSyncActiveChanged)
     Q_PROPERTY(bool headerSyncActive READ headerSyncActive NOTIFY headerSyncChanged)
     Q_PROPERTY(bool headerPresync READ headerPresync NOTIFY headerSyncChanged)
@@ -91,6 +95,7 @@ public:
     void setRemainingSyncTime(double new_progress);
     double verificationProgress() const { return m_verification_progress; }
     void setVerificationProgress(double new_progress);
+    bool initialSyncComplete() const { return m_initial_sync_complete; }
     bool blockSyncActive() const { return m_block_sync_active; }
     bool headerSyncActive() const { return m_header_sync_active; }
     bool headerPresync() const { return m_header_presync; }
@@ -147,6 +152,7 @@ Q_SIGNALS:
     void requestedInitialize();
     void requestedShutdown();
     void verificationProgressChanged();
+    void initialSyncCompleteChanged();
     void blockSyncActiveChanged();
     void headerSyncChanged();
     void pauseChanged(bool new_pause);
@@ -209,6 +215,7 @@ private:
     int m_header_tip_height{0};
     int64_t m_header_tip_time{0};
     bool m_node_ready{false};
+    bool m_initial_sync_complete{false};
     bool m_initialization_requested{false};
     bool m_shutdown_requested{false};
     bool m_runtime_dialogs_enabled{false};
@@ -255,8 +262,10 @@ private:
     void recordStartupWarningMessage(const QString& message);
     void showStartupWarnings();
     void setWarnings(const QString& warnings);
+    void setNodeReady(bool ready);
     void setBlockSyncActive(bool active);
     void setHeaderSyncState(int height, int64_t block_time, bool presync);
+    void maybeCompleteInitialSync();
     void showRuntimeMessageBox(const QString& message, unsigned int style);
     bool showRuntimeQuestion(const QString& message, unsigned int style);
     bool showRuntimeDialogOnGuiThread(const QString& message, unsigned int style, bool question);

--- a/qml/models/syncprogresstracker.cpp
+++ b/qml/models/syncprogresstracker.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/syncprogresstracker.h>
+
+#include <cmath>
+#include <limits>
+
+std::optional<int64_t> SyncProgressTracker::addSample(int64_t monotonic_milliseconds, double progress)
+{
+    if (!std::isfinite(progress)) return std::nullopt;
+    if (!m_samples.empty() &&
+        (monotonic_milliseconds < m_samples.back().milliseconds || progress < m_samples.back().progress)) {
+        reset();
+    }
+
+    m_samples.push_back({monotonic_milliseconds, progress});
+    ++m_samples_since_publication;
+
+    const int64_t cutoff{monotonic_milliseconds - WINDOW_MILLISECONDS};
+    // Retain the newest sample at or before the cutoff as the baseline.
+    while (m_samples.size() > 2 && m_samples[1].milliseconds <= cutoff) {
+        m_samples.pop_front();
+    }
+    while (m_samples.size() > MAX_SAMPLES) m_samples.pop_front();
+
+    if (m_samples_since_publication < PUBLISH_SAMPLE_INTERVAL || m_samples.size() < 2) {
+        return std::nullopt;
+    }
+    m_samples_since_publication = 0;
+
+    const Sample& oldest{m_samples.front()};
+    const Sample& newest{m_samples.back()};
+    const double progress_delta{newest.progress - oldest.progress};
+    const int64_t time_delta{newest.milliseconds - oldest.milliseconds};
+    if (progress_delta <= 0.0 || time_delta <= 0) return std::nullopt;
+
+    const long double remaining{
+        static_cast<long double>(1.0 - newest.progress) /
+        progress_delta *
+        static_cast<long double>(time_delta)};
+    if (!std::isfinite(remaining) || remaining < 0.0L) return std::nullopt;
+    if (remaining > std::numeric_limits<int64_t>::max()) return std::numeric_limits<int64_t>::max();
+    return static_cast<int64_t>(remaining);
+}
+
+void SyncProgressTracker::reset()
+{
+    m_samples.clear();
+    m_samples_since_publication = 0;
+}

--- a/qml/models/syncprogresstracker.h
+++ b/qml/models/syncprogresstracker.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QML_MODELS_SYNCPROGRESSTRACKER_H
+#define BITCOIN_QML_MODELS_SYNCPROGRESSTRACKER_H
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <optional>
+
+/**
+ * Bounded, amortized-O(1) estimator for remaining block synchronization time.
+ *
+ * Sample times are monotonic milliseconds, not wall-clock timestamps. The
+ * tracker keeps one sample at the beginning of a rolling window and publishes
+ * only periodically, avoiding a vector shift and linear scan for every block.
+ */
+class SyncProgressTracker
+{
+public:
+    static constexpr int64_t WINDOW_MILLISECONDS{500'000};
+    static constexpr std::size_t MAX_SAMPLES{5'000};
+    static constexpr std::size_t PUBLISH_SAMPLE_INTERVAL{1'000};
+
+    std::optional<int64_t> addSample(int64_t monotonic_milliseconds, double progress);
+    void reset();
+    std::size_t sampleCount() const { return m_samples.size(); }
+
+private:
+    struct Sample {
+        int64_t milliseconds;
+        double progress;
+    };
+
+    std::deque<Sample> m_samples;
+    std::size_t m_samples_since_publication{0};
+};
+
+#endif // BITCOIN_QML_MODELS_SYNCPROGRESSTRACKER_H

--- a/qml/pages/node/NodeRunner.qml
+++ b/qml/pages/node/NodeRunner.qml
@@ -73,5 +73,6 @@ Page {
         parentWidth: parent.width - 40
         parentHeight: parent.height
         anchors.centerIn: parent
+        renderingActive: root.visible
     }
 }

--- a/qml/pages/node/Peers.qml
+++ b/qml/pages/node/Peers.qml
@@ -168,6 +168,7 @@ Page {
                             spacing: 20
                             PeersIndicator {
                                 paused: false
+                                active: root.visible
                                 numOutboundPeers: nodeModel.numOutboundPeers
                                 maxNumOutboundPeers: nodeModel.maxNumOutboundPeers
                             }

--- a/qml/pages/wallet/DesktopWallets.qml
+++ b/qml/pages/wallet/DesktopWallets.qml
@@ -181,6 +181,7 @@ Page {
                 ButtonGroup.group: navigationTabs
                 customContent: MiniBlockClock {
                     pageSelected: blockClockTabButton.checked
+                    renderingActive: root.visible
                 }
 
                 Tooltip {
@@ -322,6 +323,7 @@ Page {
                 parentHeight: blockClockTab.height
                 anchors.centerIn: blockClockTab
                 showNetworkIndicator: false
+                renderingActive: root.visible && blockClockTabButton.checked
             }
         }
         PageStack {

--- a/qml/pages/wallet/DesktopWallets.qml
+++ b/qml/pages/wallet/DesktopWallets.qml
@@ -186,8 +186,9 @@ Page {
 
                 Tooltip {
                     id: blockClockTooltip
+                    objectName: "blockClockTooltip"
                     property var syncState: Utils.formatRemainingSyncTime(nodeModel.remainingSyncTime)
-                    property bool synced: nodeModel.verificationProgress > 0.999
+                    property bool synced: nodeModel.initialSyncComplete
                     property bool paused: nodeModel.pause
                     property bool connected: nodeModel.numPeers > 0
                     property bool faulted: nodeModel.faulted

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(bitcoinqml_unit_tests
   test_unit_tests_main.cpp
   test_bitcoinaddress.cpp
   test_blockclockdial.cpp
+  test_blockclockmodel.cpp
   test_bitcoinuri.cpp
   test_bitcoinamount.cpp
   test_debuglogmodel.cpp
@@ -41,6 +42,7 @@ add_executable(bitcoinqml_unit_tests
   test_rpccommandexecutor.cpp
   test_rpcconsolemodel.cpp
   test_sendrecipientslistmodel.cpp
+  test_syncprogresstracker.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/bitcoinuri.cpp
 )

--- a/test/mocks/qml/org/bitcoincore/qt/BlockClockDial.qml
+++ b/test/mocks/qml/org/bitcoincore/qt/BlockClockDial.qml
@@ -5,7 +5,9 @@
 import QtQuick 2.15
 
 Item {
-    property var timeRatioList: []
+    property real currentTimeFraction: 0
+    property var blockTimeFractions: []
+    property bool renderingActive: true
     property real verificationProgress: 0
     property bool connected: false
     property bool synced: false

--- a/test/mocks/qml/org/bitcoincore/qt/BlockClockDial.qml
+++ b/test/mocks/qml/org/bitcoincore/qt/BlockClockDial.qml
@@ -8,7 +8,7 @@ Item {
     property real currentTimeFraction: 0
     property var blockTimeFractions: []
     property bool renderingActive: true
-    property real verificationProgress: 0
+    property real syncProgress: 0
     property bool connected: false
     property bool synced: false
     property bool paused: false

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -2166,6 +2166,7 @@ class MockNodeModel : public QObject
     Q_PROPERTY(int numOutboundPeers MEMBER m_num_outbound_peers NOTIFY numOutboundPeersChanged)
     Q_PROPERTY(int maxNumOutboundPeers MEMBER m_max_num_outbound_peers NOTIFY maxNumOutboundPeersChanged)
     Q_PROPERTY(double verificationProgress MEMBER m_verification_progress NOTIFY verificationProgressChanged)
+    Q_PROPERTY(bool initialSyncComplete MEMBER m_initial_sync_complete NOTIFY initialSyncCompleteChanged)
     Q_PROPERTY(int remainingSyncTime MEMBER m_remaining_sync_time NOTIFY remainingSyncTimeChanged)
     Q_PROPERTY(bool headerSyncActive MEMBER m_header_sync_active NOTIFY headerSyncChanged)
     Q_PROPERTY(bool blockSyncActive MEMBER m_block_sync_active NOTIFY blockSyncActiveChanged)
@@ -2200,6 +2201,7 @@ public:
     int m_num_outbound_peers{0};
     int m_max_num_outbound_peers{8};
     double m_verification_progress{0.0};
+    bool m_initial_sync_complete{false};
     int m_remaining_sync_time{0};
     bool m_header_sync_active{false};
     bool m_block_sync_active{false};
@@ -2345,6 +2347,7 @@ Q_SIGNALS:
     void numOutboundPeersChanged();
     void maxNumOutboundPeersChanged();
     void verificationProgressChanged();
+    void initialSyncCompleteChanged();
     void remainingSyncTimeChanged();
     void headerSyncChanged();
     void blockSyncActiveChanged();

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -2134,12 +2134,27 @@ class MockChainModel : public QObject
     Q_OBJECT
     Q_PROPERTY(int assumedChainstateSize MEMBER m_assumed_chainstate_size CONSTANT)
     Q_PROPERTY(int assumedBlockchainSize MEMBER m_assumed_blockchain_size CONSTANT)
-    Q_PROPERTY(QVariantList timeRatioList MEMBER m_time_ratio_list CONSTANT)
+    Q_PROPERTY(QString networkName MEMBER m_network_name CONSTANT)
 
 public:
     int m_assumed_chainstate_size{12};
     int m_assumed_blockchain_size{610};
-    QVariantList m_time_ratio_list{0.1, 0.2, 0.4, 0.8};
+    QString m_network_name{QStringLiteral("REGTEST")};
+};
+
+class MockBlockClockModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(qreal currentTimeFraction MEMBER m_current_time_fraction NOTIFY currentTimeFractionChanged)
+    Q_PROPERTY(QList<qreal> blockTimeFractions MEMBER m_block_time_fractions NOTIFY blockTimeFractionsChanged)
+
+public:
+    qreal m_current_time_fraction{0.25};
+    QList<qreal> m_block_time_fractions{0.1, 0.2};
+
+Q_SIGNALS:
+    void currentTimeFractionChanged();
+    void blockTimeFractionsChanged();
 };
 
 class MockNodeModel : public QObject
@@ -3389,6 +3404,7 @@ public Q_SLOTS:
         static MockBuildInfo build_info;
         static MockOptionsModel options_model;
         static MockChainModel chain_model;
+        static MockBlockClockModel block_clock_model;
         static MockNodeModel node_model;
         static MockPeerTableModel peer_table_model;
         static MockNetworkTrafficTower network_traffic_tower;
@@ -3453,6 +3469,7 @@ public Q_SLOTS:
         qmlRegisterType<LineGraph>("org.bitcoincore.qt", 1, 0, "LineGraph");
         engine->rootContext()->setContextProperty(QStringLiteral("optionsModel"), &options_model);
         engine->rootContext()->setContextProperty(QStringLiteral("chainModel"), &chain_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("blockClockModel"), &block_clock_model);
         engine->rootContext()->setContextProperty(QStringLiteral("nodeModel"), &node_model);
         engine->rootContext()->setContextProperty(QStringLiteral("peerTableModel"), &peer_table_model);
         engine->rootContext()->setContextProperty(QStringLiteral("networkTrafficTower"), &network_traffic_tower);

--- a/test/qml/tst_blockclock.qml
+++ b/test/qml/tst_blockclock.qml
@@ -21,6 +21,7 @@ TestCase {
         property int maxNumOutboundPeers: 10
         property int remainingSyncTime: 0
         property real verificationProgress: 0
+        property bool initialSyncComplete: false
         property bool headerSyncActive: false
         property bool headerPresync: false
         property real headerSyncProgress: 0
@@ -61,6 +62,7 @@ TestCase {
         MiniBlockClock {
             iconSize: 18
             pageSelected: true
+            nodeModelRef: nodeModelMock
             paused: true
             faulted: false
             networkStatusModelRef: networkStatusModelMock
@@ -76,6 +78,7 @@ TestCase {
         nodeModelMock.maxNumOutboundPeers = 10
         nodeModelMock.remainingSyncTime = 0
         nodeModelMock.verificationProgress = 0
+        nodeModelMock.initialSyncComplete = false
         nodeModelMock.headerSyncActive = false
         nodeModelMock.headerPresync = false
         nodeModelMock.headerSyncProgress = 0
@@ -167,6 +170,7 @@ TestCase {
         compare(clock.state, "IBD")
         compare(clock.header, "38%")
         compare(clock.subText, "Syncing headers")
+        compare(findChild(clock, "blockClockDial").syncProgress, 0.375)
     }
 
     function test_header_presync_subtext() {
@@ -184,11 +188,31 @@ TestCase {
         compare(clock.subText, "Pre-syncing headers")
     }
 
+    function test_header_presync_subtext_fits_inside_dial() {
+        resetMocks()
+        nodeModelMock.numPeers = 1
+        nodeModelMock.headerSyncActive = true
+        nodeModelMock.headerPresync = true
+        nodeModelMock.headerSyncProgress = 0.25
+
+        for (const parentWidth of [600, 120]) {
+            const clock = createClock({parentWidth})
+            const subText = findChild(clock, "blockClockSubText")
+
+            verify(subText !== null)
+            compare(subText.text, "Pre-syncing headers")
+            verify(subText.paintedWidth <= subText.width)
+        }
+    }
+
     function test_blockclock_state() {
         resetMocks()
         nodeModelMock.numPeers = 1
         nodeModelMock.numOutboundPeers = 1
-        nodeModelMock.verificationProgress = 1.0
+        nodeModelMock.initialSyncComplete = true
+        // Completion is authoritative even when the progress estimate has not
+        // reached the old UI threshold.
+        nodeModelMock.verificationProgress = 0.75
         nodeModelMock.blockTipHeight = 123456
 
         const clock = createClock()
@@ -196,6 +220,69 @@ TestCase {
         compare(clock.state, "BLOCKCLOCK")
         compare(clock.header, Number(nodeModelMock.blockTipHeight).toLocaleString(Qt.locale(), "f", 0))
         compare(clock.subText, "Blocktime")
+    }
+
+    function test_core_ibd_state_overrides_rounded_verification_completion() {
+        resetMocks()
+        nodeModelMock.numPeers = 1
+        nodeModelMock.initialSyncComplete = false
+        nodeModelMock.verificationProgress = 0.9999
+
+        const clock = createClock()
+        const dial = findChild(clock, "blockClockDial")
+
+        compare(clock.state, "IBD")
+        compare(clock.synced, false)
+        compare(clock.header, "99.9%")
+        compare(dial.synced, false)
+        compare(dial.syncProgress, 0.9999)
+    }
+
+    function test_startup_catch_up_uses_reported_progress() {
+        resetMocks()
+        nodeModelMock.numPeers = 1
+        nodeModelMock.initialSyncComplete = false
+        nodeModelMock.verificationProgress = 0.90
+
+        const clock = createClock()
+        const dial = findChild(clock, "blockClockDial")
+
+        compare(clock.state, "IBD")
+        compare(clock.header, "90%")
+        compare(dial.syncProgress, 0.90)
+    }
+
+    function test_core_completion_allows_empty_current_period_history() {
+        resetMocks()
+        nodeModelMock.numPeers = 1
+        nodeModelMock.initialSyncComplete = true
+        nodeModelMock.verificationProgress = 0.75
+        nodeModelMock.blockTipHeight = 123456
+        blockClockModelMock.blockTimeFractions = []
+
+        const clock = createClock()
+        const dial = findChild(clock, "blockClockDial")
+
+        compare(clock.state, "BLOCKCLOCK")
+        compare(clock.synced, true)
+        compare(dial.synced, true)
+        compare(dial.blockTimeFractions.length, 0)
+    }
+
+    function test_core_completion_transition_updates_clock_state() {
+        resetMocks()
+        nodeModelMock.numPeers = 1
+        nodeModelMock.verificationProgress = 1.0
+
+        const clock = createClock()
+        compare(clock.state, "IBD")
+        compare(clock.header, "99.9%")
+
+        nodeModelMock.initialSyncComplete = true
+        wait(0)
+
+        compare(clock.state, "BLOCKCLOCK")
+        compare(clock.synced, true)
     }
 
     function test_pause_state() {
@@ -276,6 +363,29 @@ TestCase {
         compare(miniClock.showPausedState, false)
     }
 
+    function test_mini_clock_uses_core_sync_completion() {
+        resetMocks()
+        nodeModelMock.numPeers = 1
+        nodeModelMock.verificationProgress = 0.9999
+        const miniClock = createMiniBlockClock()
+        const dial = findChild(miniClock, "miniBlockClockDial")
+        miniClock.pageSelected = false
+        miniClock.paused = false
+        wait(0)
+
+        verify(dial !== null)
+        compare(miniClock.showIbdState, true)
+        compare(miniClock.showClockState, false)
+        compare(dial.syncProgress, 0.9999)
+
+        nodeModelMock.initialSyncComplete = true
+        wait(0)
+
+        compare(miniClock.showIbdState, false)
+        compare(miniClock.showClockState, true)
+        compare(dial.synced, true)
+    }
+
     function test_error_state_overrides_and_disables_toggle() {
         resetMocks()
         nodeModelMock.numPeers = 1
@@ -330,6 +440,8 @@ TestCase {
         compare(clock.formatProgressPercentage(0.51), "0.5%")
         compare(clock.formatProgressPercentage(0.051), "0.05%")
         compare(clock.formatProgressPercentage(0.001), "0%")
+        compare(clock.formatProgressPercentage(99.99, false), "99.9%")
+        compare(clock.formatProgressPercentage(100, true), "100%")
     }
 
     function test_hidden_network_indicator_removes_extra_height() {

--- a/test/qml/tst_blockclock.qml
+++ b/test/qml/tst_blockclock.qml
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import QtQuick 2.15
+import QtQuick.Window 2.15
 import QtTest 1.2
 import "../../qml/components"
 
@@ -11,6 +12,13 @@ TestCase {
     when: windowShown
     width: 800
     height: 700
+
+    Window {
+        id: presentationWindow
+        width: 800
+        height: 700
+        visible: false
+    }
 
     QtObject {
         id: nodeModelMock
@@ -201,7 +209,14 @@ TestCase {
 
             verify(subText !== null)
             compare(subText.text, "Pre-syncing headers")
-            verify(subText.paintedWidth <= subText.width)
+            tryVerify(function() {
+                return subText.paintedWidth <= subText.width
+            }, 1000)
+            verify(!subText.truncated,
+                   "text was truncated at requested pixel size " + subText.font.pixelSize +
+                   ", resolved pixel size " + subText.fontInfo.pixelSize +
+                   ", width " + subText.width +
+                   ", painted width " + subText.paintedWidth)
         }
     }
 
@@ -463,13 +478,21 @@ TestCase {
         nodeModelMock.numPeers = 1
         nodeModelMock.verificationProgress = 0.5
         nodeModelMock.remainingSyncTime = 0
-        const clock = createClock()
+        presentationWindow.visible = true
+        const clock = createTemporaryObject(blockClockComponent, presentationWindow.contentItem)
+        verify(clock !== null)
+        wait(0)
         const dial = findChild(clock, "blockClockDial")
         const estimatingAnimation = findChild(clock, "blockClockEstimatingAnimation")
         const peers = findChild(clock, "blockClockPeersIndicator")
         verify(dial !== null)
         verify(estimatingAnimation !== null)
         verify(peers !== null)
+        compare(clock.renderingActive, true)
+        compare(clock.visible, true)
+        compare(clock.windowVisible, true)
+        compare(clock.presentationActive, true)
+        compare(clock.estimating, true)
         tryCompare(estimatingAnimation, "running", true)
 
         clock.renderingActive = false
@@ -486,5 +509,60 @@ TestCase {
         compare(dial.renderingActive, true)
         compare(dial.currentTimeFraction, 0.75)
         compare(dial.blockTimeFractions.length, 3)
+
+        clock.visible = false
+        compare(clock.presentationActive, false)
+        compare(dial.renderingActive, false)
+        compare(peers.active, false)
+        tryCompare(estimatingAnimation, "running", false)
+
+        clock.visible = true
+        compare(clock.presentationActive, true)
+        compare(dial.renderingActive, true)
+        compare(peers.active, true)
+        tryCompare(estimatingAnimation, "running", true)
+        presentationWindow.visible = false
+    }
+
+    function test_hidden_window_suspends_clock_presentations() {
+        resetMocks()
+        nodeModelMock.numPeers = 1
+        nodeModelMock.verificationProgress = 0.5
+        nodeModelMock.remainingSyncTime = 0
+        presentationWindow.visible = true
+
+        const clock = createTemporaryObject(blockClockComponent, presentationWindow.contentItem)
+        verify(clock !== null)
+        const miniClock = createTemporaryObject(miniBlockClockComponent, presentationWindow.contentItem)
+        verify(miniClock !== null)
+        const dial = findChild(clock, "blockClockDial")
+        const miniDial = findChild(miniClock, "miniBlockClockDial")
+        const estimatingAnimation = findChild(clock, "blockClockEstimatingAnimation")
+        const peers = findChild(clock, "blockClockPeersIndicator")
+        verify(dial !== null)
+        verify(miniDial !== null)
+        verify(estimatingAnimation !== null)
+        verify(peers !== null)
+        tryCompare(clock, "presentationActive", true)
+        tryCompare(miniClock, "presentationActive", true)
+        compare(miniDial.renderingActive, true)
+        tryCompare(estimatingAnimation, "running", true)
+
+        presentationWindow.visible = false
+        tryCompare(clock, "presentationActive", false)
+        tryCompare(miniClock, "presentationActive", false)
+        compare(dial.renderingActive, false)
+        compare(miniDial.renderingActive, false)
+        compare(peers.presentationActive, false)
+        tryCompare(estimatingAnimation, "running", false)
+
+        presentationWindow.visible = true
+        tryCompare(clock, "presentationActive", true)
+        tryCompare(miniClock, "presentationActive", true)
+        compare(dial.renderingActive, true)
+        compare(miniDial.renderingActive, true)
+        compare(peers.presentationActive, true)
+        tryCompare(estimatingAnimation, "running", true)
+        presentationWindow.visible = false
     }
 }

--- a/test/qml/tst_blockclock.qml
+++ b/test/qml/tst_blockclock.qml
@@ -35,8 +35,13 @@ TestCase {
 
     QtObject {
         id: chainModelMock
-        property var timeRatioList: [0.25, 0.0]
-        property string currentNetworkName: "REGTEST"
+        property string networkName: "REGTEST"
+    }
+
+    QtObject {
+        id: blockClockModelMock
+        property real currentTimeFraction: 0.25
+        property var blockTimeFractions: []
     }
 
     Component {
@@ -46,6 +51,7 @@ TestCase {
             parentHeight: 600
             nodeModelRef: nodeModelMock
             chainModelRef: chainModelMock
+            blockClockModelRef: blockClockModelMock
             networkStatusModelRef: networkStatusModelMock
         }
     }
@@ -58,6 +64,7 @@ TestCase {
             paused: true
             faulted: false
             networkStatusModelRef: networkStatusModelMock
+            blockClockModelRef: blockClockModelMock
         }
     }
 
@@ -75,8 +82,9 @@ TestCase {
         nodeModelMock.pause = false
         nodeModelMock.faulted = false
         networkStatusModelMock.networkOffline = false
-        chainModelMock.timeRatioList = [0.25, 0.0]
-        chainModelMock.currentNetworkName = "REGTEST"
+        chainModelMock.networkName = "REGTEST"
+        blockClockModelMock.currentTimeFraction = 0.25
+        blockClockModelMock.blockTimeFractions = []
     }
 
     function createClock(properties) {
@@ -336,5 +344,35 @@ TestCase {
         verify(indicator !== null)
         verify(!indicator.visible)
         compare(clock.height, clock.width)
+    }
+
+    function test_inactive_clock_retains_latest_model_snapshot_without_animations() {
+        resetMocks()
+        nodeModelMock.numPeers = 1
+        nodeModelMock.verificationProgress = 0.5
+        nodeModelMock.remainingSyncTime = 0
+        const clock = createClock()
+        const dial = findChild(clock, "blockClockDial")
+        const estimatingAnimation = findChild(clock, "blockClockEstimatingAnimation")
+        const peers = findChild(clock, "blockClockPeersIndicator")
+        verify(dial !== null)
+        verify(estimatingAnimation !== null)
+        verify(peers !== null)
+        tryCompare(estimatingAnimation, "running", true)
+
+        clock.renderingActive = false
+        compare(dial.renderingActive, false)
+        compare(peers.active, false)
+        tryCompare(estimatingAnimation, "running", false)
+
+        blockClockModelMock.currentTimeFraction = 0.75
+        blockClockModelMock.blockTimeFractions = [0.1, 0.2, 0.4]
+        compare(dial.currentTimeFraction, 0.75)
+        compare(dial.blockTimeFractions.length, 3)
+
+        clock.renderingActive = true
+        compare(dial.renderingActive, true)
+        compare(dial.currentTimeFraction, 0.75)
+        compare(dial.blockTimeFractions.length, 3)
     }
 }

--- a/test/qml/tst_desktopwallets.qml
+++ b/test/qml/tst_desktopwallets.qml
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import QtQuick 2.15
+import QtQuick.Window 2.15
 import QtTest 1.2
 import "../../qml/pages/wallet"
 
@@ -11,6 +12,13 @@ TestCase {
     when: windowShown
     width: 900
     height: 600
+
+    Window {
+        id: testWindow
+        width: 900
+        height: 600
+        visible: true
+    }
 
     Component {
         id: desktopWalletsComponent
@@ -115,6 +123,29 @@ TestCase {
         activityTab.checked = true
         tryCompare(activityTab, "checked", true)
         tryCompare(popup, "visible", false)
+    }
+
+    function test_full_block_clock_is_active_only_on_its_tab() {
+        const page = createTemporaryObject(desktopWalletsComponent, testWindow.contentItem)
+        verify(page !== null)
+        const clock = findChild(page, "blockClock")
+        const sendTab = findChild(page, "sendTabButton")
+        const blockClockTab = findChild(page, "blockClockTabButton")
+        verify(clock !== null)
+        verify(sendTab !== null)
+        verify(blockClockTab !== null)
+
+        tryCompare(page, "visible", true)
+        compare(blockClockTab.checked, true)
+        tryCompare(clock, "renderingActive", true)
+
+        sendTab.checked = true
+        tryCompare(sendTab, "checked", true)
+        tryCompare(clock, "renderingActive", false)
+
+        blockClockTab.checked = true
+        tryCompare(blockClockTab, "checked", true)
+        tryCompare(clock, "renderingActive", true)
     }
 
     function test_receive_options_view_address_history_opens_settings_address_stack() {

--- a/test/qml/tst_desktopwallets.qml
+++ b/test/qml/tst_desktopwallets.qml
@@ -35,6 +35,15 @@ TestCase {
         walletController.isWalletLoaded = true
         walletController.noWalletsFound = false
         walletListModel.reset()
+        nodeModel.numPeers = 0
+        nodeModel.initialSyncComplete = false
+        nodeModel.verificationProgress = 0
+        nodeModel.remainingSyncTime = 0
+        nodeModel.headerSyncActive = false
+        nodeModel.headerPresync = false
+        nodeModel.pause = false
+        nodeModel.faulted = false
+        nodeModel.blockTipHeight = 0
     }
 
     function createDesktopWallets() {
@@ -146,6 +155,23 @@ TestCase {
         blockClockTab.checked = true
         tryCompare(blockClockTab, "checked", true)
         tryCompare(clock, "renderingActive", true)
+    }
+
+    function test_block_clock_tooltip_uses_latched_sync_completion() {
+        nodeModel.numPeers = 1
+        nodeModel.verificationProgress = 0.9999
+        nodeModel.blockTipHeight = 313899
+
+        const page = createDesktopWallets()
+        const tooltip = findChild(page, "blockClockTooltip")
+        verify(tooltip !== null)
+
+        compare(tooltip.text, "Downloading blocks\nEstimating")
+
+        nodeModel.initialSyncComplete = true
+        wait(0)
+
+        compare(tooltip.text, "Blocktime\n" + Number(nodeModel.blockTipHeight).toLocaleString(Qt.locale(), "f", 0))
     }
 
     function test_receive_options_view_address_history_opens_settings_address_stack() {

--- a/test/qml/tst_nodefeedback.qml
+++ b/test/qml/tst_nodefeedback.qml
@@ -34,6 +34,20 @@ TestCase {
     }
 
     Component {
+        id: nodeRunnerStackComponent
+        PageStack {
+            width: 640
+            height: 520
+            initialItem: NodeRunner {}
+        }
+    }
+
+    Component {
+        id: emptyPageComponent
+        Page { background: null }
+    }
+
+    Component {
         id: warningsPopupComponent
         NodeWarningsPopup {}
     }
@@ -183,6 +197,26 @@ TestCase {
         const settingsCenterY = settingsButton.mapToItem(runner, 0, settingsButton.height / 2).y
         verify(Math.abs(warningCenterY - settingsCenterY) <= 0.5)
         verify(Math.abs(infoCenterY - settingsCenterY) <= 0.5)
+    }
+
+    function test_node_runner_clock_follows_stack_visibility() {
+        const stack = createTemporaryObject(nodeRunnerStackComponent, testWindow.contentItem)
+        verify(stack !== null)
+        const runner = findChild(stack, "nodeRunner")
+        const clock = findChild(stack, "blockClock")
+        verify(runner !== null)
+        verify(clock !== null)
+        tryCompare(clock, "renderingActive", true)
+
+        stack.push(emptyPageComponent)
+        tryCompare(stack, "depth", 2)
+        tryCompare(runner, "visible", false, 1000)
+        tryCompare(clock, "renderingActive", false)
+
+        stack.pop()
+        tryCompare(stack, "depth", 1)
+        tryCompare(runner, "visible", true, 1000)
+        tryCompare(clock, "renderingActive", true)
     }
 
     function test_warning_popup_lists_current_warnings() {

--- a/test/test_blockclockdial.cpp
+++ b/test/test_blockclockdial.cpp
@@ -98,7 +98,7 @@ void BlockClockDialTests::ibdProgressRendersImmediateHalfArc()
     dial.setAnimateDial(false);
     dial.setConnected(true);
     dial.setSynced(false);
-    dial.setVerificationProgress(0.5);
+    dial.setSyncProgress(0.5);
 
     const QImage image{RenderDial(dial)};
     const QColor active_pixel{image.pixelColor(QPoint{DIAL_SIZE - 7, DIAL_SIZE / 2})};

--- a/test/test_blockclockdial.cpp
+++ b/test/test_blockclockdial.cpp
@@ -115,6 +115,7 @@ class BlockClockDialTests : public QObject
 private Q_SLOTS:
     void ibdProgressRendersImmediateHalfArc();
     void syncedGradientToggleChangesRenderedColors();
+    void syncedGradientRunsFromOlderToNewerConfirmationColors();
     void syncedGradientUpdatesWhenConfirmationColorsChange();
     void connectingDelayControlsInitialAnimation();
     void inactiveDialStopsAnimationAndRetainsLatestState();
@@ -171,6 +172,32 @@ void BlockClockDialTests::syncedGradientToggleChangesRenderedColors()
     QVERIFY2(ColorDistance(gradient_right, gradient_bottom) > 25,
              qPrintable(QStringLiteral("expected gradient samples to differ, got %1 and %2")
                             .arg(gradient_right.name(QColor::HexArgb), gradient_bottom.name(QColor::HexArgb))));
+}
+
+void BlockClockDialTests::syncedGradientRunsFromOlderToNewerConfirmationColors()
+{
+    BlockClockDial dial;
+    ConfigureDial(dial);
+    dial.setAnimateDial(false);
+    dial.setConnected(true);
+    dial.setSynced(true);
+    dial.setShowBlockSegments(false);
+    dial.setUseGradientArcWhenSynced(true);
+    dial.setCurrentTimeFraction(0.75);
+
+    const QImage image{RenderDial(dial)};
+    const QColor older_color{image.pixelColor(DialPoint(0.05))};
+    const QColor middle_color{image.pixelColor(DialPoint(0.375))};
+    const QColor newer_color{image.pixelColor(DialPoint(0.70))};
+
+    QVERIFY(ColorDistance(older_color, CONFIRMATION_COLORS[5]) <
+            ColorDistance(older_color, CONFIRMATION_COLORS[0]));
+    QVERIFY(ColorDistance(newer_color, CONFIRMATION_COLORS[0]) <
+            ColorDistance(older_color, CONFIRMATION_COLORS[0]));
+    QVERIFY(ColorDistance(older_color, CONFIRMATION_COLORS[5]) <
+            ColorDistance(newer_color, CONFIRMATION_COLORS[5]));
+    QVERIFY(older_color.green() > middle_color.green());
+    QVERIFY(middle_color.green() > newer_color.green());
 }
 
 void BlockClockDialTests::syncedGradientUpdatesWhenConfirmationColorsChange()

--- a/test/test_blockclockdial.cpp
+++ b/test/test_blockclockdial.cpp
@@ -9,6 +9,7 @@
 #include <QImage>
 #include <QPainter>
 #include <QPoint>
+#include <QtMath>
 
 #include <cmath>
 
@@ -49,6 +50,17 @@ void ConfigureDial(BlockClockDial& dial)
     dial.setShowTimeTicks(false);
 }
 
+void ConfigureSyncedDial(BlockClockDial& dial, qreal current_fraction,
+                         const QList<qreal>& block_fractions)
+{
+    ConfigureDial(dial);
+    dial.setAnimateDial(false);
+    dial.setConnected(true);
+    dial.setSynced(true);
+    dial.setCurrentTimeFraction(current_fraction);
+    dial.setBlockTimeFractions(block_fractions);
+}
+
 QImage RenderDial(BlockClockDial& dial)
 {
     QImage image{DIAL_SIZE, DIAL_SIZE, QImage::Format_ARGB32_Premultiplied};
@@ -76,6 +88,24 @@ int CountConfirmationPixels(const QImage& image)
     }
     return count;
 }
+
+QPoint DialPoint(qreal fraction)
+{
+    constexpr qreal center{DIAL_SIZE / 2.0};
+    constexpr qreal radius{DIAL_SIZE / 2.0 - 7.0};
+    const qreal angle{fraction * 2.0 * M_PI};
+    return {qRound(center + qSin(angle) * radius), qRound(center - qCos(angle) * radius)};
+}
+
+void VerifyDialColor(const QImage& image, qreal fraction, const QColor& expected)
+{
+    const QColor actual{image.pixelColor(DialPoint(fraction))};
+    QVERIFY2(ColorDistance(actual, expected) < 35,
+             qPrintable(QStringLiteral("expected %1 at %2, got %3")
+                            .arg(expected.name(QColor::HexArgb))
+                            .arg(fraction)
+                            .arg(actual.name(QColor::HexArgb))));
+}
 } // namespace
 
 class BlockClockDialTests : public QObject
@@ -89,6 +119,11 @@ private Q_SLOTS:
     void connectingDelayControlsInitialAnimation();
     void inactiveDialStopsAnimationAndRetainsLatestState();
     void paintDoesNotAdvanceAnimationState();
+    void distinctBlocksUseExactConfirmationColors();
+    void coalescedBlocksUseConfirmationGradient();
+    void coalescedBlocksSaturateAtHighestConfirmationColor();
+    void blocksCoalescedWithCurrentTimePreserveConfirmationDepth();
+    void blocksCoalescedWithPeriodStartDoNotShiftVisibleDepth();
 };
 
 void BlockClockDialTests::ibdProgressRendersImmediateHalfArc()
@@ -226,6 +261,73 @@ void BlockClockDialTests::paintDoesNotAdvanceAnimationState()
     const QImage first{RenderDial(dial)};
     const QImage second{RenderDial(dial)};
     QCOMPARE(first, second);
+}
+
+void BlockClockDialTests::distinctBlocksUseExactConfirmationColors()
+{
+    BlockClockDial dial;
+    ConfigureSyncedDial(dial, 0.75, {0.25, 0.50});
+
+    const QImage image{RenderDial(dial)};
+    VerifyDialColor(image, 0.125, CONFIRMATION_COLORS[2]);
+    VerifyDialColor(image, 0.375, CONFIRMATION_COLORS[1]);
+    VerifyDialColor(image, 0.625, CONFIRMATION_COLORS[0]);
+}
+
+void BlockClockDialTests::coalescedBlocksUseConfirmationGradient()
+{
+    BlockClockDial dial;
+    ConfigureSyncedDial(dial, 0.75, {0.25, 0.2501, 0.2502});
+
+    const QImage image{RenderDial(dial)};
+    const QColor older_color{image.pixelColor(DialPoint(0.05))};
+    const QColor middle_color{image.pixelColor(DialPoint(0.125))};
+    const QColor newer_color{image.pixelColor(DialPoint(0.20))};
+
+    QCOMPARE(dial.blockTimeFractions().size(), 3);
+    QVERIFY(ColorDistance(older_color, CONFIRMATION_COLORS[3]) <
+            ColorDistance(older_color, CONFIRMATION_COLORS[0]));
+    QVERIFY(ColorDistance(newer_color, CONFIRMATION_COLORS[0]) <
+            ColorDistance(newer_color, CONFIRMATION_COLORS[3]));
+    QVERIFY(older_color.green() > middle_color.green());
+    QVERIFY(middle_color.green() > newer_color.green());
+    QVERIFY(ColorDistance(older_color, newer_color) > 50);
+    VerifyDialColor(image, 0.50, CONFIRMATION_COLORS[0]);
+}
+
+void BlockClockDialTests::coalescedBlocksSaturateAtHighestConfirmationColor()
+{
+    BlockClockDial dial;
+    ConfigureSyncedDial(dial, 0.75, {0.25, 0.2501, 0.2502, 0.2503, 0.2504, 0.2505});
+
+    const QImage image{RenderDial(dial)};
+    VerifyDialColor(image, 0.025, CONFIRMATION_COLORS[5]);
+    VerifyDialColor(image, 0.50, CONFIRMATION_COLORS[0]);
+}
+
+void BlockClockDialTests::blocksCoalescedWithCurrentTimePreserveConfirmationDepth()
+{
+    BlockClockDial dial;
+    ConfigureSyncedDial(dial, 0.75, {0.7498, 0.7499});
+
+    const QImage image{RenderDial(dial)};
+    const QColor older_color{image.pixelColor(DialPoint(0.10))};
+    const QColor current_color{image.pixelColor(DialPoint(0.70))};
+
+    QVERIFY(ColorDistance(older_color, CONFIRMATION_COLORS[2]) <
+            ColorDistance(older_color, CONFIRMATION_COLORS[0]));
+    QVERIFY(ColorDistance(current_color, CONFIRMATION_COLORS[0]) <
+            ColorDistance(current_color, CONFIRMATION_COLORS[2]));
+}
+
+void BlockClockDialTests::blocksCoalescedWithPeriodStartDoNotShiftVisibleDepth()
+{
+    BlockClockDial dial;
+    ConfigureSyncedDial(dial, 0.75, {0.0001, 0.25});
+
+    const QImage image{RenderDial(dial)};
+    VerifyDialColor(image, 0.125, CONFIRMATION_COLORS[1]);
+    VerifyDialColor(image, 0.50, CONFIRMATION_COLORS[0]);
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN

--- a/test/test_blockclockdial.cpp
+++ b/test/test_blockclockdial.cpp
@@ -24,6 +24,13 @@ const QList<QColor> CONFIRMATION_COLORS{
     QColor{QStringLiteral("#F1D54A")},
 };
 
+class TestableBlockClockDial : public BlockClockDial
+{
+public:
+    using BlockClockDial::BlockClockDial;
+    void complete() { componentComplete(); }
+};
+
 int ColorDistance(const QColor& a, const QColor& b)
 {
     return std::abs(a.red() - b.red()) +
@@ -80,6 +87,8 @@ private Q_SLOTS:
     void syncedGradientToggleChangesRenderedColors();
     void syncedGradientUpdatesWhenConfirmationColorsChange();
     void connectingDelayControlsInitialAnimation();
+    void inactiveDialStopsAnimationAndRetainsLatestState();
+    void paintDoesNotAdvanceAnimationState();
 };
 
 void BlockClockDialTests::ibdProgressRendersImmediateHalfArc()
@@ -109,7 +118,7 @@ void BlockClockDialTests::syncedGradientToggleChangesRenderedColors()
     dial.setConnected(true);
     dial.setSynced(true);
     dial.setShowBlockSegments(false);
-    dial.setTimeRatioList({1.0, 0.0});
+    dial.setCurrentTimeFraction(1.0);
 
     dial.setUseGradientArcWhenSynced(false);
     const QImage uniform_image{RenderDial(dial)};
@@ -138,7 +147,7 @@ void BlockClockDialTests::syncedGradientUpdatesWhenConfirmationColorsChange()
     dial.setSynced(true);
     dial.setShowBlockSegments(false);
     dial.setUseGradientArcWhenSynced(true);
-    dial.setTimeRatioList({1.0, 0.0});
+    dial.setCurrentTimeFraction(1.0);
 
     const QColor initial_color{RenderDial(dial).pixelColor(QPoint{DIAL_SIZE - 7, DIAL_SIZE / 2})};
 
@@ -160,21 +169,63 @@ void BlockClockDialTests::syncedGradientUpdatesWhenConfirmationColorsChange()
 
 void BlockClockDialTests::connectingDelayControlsInitialAnimation()
 {
-    BlockClockDial delayed_dial;
+    TestableBlockClockDial delayed_dial;
     ConfigureDial(delayed_dial);
     delayed_dial.setConnected(false);
     delayed_dial.setAnimateDial(true);
     delayed_dial.setConnectingAnimationDelayMs(5000);
+    delayed_dial.complete();
     QCOMPARE(CountConfirmationPixels(RenderDial(delayed_dial)), 0);
 
-    BlockClockDial immediate_dial;
+    TestableBlockClockDial immediate_dial;
     ConfigureDial(immediate_dial);
     immediate_dial.setConnected(false);
     immediate_dial.setAnimateDial(true);
     immediate_dial.setConnectingAnimationDelayMs(0);
+    immediate_dial.complete();
 
-    RenderDial(immediate_dial);
-    QVERIFY(CountConfirmationPixels(RenderDial(immediate_dial)) > 0);
+    QTRY_VERIFY_WITH_TIMEOUT(CountConfirmationPixels(RenderDial(immediate_dial)) > 0, 250);
+}
+
+void BlockClockDialTests::inactiveDialStopsAnimationAndRetainsLatestState()
+{
+    TestableBlockClockDial dial;
+    ConfigureDial(dial);
+    dial.setConnectingAnimationDelayMs(0);
+    dial.complete();
+    QTest::qWait(20);
+
+    QTimer* animation_timer{nullptr};
+    for (QTimer* timer : dial.findChildren<QTimer*>()) {
+        if (timer->interval() == 16) animation_timer = timer;
+    }
+    QVERIFY(animation_timer);
+    QVERIFY(animation_timer->isActive());
+
+    dial.setRenderingActive(false);
+    QVERIFY(!animation_timer->isActive());
+
+    dial.setCurrentTimeFraction(0.75);
+    dial.setConnected(true);
+    dial.setSynced(true);
+    QCOMPARE(dial.currentTimeFraction(), 0.75);
+
+    dial.setRenderingActive(true);
+    QVERIFY(!animation_timer->isActive());
+    const QImage image{RenderDial(dial)};
+    QVERIFY(CountConfirmationPixels(image) > 0);
+}
+
+void BlockClockDialTests::paintDoesNotAdvanceAnimationState()
+{
+    TestableBlockClockDial dial;
+    ConfigureDial(dial);
+    dial.setRenderingActive(false);
+    dial.complete();
+
+    const QImage first{RenderDial(dial)};
+    const QImage second{RenderDial(dial)};
+    QCOMPARE(first, second);
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN

--- a/test/test_blockclockmodel.cpp
+++ b/test/test_blockclockmodel.cpp
@@ -23,10 +23,12 @@ class BlockClockModelTests : public QObject
 private Q_SLOTS:
     void currentTimeUsesNamedTwelveHourFraction();
     void unchangedSecondDoesNotRepublishCurrentTime();
+    void blockArrivalRefreshesCurrentTime();
     void blockHistoryIsSortedUniqueAndPeriodBounded();
     void historyLoadsOnInitializationAndPeriodRollover();
     void emptyHistoryDoesNotEmitRedundantChanges();
     void timerHasModelOwnershipAndCanBeDisabledForTests();
+    void timerAlignsToNextMinute();
 };
 
 void BlockClockModelTests::currentTimeUsesNamedTwelveHourFraction()
@@ -51,9 +53,26 @@ void BlockClockModelTests::unchangedSecondDoesNotRepublishCurrentTime()
     QCOMPARE(current_time_spy.count(), 1);
 }
 
+void BlockClockModelTests::blockArrivalRefreshesCurrentTime()
+{
+    QDateTime current_time{UtcTime(15)};
+    BlockClockModel model{{}, false, [&] { return current_time; }};
+    QSignalSpy current_time_spy{&model, &BlockClockModel::currentTimeFractionChanged};
+
+    current_time = UtcTime(15, 1);
+    model.recordBlockTime(UtcTime(15, 0, 30).toSecsSinceEpoch());
+
+    QCOMPARE(current_time_spy.count(), 1);
+    QVERIFY(qAbs(model.currentTimeFraction() - (181.0 / 720.0)) < 0.000001);
+    QCOMPARE(model.blockTimeFractions().size(), 1);
+    QVERIFY(qAbs(model.blockTimeFractions().constFirst() -
+                 (10830.0 / BlockClockModel::PERIOD_SECONDS)) < 0.000001);
+}
+
 void BlockClockModelTests::blockHistoryIsSortedUniqueAndPeriodBounded()
 {
-    BlockClockModel model{{}, false};
+    const QDateTime current_time{UtcTime(15)};
+    BlockClockModel model{{}, false, [current_time] { return current_time; }};
     model.updateCurrentTime(UtcTime(15));
     const qint64 start{model.periodStart()};
     QSignalSpy history_spy{&model, &BlockClockModel::blockTimeFractionsChanged};
@@ -106,13 +125,25 @@ void BlockClockModelTests::emptyHistoryDoesNotEmitRedundantChanges()
 
 void BlockClockModelTests::timerHasModelOwnershipAndCanBeDisabledForTests()
 {
-    BlockClockModel stopped_model{{}, false};
+    const QDateTime current_time{UtcTime(15)};
+    const auto current_time_provider{[current_time] { return current_time; }};
+    BlockClockModel stopped_model{{}, false, current_time_provider};
     QCOMPARE(stopped_model.timerActive(), false);
     QCOMPARE(stopped_model.findChildren<QTimer*>().size(), 1);
     QCOMPARE(stopped_model.findChildren<QTimer*>().constFirst()->parent(), &stopped_model);
 
-    BlockClockModel running_model{{}, true};
+    BlockClockModel running_model{{}, true, current_time_provider};
     QCOMPARE(running_model.timerActive(), true);
+}
+
+void BlockClockModelTests::timerAlignsToNextMinute()
+{
+    const QDateTime current_time{UtcTime(15, 0, 45).addMSecs(250)};
+    BlockClockModel model{{}, true, [current_time] { return current_time; }};
+    QTimer* timer{model.findChildren<QTimer*>().constFirst()};
+
+    QCOMPARE(timer->timerType(), Qt::PreciseTimer);
+    QCOMPARE(timer->interval(), BlockClockModel::CLOCK_UPDATE_INTERVAL_MS - 45250);
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN

--- a/test/test_blockclockmodel.cpp
+++ b/test/test_blockclockmodel.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/blockclockmodel.h>
+
+#include <test/qt_test_registry.h>
+
+#include <QtTest/QtTest>
+#include <QTimeZone>
+
+namespace {
+QDateTime UtcTime(int hour, int minute = 0, int second = 0)
+{
+    return QDateTime{QDate{2026, 7, 17}, QTime{hour, minute, second}, QTimeZone::utc()};
+}
+} // namespace
+
+class BlockClockModelTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void currentTimeUsesNamedTwelveHourFraction();
+    void unchangedSecondDoesNotRepublishCurrentTime();
+    void blockHistoryIsSortedUniqueAndPeriodBounded();
+    void historyLoadsOnInitializationAndPeriodRollover();
+    void emptyHistoryDoesNotEmitRedundantChanges();
+    void timerHasModelOwnershipAndCanBeDisabledForTests();
+};
+
+void BlockClockModelTests::currentTimeUsesNamedTwelveHourFraction()
+{
+    BlockClockModel model{{}, false};
+    model.updateCurrentTime(UtcTime(15));
+
+    QCOMPARE(model.periodStart(), UtcTime(12).toSecsSinceEpoch());
+    QVERIFY(qAbs(model.currentTimeFraction() - 0.25) < 0.000001);
+}
+
+void BlockClockModelTests::unchangedSecondDoesNotRepublishCurrentTime()
+{
+    BlockClockModel model{{}, false};
+    model.updateCurrentTime(UtcTime(15));
+    QSignalSpy current_time_spy{&model, &BlockClockModel::currentTimeFractionChanged};
+
+    model.updateCurrentTime(UtcTime(15));
+    QCOMPARE(current_time_spy.count(), 0);
+
+    model.updateCurrentTime(UtcTime(15, 0, 1));
+    QCOMPARE(current_time_spy.count(), 1);
+}
+
+void BlockClockModelTests::blockHistoryIsSortedUniqueAndPeriodBounded()
+{
+    BlockClockModel model{{}, false};
+    model.updateCurrentTime(UtcTime(15));
+    const qint64 start{model.periodStart()};
+    QSignalSpy history_spy{&model, &BlockClockModel::blockTimeFractionsChanged};
+
+    model.recordBlockTime(start - 1);
+    model.recordBlockTime(start + BlockClockModel::PERIOD_SECONDS);
+    QCOMPARE(history_spy.count(), 0);
+
+    model.recordBlockTime(start + 7200);
+    model.recordBlockTime(start + 3600);
+    model.recordBlockTime(start + 7200);
+
+    QCOMPARE(history_spy.count(), 2);
+    const QList<qreal> expected{1.0 / 12.0, 2.0 / 12.0};
+    QCOMPARE(model.blockTimeFractions().size(), expected.size());
+    for (qsizetype i{0}; i < expected.size(); ++i) {
+        QVERIFY(qAbs(model.blockTimeFractions().at(i) - expected.at(i)) < 0.000001);
+    }
+}
+
+void BlockClockModelTests::historyLoadsOnInitializationAndPeriodRollover()
+{
+    QList<qint64> requested_starts;
+    BlockClockModel model{[&](qint64 start, qint64) {
+        requested_starts.push_back(start);
+        return QList<qint64>{start + 600, start + 1200};
+    }, false};
+
+    model.updateCurrentTime(UtcTime(11, 59, 59));
+    model.initializeHistory();
+    QCOMPARE(requested_starts, QList<qint64>{UtcTime(0).toSecsSinceEpoch()});
+    QCOMPARE(model.blockTimeFractions().size(), 2);
+
+    model.updateCurrentTime(UtcTime(12));
+    QCOMPARE(requested_starts, QList<qint64>({UtcTime(0).toSecsSinceEpoch(), UtcTime(12).toSecsSinceEpoch()}));
+    QCOMPARE(model.periodStart(), UtcTime(12).toSecsSinceEpoch());
+    QCOMPARE(model.blockTimeFractions().size(), 2);
+}
+
+void BlockClockModelTests::emptyHistoryDoesNotEmitRedundantChanges()
+{
+    BlockClockModel model{[](qint64, qint64) { return QList<qint64>{}; }, false};
+    model.updateCurrentTime(UtcTime(15));
+    QSignalSpy history_spy{&model, &BlockClockModel::blockTimeFractionsChanged};
+
+    model.initializeHistory();
+    model.initializeHistory();
+    QCOMPARE(history_spy.count(), 0);
+}
+
+void BlockClockModelTests::timerHasModelOwnershipAndCanBeDisabledForTests()
+{
+    BlockClockModel stopped_model{{}, false};
+    QCOMPARE(stopped_model.timerActive(), false);
+    QCOMPARE(stopped_model.findChildren<QTimer*>().size(), 1);
+    QCOMPARE(stopped_model.findChildren<QTimer*>().constFirst()->parent(), &stopped_model);
+
+    BlockClockModel running_model{{}, true};
+    QCOMPARE(running_model.timerActive(), true);
+}
+
+#ifdef BITCOINQML_NO_TEST_MAIN
+BITCOINQML_REGISTER_QT_TEST(BlockClockModelTests)
+#else
+QTEST_MAIN(BlockClockModelTests)
+#endif
+#include "test_blockclockmodel.moc"

--- a/test/test_nodemodel.cpp
+++ b/test/test_nodemodel.cpp
@@ -419,7 +419,7 @@ void NodeModelTests::initializationSuccessDuringCoreShutdownSkipsReadyState()
 
     QSignalSpy shutdown_spy{&model, &NodeModel::requestedShutdown};
     QSignalSpy initialized_spy{&model, &NodeModel::nodeInitialized};
-    QSignalSpy ready_state_spy{&model, &NodeModel::setTimeRatioListInitial};
+    QSignalSpy ready_state_spy{&model, &NodeModel::chainStateReady};
     model.initializeResult(true, {});
 
     QCOMPARE(shutdown_spy.count(), 1);
@@ -516,7 +516,7 @@ void NodeModelTests::nodeNotificationHandlersUpdateModelThroughQueuedSignals()
 
     QSignalSpy block_tip_height_spy{&model, &NodeModel::blockTipHeightChanged};
     QSignalSpy verification_progress_spy{&model, &NodeModel::verificationProgressChanged};
-    QSignalSpy time_ratio_spy{&model, &NodeModel::setTimeRatioList};
+    QSignalSpy time_ratio_spy{&model, &NodeModel::blockTipTimeChanged};
     QSignalSpy peers_spy{&model, &NodeModel::numPeersChanged};
     QSignalSpy inbound_peers_spy{&model, &NodeModel::numInboundPeersChanged};
     QSignalSpy outbound_peers_spy{&model, &NodeModel::numOutboundPeersChanged};
@@ -598,7 +598,7 @@ void NodeModelTests::blockTipUpdatesQueuedAcrossThreadsRetainPayloadValues()
 
     std::vector<double> seen_progress;
     std::vector<int> seen_heights;
-    std::vector<int> seen_times;
+    std::vector<qint64> seen_times;
 
     QObject::connect(&model, &NodeModel::verificationProgressChanged, &model, [&] {
         seen_progress.push_back(model.verificationProgress());
@@ -606,7 +606,7 @@ void NodeModelTests::blockTipUpdatesQueuedAcrossThreadsRetainPayloadValues()
     QObject::connect(&model, &NodeModel::blockTipHeightChanged, &model, [&] {
         seen_heights.push_back(model.blockTipHeight());
     });
-    QObject::connect(&model, &NodeModel::setTimeRatioList, &model, [&](int block_time) {
+    QObject::connect(&model, &NodeModel::blockTipTimeChanged, &model, [&](qint64 block_time) {
         seen_times.push_back(block_time);
     });
 

--- a/test/test_nodemodel.cpp
+++ b/test/test_nodemodel.cpp
@@ -119,6 +119,8 @@ private Q_SLOTS:
     void nodeNotificationHandlersUpdateModelThroughQueuedSignals();
     void bannedListNotificationFromGuiThreadIsNotDeliveredReentrantly();
     void blockTipUpdatesQueuedAcrossThreadsRetainPayloadValues();
+    void initialSyncCompletionIgnoresVerificationEstimateForGenesis();
+    void initialSyncCompletionWaitsForStartupCatchUpAndLatches();
     void blockSyncActiveFollowsInitializationAndBlockTipState();
     void alertNotificationsRefreshWarningList();
     void headerTipNotificationsExposeHeaderSyncProgress();
@@ -649,8 +651,10 @@ void NodeModelTests::blockSyncActiveFollowsInitializationAndBlockTipState()
     WaitForInitialMempoolRefresh(mempool);
     QVERIFY(block_tip_fn);
     QVERIFY(!model.blockSyncActive());
+    QVERIFY(!model.initialSyncComplete());
 
     QSignalSpy block_sync_spy{&model, &NodeModel::blockSyncActiveChanged};
+    QSignalSpy sync_complete_spy{&model, &NodeModel::initialSyncCompleteChanged};
     model.initializeResult(true, interfaces::BlockAndHeaderTipInfo{
         .block_height = 0,
         .block_time = 1'700'000'000,
@@ -659,27 +663,127 @@ void NodeModelTests::blockSyncActiveFollowsInitializationAndBlockTipState()
         .verification_progress = 0.25,
     });
 
-    QCOMPARE(block_sync_spy.count(), 0);
-    QVERIFY(!model.blockSyncActive());
-
-    model.initializeResult(true, interfaces::BlockAndHeaderTipInfo{
-        .block_height = 100,
-        .block_time = 1'700'000'000,
-        .header_height = 100,
-        .header_time = GetTime(),
-        .verification_progress = 0.25,
-    });
-
     QCOMPARE(block_sync_spy.count(), 1);
     QVERIFY(model.blockSyncActive());
+    QVERIFY(!model.initialSyncComplete());
+    QCOMPARE(sync_complete_spy.count(), 0);
 
     block_tip_fn(SynchronizationState::POST_INIT, interfaces::BlockTip{101, 1'700'000'001, uint256{}}, 0.25);
     QTRY_COMPARE_WITH_TIMEOUT(block_sync_spy.count(), 2, ASYNC_TIMEOUT_MS);
     QVERIFY(!model.blockSyncActive());
+    QVERIFY(model.initialSyncComplete());
+    QCOMPARE(sync_complete_spy.count(), 1);
 
     block_tip_fn(SynchronizationState::INIT_DOWNLOAD, interfaces::BlockTip{102, 1'700'000'002, uint256{}}, 0.26);
     QTRY_COMPARE_WITH_TIMEOUT(block_sync_spy.count(), 3, ASYNC_TIMEOUT_MS);
     QVERIFY(model.blockSyncActive());
+    QVERIFY(model.initialSyncComplete());
+    QCOMPARE(sync_complete_spy.count(), 1);
+}
+
+void NodeModelTests::initialSyncCompletionIgnoresVerificationEstimateForGenesis()
+{
+    NiceMock<MockNode> node;
+    MempoolState mempool;
+
+    InstallDefaultHandlers(node);
+    InstallMempoolGetters(node, mempool);
+    ON_CALL(node, isInitialBlockDownload()).WillByDefault(Return(false));
+
+    NodeModel model{node};
+    WaitForInitialMempoolRefresh(mempool);
+    QSignalSpy sync_complete_spy{&model, &NodeModel::initialSyncCompleteChanged};
+
+    // A valid genesis-only chain can be complete (for example, regtest), and
+    // the verification estimate is not a completion predicate.
+    model.initializeResult(true, interfaces::BlockAndHeaderTipInfo{
+        .block_height = 0,
+        .block_time = 1'700'000'000,
+        .header_height = 0,
+        .header_time = GetTime(),
+        .verification_progress = 0.25,
+    });
+
+    QVERIFY(!model.blockSyncActive());
+    QVERIFY(model.initialSyncComplete());
+    QCOMPARE(sync_complete_spy.count(), 1);
+}
+
+void NodeModelTests::initialSyncCompletionWaitsForStartupCatchUpAndLatches()
+{
+    NiceMock<MockNode> node;
+    MempoolState mempool;
+    interfaces::Node::NotifyBlockTipFn block_tip_fn;
+    interfaces::Node::NotifyHeaderTipFn header_tip_fn;
+
+    InstallDefaultHandlers(node);
+    InstallMempoolGetters(node, mempool);
+    ON_CALL(node, isInitialBlockDownload()).WillByDefault(Return(false));
+    ON_CALL(node, handleNotifyBlockTip(testing::_))
+        .WillByDefault(Invoke([&](interfaces::Node::NotifyBlockTipFn fn) {
+            block_tip_fn = std::move(fn);
+            return MakeNoopHandler();
+        }));
+    ON_CALL(node, handleNotifyHeaderTip(testing::_))
+        .WillByDefault(Invoke([&](interfaces::Node::NotifyHeaderTipFn fn) {
+            header_tip_fn = std::move(fn);
+            return MakeNoopHandler();
+        }));
+
+    NodeModel model{node};
+    WaitForInitialMempoolRefresh(mempool);
+    QVERIFY(block_tip_fn);
+    QVERIFY(header_tip_fn);
+    QSignalSpy sync_complete_spy{&model, &NodeModel::initialSyncCompleteChanged};
+
+    const int64_t stale_header_time{
+        GetTime() - 25 * Params().GetConsensus().nPowTargetSpacing};
+    model.initializeResult(true, interfaces::BlockAndHeaderTipInfo{
+        .block_height = 313'768,
+        .block_time = stale_header_time,
+        .header_height = 313'768,
+        .header_time = stale_header_time,
+        .verification_progress = 0.90,
+    });
+
+    // Core can latch out of IBD before connecting to a peer when the saved tip
+    // is recent by Core's standard. The stale header still keeps the startup
+    // transition pending.
+    QVERIFY(!model.blockSyncActive());
+    QVERIFY(model.headerSyncActive());
+    QVERIFY(!model.initialSyncComplete());
+    QCOMPARE(sync_complete_spy.count(), 0);
+
+    header_tip_fn(SynchronizationState::POST_INIT,
+                  interfaces::BlockTip{313'900, GetTime(), uint256{}},
+                  /*presync=*/false);
+    QTRY_VERIFY_WITH_TIMEOUT(!model.headerSyncActive(), ASYNC_TIMEOUT_MS);
+    QVERIFY(!model.initialSyncComplete());
+
+    block_tip_fn(SynchronizationState::POST_INIT,
+                 interfaces::BlockTip{313'899, GetTime(), uint256{}},
+                 0.9999);
+    QTRY_COMPARE_WITH_TIMEOUT(model.blockTipHeight(), 313'899, ASYNC_TIMEOUT_MS);
+    QVERIFY(!model.initialSyncComplete());
+    QCOMPARE(sync_complete_spy.count(), 0);
+
+    block_tip_fn(SynchronizationState::POST_INIT,
+                 interfaces::BlockTip{313'900, GetTime(), uint256{}},
+                 1.0);
+    QTRY_VERIFY_WITH_TIMEOUT(model.initialSyncComplete(), ASYNC_TIMEOUT_MS);
+    QCOMPARE(sync_complete_spy.count(), 1);
+
+    // A header is normally announced before its block. Once startup sync has
+    // completed, that ordinary one-block gap must not regress the clock.
+    header_tip_fn(SynchronizationState::POST_INIT,
+                  interfaces::BlockTip{313'901, GetTime(), uint256{}},
+                  /*presync=*/false);
+    block_tip_fn(SynchronizationState::POST_INIT,
+                 interfaces::BlockTip{313'901, GetTime(), uint256{}},
+                 1.0);
+    QTRY_COMPARE_WITH_TIMEOUT(model.blockTipHeight(), 313'901, ASYNC_TIMEOUT_MS);
+    QVERIFY(model.initialSyncComplete());
+    QCOMPARE(sync_complete_spy.count(), 1);
 }
 
 void NodeModelTests::alertNotificationsRefreshWarningList()

--- a/test/test_nodemodel.cpp
+++ b/test/test_nodemodel.cpp
@@ -683,12 +683,12 @@ void NodeModelTests::blockSyncActiveFollowsInitializationAndBlockTipState()
 
 void NodeModelTests::initialSyncCompletionIgnoresVerificationEstimateForGenesis()
 {
-    NiceMock<MockNode> node;
+    MockNode node;
     MempoolState mempool;
 
-    InstallDefaultHandlers(node);
-    InstallMempoolGetters(node, mempool);
-    ON_CALL(node, isInitialBlockDownload()).WillByDefault(Return(false));
+    ConfigureNodeModelDefaults(node);
+    ConfigureMempoolGetters(node, mempool);
+    node.is_initial_block_download_fn = [] { return false; };
 
     NodeModel model{node};
     WaitForInitialMempoolRefresh(mempool);
@@ -711,24 +711,22 @@ void NodeModelTests::initialSyncCompletionIgnoresVerificationEstimateForGenesis(
 
 void NodeModelTests::initialSyncCompletionWaitsForStartupCatchUpAndLatches()
 {
-    NiceMock<MockNode> node;
+    MockNode node;
     MempoolState mempool;
     interfaces::Node::NotifyBlockTipFn block_tip_fn;
     interfaces::Node::NotifyHeaderTipFn header_tip_fn;
 
-    InstallDefaultHandlers(node);
-    InstallMempoolGetters(node, mempool);
-    ON_CALL(node, isInitialBlockDownload()).WillByDefault(Return(false));
-    ON_CALL(node, handleNotifyBlockTip(testing::_))
-        .WillByDefault(Invoke([&](interfaces::Node::NotifyBlockTipFn fn) {
-            block_tip_fn = std::move(fn);
-            return MakeNoopHandler();
-        }));
-    ON_CALL(node, handleNotifyHeaderTip(testing::_))
-        .WillByDefault(Invoke([&](interfaces::Node::NotifyHeaderTipFn fn) {
-            header_tip_fn = std::move(fn);
-            return MakeNoopHandler();
-        }));
+    ConfigureNodeModelDefaults(node);
+    ConfigureMempoolGetters(node, mempool);
+    node.is_initial_block_download_fn = [] { return false; };
+    node.handle_notify_block_tip_fn = [&](interfaces::Node::NotifyBlockTipFn fn) {
+        block_tip_fn = std::move(fn);
+        return MakeNoopHandler();
+    };
+    node.handle_notify_header_tip_fn = [&](interfaces::Node::NotifyHeaderTipFn fn) {
+        header_tip_fn = std::move(fn);
+        return MakeNoopHandler();
+    };
 
     NodeModel model{node};
     WaitForInitialMempoolRefresh(mempool);

--- a/test/test_syncprogresstracker.cpp
+++ b/test/test_syncprogresstracker.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qml/models/syncprogresstracker.h>
+
+#include <test/qt_test_registry.h>
+
+#include <QtTest/QtTest>
+
+class SyncProgressTrackerTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void publishesAtBoundedCadence();
+    void boundsHistoryWithoutDiscardingTheWindow();
+    void resetsForProgressOrClockRegression();
+};
+
+void SyncProgressTrackerTests::publishesAtBoundedCadence()
+{
+    SyncProgressTracker tracker;
+    std::optional<int64_t> estimate;
+    for (std::size_t i{0}; i < SyncProgressTracker::PUBLISH_SAMPLE_INTERVAL; ++i) {
+        estimate = tracker.addSample(static_cast<int64_t>(i * 10), static_cast<double>(i) / 2000.0);
+    }
+
+    QVERIFY(estimate.has_value());
+    QVERIFY(*estimate > 0);
+}
+
+void SyncProgressTrackerTests::boundsHistoryWithoutDiscardingTheWindow()
+{
+    SyncProgressTracker tracker;
+    for (std::size_t i{0}; i < SyncProgressTracker::MAX_SAMPLES + 500; ++i) {
+        tracker.addSample(static_cast<int64_t>(i), static_cast<double>(i) / 10'000.0);
+    }
+
+    QCOMPARE(tracker.sampleCount(), SyncProgressTracker::MAX_SAMPLES);
+}
+
+void SyncProgressTrackerTests::resetsForProgressOrClockRegression()
+{
+    SyncProgressTracker tracker;
+    tracker.addSample(100, 0.2);
+    tracker.addSample(200, 0.3);
+    QCOMPARE(tracker.sampleCount(), std::size_t{2});
+
+    tracker.addSample(300, 0.1);
+    QCOMPARE(tracker.sampleCount(), std::size_t{1});
+
+    tracker.addSample(250, 0.2);
+    QCOMPARE(tracker.sampleCount(), std::size_t{1});
+}
+
+#ifdef BITCOINQML_NO_TEST_MAIN
+BITCOINQML_REGISTER_QT_TEST(SyncProgressTrackerTests)
+#else
+QTEST_MAIN(SyncProgressTrackerTests)
+#endif
+#include "test_syncprogresstracker.moc"


### PR DESCRIPTION
## Summary

This PR fixes how the block clock represents sync/catch-up state and how confirmation history renders in both the full and mini clocks.

- Keep the UI in sync mode until Core has left IBD and both headers and the active chain have caught up. Near-tip catch-up remains at 99.9% instead of prematurely showing the normal clock.
- Render rounded confirmation segments without losing confirmation depth when closely spaced block boundaries coalesce, and use one continuous gradient across combined blocks.
- Correct the mini block clock gradient so clockwise time moves from older, higher-confirmation yellow toward newer, zero-confirmation red.
- Move timeline ownership from `ChainModel` to `BlockClockModel` and stop presentation work while the clock is not visible. Hidden pages or tabs—and hidden or minimized windows—do not schedule dial repaints or run dial, peer-indicator, or estimating animations. The backing model stays current with minute-aligned clock updates and an immediate refresh when a block arrives, so the clock renders the latest state when it becomes visible again.

## Visual evidence

### Catch-up sync-state bug

The unfixed build briefly shows the normal red clock while the active chain is still rapidly catching up from a stale signet tip. The new sync-state latch keeps the UI in syncing state at 99.9% until both header and block catch-up are complete.

https://github.com/user-attachments/assets/537fae60-f8ff-49b7-874c-8f497da66b03

### Confirmation segment rendering

| Before | After |
| --- | --- |
| <img width="400" alt="Before: separated confirmation segments" src="https://github.com/user-attachments/assets/09d06697-6c6a-453f-b89e-e9f89b1a7730"> | <img width="400" alt="After: rounded coalesced segments with a continuous gradient" src="https://github.com/user-attachments/assets/fa69fc51-cb3d-4009-8a5b-c7339e5ce8ca"> |
| Every block was drawn individually. When several boundaries landed only a few pixels apart, the segments crowded together and their confirmation-color changes became difficult to see. | Rounded segments coalesce when necessary while preserving confirmation depth and a continuous gradient. |

### Mini block clock gradient

The mini clock now uses the same direction as the full clock: older, higher-confirmation time is yellow, transitioning clockwise toward the newest, zero-confirmation time in red.

<img width="215" alt="Fixed mini block clock gradient" src="https://github.com/user-attachments/assets/448c253c-cf6d-431f-8ee2-c881076cf577">

## Motivation

`verificationProgress &gt; 0.999` can report the normal clock too early. With a saved signet tip at height 313768, Core had already left IBD at 0.999830; once a peer announced height 313904, the UI showed a normal clock while 136 blocks rapidly caught up.

The existing timeline also mixed model data with paint geometry, kept repaint requests, timers, and animations active while views were hidden, and lost confirmation transitions when rounded segments were too close to render separately.

## Related issues

Fixes #227.
Fixes #743.
Fixes #785.

Related to #576.
Follow-up to #609.

## Testing

- Built `bitcoin-core-app`, `bitcoinqml_unit_tests`, and `bitcoinqml_qmltests`.
- Ran `QT_QPA_PLATFORM=offscreen QT_QUICK_BACKEND=software LIBGL_ALWAYS_SOFTWARE=1 ctest --test-dir build --output-on-failure` (2/2 passed).
- Built each commit in the branch independently.
- Ran Bitcoin lint checks for commit messages, tabs/whitespace, and trailing newlines.
- Ran `git diff --check`.
- Verified visibility gating in the C++ and QML tests: inactive clocks stop dial timers, estimating animation, peer-indicator animation, and repaint scheduling while model state remains current for reactivation.
- Added `BlockClockModel` coverage for minute alignment and block-triggered time refresh (`BlockClockModelTests`: 10/10 passed), and reran the QML suite (389/389 passed).
- Manually reproduced stale-signet catch-up with the unfixed and fixed builds.
