### PR TITLE
Improve debug log performance

### DIFF
--- a/qml/components/DebugLogOutputView.qml
+++ b/qml/components/DebugLogOutputView.qml
@@ -39,26 +39,178 @@ Item {
     readonly property int effectiveLineNumberWidth: lineNumberDigits <= 3
                                                      ? lineNumberWidth
                                                      : Math.max(lineNumberWidth, Math.ceil(lineNumberMetrics.advanceWidth))
-    readonly property bool atBottom: flick.contentHeight <= flick.height ||
-                                     flick.contentY + flick.height >= flick.contentHeight - 1
-    readonly property bool atTop: flick.contentY <= 0
-    readonly property real contentY: flick.contentY
-    readonly property int count: rowRepeater.count
+    readonly property bool atBottom: list.atYEnd
+    readonly property bool atTop: list.atYBeginning
+    readonly property real contentY: list.contentY
+    readonly property real contentHeight: list.contentHeight
+    readonly property real originY: list.originY
+    readonly property int count: list.count
+    readonly property int instantiatedDelegateCount: root._instantiatedDelegateCount
+
+    // These values describe the topmost visible row immediately before a
+    // newest-first insertion at row zero. Once the insertion completes, that
+    // row has moved down by the size of the inserted batch. Restoring its
+    // pixel offset keeps the text under the user's eyes stationary.
+    property int _prependAnchorIndex: -1
+    property real _prependAnchorOffset: 0
+    property int _prependCount: 0
+    property bool _prependRestorePending: false
+    property int _prependRestoreGeneration: 0
+    property real _appendAnchorContentY: 0
+    property int _appendCount: 0
+    property bool _appendRestorePending: false
+    property int _appendRestoreGeneration: 0
+    property int _instantiatedDelegateCount: 0
 
     signal scrolled(real y)
 
     function scrollToTop() {
-        flick.contentY = 0
-        flick.returnToBounds()
+        list.positionViewAtBeginning()
+        list.returnToBounds()
     }
 
     function scrollToBottom() {
-        if (flick.contentHeight > flick.height) {
-            flick.contentY = flick.contentHeight - flick.height
-        } else {
-            flick.contentY = 0
+        list.forceLayout()
+        list.positionViewAtEnd()
+        // positionViewAtEnd() aligns the final delegate, but ListView's
+        // bottomMargin sits beyond that delegate. Include it so atYEnd is true
+        // and the external Load more affordance becomes available.
+        if (list.contentHeight + list.bottomMargin > list.height) {
+            list.contentY = list.originY + list.contentHeight + list.bottomMargin - list.height
         }
-        flick.returnToBounds()
+        list.returnToBounds()
+    }
+
+    function positionViewAtIndex(index, mode) {
+        list.positionViewAtIndex(index, mode === undefined ? ListView.Visible : mode)
+    }
+
+    function itemAtIndex(index) {
+        return list.itemAtIndex(index)
+    }
+
+    function forceLayout() {
+        list.forceLayout()
+    }
+
+    function _firstVisibleIndex() {
+        // contentY can fall in the spacing between two variable-height rows.
+        // Scan a small distance into the viewport rather than treating that
+        // gap as if the view had no visible anchor.
+        // ListView's origin can move away from zero as variable-height rows are
+        // inserted or removed. indexAt() expects content coordinates, so use
+        // contentY directly rather than treating zero as the logical start.
+        const firstY = list.contentY
+        const scanDistance = Math.min(list.height, root.rowSpacing + root.textLineHeight + 2)
+        for (let offset = 0; offset <= scanDistance; ++offset) {
+            const candidate = list.indexAt(1, firstY + offset)
+            if (candidate >= 0) return candidate
+        }
+        return -1
+    }
+
+    function _capturePrependAnchor(first, last) {
+        root._prependAnchorIndex = -1
+        root._prependCount = 0
+
+        if (first !== 0) return
+
+        // A full snapshot diff can publish an older suffix before its newer
+        // prefix. Restore the pre-append viewport synchronously so the prepend
+        // anchor is captured from what the user was actually looking at.
+        root._restorePendingAppendAnchor()
+        if (list.count === 0 || root.atTop) return
+
+        list.forceLayout()
+        const anchorIndex = root._firstVisibleIndex()
+        if (anchorIndex < 0) return
+
+        const anchorItem = list.itemAtIndex(anchorIndex)
+        if (!anchorItem) return
+
+        root._prependAnchorIndex = anchorIndex
+        root._prependAnchorOffset = anchorItem.y - list.contentY
+        root._prependCount = last - first + 1
+    }
+
+    function _schedulePrependAnchorRestore(first, last) {
+        if (first !== 0 || root._prependAnchorIndex < 0 || root._prependCount !== last - first + 1) {
+            root._prependAnchorIndex = -1
+            root._prependCount = 0
+            return
+        }
+
+        const targetIndex = root._prependAnchorIndex + root._prependCount
+        const targetOffset = root._prependAnchorOffset
+        root._prependAnchorIndex = -1
+        root._prependCount = 0
+        root._prependRestorePending = true
+        const generation = ++root._prependRestoreGeneration
+        ++root._appendRestoreGeneration
+        root._appendRestorePending = false
+        Qt.callLater(function() {
+            if (generation !== root._prependRestoreGeneration) return
+            root._restorePrependAnchor(targetIndex, targetOffset)
+            root._prependRestorePending = false
+        })
+    }
+
+    function _restorePrependAnchor(targetIndex, targetOffset) {
+        if (targetIndex < 0 || list.count === 0) return
+
+        const boundedIndex = Math.min(targetIndex, list.count - 1)
+        list.forceLayout()
+        list.positionViewAtIndex(boundedIndex, ListView.Beginning)
+        list.forceLayout()
+
+        const anchorItem = list.itemAtIndex(boundedIndex)
+        if (!anchorItem) return
+
+        list.contentY = anchorItem.y - targetOffset
+        list.returnToBounds()
+    }
+
+    function _captureAppendAnchor(first, last) {
+        root._appendCount = 0
+        if (first !== list.count || first === 0 || root._prependRestorePending) return
+
+        // Coalesce multiple suffix batches in the same event turn around the
+        // viewport that preceded all of them.
+        root._restorePendingAppendAnchor()
+        root._appendAnchorContentY = list.contentY
+        root._appendCount = last - first + 1
+    }
+
+    function _scheduleAppendAnchorRestore(first, last) {
+        if (root._appendCount === 0) return
+
+        if (root._appendCount !== last - first + 1) {
+            root._appendCount = 0
+            return
+        }
+
+        const anchoredContentY = root._appendAnchorContentY
+        root._appendCount = 0
+        root._appendRestorePending = true
+        const generation = ++root._appendRestoreGeneration
+        Qt.callLater(function() {
+            if (generation !== root._appendRestoreGeneration || root._prependRestorePending) return
+            list.forceLayout()
+            list.contentY = anchoredContentY
+            list.returnToBounds()
+            root._appendRestorePending = false
+        })
+    }
+
+    function _restorePendingAppendAnchor() {
+        if (!root._appendRestorePending) return
+
+        ++root._appendRestoreGeneration
+        root._appendRestorePending = false
+        list.forceLayout()
+        list.contentY = root._appendAnchorContentY
+        list.returnToBounds()
+        list.forceLayout()
     }
 
     TextMetrics {
@@ -69,13 +221,29 @@ Item {
         text: root.lineNumberSampleText
     }
 
-    Flickable {
-        id: flick
-        anchors.fill: parent
+    ListView {
+        id: list
+        objectName: root.objectName.length > 0 ? root.objectName + "_list" : ""
+        x: root.horizontalPadding
+        width: Math.max(0, root.width - (root.horizontalPadding * 2))
+        height: root.height
         clip: true
-        contentWidth: width
-        contentHeight: contentColumn.height
+        model: root.listModel
+        spacing: root.rowSpacing
+        cacheBuffer: root.textLineHeight * 4
+        // Text selection belongs to an individual row. Avoid carrying a
+        // TextEdit's selection state into a different row through pooling;
+        // ListView remains virtualized even without delegate reuse.
+        reuseItems: false
+        bottomMargin: root.bottomPadding
         boundsBehavior: Flickable.StopAtBounds
+        // Keep the top padding inside the scrollable content, matching the
+        // existing geometry (the first row starts at y=topPadding).
+        header: Item {
+            width: list.width
+            height: root.topPadding
+        }
+        headerPositioning: ListView.InlineHeader
 
         ScrollBar.vertical: ScrollBar {
             policy: ScrollBar.AsNeeded
@@ -84,44 +252,107 @@ Item {
 
         onContentYChanged: root.scrolled(contentY)
 
-        Column {
-            id: contentColumn
-            objectName: root.objectName.length > 0 ? root.objectName + "_contentColumn" : ""
-            x: root.horizontalPadding
-            width: flick.width - (root.horizontalPadding * 2)
-            topPadding: root.topPadding
-            bottomPadding: root.bottomPadding
-            spacing: root.rowSpacing
+        delegate: RowLayout {
+            id: rowRoot
 
-            Repeater {
-                id: rowRepeater
-                model: root.listModel
+            required property var model
+            required property int index
 
-                delegate: RowLayout {
-                    id: rowRoot
+            readonly property string rowCommand: rowRoot.model.command ?? ""
+            readonly property string rowDate: rowRoot.model.dateLabel ?? ""
+            readonly property string rowMessage: rowRoot.model.message ?? ""
+            // The newest entry is always row one. Computing this from the
+            // delegate index means a prepend does not require dataChanged for
+            // every existing row merely to renumber it.
+            readonly property string rowNumber: String(rowRoot.index + 1)
+            readonly property int rowSeverity: Number(rowRoot.model.severity ?? DebugLogModel.InfoSeverity)
+            readonly property bool hasCommand: rowCommand.length > 0
 
-                    required property var model
-                    required property int index
+            objectName: root.objectName.length > 0 ? root.objectName + "_row_" + index : ""
+            width: list.width
+            height: implicitHeight
+            spacing: root.columnSpacing
 
-                    readonly property string rowCommand: rowRoot.model.command ?? ""
-                    readonly property string rowDate: rowRoot.model.dateLabel ?? ""
-                    readonly property string rowMessage: rowRoot.model.message ?? ""
-                    readonly property string rowNumber: rowRoot.model.lineNumber ?? ""
-                    readonly property int rowSeverity: Number(rowRoot.model.severity ?? DebugLogModel.InfoSeverity)
-                    readonly property bool hasCommand: rowCommand.length > 0
+            Accessible.role: Accessible.ListItem
+            Accessible.name: rowCommand.length > 0
+                             ? rowCommand + " " + rowMessage
+                             : rowMessage
 
-                    objectName: root.objectName.length > 0 ? root.objectName + "_row_" + index : ""
-                    width: contentColumn.width
+            Component.onCompleted: ++root._instantiatedDelegateCount
+            Component.onDestruction: --root._instantiatedDelegateCount
+
+            Text {
+                objectName: root.objectName.length > 0 ? root.objectName + "_lineNumber_" + rowRoot.index : ""
+                text: rowRoot.rowNumber
+                color: Theme.color.neutral7
+                font.family: root.fontFamily
+                font.styleName: root.fontStyleName
+                font.pixelSize: root.fontPixelSize
+                lineHeight: root.textLineHeight
+                lineHeightMode: Text.FixedHeight
+                horizontalAlignment: Text.AlignRight
+                wrapMode: Text.NoWrap
+
+                Layout.preferredWidth: root.effectiveLineNumberWidth
+                Layout.alignment: Qt.AlignTop
+            }
+
+            ColumnLayout {
+                objectName: root.objectName.length > 0 ? root.objectName + "_entryContent_" + rowRoot.index : ""
+                spacing: root.contentSpacing
+
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignTop
+
+                RowLayout {
+                    objectName: root.objectName.length > 0 ? root.objectName + "_header_" + rowRoot.index : ""
                     spacing: root.columnSpacing
 
-                    Accessible.role: Accessible.ListItem
-                    Accessible.name: rowCommand.length > 0
-                                     ? rowCommand + " " + rowMessage
-                                     : rowMessage
+                    Layout.fillWidth: true
 
                     Text {
-                        objectName: root.objectName.length > 0 ? root.objectName + "_lineNumber_" + rowRoot.index : ""
-                        text: rowRoot.rowNumber
+                        objectName: root.objectName.length > 0 ? root.objectName + "_command_" + rowRoot.index : ""
+                        text: rowRoot.rowCommand
+                        visible: rowRoot.hasCommand
+                        color: rowRoot.rowSeverity === DebugLogModel.ErrorSeverity
+                               ? Theme.color.red
+                               : Theme.color.green
+                        font.family: root.fontFamily
+                        font.styleName: root.fontStyleName
+                        font.pixelSize: root.fontPixelSize
+                        lineHeight: root.textLineHeight
+                        lineHeightMode: Text.FixedHeight
+                        elide: Text.ElideRight
+                        wrapMode: Text.NoWrap
+
+                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignTop
+                    }
+
+                    TextEdit {
+                        objectName: root.objectName.length > 0 ? root.objectName + "_commandlessMessage_" + rowRoot.index : ""
+                        text: rowRoot.rowMessage
+                        visible: !rowRoot.hasCommand
+                        readOnly: true
+                        selectByMouse: true
+                        persistentSelection: false
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WrapAnywhere
+                        font.family: root.fontFamily
+                        font.styleName: root.fontStyleName
+                        font.pixelSize: root.fontPixelSize
+                        color: Theme.color.neutral9
+                        selectionColor: Theme.color.orange
+                        selectedTextColor: Theme.color.white
+                        activeFocusOnPress: true
+
+                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignTop
+                    }
+
+                    Text {
+                        objectName: root.objectName.length > 0 ? root.objectName + "_date_" + rowRoot.index : ""
+                        text: rowRoot.rowDate
                         color: Theme.color.neutral7
                         font.family: root.fontFamily
                         font.styleName: root.fontStyleName
@@ -131,107 +362,51 @@ Item {
                         horizontalAlignment: Text.AlignRight
                         wrapMode: Text.NoWrap
 
-                        Layout.preferredWidth: root.effectiveLineNumberWidth
                         Layout.alignment: Qt.AlignTop
                     }
+                }
 
-                    ColumnLayout {
-                        objectName: root.objectName.length > 0 ? root.objectName + "_entryContent_" + rowRoot.index : ""
-                        spacing: root.contentSpacing
+                TextEdit {
+                    objectName: root.objectName.length > 0 ? root.objectName + "_message_" + rowRoot.index : ""
+                    text: rowRoot.rowMessage
+                    visible: rowRoot.hasCommand
+                    readOnly: true
+                    selectByMouse: true
+                    persistentSelection: false
+                    textFormat: Text.PlainText
+                    wrapMode: Text.WrapAnywhere
+                    font.family: root.fontFamily
+                    font.styleName: root.fontStyleName
+                    font.pixelSize: root.fontPixelSize
+                    color: Theme.color.neutral9
+                    selectionColor: Theme.color.orange
+                    selectedTextColor: Theme.color.white
+                    activeFocusOnPress: true
 
-                        Layout.fillWidth: true
-                        Layout.alignment: Qt.AlignTop
-
-                        RowLayout {
-                            objectName: root.objectName.length > 0 ? root.objectName + "_header_" + rowRoot.index : ""
-                            spacing: root.columnSpacing
-
-                            Layout.fillWidth: true
-
-                            Text {
-                                objectName: root.objectName.length > 0 ? root.objectName + "_command_" + rowRoot.index : ""
-                                text: rowRoot.rowCommand
-                                visible: rowRoot.hasCommand
-                                color: rowRoot.rowSeverity === DebugLogModel.ErrorSeverity
-                                       ? Theme.color.red
-                                       : Theme.color.green
-                                font.family: root.fontFamily
-                                font.styleName: root.fontStyleName
-                                font.pixelSize: root.fontPixelSize
-                                lineHeight: root.textLineHeight
-                                lineHeightMode: Text.FixedHeight
-                                elide: Text.ElideRight
-                                wrapMode: Text.NoWrap
-
-                                Layout.fillWidth: true
-                                Layout.alignment: Qt.AlignTop
-                            }
-
-                            TextEdit {
-                                objectName: root.objectName.length > 0 ? root.objectName + "_commandlessMessage_" + rowRoot.index : ""
-                                text: rowRoot.rowMessage
-                                visible: !rowRoot.hasCommand
-                                readOnly: true
-                                selectByMouse: true
-                                persistentSelection: false
-                                textFormat: Text.PlainText
-                                wrapMode: Text.WrapAnywhere
-                                font.family: root.fontFamily
-                                font.styleName: root.fontStyleName
-                                font.pixelSize: root.fontPixelSize
-                                color: Theme.color.neutral9
-                                selectionColor: Theme.color.orange
-                                selectedTextColor: Theme.color.white
-                                activeFocusOnPress: true
-
-                                Layout.fillWidth: true
-                                Layout.alignment: Qt.AlignTop
-                            }
-
-                            Text {
-                                objectName: root.objectName.length > 0 ? root.objectName + "_date_" + rowRoot.index : ""
-                                text: rowRoot.rowDate
-                                color: Theme.color.neutral7
-                                font.family: root.fontFamily
-                                font.styleName: root.fontStyleName
-                                font.pixelSize: root.fontPixelSize
-                                lineHeight: root.textLineHeight
-                                lineHeightMode: Text.FixedHeight
-                                horizontalAlignment: Text.AlignRight
-                                wrapMode: Text.NoWrap
-
-                                Layout.alignment: Qt.AlignTop
-                            }
-                        }
-
-                        TextEdit {
-                            objectName: root.objectName.length > 0 ? root.objectName + "_message_" + rowRoot.index : ""
-                            text: rowRoot.rowMessage
-                            visible: rowRoot.hasCommand
-                            readOnly: true
-                            selectByMouse: true
-                            persistentSelection: false
-                            textFormat: Text.PlainText
-                            wrapMode: Text.WrapAnywhere
-                            font.family: root.fontFamily
-                            font.styleName: root.fontStyleName
-                            font.pixelSize: root.fontPixelSize
-                            color: Theme.color.neutral9
-                            selectionColor: Theme.color.orange
-                            selectedTextColor: Theme.color.white
-                            activeFocusOnPress: true
-
-                            Layout.fillWidth: true
-                            Layout.alignment: Qt.AlignTop
-                        }
-                    }
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignTop
                 }
             }
         }
     }
 
     Connections {
-        target: flick
+        target: root.listModel
+        enabled: root.listModel !== null
+
+        function onRowsAboutToBeInserted(parent, first, last) {
+            root._capturePrependAnchor(first, last)
+            root._captureAppendAnchor(first, last)
+        }
+
+        function onRowsInserted(parent, first, last) {
+            root._schedulePrependAnchorRestore(first, last)
+            root._scheduleAppendAnchorRestore(first, last)
+        }
+    }
+
+    Connections {
+        target: list
         enabled: root.autoScrollToBottom
         function onContentHeightChanged() {
             root.scrollToBottom()

--- a/qml/models/debuglogmodel.cpp
+++ b/qml/models/debuglogmodel.cpp
@@ -97,17 +97,43 @@ void DebugLogModel::setLoadLimit(int limit)
     Q_EMIT loadLimitChanged();
 }
 
+void DebugLogModel::setActive(bool active)
+{
+    if (m_active == active || m_stopping) return;
+
+    m_active = active;
+    ++m_activation_generation;
+    Q_EMIT activeChanged();
+
+    const QString path_str = QString::fromStdString(m_log_path.utf8string());
+    if (m_active) {
+        if (!path_str.isEmpty() && !m_watcher.files().contains(path_str)) {
+            m_watcher.addPath(path_str);
+        }
+        refresh(/*full_load=*/true);
+        return;
+    }
+
+    m_debounce.stop();
+    const auto watched_files = m_watcher.files();
+    if (!watched_files.isEmpty()) {
+        m_watcher.removePaths(watched_files);
+    }
+    m_refresh_pending = false;
+    m_pending_full_load = false;
+}
+
 void DebugLogModel::setFilter(const QString& filter)
 {
     if (m_filter == filter) return;
     m_filter = filter;
     Q_EMIT filterChanged();
-    buildDisplayLines();
+    if (m_active) buildDisplayLines();
 }
 
 void DebugLogModel::refresh(bool full_load)
 {
-    if (m_stopping) return;
+    if (!m_active || m_stopping) return;
 
     // Single-read-in-flight guard. If a read is already running, fold this
     // request into a trailing re-run rather than piling another job onto the
@@ -129,6 +155,7 @@ void DebugLogModel::refresh(bool full_load)
 
     const fs::path path = m_log_path;
     const int load_limit = m_load_limit;
+    const quint64 activation_generation = m_activation_generation;
 
     if (!m_reader || !m_reader_thread || !m_reader_thread->isRunning()) {
         m_read_in_flight = false;
@@ -136,7 +163,7 @@ void DebugLogModel::refresh(bool full_load)
     }
 
     const bool queued = QMetaObject::invokeMethod(m_reader,
-        [this, path, load_limit, full_load, prev_top_identity]() mutable {
+        [this, path, load_limit, full_load, prev_top_identity, activation_generation]() mutable {
             if (m_read_cancelled.load(std::memory_order_relaxed)) return;
 
             ReadResult result = ReadAndFilter(path, load_limit, full_load, m_read_cancelled);
@@ -146,8 +173,19 @@ void DebugLogModel::refresh(bool full_load)
                 [this,
                  result = std::move(result),
                  prev_top_identity,
-                 full_load]() mutable {
+                 full_load,
+                 activation_generation]() mutable {
                     if (m_stopping || m_read_cancelled.load(std::memory_order_relaxed)) return;
+                    if (!m_active || activation_generation != m_activation_generation) {
+                        m_read_in_flight = false;
+                        if (m_active && m_refresh_pending) {
+                            m_refresh_pending = false;
+                            const bool do_full = m_pending_full_load;
+                            m_pending_full_load = false;
+                            refresh(do_full);
+                        }
+                        return;
+                    }
                     onReadCompleted(result, prev_top_identity, full_load);
                 },
                 Qt::QueuedConnection);
@@ -196,7 +234,7 @@ bool DebugLogModel::openLogFile()
 
 void DebugLogModel::updateRelativeTimes()
 {
-    if (m_all_lines.isEmpty() && m_display_lines.isEmpty()) return;
+    if (!m_active || (m_all_lines.isEmpty() && m_display_lines.isEmpty())) return;
     const qint64 now_ms = QDateTime::currentMSecsSinceEpoch();
 
     for (LogLine& line : m_all_lines) {
@@ -351,7 +389,7 @@ void DebugLogModel::onReadCompleted(const ReadResult& result,
                                    const QString& prev_top_identity,
                                    bool full_load)
 {
-    if (m_stopping) return;
+    if (!m_active || m_stopping) return;
 
     // Propagate open-error state from the background read.
     if (!result.file_opened) {
@@ -377,7 +415,7 @@ void DebugLogModel::onReadCompleted(const ReadResult& result,
     // if the log file did not exist yet. Re-add after a successful read so
     // auto-refresh works from here on.
     const QString path_str = QString::fromStdString(m_log_path.utf8string());
-    if (!m_watcher.files().contains(path_str)) {
+    if (m_active && !m_watcher.files().contains(path_str)) {
         m_watcher.addPath(path_str);
     }
 
@@ -458,14 +496,15 @@ void DebugLogModel::onReadCompleted(const ReadResult& result,
 void DebugLogModel::connectFileWatcher()
 {
     const QString path_str = QString::fromStdString(m_log_path.utf8string());
-    if (path_str.isEmpty()) return;
-    m_watcher.addPath(path_str);
     connect(&m_watcher, &QFileSystemWatcher::fileChanged,
             this, [this](const QString& path) {
-                if (m_stopping) return;
+                if (!m_active || m_stopping) return;
                 m_watcher.addPath(path); // re-add in case of log rotation
                 m_debounce.start();
             });
+    if (m_active && !path_str.isEmpty()) {
+        m_watcher.addPath(path_str);
+    }
 }
 
 void DebugLogModel::buildDisplayLines()

--- a/qml/models/debuglogmodel.cpp
+++ b/qml/models/debuglogmodel.cpp
@@ -12,10 +12,10 @@
 #include <QDateTime>
 #include <QDesktopServices>
 #include <QFile>
+#include <QFileInfo>
 #include <QMetaObject>
 #include <QObject>
 #include <QRegularExpression>
-#include <QTextStream>
 #include <QThread>
 #include <QTimer>
 #include <QUrl>
@@ -24,6 +24,19 @@ static const QRegularExpression TIMESTAMP_RX(
     QStringLiteral(R"(^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s*(.*)$)"));
 static const QRegularExpression COMMAND_PREFIX_RX(
     QStringLiteral(R"(^([^:]{1,80}):\s+(.*)$)"));
+
+namespace {
+constexpr qint64 TAIL_READ_BLOCK_SIZE{64 * 1024};
+constexpr qint64 FILE_ANCHOR_SIZE{256};
+constexpr qint64 MAX_DELTA_BYTES{8 * 1024 * 1024};
+
+QByteArray ReadAnchor(QFile& file, qint64 file_size)
+{
+    const qint64 anchor_size = std::min(file_size, FILE_ANCHOR_SIZE);
+    if (anchor_size <= 0 || !file.seek(file_size - anchor_size)) return {};
+    return file.read(anchor_size);
+}
+} // namespace
 
 DebugLogModel::DebugLogModel(const fs::path& log_path, QObject* parent)
     : QAbstractListModel(parent)
@@ -66,7 +79,9 @@ QVariant DebugLogModel::data(const QModelIndex& index, int role) const
 
     const LogLine& line = m_display_lines.at(index.row());
     switch (role) {
-    case LineNumberRole:   return line.lineNumber;
+    // The number is derived from the model row. Prepending new records no
+    // longer requires copying and renumbering every stored LogLine.
+    case LineNumberRole:   return QString::number(index.row() + 1);
     case ContentRole:      return line.content;
     case RelativeTimeRole: return line.relativeTime;
     case CommandRole:      return line.command;
@@ -92,9 +107,28 @@ QHash<int, QByteArray> DebugLogModel::roleNames() const
 
 void DebugLogModel::setLoadLimit(int limit)
 {
+    limit = std::clamp(limit, 1, kMaxLoadLimit);
     if (m_load_limit == limit) return;
+    const int previous_limit = m_load_limit;
     m_load_limit = limit;
     Q_EMIT loadLimitChanged();
+
+    if (m_all_lines.size() > m_load_limit) {
+        QList<LogLine> retained = m_all_lines.first(m_load_limit);
+        applyLines(std::move(retained), /*force_reset=*/false);
+        m_loaded_limit = std::min(m_loaded_limit, m_load_limit);
+        const bool has_more = m_load_limit < kMaxLoadLimit;
+        if (m_has_more_lines != has_more) {
+            m_has_more_lines = has_more;
+            Q_EMIT hasMoreLinesChanged();
+        }
+    }
+
+    if (m_load_limit > previous_limit) {
+        if (m_active) {
+            refresh(/*full_load=*/true);
+        }
+    }
 }
 
 void DebugLogModel::setActive(bool active)
@@ -105,12 +139,11 @@ void DebugLogModel::setActive(bool active)
     ++m_activation_generation;
     Q_EMIT activeChanged();
 
-    const QString path_str = QString::fromStdString(m_log_path.utf8string());
     if (m_active) {
-        if (!path_str.isEmpty() && !m_watcher.files().contains(path_str)) {
-            m_watcher.addPath(path_str);
-        }
-        refresh(/*full_load=*/true);
+        watchLogPath();
+        // Retained rows can paint immediately on reactivation. Catch up from
+        // the saved file offset unless the retained tail is too narrow.
+        refresh(/*full_load=*/m_loaded_limit < m_load_limit);
         return;
     }
 
@@ -118,6 +151,10 @@ void DebugLogModel::setActive(bool active)
     const auto watched_files = m_watcher.files();
     if (!watched_files.isEmpty()) {
         m_watcher.removePaths(watched_files);
+    }
+    const auto watched_directories = m_watcher.directories();
+    if (!watched_directories.isEmpty()) {
+        m_watcher.removePaths(watched_directories);
     }
     m_refresh_pending = false;
     m_pending_full_load = false;
@@ -128,7 +165,9 @@ void DebugLogModel::setFilter(const QString& filter)
     if (m_filter == filter) return;
     m_filter = filter;
     Q_EMIT filterChanged();
-    if (m_active) buildDisplayLines();
+    // Cached rows remain observable while inactive, so keep the display
+    // projection in sync even when the page is currently unloaded.
+    buildDisplayLines(/*force_reset=*/true);
 }
 
 void DebugLogModel::refresh(bool full_load)
@@ -149,12 +188,12 @@ void DebugLogModel::refresh(bool full_load)
     }
     m_read_in_flight = true;
 
-    const QString prev_top_identity = m_all_lines.isEmpty()
-        ? QString{}
-        : m_all_lines.first().identity;
-
     const fs::path path = m_log_path;
     const int load_limit = m_load_limit;
+    const qint64 previous_file_size = m_file_size;
+    const QByteArray previous_partial = m_trailing_partial;
+    const bool previous_discarding_oversized_line = m_discarding_oversized_line;
+    const QByteArray previous_anchor = m_file_anchor;
     const quint64 activation_generation = m_activation_generation;
 
     if (!m_reader || !m_reader_thread || !m_reader_thread->isRunning()) {
@@ -163,16 +202,30 @@ void DebugLogModel::refresh(bool full_load)
     }
 
     const bool queued = QMetaObject::invokeMethod(m_reader,
-        [this, path, load_limit, full_load, prev_top_identity, activation_generation]() mutable {
+        [this,
+         path,
+         load_limit,
+         full_load,
+         previous_file_size,
+         previous_partial,
+         previous_discarding_oversized_line,
+         previous_anchor,
+         activation_generation]() mutable {
             if (m_read_cancelled.load(std::memory_order_relaxed)) return;
 
-            ReadResult result = ReadAndFilter(path, load_limit, full_load, m_read_cancelled);
+            ReadResult result = ReadAndFilter(path,
+                                              load_limit,
+                                              full_load,
+                                              previous_file_size,
+                                              previous_partial,
+                                              previous_discarding_oversized_line,
+                                              previous_anchor,
+                                              m_read_cancelled);
             if (m_read_cancelled.load(std::memory_order_relaxed)) return;
 
             QMetaObject::invokeMethod(this,
                 [this,
                  result = std::move(result),
-                 prev_top_identity,
                  full_load,
                  activation_generation]() mutable {
                     if (m_stopping || m_read_cancelled.load(std::memory_order_relaxed)) return;
@@ -186,7 +239,7 @@ void DebugLogModel::refresh(bool full_load)
                         }
                         return;
                     }
-                    onReadCompleted(result, prev_top_identity, full_load);
+                    onReadCompleted(result, full_load);
                 },
                 Qt::QueuedConnection);
         },
@@ -272,6 +325,10 @@ void DebugLogModel::stop()
     if (!watched_files.isEmpty()) {
         m_watcher.removePaths(watched_files);
     }
+    const auto watched_directories = m_watcher.directories();
+    if (!watched_directories.isEmpty()) {
+        m_watcher.removePaths(watched_directories);
+    }
 
     m_refresh_pending = false;
     m_pending_full_load = false;
@@ -290,105 +347,293 @@ void DebugLogModel::stop()
 DebugLogModel::ReadResult DebugLogModel::ReadAndFilter(const fs::path& log_path,
                                                       int load_limit,
                                                       bool full_load,
+                                                      qint64 previous_file_size,
+                                                      const QByteArray& previous_partial,
+                                                      bool previous_discarding_oversized_line,
+                                                      const QByteArray& previous_anchor,
                                                       const std::atomic_bool& cancelled)
 {
-    ReadResult result;
-    if (cancelled.load(std::memory_order_relaxed)) return result;
+    if (cancelled.load(std::memory_order_relaxed)) return {};
+    if (full_load || previous_file_size < 0) {
+        return ReadTail(log_path, load_limit, cancelled);
+    }
 
     const QString path_str = QString::fromStdString(log_path.utf8string());
-    QFile probe(path_str);
-    if (!probe.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    QFile file(path_str);
+    ReadResult result;
+    if (!file.open(QIODevice::ReadOnly)) {
         result.error_message = fs::exists(log_path)
             ? QObject::tr("Could not open debug log file: %1").arg(path_str)
             : QObject::tr("Debug log file not found: %1").arg(path_str);
         return result;
     }
-    probe.close();
     result.file_opened = true;
 
-    // Doubling loop for a full load: ensure load_limit non-blank lines even
-    // when the tail of the file is dominated by header/banner blanks. For an
-    // incremental refresh we just take the last load_limit raw lines.
-    QList<LogLine> filtered;
-    int fetch_size = load_limit;
-    while (true) {
-        if (cancelled.load(std::memory_order_relaxed)) return {};
-
-        const QList<LogLine> raw = ReadRawLines(log_path, fetch_size, cancelled);
-        if (cancelled.load(std::memory_order_relaxed)) return {};
-
-        filtered.clear();
-        for (const LogLine& l : raw) {
-            if (cancelled.load(std::memory_order_relaxed)) return {};
-            if (!l.content.trimmed().isEmpty() || l.timestamp_ms >= 0)
-                filtered.append(l);
-        }
-        if (!full_load) break;
-        if (filtered.size() >= load_limit || raw.size() < fetch_size) break;
-        fetch_size *= 2;
+    // Validate bytes at the old end-of-file before trusting the saved offset.
+    // This detects truncation and the common rotate-and-recreate case without
+    // relying on platform-specific inode APIs. On failure, rebuild from a
+    // bounded tail snapshot.
+    const qint64 snapshot_size = file.size();
+    bool continuity_valid = snapshot_size >= previous_file_size
+        && previous_partial.size() <= previous_file_size;
+    if (continuity_valid && previous_file_size > 0) {
+        continuity_valid = !previous_anchor.isEmpty()
+            && file.seek(previous_file_size - previous_anchor.size())
+            && file.read(previous_anchor.size()) == previous_anchor;
     }
-    result.filtered = std::move(filtered);
+    if (!continuity_valid) {
+        file.close();
+        result = ReadTail(log_path, load_limit, cancelled);
+        result.continuity_lost = result.file_opened;
+        return result;
+    }
+
+    const qint64 appended_size = snapshot_size - previous_file_size;
+    if (appended_size > MAX_DELTA_BYTES
+        || previous_partial.size() > MAX_DELTA_BYTES - appended_size) {
+        file.close();
+        return ReadTail(log_path, load_limit, cancelled);
+    }
+
+    if (cancelled.load(std::memory_order_relaxed)
+        || !file.seek(previous_file_size)) {
+        return {};
+    }
+    const QByteArray appended = file.read(appended_size);
+    if (appended.size() != appended_size) {
+        file.close();
+        result = ReadTail(log_path, load_limit, cancelled);
+        result.continuity_lost = result.file_opened;
+        return result;
+    }
+
+    QByteArray combined;
+    qint64 combined_offset{previous_file_size - previous_partial.size()};
+    if (previous_discarding_oversized_line) {
+        const qsizetype newline = appended.indexOf('\n');
+        if (newline < 0) {
+            result.full_snapshot = false;
+            result.file_size = snapshot_size;
+            result.file_anchor = ReadAnchor(file, snapshot_size);
+            result.discarding_oversized_line = true;
+            return result;
+        }
+        combined = appended.mid(newline + 1);
+        combined_offset = previous_file_size + newline + 1;
+    } else {
+        combined = previous_partial + appended;
+    }
+
+    const qsizetype last_newline = combined.lastIndexOf('\n');
+    result.full_snapshot = false;
+    result.file_size = snapshot_size;
+    result.file_anchor = ReadAnchor(file, snapshot_size);
+    if (last_newline < 0) {
+        if (combined.size() <= kMaxLogLineBytes) {
+            result.trailing_partial = combined;
+        } else {
+            result.discarding_oversized_line = true;
+        }
+        return result;
+    }
+
+    const qsizetype complete_size = last_newline + 1;
+    result.trailing_partial = combined.mid(complete_size);
+    if (result.trailing_partial.size() > kMaxLogLineBytes) {
+        result.trailing_partial.clear();
+        result.discarding_oversized_line = true;
+    }
+    result.lines = ParseCompleteLines(
+        combined.first(complete_size),
+        combined_offset,
+        std::min(load_limit, kMaxLoadLimit) + 1,
+        cancelled);
+    result.has_more_lines = result.lines.size() > load_limit;
     return result;
 }
 
-QList<DebugLogModel::LogLine> DebugLogModel::ReadRawLines(const fs::path& log_path,
-                                                         int max_lines,
-                                                         const std::atomic_bool& cancelled)
+DebugLogModel::ReadResult DebugLogModel::ReadTail(const fs::path& log_path,
+                                                 int load_limit,
+                                                 const std::atomic_bool& cancelled)
 {
-    if (cancelled.load(std::memory_order_relaxed)) return {};
+    ReadResult result;
+    if (cancelled.load(std::memory_order_relaxed)) return result;
 
     const QString path_str = QString::fromStdString(log_path.utf8string());
     QFile file(path_str);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) return {};
-
-    // Seek near the end to avoid reading the entire file. debug.log on an
-    // active mainnet node can exceed 100 MB; estimate 500 bytes per line.
-    const qint64 seek_pos = std::max(qint64{0},
-        file.size() - static_cast<qint64>(max_lines) * 500);
-    if (seek_pos > 0) file.seek(seek_pos);
-
-    QTextStream in(&file);
-    if (seek_pos > 0) in.readLine(); // discard potentially partial first line
-
-    QStringList raw;
-    raw.reserve(max_lines);
-    while (!in.atEnd()) {
-        if (cancelled.load(std::memory_order_relaxed)) return {};
-        raw.append(in.readLine());
+    if (!file.open(QIODevice::ReadOnly)) {
+        result.error_message = fs::exists(log_path)
+            ? QObject::tr("Could not open debug log file: %1").arg(path_str)
+            : QObject::tr("Debug log file not found: %1").arg(path_str);
+        return result;
     }
-    if (raw.size() > max_lines)
-        raw = raw.mid(raw.size() - max_lines);
 
-    const qint64 now_ms = QDateTime::currentMSecsSinceEpoch();
-    QList<LogLine> result;
-    result.reserve(raw.size());
-    for (const QString& line : raw) {
+    result.file_opened = true;
+    result.full_snapshot = true;
+    result.snapshot_limit = std::min(load_limit, kMaxLoadLimit);
+    result.file_size = file.size();
+    result.file_anchor = ReadAnchor(file, result.file_size);
+
+    // Find the final newline without accumulating the unfinished suffix on
+    // every backward step. Bitcoin Core normally writes newline-terminated
+    // entries, but the viewer can observe an in-progress or interrupted write.
+    qint64 complete_end{-1};
+    qint64 cursor = result.file_size;
+    while (cursor > 0) {
         if (cancelled.load(std::memory_order_relaxed)) return {};
-
-        LogLine entry;
-        QString raw_message;
-        const QRegularExpressionMatch m = TIMESTAMP_RX.match(line);
-        if (m.hasMatch()) {
-            const QDateTime dt = QDateTime::fromString(m.captured(1), Qt::ISODateWithMs);
-            entry.timestamp_ms = dt.isValid() ? dt.toMSecsSinceEpoch() : -1;
-            raw_message = m.captured(2);
-        } else {
-            entry.timestamp_ms = -1;
-            raw_message = line;
+        const qint64 start = std::max(qint64{0}, cursor - TAIL_READ_BLOCK_SIZE);
+        if (!file.seek(start)) return {};
+        const QByteArray chunk = file.read(cursor - start);
+        if (chunk.size() != cursor - start) return {};
+        const qsizetype last_newline = chunk.lastIndexOf('\n');
+        if (last_newline >= 0) {
+            complete_end = start + last_newline + 1;
+            break;
         }
-        PopulateParsedFields(entry, raw_message);
-        entry.relativeTime = entry.timestamp_ms >= 0
-            ? RelativeTimeLabelStatic(entry.timestamp_ms, now_ms)
-            : QString{};
-        result.append(entry);
+        cursor = start;
+    }
+
+    const qint64 partial_start = std::max(qint64{0}, complete_end);
+    const qint64 partial_size = result.file_size - partial_start;
+    if (partial_size > kMaxLogLineBytes) {
+        result.discarding_oversized_line = true;
+    } else if (partial_size > 0) {
+        if (!file.seek(partial_start)) return {};
+        result.trailing_partial = file.read(partial_size);
+        if (result.trailing_partial.size() != partial_size) return {};
+    }
+    if (complete_end < 0) {
+        return result;
+    }
+
+    const int target = std::min(load_limit, kMaxLoadLimit) + 1;
+    QList<LogLine> newest_first;
+    newest_first.reserve(target);
+    QByteArray carry;
+    bool discarding_oversized_line{false};
+    cursor = complete_end;
+
+    // Process complete lines from newest to oldest. At most one boundary-
+    // spanning line is carried. If it exceeds the viewer limit, discard its
+    // remaining prefix until the preceding newline restores framing.
+    while (cursor > 0 && newest_first.size() < target) {
+        if (cancelled.load(std::memory_order_relaxed)) return {};
+        const qint64 start = std::max(qint64{0}, cursor - TAIL_READ_BLOCK_SIZE);
+        if (!file.seek(start)) return {};
+        const QByteArray chunk = file.read(cursor - start);
+        if (chunk.size() != cursor - start) return {};
+
+        QByteArray data;
+        if (discarding_oversized_line) {
+            const qsizetype preceding_newline = chunk.lastIndexOf('\n');
+            if (preceding_newline < 0) {
+                cursor = start;
+                continue;
+            }
+            data = chunk.first(preceding_newline + 1);
+            discarding_oversized_line = false;
+        } else {
+            data = chunk + carry;
+        }
+
+        QByteArray complete_segment;
+        qint64 segment_offset{start};
+        if (start == 0) {
+            complete_segment = data;
+            carry.clear();
+        } else {
+            const qsizetype first_newline = data.indexOf('\n');
+            if (first_newline < 0) {
+                if (data.size() > kMaxLogLineBytes) {
+                    carry.clear();
+                    discarding_oversized_line = true;
+                } else {
+                    carry = data;
+                }
+                cursor = start;
+                continue;
+            }
+            complete_segment = data.mid(first_newline + 1);
+            segment_offset = start + first_newline + 1;
+            carry = data.first(first_newline + 1);
+            if (carry.size() > kMaxLogLineBytes) {
+                carry.clear();
+                discarding_oversized_line = true;
+            }
+        }
+
+        QList<LogLine> parsed = ParseCompleteLines(
+            complete_segment,
+            segment_offset,
+            target - newest_first.size(),
+            cancelled);
+        newest_first.append(std::move(parsed));
+        cursor = start;
+    }
+
+    result.has_more_lines = newest_first.size() > load_limit;
+    if (newest_first.size() > load_limit) newest_first.removeLast();
+    result.lines = std::move(newest_first);
+    return result;
+}
+
+QList<DebugLogModel::LogLine> DebugLogModel::ParseCompleteLines(
+    const QByteArray& bytes,
+    qint64 base_offset,
+    int max_filtered_lines,
+    const std::atomic_bool& cancelled)
+{
+    QList<LogLine> result;
+    result.reserve(std::min<int>(max_filtered_lines, 1024));
+    const qint64 now_ms = QDateTime::currentMSecsSinceEpoch();
+
+    qsizetype scan_end = bytes.size();
+    while (scan_end > 0 && result.size() < max_filtered_lines) {
+        if (cancelled.load(std::memory_order_relaxed)) return {};
+        const qsizetype terminator = bytes.at(scan_end - 1) == '\n'
+            ? scan_end - 1
+            : scan_end;
+        const qsizetype previous_newline = terminator > 0
+            ? bytes.lastIndexOf('\n', terminator - 1)
+            : -1;
+        const qsizetype start = previous_newline + 1;
+        const qsizetype line_size = terminator - start;
+        if (line_size <= kMaxLogLineBytes) {
+            QByteArray raw = bytes.mid(start, line_size);
+            if (raw.endsWith('\r')) raw.chop(1);
+
+            LogLine entry;
+            entry.source_offset = base_offset + start;
+            QString raw_message;
+            const QString line = QString::fromUtf8(raw);
+            const QRegularExpressionMatch match = TIMESTAMP_RX.match(line);
+            if (match.hasMatch()) {
+                const QDateTime dt = QDateTime::fromString(match.captured(1), Qt::ISODateWithMs);
+                entry.timestamp_ms = dt.isValid() ? dt.toMSecsSinceEpoch() : -1;
+                raw_message = match.captured(2);
+            } else {
+                entry.timestamp_ms = -1;
+                raw_message = line;
+            }
+            PopulateParsedFields(entry, raw_message);
+            entry.relativeTime = entry.timestamp_ms >= 0
+                ? RelativeTimeLabelStatic(entry.timestamp_ms, now_ms)
+                : QString{};
+            if (!entry.content.trimmed().isEmpty() || entry.timestamp_ms >= 0) {
+                result.append(std::move(entry));
+            }
+        }
+
+        if (previous_newline < 0) break;
+        scan_end = previous_newline + 1;
     }
     return result;
 }
 
 void DebugLogModel::onReadCompleted(const ReadResult& result,
-                                   const QString& prev_top_identity,
                                    bool full_load)
 {
+    Q_UNUSED(full_load);
     if (!m_active || m_stopping) return;
 
     // Propagate open-error state from the background read.
@@ -397,6 +642,7 @@ void DebugLogModel::onReadCompleted(const ReadResult& result,
             m_open_error = result.error_message;
             Q_EMIT openErrorChanged();
         }
+        watchLogPath();
         m_read_in_flight = false;
         // Trailing refresh re-arm still honoured so a recovered file reloads.
         if (m_refresh_pending) {
@@ -414,133 +660,281 @@ void DebugLogModel::onReadCompleted(const ReadResult& result,
     // The watcher may have failed to register the path at construction time
     // if the log file did not exist yet. Re-add after a successful read so
     // auto-refresh works from here on.
-    const QString path_str = QString::fromStdString(m_log_path.utf8string());
-    if (m_active && !m_watcher.files().contains(path_str)) {
-        m_watcher.addPath(path_str);
-    }
+    watchLogPath();
 
-    const QList<LogLine>& filtered = result.filtered;
+    m_file_size = result.file_size;
+    m_trailing_partial = result.trailing_partial;
+    m_discarding_oversized_line = result.discarding_oversized_line;
+    m_file_anchor = result.file_anchor;
 
-    if (full_load || m_all_lines.isEmpty()) {
-        const bool new_has_more = filtered.size() > m_load_limit
-                                  || m_load_limit >= kMaxLoadLimit;
-        const int start = filtered.size() > m_load_limit
-            ? filtered.size() - m_load_limit : 0;
+    int newly_completed{0};
+    bool next_has_more{m_has_more_lines};
+    bool force_reset{result.continuity_lost};
 
-        QList<LogLine> new_lines;
-        new_lines.reserve(std::min<int>(m_load_limit, filtered.size()));
-        for (int i = filtered.size() - 1; i >= start; i--)
-            new_lines.append(filtered[i]);
-
-        m_all_lines = std::move(new_lines);
-
-        // At the hard ceiling, stop advertising "has more".
-        const bool announced_has_more = new_has_more && m_load_limit < kMaxLoadLimit;
-        if (m_has_more_lines != announced_has_more) {
-            m_has_more_lines = announced_has_more;
-            Q_EMIT hasMoreLinesChanged();
-        }
+    if (result.full_snapshot) {
+        QList<LogLine> next_lines = result.lines;
+        if (next_lines.size() > m_load_limit) next_lines.resize(m_load_limit);
+        next_has_more = (result.has_more_lines || result.lines.size() > m_load_limit)
+            && m_load_limit < kMaxLoadLimit;
+        force_reset = force_reset || m_all_lines.isEmpty();
+        applyLines(std::move(next_lines), force_reset);
+        // A result captured before a rapid limit change only satisfies the
+        // smaller of its request and the current retained capacity.
+        m_loaded_limit = std::min(result.snapshot_limit, m_load_limit);
     } else {
-        // Incremental refresh: prepend lines newer than the previous top entry.
-        if (!prev_top_identity.isEmpty()) {
-            QList<LogLine> new_entries;
-            bool found_prev = false;
-            for (int j = filtered.size() - 1; j >= 0; j--) {
-                if (filtered[j].identity == prev_top_identity) {
-                    found_prev = true;
-                    break;
-                }
-                new_entries.append(filtered[j]);
-            }
-            if (found_prev && !new_entries.isEmpty()) {
-                m_all_lines = new_entries + m_all_lines;
-            } else if (!found_prev) {
-                // Log rotated or missed window — full reset from the fresh read.
-                const bool new_has_more = filtered.size() > m_load_limit;
-                const int start = new_has_more ? filtered.size() - m_load_limit : 0;
-                m_all_lines.clear();
-                m_all_lines.reserve(m_load_limit);
-                for (int i = filtered.size() - 1; i >= start; i--)
-                    m_all_lines.append(filtered[i]);
-                const bool announced_has_more = new_has_more && m_load_limit < kMaxLoadLimit;
-                if (m_has_more_lines != announced_has_more) {
-                    m_has_more_lines = announced_has_more;
-                    Q_EMIT hasMoreLinesChanged();
-                }
-            }
-        }
+        newly_completed = result.lines.size();
+        const bool pruned = applyDelta(result.lines);
+        next_has_more = (m_has_more_lines || result.has_more_lines || pruned)
+            && m_load_limit < kMaxLoadLimit;
     }
 
-    // Emit newLinesAdded for the "new entries" pill.
-    if (!prev_top_identity.isEmpty()) {
-        for (int k = 0; k < m_all_lines.size(); k++) {
-            if (m_all_lines[k].identity == prev_top_identity) {
-                if (k > 0) Q_EMIT newLinesAdded(k);
-                break;
-            }
-        }
+    if (m_has_more_lines != next_has_more) {
+        m_has_more_lines = next_has_more;
+        Q_EMIT hasMoreLinesChanged();
+    }
+    if (newly_completed > 0) {
+        Q_EMIT newLinesAdded(std::min(newly_completed, m_load_limit));
     }
 
-    buildDisplayLines();
-
+    const bool needs_wider_tail = m_loaded_limit < m_load_limit;
+    const bool run_trailing_refresh = m_refresh_pending || needs_wider_tail;
+    const bool do_full = m_pending_full_load || needs_wider_tail;
+    m_refresh_pending = false;
+    m_pending_full_load = false;
     m_read_in_flight = false;
-    // If changes arrived while we were reading, run one trailing refresh.
-    if (!m_stopping && m_refresh_pending) {
-        m_refresh_pending = false;
-        const bool do_full = m_pending_full_load;
-        m_pending_full_load = false;
-        refresh(do_full);
-    }
+    if (!m_stopping && run_trailing_refresh) refresh(do_full);
 }
 
 void DebugLogModel::connectFileWatcher()
 {
-    const QString path_str = QString::fromStdString(m_log_path.utf8string());
     connect(&m_watcher, &QFileSystemWatcher::fileChanged,
-            this, [this](const QString& path) {
+            this, [this](const QString&) {
                 if (!m_active || m_stopping) return;
-                m_watcher.addPath(path); // re-add in case of log rotation
+                watchLogPath();
                 m_debounce.start();
             });
-    if (m_active && !path_str.isEmpty()) {
-        m_watcher.addPath(path_str);
+    connect(&m_watcher, &QFileSystemWatcher::directoryChanged,
+            this, [this](const QString&) {
+                if (!m_active || m_stopping) return;
+                watchLogPath();
+                m_debounce.start();
+            });
+}
+
+void DebugLogModel::watchLogPath()
+{
+    if (!m_active || m_stopping) return;
+
+    const QString path = QString::fromStdString(m_log_path.utf8string());
+    if (path.isEmpty()) return;
+
+    const QFileInfo info(path);
+    if (info.exists()) {
+        if (!m_watcher.files().contains(path)) m_watcher.addPath(path);
+        if (m_watcher.files().contains(path)) {
+            const auto watched_directories = m_watcher.directories();
+            if (!watched_directories.isEmpty()) {
+                m_watcher.removePaths(watched_directories);
+            }
+            return;
+        }
+    }
+
+    const auto watched_files = m_watcher.files();
+    if (!watched_files.isEmpty()) m_watcher.removePaths(watched_files);
+    const QString parent_path = info.absolutePath();
+    if (!parent_path.isEmpty() && !m_watcher.directories().contains(parent_path)) {
+        m_watcher.addPath(parent_path);
     }
 }
 
-void DebugLogModel::buildDisplayLines()
+QList<DebugLogModel::LogLine> DebugLogModel::filteredLines(
+    const QList<LogLine>& lines) const
 {
-    // Apply search filter.
     QList<LogLine> filtered;
     if (m_filter.isEmpty()) {
-        filtered = m_all_lines;
+        filtered = lines;
     } else {
         const QString f = m_filter.toLower();
-        for (const LogLine& line : m_all_lines) {
+        for (const LogLine& line : lines) {
             if (line.content.toLower().contains(f))
                 filtered.append(line);
         }
     }
+    return filtered;
+}
 
-    // Assign display line numbers (1-based, in display order = newest-first).
-    for (int i = 0; i < filtered.size(); i++)
-        filtered[i].lineNumber = QString::number(i + 1);
+void DebugLogModel::applyLines(QList<LogLine> lines, bool force_reset)
+{
+    QList<LogLine> display = filteredLines(lines);
+    if (force_reset) {
+        beginResetModel();
+        m_all_lines = std::move(lines);
+        m_display_lines = std::move(display);
+        endResetModel();
+        return;
+    }
 
-    // Skip the reset when nothing displayed actually changed. A model reset
-    // forces the (non-virtualised) Repeater viewer to destroy and rebuild every
-    // row delegate on the GUI thread, which freezes the UI; a manual refresh on
-    // an idle log would otherwise pay that cost for no change.
-    if (filtered == m_display_lines) return;
+    m_all_lines = std::move(lines);
+    applyDisplayLines(std::move(display), /*force_reset=*/false);
+}
 
-    beginResetModel();
-    m_display_lines = filtered;
-    endResetModel();
+bool DebugLogModel::applyDelta(QList<LogLine> lines)
+{
+    if (lines.isEmpty()) return false;
+
+    const bool omitted_new_lines = lines.size() > m_load_limit;
+    if (omitted_new_lines) lines.resize(m_load_limit);
+
+    const int old_size = static_cast<int>(m_all_lines.size());
+    const int new_size = static_cast<int>(lines.size());
+    const int old_keep_count = std::min(
+        old_size, std::max(0, m_load_limit - new_size));
+    const int old_remove_count = old_size - old_keep_count;
+
+    int display_remove_count{0};
+    if (m_filter.isEmpty()) {
+        display_remove_count = old_remove_count;
+    } else if (old_remove_count > 0) {
+        const QString filter = m_filter.toLower();
+        for (int i = old_keep_count; i < m_all_lines.size(); ++i) {
+            if (m_all_lines.at(i).content.toLower().contains(filter)) {
+                ++display_remove_count;
+            }
+        }
+    }
+
+    QList<LogLine> display_insert = filteredLines(lines);
+    const int display_insert_count = display_insert.size();
+    const int surviving_display_count = m_display_lines.size() - display_remove_count;
+
+    // Publish the prepend first so a ListView can anchor the previously visible
+    // row. Any cap-induced removal is confined to the oldest filtered suffix.
+    if (!display_insert.isEmpty()) {
+        beginInsertRows(QModelIndex{}, 0, display_insert.size() - 1);
+        display_insert.reserve(display_insert.size() + m_display_lines.size());
+        display_insert.append(m_display_lines);
+        m_display_lines = std::move(display_insert);
+        endInsertRows();
+    }
+    if (display_remove_count > 0) {
+        const int first = display_insert_count + surviving_display_count;
+        beginRemoveRows(QModelIndex{}, first, m_display_lines.size() - 1);
+        m_display_lines.erase(m_display_lines.begin() + first,
+                              m_display_lines.end());
+        endRemoveRows();
+    }
+
+    lines.reserve(lines.size() + old_keep_count);
+    lines.append(m_all_lines.cbegin(), m_all_lines.cbegin() + old_keep_count);
+    m_all_lines = std::move(lines);
+
+    if (display_insert_count > 0 && surviving_display_count > 0) {
+        Q_EMIT dataChanged(index(display_insert_count, 0),
+                           index(display_insert_count + surviving_display_count - 1, 0),
+                           {LineNumberRole});
+    }
+    return omitted_new_lines || old_remove_count > 0;
+}
+
+void DebugLogModel::applyDisplayLines(QList<LogLine> lines, bool force_reset)
+{
+    if (!force_reset && lines == m_display_lines) return;
+    if (force_reset) {
+        beginResetModel();
+        m_display_lines = std::move(lines);
+        endResetModel();
+        return;
+    }
+
+    if (m_display_lines.isEmpty()) {
+        if (lines.isEmpty()) return;
+        beginInsertRows(QModelIndex{}, 0, lines.size() - 1);
+        m_display_lines = std::move(lines);
+        endInsertRows();
+        return;
+    }
+    if (lines.isEmpty()) {
+        beginRemoveRows(QModelIndex{}, 0, m_display_lines.size() - 1);
+        m_display_lines.clear();
+        endRemoveRows();
+        return;
+    }
+
+    // Appends to debug.log can only add a prefix (newest rows) and pruning can
+    // only remove a suffix. loadMore does the inverse operation at the bottom.
+    // Locate the old first row in the new projection and preserve the largest
+    // contiguous run from there. Stable byte offsets distinguish identical
+    // timestamp/message duplicates.
+    int prefix_count{-1};
+    for (int i = 0; i < lines.size(); ++i) {
+        if (lines.at(i) == m_display_lines.first()) {
+            prefix_count = i;
+            break;
+        }
+    }
+    if (prefix_count < 0) {
+        beginRemoveRows(QModelIndex{}, 0, m_display_lines.size() - 1);
+        m_display_lines.clear();
+        endRemoveRows();
+        beginInsertRows(QModelIndex{}, 0, lines.size() - 1);
+        m_display_lines = std::move(lines);
+        endInsertRows();
+        return;
+    }
+
+    int common_count{0};
+    while (common_count < m_display_lines.size()
+           && prefix_count + common_count < lines.size()
+           && m_display_lines.at(common_count) == lines.at(prefix_count + common_count)) {
+        ++common_count;
+    }
+
+    const int old_suffix_count = m_display_lines.size() - common_count;
+    if (old_suffix_count > 0) {
+        beginRemoveRows(QModelIndex{}, common_count, m_display_lines.size() - 1);
+        m_display_lines.erase(m_display_lines.begin() + common_count,
+                              m_display_lines.end());
+        endRemoveRows();
+    }
+
+    const int new_suffix_start = prefix_count + common_count;
+    if (new_suffix_start < lines.size()) {
+        const int first = m_display_lines.size();
+        const int count = lines.size() - new_suffix_start;
+        beginInsertRows(QModelIndex{}, first, first + count - 1);
+        for (int i = new_suffix_start; i < lines.size(); ++i) {
+            m_display_lines.append(lines.at(i));
+        }
+        endInsertRows();
+    }
+
+    // Apply a racing loadMore suffix before a live-update prefix. The QML
+    // view restores both anchors asynchronously; making the prepend the final
+    // structural notification ensures its top-row anchor wins.
+    if (prefix_count > 0) {
+        beginInsertRows(QModelIndex{}, 0, prefix_count - 1);
+        for (int i = prefix_count - 1; i >= 0; --i) {
+            m_display_lines.prepend(lines.at(i));
+        }
+        endInsertRows();
+    }
+
+    if (prefix_count > 0 && common_count > 0) {
+        Q_EMIT dataChanged(index(prefix_count, 0),
+                           index(m_display_lines.size() - 1, 0),
+                           {LineNumberRole});
+    }
+}
+
+void DebugLogModel::buildDisplayLines(bool force_reset)
+{
+    applyDisplayLines(filteredLines(m_all_lines), force_reset);
 }
 
 void DebugLogModel::PopulateParsedFields(LogLine& entry, const QString& raw_message)
 {
     entry.content = raw_message.toHtmlEscaped();
-    entry.identity = QString::number(entry.timestamp_ms) + QStringLiteral("\n") + raw_message;
-
     const QString trimmed = raw_message.trimmed();
     entry.command.clear();
     entry.message = trimmed;

--- a/qml/models/debuglogmodel.h
+++ b/qml/models/debuglogmodel.h
@@ -8,6 +8,7 @@
 #include <util/fs.h>
 
 #include <QAbstractListModel>
+#include <QByteArray>
 #include <QFileSystemWatcher>
 #include <QList>
 #include <QString>
@@ -69,6 +70,10 @@ public:
     //! Hard ceiling on loadLimit to protect against unbounded memory growth.
     static constexpr int kMaxLoadLimit = 50'000;
 
+    //! Individual physical log lines larger than this are omitted from the
+    //! in-app viewer. The debug.log file itself is never modified.
+    static constexpr qsizetype kMaxLogLineBytes = 1024 * 1024;
+
     explicit DebugLogModel(const fs::path& log_path, QObject* parent = nullptr);
     ~DebugLogModel() override;
 
@@ -107,25 +112,23 @@ Q_SIGNALS:
 
 private:
     struct LogLine {
-        QString lineNumber;
         QString content;      // HTML-escaped full message text
         QString command;      // parsed message prefix, plain text
         QString message;      // parsed message body, plain text
-        QString identity;     // stable identity for incremental refresh matching
+        qint64  source_offset{-1}; // byte offset in debug.log (stable across appends)
         qint64  timestamp_ms; // epoch ms, -1 if not parseable
         QString relativeTime; // cached human-readable age
         Severity severity{InfoSeverity};
 
-        // Identity for change detection in buildDisplayLines(). relativeTime is
-        // derived (refreshed separately by the relative-time timer) and so is
-        // deliberately excluded.
+        // Identity for incremental display diffs. relativeTime is derived
+        // (refreshed separately by the relative-time timer) and deliberately
+        // excluded.
         bool operator==(const LogLine& o) const
         {
-            return lineNumber == o.lineNumber
+            return source_offset == o.source_offset
                 && content == o.content
                 && command == o.command
                 && message == o.message
-                && identity == o.identity
                 && severity == o.severity
                 && timestamp_ms == o.timestamp_ms;
         }
@@ -137,7 +140,19 @@ private:
     struct ReadResult {
         bool file_opened{false};
         QString error_message;
-        QList<LogLine> filtered; // oldest-first, already filtered of blank lines
+        //! A full snapshot is newest-first and contains at most loadLimit
+        //! entries. A delta contains only newly completed lines, newest-first.
+        QList<LogLine> lines;
+        bool full_snapshot{true};
+        bool continuity_lost{false};
+        bool has_more_lines{false};
+        int snapshot_limit{0};
+        qint64 file_size{-1};
+        QByteArray trailing_partial;
+        //! True after an unfinished line exceeds kMaxLogLineBytes. Subsequent
+        //! bytes are ignored until its terminating newline restores framing.
+        bool discarding_oversized_line{false};
+        QByteArray file_anchor;
     };
 
     //! File-reading worker. Pure function — no QObject / signal access —
@@ -145,21 +160,35 @@ private:
     static ReadResult ReadAndFilter(const fs::path& log_path,
                                     int load_limit,
                                     bool full_load,
+                                    qint64 previous_file_size,
+                                    const QByteArray& previous_partial,
+                                    bool previous_discarding_oversized_line,
+                                    const QByteArray& previous_anchor,
                                     const std::atomic_bool& cancelled);
 
-    //! Raw file read (one pass). Called from ReadAndFilter.
-    static QList<LogLine> ReadRawLines(const fs::path& log_path,
-                                       int max_lines,
-                                       const std::atomic_bool& cancelled);
+    //! Read a bounded tail snapshot by scanning backward in fixed-size blocks.
+    static ReadResult ReadTail(const fs::path& log_path,
+                               int load_limit,
+                               const std::atomic_bool& cancelled);
+
+    //! Parse complete newline-terminated records, returning newest first.
+    static QList<LogLine> ParseCompleteLines(const QByteArray& bytes,
+                                             qint64 base_offset,
+                                             int max_filtered_lines,
+                                             const std::atomic_bool& cancelled);
 
     //! Completion handler invoked on the GUI thread after ReadAndFilter
     //! returns. Applies the result to m_all_lines and rebuilds the display.
     void onReadCompleted(const ReadResult& result,
-                         const QString& prev_top_identity,
                          bool full_load);
 
     void connectFileWatcher();
-    void buildDisplayLines();
+    void watchLogPath();
+    void buildDisplayLines(bool force_reset = false);
+    void applyLines(QList<LogLine> lines, bool force_reset);
+    bool applyDelta(QList<LogLine> lines);
+    void applyDisplayLines(QList<LogLine> lines, bool force_reset);
+    QList<LogLine> filteredLines(const QList<LogLine>& lines) const;
     QString relativeTimeLabel(qint64 timestamp_ms, qint64 now_ms) const;
 
     static void PopulateParsedFields(LogLine& entry, const QString& raw_message);
@@ -176,7 +205,19 @@ private:
     QString m_filter;
     int  m_load_limit{1000};
     bool m_has_more_lines{false};
+    //! Tail capacity represented by m_all_lines. Kept separate from rowCount
+    //! so empty/short logs and interrupted loadMore requests are unambiguous.
+    int m_loaded_limit{0};
     QString m_open_error;
+
+    //! End-of-file state from the last successful worker read. Normal
+    //! refreshes validate the anchor, seek to file_size, and parse only bytes
+    //! appended since then. A bounded partial final line is carried across
+    //! reads; an oversized one is discarded through its terminating newline.
+    qint64 m_file_size{-1};
+    QByteArray m_trailing_partial;
+    bool m_discarding_oversized_line{false};
+    QByteArray m_file_anchor;
 
     QFileSystemWatcher m_watcher;
     QTimer m_debounce;

--- a/qml/models/debuglogmodel.h
+++ b/qml/models/debuglogmodel.h
@@ -33,15 +33,16 @@ class QThread;
 //! Pagination: only the most recent `loadLimit` lines are kept in memory.
 //! Call loadMore() to increase the limit by 1000, up to kMaxLoadLimit.
 //!
-//! File watching: the model connects a QFileSystemWatcher to the log file and
-//! coalesces rapid writes with a 500 ms debounce timer before calling refresh().
-//! Reads themselves run on a dedicated worker thread so a busy, noisy node cannot
+//! File watching: the model only watches the log while active and coalesces
+//! rapid writes with a 500 ms debounce timer before calling refresh(). Reads
+//! themselves run on a dedicated worker thread so a busy, noisy node cannot
 //! stall the UI on every debug-log burst.
 class DebugLogModel : public QAbstractListModel
 {
     Q_OBJECT
 
     Q_PROPERTY(bool hasMoreLines READ hasMoreLines NOTIFY hasMoreLinesChanged)
+    Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged)
     Q_PROPERTY(int  loadLimit   READ loadLimit    WRITE setLoadLimit   NOTIFY loadLimitChanged)
     Q_PROPERTY(QString filter   READ filter       WRITE setFilter      NOTIFY filterChanged)
     Q_PROPERTY(QString openError READ openError   NOTIFY openErrorChanged)
@@ -78,6 +79,9 @@ public:
 
     bool hasMoreLines() const { return m_has_more_lines; }
 
+    bool active() const { return m_active; }
+    void setActive(bool active);
+
     int loadLimit() const { return m_load_limit; }
     void setLoadLimit(int limit);
 
@@ -94,6 +98,7 @@ public:
 
 Q_SIGNALS:
     void hasMoreLinesChanged();
+    void activeChanged();
     void loadLimitChanged();
     void filterChanged();
     void openErrorChanged();
@@ -183,7 +188,9 @@ private:
     bool m_read_in_flight{false};
     bool m_refresh_pending{false};
     bool m_pending_full_load{false};
+    bool m_active{false};
     bool m_stopping{false};
+    quint64 m_activation_generation{0};
     std::atomic_bool m_read_cancelled{false};
 };
 

--- a/qml/pages/node/NodeSettings.qml
+++ b/qml/pages/node/NodeSettings.qml
@@ -280,7 +280,12 @@ Page {
                         sourceComponent: NetworkTraffic { showBackButton: false; showHeader: false }
                     }
                     MempoolInformationSettings { showBackButton: false }
-                    SettingsDebugLog { showBackButton: false }
+                    Loader {
+                        id: debugLogLoader
+                        objectName: "settingsDebugLogLoader"
+                        active: root.visible && root.currentSection === 8
+                        sourceComponent: SettingsDebugLog { showBackButton: false }
+                    }
                     PageStack {
                         id: aboutStack
                         initialItem: SettingsAbout {

--- a/qml/pages/settings/SettingsDebugLog.qml
+++ b/qml/pages/settings/SettingsDebugLog.qml
@@ -320,5 +320,6 @@ Page {
         }
     }
 
-    Component.onCompleted: debugLogModel.refresh(true)
+    Component.onCompleted: debugLogModel.active = true
+    Component.onDestruction: debugLogModel.active = false
 }

--- a/qml/pages/settings/SettingsDebugLog.qml
+++ b/qml/pages/settings/SettingsDebugLog.qml
@@ -132,6 +132,11 @@ Page {
                 color: Theme.color.neutral9
                 placeholderTextColor: Theme.color.neutral5
                 placeholderText: qsTr("Search...")
+                // The page is unloaded whenever another Settings section is
+                // selected, while the C++ model intentionally retains its
+                // filter. Mirror that retained value on re-entry so the field
+                // and the rows cannot disagree.
+                text: debugLogModel.filter
                 verticalAlignment: TextInput.AlignVCenter
                 selectByMouse: true
                 Accessible.name: qsTr("Search debug log")
@@ -201,11 +206,13 @@ Page {
             topPadding: 10
             accessibleName: qsTr("Debug log entries")
             autoScrollToBottom: false
-            // DebugLogModel renders newest-first at the top, so y > 0 means
-            // "scrolled away from the newest entries" — which is exactly when
-            // the "N new entries" pill should be offered.
-            onScrolled: function(y) {
-                root.userIsScrolled = (y > 0)
+            // DebugLogModel renders newest-first at the top, so leaving the
+            // beginning is exactly when the "N new entries" pill applies.
+            onScrolled: function() {
+                // A ListView's content origin is not guaranteed to be zero,
+                // particularly with variable-height rows and incremental model
+                // changes. Its boundary state is the authoritative answer.
+                root.userIsScrolled = !logView.atTop
                 if (logView.atTop && root.pendingNewLines > 0) {
                     root.pendingNewLines = 0
                 }
@@ -220,6 +227,7 @@ Page {
             Layout.preferredHeight: 36
 
             TextButton {
+                objectName: "debugLogLoadMoreButton"
                 anchors.centerIn: parent
                 text: qsTr("Load more")
                 textSize: 13

--- a/test/functional/qml_test_debug_log.py
+++ b/test/functional/qml_test_debug_log.py
@@ -6,9 +6,11 @@
 
 Walks through Settings → Debug Log and verifies:
   1. The viewer page loads with a visible search bar and log list.
-  2. The log list is non-empty (entries were actually loaded).
+  2. The initial load is capped while older entries remain available.
   3. Typing in the search field filters the list; clearing it restores
      the full count.
+  4. Auto-refresh replaces the capped tail without growing it unboundedly.
+  5. The list virtualizes offscreen rows and can load older rows on demand.
 
 This test requires the binary to be built with -DENABLE_TEST_AUTOMATION=ON.
 """
@@ -22,7 +24,11 @@ import sys
 import tempfile
 
 from qml_test_harness import GUI_STARTUP_TIMEOUT, dump_qml_tree, find_gui_binary, setup_datadir
-from qml_driver import QmlDriver, QmlDriverError
+from qml_driver import QmlDriver
+
+
+INITIAL_LOAD_LIMIT = 1000
+SEEDED_HISTORY_LINES = 1200
 
 
 def assert_close(actual, expected, label, tolerance=1):
@@ -43,6 +49,19 @@ class DebugLogHarness:
         self.process = None
         self.driver = None
         self.datadir = setup_datadir(self.tmpdir)
+        self._seed_debug_log_history()
+
+    def _seed_debug_log_history(self):
+        """Create enough history to exercise the initial cap and Load more."""
+        network_dir = os.path.join(self.datadir, "regtest")
+        os.makedirs(network_dir, exist_ok=True)
+        log_path = os.path.join(network_dir, "debug.log")
+        with open(log_path, "w", encoding="utf-8") as f:
+            for i in range(SEEDED_HISTORY_LINES):
+                f.write(
+                    "2026-01-01T00:00:00Z "
+                    f"test-automation seeded-history marker {i}\n"
+                )
 
     def start(self):
         env = dict(os.environ)
@@ -114,10 +133,15 @@ def test_viewer_visibility(gui):
 
 
 def test_log_has_entries(gui):
-    """Verify that log entries were actually loaded into the list view."""
+    """Verify that the first snapshot is capped at 1,000 rows."""
     print("\n── test_log_has_entries ──────────────────────────────────────────")
-    count = gui.get_property("debugLogListView", "count")
-    assert count > 0, f"Expected log entries to be loaded, got count={count}"
+    count = gui.wait_for_property(
+        "debugLogListView", "count", INITIAL_LOAD_LIMIT, timeout_ms=5000
+    )
+    assert count == INITIAL_LOAD_LIMIT, (
+        f"Expected the initial load to be capped at {INITIAL_LOAD_LIMIT}, "
+        f"got count={count}"
+    )
     print(f"  PASSED: debugLogListView.count = {count}")
     return count
 
@@ -130,7 +154,6 @@ def test_search_layout_matches_design(gui):
     gui.wait_for_property("debugLogSearchDivider", "height", 1, timeout_ms=3000)
     gui.wait_for_property("debugLogListView", "topPadding", 10, timeout_ms=3000)
     gui.wait_for_property("debugLogListView_row_0", "visible", True, timeout_ms=3000)
-    gui.wait_for_property("debugLogListView_row_0", "y", 10, timeout_ms=3000)
     gui.wait_for_property("debugLogListView_lineNumber_0", "visible", True, timeout_ms=3000)
     gui.wait_for_property("debugLogListView_date_0", "visible", True, timeout_ms=3000)
 
@@ -147,6 +170,13 @@ def test_search_layout_matches_design(gui):
     divider_y = gui.get_property("debugLogSearchDivider", "y")
     divider_height = gui.get_property("debugLogSearchDivider", "height")
     list_y = gui.get_property("debugLogListView", "y")
+    first_row_viewport_y = (
+        gui.get_property("debugLogListView_row_0", "y")
+        - gui.get_property("debugLogListView", "contentY")
+    )
+    effective_line_number_width = gui.get_property(
+        "debugLogListView", "effectiveLineNumberWidth"
+    )
     page_width = gui.get_property("settingsDebugLog", "width")
     content_width = gui.get_property("debugLogContentLayout", "width")
     expected_content_width = max(0, min(page_width - 40, 600))
@@ -197,20 +227,24 @@ def test_search_layout_matches_design(gui):
                  "debug log entry command/content spacing")
     assert_close(gui.get_property("debugLogListView", "lineNumberWidth"), 20,
                  "debug log line number slot width")
-    assert_close(gui.get_property("debugLogListView", "effectiveLineNumberWidth"), 20,
-                 "debug log effective line number slot width")
+    assert effective_line_number_width >= 20, (
+        "Expected the effective line-number slot to honor its 20px minimum"
+    )
     assert_close(gui.get_property("debugLogListView", "fontPixelSize"), 12,
                  "debug log entry font size")
     assert_close(gui.get_property("debugLogListView", "textLineHeight"), 17,
                  "debug log entry line height")
-    assert_close(gui.get_property("debugLogListView_row_0", "y"), 10,
-                 "first debug log row y")
+    assert_close(first_row_viewport_y, 10,
+                 "first debug log row viewport y")
     assert_close(gui.get_property("debugLogListView_row_0", "spacing"), 10,
                  "first debug log row column gap")
     assert_close(gui.get_property("debugLogListView_entryContent_0", "spacing"), 2,
                  "first debug log entry internal gap")
-    assert_close(gui.get_property("debugLogListView_lineNumber_0", "width"), 20,
-                 "first debug log line number width")
+    assert_close(
+        gui.get_property("debugLogListView_lineNumber_0", "width"),
+        effective_line_number_width,
+        "first debug log line number width",
+    )
     first_text_object = (
         "debugLogListView_message_0"
         if first_row_has_command
@@ -236,7 +270,7 @@ def test_refresh_button(gui, original_count):
 
 
 def test_auto_refresh(gui, datadir, current_count):
-    """Appending to debug.log triggers auto-refresh and grows the entry count."""
+    """Appending refreshes the capped tail without exceeding its load limit."""
     print("\n── test_auto_refresh ─────────────────────────────────────────────")
     log_path = os.path.join(datadir, "regtest", "debug.log")
     ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -244,38 +278,48 @@ def test_auto_refresh(gui, datadir, current_count):
     marker = f"{ts} {marker_body}"
     with open(log_path, "a", encoding="utf-8") as f:
         f.write(marker + "\n")
-    try:
-        new_count = gui.wait_for_property(
-            "debugLogListView", "count", lambda c: c > current_count, timeout_ms=5000
-        )
-    except QmlDriverError:
-        gui.click("debugLogRefreshButton")
-        new_count = gui.wait_for_property(
-            "debugLogListView", "count", lambda c: c > current_count, timeout_ms=3000
-        )
-    assert new_count > current_count, (
-        f"Expected count to grow beyond {current_count} after appending to debug.log, "
-        f"got {new_count}"
-    )
-    print(f"  PASSED: count grew from {current_count} to {new_count} after file append")
 
+    # A capped model can insert the new row and remove one old row without
+    # changing count. Filter for the unique marker to observe the actual data
+    # update rather than treating row-count growth as the refresh signal.
     gui.set_text("debugLogSearchField", marker_body)
-    gui.wait_for_property("debugLogListView", "count", lambda c: c >= 1, timeout_ms=3000)
+    gui.wait_for_property("debugLogListView", "count", 1, timeout_ms=5000)
+    gui.wait_for_property(
+        "debugLogListView_commandlessMessage_0",
+        "text",
+        marker_body,
+        timeout_ms=3000,
+    )
+
     gui.wait_for_property("debugLogListView_command_0", "visible", False, timeout_ms=3000)
     gui.wait_for_property("debugLogListView_commandlessMessage_0", "visible", True, timeout_ms=3000)
-    gui.wait_for_property("debugLogListView_commandlessMessage_0", "text", marker_body, timeout_ms=3000)
     gui.wait_for_property("debugLogListView_message_0", "visible", False, timeout_ms=3000)
+    gui.invoke("debugLogListView_commandlessMessage_0", "selectAll")
+    gui.wait_for_property(
+        "debugLogListView_commandlessMessage_0",
+        "selectedText",
+        marker_body,
+        timeout_ms=3000,
+    )
     print("  PASSED: commandless log entry renders inline with the date")
 
     gui.set_text("debugLogSearchField", "")
     restored_count = gui.wait_for_property(
-        "debugLogListView", "count", lambda c: c >= new_count, timeout_ms=3000
+        "debugLogListView", "count", current_count, timeout_ms=3000
+    )
+    assert restored_count == INITIAL_LOAD_LIMIT, (
+        f"Expected auto-refresh to retain the {INITIAL_LOAD_LIMIT}-row cap, "
+        f"got {restored_count}"
+    )
+    print(
+        f"  PASSED: appended entry loaded and count remained capped at "
+        f"{restored_count}"
     )
     return restored_count
 
 
 def test_four_digit_line_numbers_are_not_clipped(gui, datadir, current_count):
-    """Verify the line-number column expands once visible numbers reach four digits."""
+    """Verify virtualized offscreen rows and the four-digit number column."""
     print("\n── test_four_digit_line_numbers_are_not_clipped ────────────────")
     target_count = 1000
     needed = max(0, target_count - current_count)
@@ -293,20 +337,63 @@ def test_four_digit_line_numbers_are_not_clipped(gui, datadir, current_count):
         f"Expected at least {target_count} lines after append, got {count}"
     )
 
-    gui.wait_for_property(
-        "debugLogListView_lineNumber_999", "text", str(target_count), timeout_ms=3000
+    last_index = count - 1
+    last_line_number = f"debugLogListView_lineNumber_{last_index}"
+    gui.invoke("debugLogListView", "scrollToTop")
+    gui.wait_for_property("debugLogListView", "atTop", True, timeout_ms=3000)
+    assert not gui.object_exists(last_line_number), (
+        f"Expected offscreen row {last_index} not to be instantiated at the top"
     )
-    line_number_width = gui.get_property("debugLogListView_lineNumber_999", "width")
-    line_number_implicit_width = gui.get_property(
-        "debugLogListView_lineNumber_999", "implicitWidth"
-    )
+
+    gui.invoke("debugLogListView", "scrollToBottom")
+    gui.wait_for_property("debugLogListView", "atBottom", True, timeout_ms=3000)
+    gui.wait_for_property(last_line_number, "text", str(count), timeout_ms=3000)
+    line_number_width = gui.get_property(last_line_number, "width")
+    line_number_implicit_width = gui.get_property(last_line_number, "implicitWidth")
     assert line_number_width >= line_number_implicit_width, (
         f"Expected four-digit line number width {line_number_width} to fit "
         f"implicit width {line_number_implicit_width}"
     )
     assert gui.get_property("debugLogListView", "effectiveLineNumberWidth") > 20, \
         "Expected effective line-number slot to expand beyond the design minimum"
-    print("  PASSED: four-digit line numbers fit expanded line-number slot")
+    print("  PASSED: offscreen rows are virtualized and four-digit line numbers fit")
+
+
+def test_load_more_at_bottom(gui, current_count):
+    """The bottom affordance appends older rows without moving the viewport."""
+    print("\n── test_load_more_at_bottom ───────────────────────")
+    gui.invoke("debugLogListView", "scrollToBottom")
+    gui.wait_for_property("debugLogListView", "atBottom", True, timeout_ms=3000)
+    gui.wait_for_property("debugLogLoadMoreButton", "visible", True, timeout_ms=3000)
+    content_y_before = gui.get_property("debugLogListView", "contentY")
+
+    gui.click("debugLogLoadMoreButton")
+    expanded_count = gui.wait_for_property(
+        "debugLogListView", "count", lambda c: c > current_count, timeout_ms=5000
+    )
+    content_y_after = gui.get_property("debugLogListView", "contentY")
+    assert_close(
+        content_y_after,
+        content_y_before,
+        "load-more viewport anchor",
+        tolerance=2,
+    )
+    gui.wait_for_property("debugLogLoadMoreButton", "visible", False, timeout_ms=3000)
+
+    oldest_index = expanded_count - 1
+    oldest_message = f"debugLogListView_commandlessMessage_{oldest_index}"
+    gui.invoke("debugLogListView", "scrollToBottom")
+    gui.wait_for_property(
+        oldest_message,
+        "text",
+        "test-automation seeded-history marker 0",
+        timeout_ms=3000,
+    )
+    print(
+        f"  PASSED: loaded {expanded_count - current_count} older rows without "
+        "moving the viewport, including the oldest seeded row"
+    )
+    return expanded_count
 
 
 def test_close_settings(gui):
@@ -363,9 +450,10 @@ def run_tests():
         total = test_log_has_entries(gui)
         test_search_layout_matches_design(gui)
         test_search_filter(gui, total)
-        total = test_refresh_button(gui, total)
         total = test_auto_refresh(gui, harness.datadir, total)
+        total = test_refresh_button(gui, total)
         test_four_digit_line_numbers_are_not_clipped(gui, harness.datadir, total)
+        total = test_load_more_at_bottom(gui, total)
         test_close_settings(gui)
 
         print("\n" + "=" * 50)

--- a/test/qml/bitcoin_qmltests.qrc
+++ b/test/qml/bitcoin_qmltests.qrc
@@ -14,6 +14,7 @@
         <file>tst_createpassword.qml</file>
         <file>tst_createtypeselector.qml</file>
         <file>tst_createwalletwizard.qml</file>
+        <file>tst_debuglogoutputview.qml</file>
         <file>tst_desktopwallets.qml</file>
         <file>tst_displaysettings.qml</file>
         <file>tst_dropdownbutton.qml</file>

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -3078,6 +3078,65 @@ private:
     bool m_minimize_on_close{false};
 };
 
+class MockDebugLogModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged)
+    Q_PROPERTY(bool hasMoreLines READ hasMoreLines NOTIFY hasMoreLinesChanged)
+    Q_PROPERTY(QString filter READ filter WRITE setFilter NOTIFY filterChanged)
+    Q_PROPERTY(QString openError READ openError NOTIFY openErrorChanged)
+
+public:
+    enum Severity {
+        InfoSeverity = 0,
+        WarningSeverity,
+        ErrorSeverity,
+    };
+    Q_ENUM(Severity)
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override
+    {
+        Q_UNUSED(parent);
+        return 0;
+    }
+
+    QVariant data(const QModelIndex&, int = Qt::DisplayRole) const override { return {}; }
+
+    bool active() const { return m_active; }
+    void setActive(bool active)
+    {
+        if (m_active == active) return;
+        m_active = active;
+        Q_EMIT activeChanged();
+    }
+
+    bool hasMoreLines() const { return false; }
+    QString filter() const { return m_filter; }
+    void setFilter(const QString& filter)
+    {
+        if (m_filter == filter) return;
+        m_filter = filter;
+        Q_EMIT filterChanged();
+    }
+    QString openError() const { return {}; }
+
+    Q_INVOKABLE void refresh(bool = false) {}
+    Q_INVOKABLE void loadMore() {}
+    Q_INVOKABLE bool openLogFile() { return true; }
+    Q_INVOKABLE void updateRelativeTimes() {}
+
+Q_SIGNALS:
+    void activeChanged();
+    void hasMoreLinesChanged();
+    void filterChanged();
+    void openErrorChanged();
+    void newLinesAdded(int count);
+
+private:
+    bool m_active{false};
+    QString m_filter;
+};
+
 class QmlTestsSetup : public QObject
 {
     Q_OBJECT
@@ -3108,6 +3167,7 @@ public Q_SLOTS:
         static MockActivityListModel activity_list_model;
         static MockBumpTransactionModel bump_model;
         static MockDesktopWindowBehaviorModel desktop_window_behavior_model;
+        static MockDebugLogModel debug_log_model;
         recipients_model.setCurrent(&send_recipient);
         wallet_model.setActivityListModel(&activity_list_model);
         wallet_model.setBumpModel(&bump_model);
@@ -3142,6 +3202,13 @@ public Q_SLOTS:
             "WalletQmlModelTransaction",
             "Test stub type"
         );
+        qmlRegisterUncreatableType<MockDebugLogModel>(
+            "org.bitcoincore.qt",
+            1,
+            0,
+            "DebugLogModel",
+            "Test stub type"
+        );
         qmlRegisterType<BlockClockDial>("org.bitcoincore.qt", 1, 0, "BlockClockDial");
         qmlRegisterType<LineGraph>("org.bitcoincore.qt", 1, 0, "LineGraph");
         engine->rootContext()->setContextProperty(QStringLiteral("optionsModel"), &options_model);
@@ -3166,6 +3233,8 @@ public Q_SLOTS:
         engine->rootContext()->setContextProperty(QStringLiteral("testCoinsListModel"), &coins_list_model);
         engine->rootContext()->setContextProperty(QStringLiteral("testBumpModel"), &bump_model);
         engine->rootContext()->setContextProperty(QStringLiteral("desktopWindowBehaviorModel"), &desktop_window_behavior_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("debugLogModel"), &debug_log_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("testDebugLogModel"), &debug_log_model);
         engine->addImportPath(QStringLiteral(BITCOINQML_QML_SOURCE_DIR));
     }
 };

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -3085,8 +3085,21 @@ class MockDebugLogModel : public QAbstractListModel
     Q_PROPERTY(bool hasMoreLines READ hasMoreLines NOTIFY hasMoreLinesChanged)
     Q_PROPERTY(QString filter READ filter WRITE setFilter NOTIFY filterChanged)
     Q_PROPERTY(QString openError READ openError NOTIFY openErrorChanged)
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(int loadMoreCalls READ loadMoreCalls NOTIFY loadMoreCallsChanged)
 
 public:
+    enum Role {
+        LineNumberRole = Qt::UserRole + 1,
+        ContentRole,
+        RelativeTimeRole,
+        CommandRole,
+        MessageRole,
+        DateLabelRole,
+        SeverityRole,
+    };
+    Q_ENUM(Role)
+
     enum Severity {
         InfoSeverity = 0,
         WarningSeverity,
@@ -3096,11 +3109,39 @@ public:
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override
     {
-        Q_UNUSED(parent);
-        return 0;
+        return parent.isValid() ? 0 : m_rows.size();
     }
 
-    QVariant data(const QModelIndex&, int = Qt::DisplayRole) const override { return {}; }
+    int count() const { return m_rows.size(); }
+
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override
+    {
+        if (!index.isValid() || index.row() < 0 || index.row() >= m_rows.size()) return {};
+        const Row& row = m_rows.at(index.row());
+        switch (role) {
+        case LineNumberRole: return QString::number(index.row() + 1);
+        case ContentRole: return row.message;
+        case RelativeTimeRole: return row.date_label;
+        case CommandRole: return row.command;
+        case MessageRole: return row.message;
+        case DateLabelRole: return row.date_label;
+        case SeverityRole: return row.severity;
+        default: return {};
+        }
+    }
+
+    QHash<int, QByteArray> roleNames() const override
+    {
+        return {
+            {LineNumberRole, "lineNumber"},
+            {ContentRole, "content"},
+            {RelativeTimeRole, "relativeTime"},
+            {CommandRole, "command"},
+            {MessageRole, "message"},
+            {DateLabelRole, "dateLabel"},
+            {SeverityRole, "severity"},
+        };
+    }
 
     bool active() const { return m_active; }
     void setActive(bool active)
@@ -3110,7 +3151,7 @@ public:
         Q_EMIT activeChanged();
     }
 
-    bool hasMoreLines() const { return false; }
+    bool hasMoreLines() const { return m_has_more_lines; }
     QString filter() const { return m_filter; }
     void setFilter(const QString& filter)
     {
@@ -3119,11 +3160,119 @@ public:
         Q_EMIT filterChanged();
     }
     QString openError() const { return {}; }
+    int loadMoreCalls() const { return m_load_more_calls; }
 
     Q_INVOKABLE void refresh(bool = false) {}
-    Q_INVOKABLE void loadMore() {}
+    Q_INVOKABLE void loadMore()
+    {
+        ++m_load_more_calls;
+        Q_EMIT loadMoreCallsChanged();
+        appendRowsForTest(20);
+        setHasMoreLinesForTest(false);
+    }
     Q_INVOKABLE bool openLogFile() { return true; }
     Q_INVOKABLE void updateRelativeTimes() {}
+
+    Q_INVOKABLE void resetForTest(int count, bool has_more_lines)
+    {
+        beginResetModel();
+        m_rows.clear();
+        m_rows.reserve(count);
+        for (int i = 0; i < count; ++i) {
+            m_rows.append(makeRow(QStringLiteral("entry-%1").arg(i)));
+        }
+        endResetModel();
+        m_next_new_row = 0;
+        m_next_old_row = count;
+        m_load_more_calls = 0;
+        Q_EMIT countChanged();
+        Q_EMIT loadMoreCallsChanged();
+        setHasMoreLinesForTest(has_more_lines);
+    }
+
+    Q_INVOKABLE void prependRowsForTest(int count)
+    {
+        if (count <= 0) return;
+
+        QList<Row> added;
+        added.reserve(count);
+        for (int i = 0; i < count; ++i) {
+            added.append(makeRow(QStringLiteral("new-%1").arg(m_next_new_row++)));
+        }
+
+        beginInsertRows(QModelIndex(), 0, count - 1);
+        for (int i = count - 1; i >= 0; --i) {
+            m_rows.prepend(std::move(added[i]));
+        }
+        endInsertRows();
+        Q_EMIT countChanged();
+        Q_EMIT newLinesAdded(count);
+    }
+
+    Q_INVOKABLE void appendRowsForTest(int count)
+    {
+        if (count <= 0) return;
+
+        const int first = m_rows.size();
+        beginInsertRows(QModelIndex(), first, first + count - 1);
+        for (int i = 0; i < count; ++i) {
+            m_rows.append(makeRow(QStringLiteral("old-%1").arg(m_next_old_row++)));
+        }
+        endInsertRows();
+        Q_EMIT countChanged();
+    }
+
+    Q_INVOKABLE void removeRowsFromEndForTest(int count)
+    {
+        count = std::min<int>(count, m_rows.size());
+        if (count <= 0) return;
+
+        const int first = m_rows.size() - count;
+        beginRemoveRows(QModelIndex(), first, m_rows.size() - 1);
+        m_rows.remove(first, count);
+        endRemoveRows();
+        Q_EMIT countChanged();
+    }
+
+    Q_INVOKABLE void prependAndPruneRowsForTest(int prepend_count, int prune_count)
+    {
+        prependRowsForTest(prepend_count);
+        removeRowsFromEndForTest(prune_count);
+    }
+
+    Q_INVOKABLE void prependAndAppendRowsForTest(int prepend_count,
+                                                 int append_count,
+                                                 bool prepend_first)
+    {
+        if (prepend_first) {
+            prependRowsForTest(prepend_count);
+            appendRowsForTest(append_count);
+        } else {
+            appendRowsForTest(append_count);
+            prependRowsForTest(prepend_count);
+        }
+    }
+
+    Q_INVOKABLE void setMessageForTest(int row, const QString& message)
+    {
+        if (row < 0 || row >= m_rows.size() || m_rows.at(row).message == message) return;
+        m_rows[row].message = message;
+        const QModelIndex changed_index = index(row, 0);
+        Q_EMIT dataChanged(changed_index, changed_index, {ContentRole, MessageRole});
+    }
+
+    Q_INVOKABLE QString messageAt(int row) const
+    {
+        if (row < 0 || row >= m_rows.size()) return {};
+        return m_rows.at(row).message;
+    }
+
+    Q_INVOKABLE void setHasMoreLinesForTest(bool has_more_lines)
+    {
+        if (m_has_more_lines == has_more_lines) return;
+        m_has_more_lines = has_more_lines;
+        Q_EMIT hasMoreLinesChanged();
+    }
 
 Q_SIGNALS:
     void activeChanged();
@@ -3131,10 +3280,34 @@ Q_SIGNALS:
     void filterChanged();
     void openErrorChanged();
     void newLinesAdded(int count);
+    void countChanged();
+    void loadMoreCallsChanged();
 
 private:
+    struct Row {
+        QString command;
+        QString message;
+        QString date_label;
+        int severity{InfoSeverity};
+    };
+
+    static Row makeRow(const QString& message)
+    {
+        return Row{
+            QStringLiteral("test"),
+            message,
+            QStringLiteral("just now"),
+            InfoSeverity,
+        };
+    }
+
     bool m_active{false};
+    bool m_has_more_lines{false};
     QString m_filter;
+    QList<Row> m_rows;
+    int m_load_more_calls{0};
+    int m_next_new_row{0};
+    int m_next_old_row{0};
 };
 
 class QmlTestsSetup : public QObject

--- a/test/qml/tst_debuglogoutputview.qml
+++ b/test/qml/tst_debuglogoutputview.qml
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Window 2.15
+import QtTest 1.2
+import org.bitcoincore.qt 1.0
+import "../../qml/components"
+
+TestCase {
+    name: "DebugLogOutputView"
+    when: windowShown
+    width: 440
+    height: 300
+
+    Window {
+        id: testWindow
+        width: 440
+        height: 300
+        visible: true
+    }
+
+    Component {
+        id: outputViewComponent
+
+        DebugLogOutputView {
+            objectName: "testDebugLogOutputView"
+            width: 400
+            height: 240
+            listModel: testDebugLogModel
+            accessibleName: "Test debug log"
+        }
+    }
+
+    function init() {
+        testDebugLogModel.resetForTest(0, false)
+    }
+
+    function createOutputView() {
+        const view = createTemporaryObject(outputViewComponent, testWindow.contentItem)
+        verify(view !== null)
+        tryCompare(view, "count", testDebugLogModel.count)
+        return view
+    }
+
+    function test_virtualizes_rows_and_scroll_helpers_reach_each_end() {
+        testDebugLogModel.resetForTest(250, false)
+        const view = createOutputView()
+        const list = findChild(view, "testDebugLogOutputView_list")
+        verify(list !== null)
+
+        tryVerify(function() { return view.instantiatedDelegateCount > 0 })
+        verify(view.instantiatedDelegateCount < view.count,
+               "ListView should instantiate only a viewport-sized subset")
+        verify(list.itemAtIndex(0) !== null)
+        compare(list.itemAtIndex(200), null)
+        compare(view.atTop, true)
+        compare(view.atBottom, false)
+
+        view.scrollToBottom()
+        tryCompare(view, "atBottom", true)
+        tryVerify(function() { return list.itemAtIndex(249) !== null })
+        compare(findChild(list.itemAtIndex(249), "testDebugLogOutputView_lineNumber_249").text, "250")
+
+        view.scrollToTop()
+        tryCompare(view, "atTop", true)
+        tryVerify(function() { return list.itemAtIndex(0) !== null })
+    }
+
+    function test_variable_height_prepend_and_tail_prune_keep_anchor() {
+        testDebugLogModel.resetForTest(160, false)
+        const wrappedMessage = "A wrapped debug-log message with selectable text. ".repeat(24)
+        testDebugLogModel.setMessageForTest(10, wrappedMessage)
+        testDebugLogModel.setMessageForTest(50, wrappedMessage)
+        const view = createOutputView()
+        const list = findChild(view, "testDebugLogOutputView_list")
+        verify(list !== null)
+
+        list.positionViewAtIndex(50, ListView.Beginning)
+        tryVerify(function() {
+            const item = list.itemAtIndex(50)
+            return !view.atTop && item !== null && item.height > view.textLineHeight * 3
+        })
+        // Visiting another wrapped row first makes ListView refine its delegate
+        // size estimate. Returning nearer the beginning then exercises an
+        // anchor whose contentY is relative to a shifted (non-zero) origin.
+        list.positionViewAtIndex(10, ListView.Beginning)
+        tryVerify(function() {
+            const item = list.itemAtIndex(10)
+            return item !== null && item.height > view.textLineHeight * 3
+        })
+
+        const anchorMessage = testDebugLogModel.messageAt(10)
+        const anchorOffset = list.itemAtIndex(10).y - view.contentY
+        testDebugLogModel.prependAndPruneRowsForTest(3, 3)
+
+        tryCompare(view, "count", 160)
+        compare(testDebugLogModel.messageAt(13), anchorMessage)
+        tryVerify(function() {
+            const shiftedAnchor = list.itemAtIndex(13)
+            return shiftedAnchor !== null
+                && Math.abs((shiftedAnchor.y - view.contentY) - anchorOffset) < 0.5
+        })
+        compare(view.atTop, false)
+
+        const shiftedMessage = findChild(
+            list.itemAtIndex(13), "testDebugLogOutputView_message_13")
+        verify(shiftedMessage !== null)
+        compare(shiftedMessage.visible, true)
+        shiftedMessage.selectAll()
+        compare(shiftedMessage.selectedText, wrappedMessage)
+
+        // Exercise the end calculation after a variable-height incremental
+        // update, when ListView's logical origin is allowed to be non-zero.
+        view.scrollToBottom()
+        tryCompare(view, "atBottom", true)
+    }
+
+    function test_prepend_while_at_top_keeps_newest_rows_visible() {
+        testDebugLogModel.resetForTest(80, false)
+        const view = createOutputView()
+        const list = findChild(view, "testDebugLogOutputView_list")
+        verify(list !== null)
+        compare(view.atTop, true)
+
+        testDebugLogModel.prependRowsForTest(2)
+
+        tryCompare(view, "count", 82)
+        tryCompare(view, "atTop", true)
+        tryVerify(function() { return list.itemAtIndex(0) !== null })
+        compare(testDebugLogModel.messageAt(0), "new-0")
+        compare(findChild(list.itemAtIndex(0), "testDebugLogOutputView_lineNumber_0").text, "1")
+    }
+
+    function test_appending_older_rows_does_not_jump_to_new_bottom() {
+        testDebugLogModel.resetForTest(100, true)
+        const view = createOutputView()
+        view.scrollToBottom()
+        tryCompare(view, "atBottom", true)
+        const anchoredContentY = view.contentY
+
+        testDebugLogModel.appendRowsForTest(20)
+
+        tryCompare(view, "count", 120)
+        tryVerify(function() { return !view.atBottom })
+        verify(Math.abs(view.contentY - anchoredContentY) < 0.5,
+               "Appending older rows should preserve the current viewport")
+    }
+
+    function test_full_snapshot_prefix_and_suffix_keep_prepend_anchor_data() {
+        return [
+            { tag: "prefix-first", prependFirst: true },
+            { tag: "suffix-first", prependFirst: false },
+        ]
+    }
+
+    function test_full_snapshot_prefix_and_suffix_keep_prepend_anchor(data) {
+        testDebugLogModel.resetForTest(160, false)
+        const view = createOutputView()
+        const list = findChild(view, "testDebugLogOutputView_list")
+        verify(list !== null)
+
+        list.positionViewAtIndex(50, ListView.Beginning)
+        tryVerify(function() { return list.itemAtIndex(50) !== null && !view.atTop })
+        const anchorMessage = testDebugLogModel.messageAt(50)
+        const anchorOffset = list.itemAtIndex(50).y - view.contentY
+
+        // A reconciled snapshot can expose both ends in one GUI event turn.
+        // The viewport must follow the shifted original row regardless of the
+        // order in which those two insertion batches are published.
+        testDebugLogModel.prependAndAppendRowsForTest(3, 2, data.prependFirst)
+
+        tryCompare(view, "count", 165)
+        compare(testDebugLogModel.messageAt(53), anchorMessage)
+        tryVerify(function() {
+            const shiftedAnchor = list.itemAtIndex(53)
+            return shiftedAnchor !== null
+                && Math.abs((shiftedAnchor.y - view.contentY) - anchorOffset) < 0.5
+        })
+    }
+}

--- a/test/qml/tst_nodesettings.qml
+++ b/test/qml/tst_nodesettings.qml
@@ -40,6 +40,7 @@ TestCase {
         AppMode.walletEnabled = true
         AppMode.isDesktop = true
         testNetworkTrafficTower.active = false
+        testDebugLogModel.active = false
     }
 
     function createNodeSettingsPage() {
@@ -116,6 +117,39 @@ TestCase {
         tryCompare(testNetworkTrafficTower, "active", false)
         tryVerify(function() { return findChild(page, "networkTrafficPage") === null })
     }
+
+    function test_debug_log_only_active_while_selected() {
+        const page = createNodeSettingsPage()
+
+        compare(testDebugLogModel.active, false)
+        verify(findChild(page, "settingsDebugLog") === null)
+
+        const debugLogItem = findChild(page, "settings_debuglog")
+        verify(debugLogItem !== null)
+        mouseClick(debugLogItem, debugLogItem.width / 2, debugLogItem.height / 2)
+        tryCompare(page, "currentSection", 8)
+        tryCompare(testDebugLogModel, "active", true)
+        verify(findChild(page, "settingsDebugLog") !== null)
+
+        // DesktopWallets keeps NodeSettings in its outer StackLayout. Leaving
+        // Settings for Send must unload the debug log even if it remains the
+        // selected Settings section.
+        page.visible = false
+        tryCompare(testDebugLogModel, "active", false)
+        tryVerify(function() { return findChild(page, "settingsDebugLog") === null })
+
+        page.visible = true
+        tryCompare(testDebugLogModel, "active", true)
+        verify(findChild(page, "settingsDebugLog") !== null)
+
+        const displayItem = findChild(page, "settings_display")
+        verify(displayItem !== null)
+        mouseClick(displayItem, displayItem.width / 2, displayItem.height / 2)
+        tryCompare(page, "currentSection", 2)
+        tryCompare(testDebugLogModel, "active", false)
+        tryVerify(function() { return findChild(page, "settingsDebugLog") === null })
+    }
+
     function test_wallet_section_hidden_when_disabled() {
         AppMode.walletEnabled = false
 

--- a/test/qml/tst_nodesettings.qml
+++ b/test/qml/tst_nodesettings.qml
@@ -41,6 +41,8 @@ TestCase {
         AppMode.isDesktop = true
         testNetworkTrafficTower.active = false
         testDebugLogModel.active = false
+        testDebugLogModel.filter = ""
+        testDebugLogModel.resetForTest(0, false)
     }
 
     function createNodeSettingsPage() {
@@ -150,6 +152,64 @@ TestCase {
         tryVerify(function() { return findChild(page, "settingsDebugLog") === null })
     }
 
+    function test_debug_log_load_more_appends_without_jumping_to_new_bottom() {
+        testDebugLogModel.resetForTest(100, true)
+        const page = createNodeSettingsPage()
+
+        const debugLogItem = findChild(page, "settings_debuglog")
+        verify(debugLogItem !== null)
+        mouseClick(debugLogItem, debugLogItem.width / 2, debugLogItem.height / 2)
+        tryCompare(page, "currentSection", 8)
+
+        const logView = findChild(page, "debugLogListView")
+        const loadMoreButton = findChild(page, "debugLogLoadMoreButton")
+        verify(logView !== null)
+        verify(loadMoreButton !== null)
+        tryCompare(logView, "count", 100)
+
+        logView.scrollToBottom()
+        tryCompare(logView, "atBottom", true)
+        tryCompare(loadMoreButton, "visible", true)
+        const anchoredContentY = logView.contentY
+        mouseClick(loadMoreButton, loadMoreButton.width / 2, loadMoreButton.height / 2)
+
+        tryCompare(testDebugLogModel, "loadMoreCalls", 1)
+        tryCompare(logView, "count", 120)
+        tryCompare(loadMoreButton, "visible", false)
+        verify(Math.abs(logView.contentY - anchoredContentY) < 0.5,
+               "Loading older rows should leave the previous bottom entries anchored: before="
+               + anchoredContentY + ", after=" + logView.contentY
+               + ", contentHeight=" + logView.contentHeight)
+        compare(logView.atBottom, false)
+    }
+
+    function test_debug_log_filter_matches_model_after_page_reentry() {
+        testDebugLogModel.filter = "retained filter"
+        const page = createNodeSettingsPage()
+
+        const debugLogItem = findChild(page, "settings_debuglog")
+        verify(debugLogItem !== null)
+        mouseClick(debugLogItem, debugLogItem.width / 2, debugLogItem.height / 2)
+        tryCompare(page, "currentSection", 8)
+
+        let searchField = findChild(page, "debugLogSearchField")
+        verify(searchField !== null)
+        compare(searchField.text, "retained filter")
+        searchField.text = "updated filter"
+        tryCompare(testDebugLogModel, "filter", "updated filter", 1000)
+
+        const displayItem = findChild(page, "settings_display")
+        verify(displayItem !== null)
+        mouseClick(displayItem, displayItem.width / 2, displayItem.height / 2)
+        tryCompare(page, "currentSection", 2)
+        tryVerify(function() { return findChild(page, "settingsDebugLog") === null })
+
+        mouseClick(debugLogItem, debugLogItem.width / 2, debugLogItem.height / 2)
+        tryCompare(page, "currentSection", 8)
+        searchField = findChild(page, "debugLogSearchField")
+        verify(searchField !== null)
+        compare(searchField.text, "updated filter")
+    }
     function test_wallet_section_hidden_when_disabled() {
         AppMode.walletEnabled = false
 

--- a/test/test_debuglogmodel.cpp
+++ b/test/test_debuglogmodel.cpp
@@ -13,14 +13,62 @@
 
 #include <util/fs.h>
 
+namespace {
+QByteArray Record(const QByteArray& message)
+{
+    return QByteArray{"2026-06-19T10:00:00Z "} + message + '\n';
+}
+
+bool WriteBytes(const QString& path, const QByteArray& bytes,
+                QIODevice::OpenMode mode = QIODevice::WriteOnly)
+{
+    QFile file(path);
+    if (!file.open(mode)) return false;
+    return file.write(bytes) == bytes.size();
+}
+
+QByteArray NumberedRecords(int first, int count)
+{
+    QByteArray bytes;
+    for (int i = first; i < first + count; ++i) {
+        bytes += Record("line " + QByteArray::number(i));
+    }
+    return bytes;
+}
+
+QByteArray OversizedLine(char fill)
+{
+    return QByteArray(DebugLogModel::kMaxLogLineBytes + 1, fill);
+}
+
+QString ContentAt(const DebugLogModel& model, int row)
+{
+    return model.data(model.index(row, 0), DebugLogModel::ContentRole).toString();
+}
+} // namespace
+
 class DebugLogModelTests : public QObject
 {
     Q_OBJECT
 
 private Q_SLOTS:
     void inactiveModel_ignoresRefreshUntilActivated();
-    void parsed_roles_extract_structured_log_lines();
-    void refresh_resetsOnlyOnContentChange();
+    void parsedRoles_extractStructuredLogLines();
+    void initialLoad_isSingleBatchAndDetectsHasMore();
+    void initialLoad_handlesBlankLinesAtBlockBoundaries();
+    void initialLoad_discardsOversizedPartialAndResynchronizes();
+    void initialLoad_skipsOversizedCompleteLine();
+    void deltaAfterEmptyLoad_preservesHasMoreSentinel();
+    void liveRefresh_insertsAtTopWithoutResetAndPrunesTail();
+    void liveRefresh_canFullyDisplaceCacheWithoutReset();
+    void liveRefresh_handlesDuplicateRecordsAndPartialWrites();
+    void liveRefresh_discardsOversizedPartialUntilNewline();
+    void liveRefresh_skipsOversizedCompleteLine();
+    void loadMore_insertsOlderRowsAtBottom();
+    void widerTailRequest_survivesRacesAndDeactivation();
+    void filter_updatesIncrementallyAndWhileInactive();
+    void rotation_fallsBackToFullSnapshot();
+    void loadLimit_changesKeepRetainedCacheBounded();
 };
 
 void DebugLogModelTests::inactiveModel_ignoresRefreshUntilActivated()
@@ -28,11 +76,7 @@ void DebugLogModelTests::inactiveModel_ignoresRefreshUntilActivated()
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
     const QString log_path = dir.filePath("debug.log");
-
-    QFile file(log_path);
-    QVERIFY(file.open(QIODevice::WriteOnly));
-    file.write("2026-06-19T10:00:00Z line one\n");
-    file.close();
+    QVERIFY(WriteBytes(log_path, Record("line one")));
 
     DebugLogModel model(fs::PathFromString(log_path.toStdString()));
     QVERIFY(!model.active());
@@ -45,35 +89,35 @@ void DebugLogModelTests::inactiveModel_ignoresRefreshUntilActivated()
     QTRY_COMPARE(model.rowCount(), 1);
 
     model.setActive(false);
-    QVERIFY(!model.active());
-
-    QVERIFY(file.open(QIODevice::Append | QIODevice::WriteOnly));
-    file.write("2026-06-19T10:00:01Z line two\n");
-    file.close();
+    QVERIFY(WriteBytes(log_path, Record("line two"),
+                       QIODevice::Append | QIODevice::WriteOnly));
     model.refresh(/*full_load=*/true);
     QTest::qWait(50);
     QCOMPARE(model.rowCount(), 1);
 
+    // Reactivation paints the retained row immediately, then catches up from
+    // the saved byte offset without requiring another full tail read.
+    QSignalSpy insert_spy(&model, &QAbstractItemModel::rowsInserted);
+    QSignalSpy reset_spy(&model, &QAbstractItemModel::modelReset);
     model.setActive(true);
-    QTRY_COMPARE(model.rowCount(), 2);
+    QTRY_COMPARE(ContentAt(model, 0), QStringLiteral("line two"));
+    QCOMPARE(model.rowCount(), 2);
+    QCOMPARE(insert_spy.count(), 1);
+    QCOMPARE(reset_spy.count(), 0);
 }
 
-void DebugLogModelTests::parsed_roles_extract_structured_log_lines()
+void DebugLogModelTests::parsedRoles_extractStructuredLogLines()
 {
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
     const QString log_path = dir.filePath("debug.log");
 
-    auto append_line = [&](const QByteArray& line) {
-        QFile file(log_path);
-        QVERIFY(file.open(QIODevice::Append | QIODevice::WriteOnly));
-        file.write(line + '\n');
-    };
-
-    append_line("2026-06-19T09:59:59Z connect() to 127.0.0.1:9050 failed after wait: Connection refused (61)");
-    append_line("2026-06-19T10:00:00Z Writing 0 mempool transactions to file...");
-    append_line("2026-06-19T10:00:01Z ERROR: boom <bad>");
-    append_line("2026-06-19T10:00:02Z UpdateTip: new best=abc height=1");
+    QByteArray records;
+    records += Record("connect() to 127.0.0.1:9050 failed after wait: Connection refused (61)");
+    records += Record("Writing 0 mempool transactions to file...");
+    records += Record("ERROR: boom <bad>");
+    records += Record("UpdateTip: new best=abc height=1");
+    QVERIFY(WriteBytes(log_path, records));
 
     DebugLogModel model(fs::PathFromString(log_path.toStdString()));
     model.setActive(true);
@@ -95,63 +139,472 @@ void DebugLogModelTests::parsed_roles_extract_structured_log_lines()
 
     const QModelIndex plain = model.index(2, 0);
     QCOMPARE(model.data(plain, DebugLogModel::CommandRole).toString(), QString{});
-    QCOMPARE(model.data(plain, DebugLogModel::MessageRole).toString(), QStringLiteral("Writing 0 mempool transactions to file..."));
-    QCOMPARE(model.data(plain, DebugLogModel::SeverityRole).toInt(), int(DebugLogModel::InfoSeverity));
+    QCOMPARE(model.data(plain, DebugLogModel::MessageRole).toString(),
+             QStringLiteral("Writing 0 mempool transactions to file..."));
 
     const QModelIndex endpoint = model.index(3, 0);
     QCOMPARE(model.data(endpoint, DebugLogModel::CommandRole).toString(), QString{});
     QCOMPARE(model.data(endpoint, DebugLogModel::MessageRole).toString(),
              QStringLiteral("connect() to 127.0.0.1:9050 failed after wait: Connection refused (61)"));
-    QCOMPARE(model.data(endpoint, DebugLogModel::SeverityRole).toInt(), int(DebugLogModel::InfoSeverity));
 }
 
-// buildDisplayLines() skips the model reset when the displayed lines are
-// unchanged, so a redundant refresh on an idle log does not force the
-// (non-virtualised) viewer to rebuild every delegate on the GUI thread.
-//
-// The model reads on a worker thread, so the test asserts the observable
-// consequence: the number of modelReset() emissions equals the number of real
-// content changes, regardless of how many refresh() calls are issued in
-// between. Lines are appended (never truncated) in a single write each, so a
-// concurrent read can only ever observe a complete prefix of the file and the
-// reset count stays deterministic.
-void DebugLogModelTests::refresh_resetsOnlyOnContentChange()
+void DebugLogModelTests::initialLoad_isSingleBatchAndDetectsHasMore()
+{
+    QTemporaryDir exact_dir;
+    QVERIFY(exact_dir.isValid());
+    const QString exact_path = exact_dir.filePath("debug.log");
+    QVERIFY(WriteBytes(exact_path, NumberedRecords(0, 1000)));
+
+    DebugLogModel exact_model(fs::PathFromString(exact_path.toStdString()));
+    QSignalSpy exact_reset_spy(&exact_model, &QAbstractItemModel::modelReset);
+    QSignalSpy exact_insert_spy(&exact_model, &QAbstractItemModel::rowsInserted);
+    exact_model.setActive(true);
+    QTRY_COMPARE(exact_model.rowCount(), 1000);
+    QVERIFY(!exact_model.hasMoreLines());
+    QCOMPARE(exact_reset_spy.count(), 1);
+    QCOMPARE(exact_insert_spy.count(), 0);
+
+    QTemporaryDir extra_dir;
+    QVERIFY(extra_dir.isValid());
+    const QString extra_path = extra_dir.filePath("debug.log");
+    QVERIFY(WriteBytes(extra_path, NumberedRecords(0, 1001)));
+
+    DebugLogModel extra_model(fs::PathFromString(extra_path.toStdString()));
+    QSignalSpy reset_spy(&extra_model, &QAbstractItemModel::modelReset);
+    extra_model.setActive(true);
+    QTRY_COMPARE(extra_model.rowCount(), 1000);
+    QTRY_VERIFY(extra_model.hasMoreLines());
+    QCOMPARE(reset_spy.count(), 1);
+    QCOMPARE(ContentAt(extra_model, 0), QStringLiteral("line 1000"));
+    QCOMPARE(ContentAt(extra_model, 999), QStringLiteral("line 1"));
+}
+
+void DebugLogModelTests::initialLoad_handlesBlankLinesAtBlockBoundaries()
 {
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
     const QString log_path = dir.filePath("debug.log");
 
-    auto append_line = [&](const QByteArray& line) {
-        QFile file(log_path);
-        QVERIFY(file.open(QIODevice::Append | QIODevice::WriteOnly));
-        file.write(line + '\n');
-    };
+    QByteArray bytes;
+    // More than one 64 KiB read block, with empty records around and across
+    // block boundaries. Empty lines must neither hang parsing nor consume the
+    // requested nonblank-line budget.
+    for (int i = 0; i < 1400; ++i) {
+        bytes += (i % 3 == 0) ? QByteArray{"\n"} : Record("payload " + QByteArray::number(i) + QByteArray(90, 'x'));
+    }
+    bytes += Record("very long " + QByteArray(70 * 1024, 'y'));
+    QVERIFY(bytes.size() > 64 * 1024);
+    QVERIFY(WriteBytes(log_path, bytes));
 
-    append_line("2026-06-19T10:00:00Z line one");
-    append_line("2026-06-19T10:00:01Z line two");
-    append_line("2026-06-19T10:00:02Z line three");
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setLoadLimit(400);
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 400);
+    QVERIFY(model.hasMoreLines());
+    QVERIFY(ContentAt(model, 0).startsWith(QStringLiteral("very long y")));
+    QVERIFY(ContentAt(model, 0).size() > 64 * 1024);
+}
+
+void DebugLogModelTests::initialLoad_discardsOversizedPartialAndResynchronizes()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path,
+                       Record("older one") + Record("older two") + OversizedLine('x')));
 
     DebugLogModel model(fs::PathFromString(log_path.toStdString()));
     model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 2);
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("older two"));
+    QCOMPARE(ContentAt(model, 1), QStringLiteral("older one"));
+
+    // The newline completes the discarded physical line. Parsing resumes with
+    // the first normal record after it instead of exposing a tail fragment.
+    QVERIFY(WriteBytes(log_path, QByteArray{"\n"} + Record("after oversized"),
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTRY_COMPARE(model.rowCount(), 3);
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("after oversized"));
+    QCOMPARE(ContentAt(model, 1), QStringLiteral("older two"));
+}
+
+void DebugLogModelTests::initialLoad_skipsOversizedCompleteLine()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path,
+                       Record("older") + OversizedLine('x') + '\n' + Record("newer")));
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 2);
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("newer"));
+    QCOMPARE(ContentAt(model, 1), QStringLiteral("older"));
+}
+
+void DebugLogModelTests::deltaAfterEmptyLoad_preservesHasMoreSentinel()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path, {}));
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    QSignalSpy reset_spy(&model, &QAbstractItemModel::modelReset);
+    model.setActive(true);
+    QTRY_COMPARE(reset_spy.count(), 1);
+    QCOMPARE(model.rowCount(), 0);
+
+    QVERIFY(WriteBytes(log_path, NumberedRecords(0, 1001),
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTRY_COMPARE(model.rowCount(), 1000);
+    QTRY_VERIFY(model.hasMoreLines());
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("line 1000"));
+    QCOMPARE(ContentAt(model, 999), QStringLiteral("line 1"));
+    QCOMPARE(reset_spy.count(), 1);
+
+    model.loadMore();
+    QTRY_COMPARE(model.rowCount(), 1001);
+    QVERIFY(!model.hasMoreLines());
+    QCOMPARE(ContentAt(model, 1000), QStringLiteral("line 0"));
+}
+
+void DebugLogModelTests::liveRefresh_insertsAtTopWithoutResetAndPrunesTail()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path, NumberedRecords(0, 3)));
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setLoadLimit(3);
+    model.setActive(true);
     QTRY_COMPARE(model.rowCount(), 3);
 
+    QSignalSpy insert_spy(&model, &QAbstractItemModel::rowsInserted);
+    QSignalSpy remove_spy(&model, &QAbstractItemModel::rowsRemoved);
     QSignalSpy reset_spy(&model, &QAbstractItemModel::modelReset);
+    QSignalSpy new_lines_spy(&model, &DebugLogModel::newLinesAdded);
 
-    // First real change: one new line must reset exactly once.
-    append_line("2026-06-19T10:00:03Z line four");
-    model.refresh(/*full_load=*/true);
+    QVERIFY(WriteBytes(log_path, NumberedRecords(3, 2),
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+
+    QTRY_COMPARE(ContentAt(model, 0), QStringLiteral("line 4"));
+    QCOMPARE(model.rowCount(), 3);
+    QCOMPARE(ContentAt(model, 1), QStringLiteral("line 3"));
+    QCOMPARE(ContentAt(model, 2), QStringLiteral("line 2"));
+    QCOMPARE(model.data(model.index(2, 0), DebugLogModel::LineNumberRole).toString(),
+             QStringLiteral("3"));
+    QCOMPARE(insert_spy.count(), 1);
+    QCOMPARE(insert_spy.at(0).at(1).toInt(), 0);
+    QCOMPARE(insert_spy.at(0).at(2).toInt(), 1);
+    QCOMPARE(remove_spy.count(), 1);
+    QCOMPARE(remove_spy.at(0).at(1).toInt(), 3);
+    QCOMPARE(remove_spy.at(0).at(2).toInt(), 4);
+    QCOMPARE(reset_spy.count(), 0);
+    QCOMPARE(new_lines_spy.count(), 1);
+    QCOMPARE(new_lines_spy.at(0).at(0).toInt(), 2);
+    QVERIFY(model.hasMoreLines());
+
+    model.refresh();
+    QTest::qWait(50);
+    QCOMPARE(insert_spy.count(), 1);
+    QCOMPARE(reset_spy.count(), 0);
+}
+
+void DebugLogModelTests::liveRefresh_canFullyDisplaceCacheWithoutReset()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path, NumberedRecords(0, 3)));
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setLoadLimit(3);
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 3);
+
+    QSignalSpy insert_spy(&model, &QAbstractItemModel::rowsInserted);
+    QSignalSpy remove_spy(&model, &QAbstractItemModel::rowsRemoved);
+    QSignalSpy reset_spy(&model, &QAbstractItemModel::modelReset);
+    QVERIFY(WriteBytes(log_path, NumberedRecords(3, 4),
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+
+    QTRY_COMPARE(ContentAt(model, 0), QStringLiteral("line 6"));
+    QCOMPARE(model.rowCount(), 3);
+    QCOMPARE(ContentAt(model, 1), QStringLiteral("line 5"));
+    QCOMPARE(ContentAt(model, 2), QStringLiteral("line 4"));
+    QCOMPARE(insert_spy.count(), 1);
+    QCOMPARE(insert_spy.at(0).at(1).toInt(), 0);
+    QCOMPARE(insert_spy.at(0).at(2).toInt(), 2);
+    QCOMPARE(remove_spy.count(), 1);
+    QCOMPARE(remove_spy.at(0).at(1).toInt(), 3);
+    QCOMPARE(remove_spy.at(0).at(2).toInt(), 5);
+    QCOMPARE(reset_spy.count(), 0);
+    QVERIFY(model.hasMoreLines());
+}
+
+void DebugLogModelTests::liveRefresh_handlesDuplicateRecordsAndPartialWrites()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    const QByteArray duplicate = Record("identical");
+    QVERIFY(WriteBytes(log_path, duplicate + duplicate));
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 2);
+
+    QSignalSpy insert_spy(&model, &QAbstractItemModel::rowsInserted);
+    QSignalSpy reset_spy(&model, &QAbstractItemModel::modelReset);
+    QVERIFY(WriteBytes(log_path, duplicate, QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTRY_COMPARE(model.rowCount(), 3);
+    QCOMPARE(insert_spy.count(), 1);
+    QCOMPARE(reset_spy.count(), 0);
+
+    // The incomplete record is retained off-model until its newline arrives.
+    QVERIFY(WriteBytes(log_path, QByteArray{"2026-06-19T10:00:00Z split"},
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTest::qWait(50);
+    QCOMPARE(model.rowCount(), 3);
+    QCOMPARE(insert_spy.count(), 1);
+
+    QVERIFY(WriteBytes(log_path, QByteArray{" record\n"},
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
     QTRY_COMPARE(model.rowCount(), 4);
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("split record"));
+    QCOMPARE(insert_spy.count(), 2);
+    QCOMPARE(reset_spy.count(), 0);
+}
 
-    // Redundant refresh on the now-unchanged file: must not reset.
-    model.refresh(/*full_load=*/true);
+void DebugLogModelTests::liveRefresh_discardsOversizedPartialUntilNewline()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path, Record("baseline")));
 
-    // Second real change flushes any pending read and resets once more.
-    append_line("2026-06-19T10:00:04Z line five");
-    model.refresh(/*full_load=*/true);
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 1);
+
+    QVERIFY(WriteBytes(log_path,
+                       QByteArray(DebugLogModel::kMaxLogLineBytes - 16, 'x'),
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTest::qWait(100);
+    QCOMPARE(model.rowCount(), 1);
+
+    // Cross the limit in a later watcher read, then verify further fragments
+    // remain discarded until the record boundary arrives.
+    QVERIFY(WriteBytes(log_path, QByteArray(32, 'y'),
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTest::qWait(100);
+    QVERIFY(WriteBytes(log_path, QByteArray{"ignored tail"},
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTest::qWait(100);
+    QCOMPARE(model.rowCount(), 1);
+
+    QVERIFY(WriteBytes(log_path, QByteArray{"\n"} + Record("after oversized"),
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTRY_COMPARE(model.rowCount(), 2);
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("after oversized"));
+    QCOMPARE(ContentAt(model, 1), QStringLiteral("baseline"));
+}
+
+void DebugLogModelTests::liveRefresh_skipsOversizedCompleteLine()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path, Record("baseline")));
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 1);
+
+    QVERIFY(WriteBytes(log_path,
+                       Record("before oversized") + OversizedLine('x') + '\n'
+                           + Record("after oversized"),
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTRY_COMPARE(model.rowCount(), 3);
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("after oversized"));
+    QCOMPARE(ContentAt(model, 1), QStringLiteral("before oversized"));
+    QCOMPARE(ContentAt(model, 2), QStringLiteral("baseline"));
+}
+
+void DebugLogModelTests::loadMore_insertsOlderRowsAtBottom()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path, NumberedRecords(0, 1200)));
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 1000);
+    QVERIFY(model.hasMoreLines());
+
+    QSignalSpy insert_spy(&model, &QAbstractItemModel::rowsInserted);
+    QSignalSpy reset_spy(&model, &QAbstractItemModel::modelReset);
+    model.loadMore();
+
+    QTRY_COMPARE(model.rowCount(), 1200);
+    QCOMPARE(model.loadLimit(), 2000);
+    QVERIFY(!model.hasMoreLines());
+    QCOMPARE(ContentAt(model, 999), QStringLiteral("line 200"));
+    QCOMPARE(ContentAt(model, 1000), QStringLiteral("line 199"));
+    QCOMPARE(ContentAt(model, 1199), QStringLiteral("line 0"));
+    QCOMPARE(insert_spy.count(), 1);
+    QCOMPARE(insert_spy.at(0).at(1).toInt(), 1000);
+    QCOMPARE(insert_spy.at(0).at(2).toInt(), 1199);
+    QCOMPARE(reset_spy.count(), 0);
+}
+
+void DebugLogModelTests::widerTailRequest_survivesRacesAndDeactivation()
+{
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString log_path = dir.filePath("debug.log");
+        QVERIFY(WriteBytes(log_path, NumberedRecords(0, 2500)));
+
+        DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+        model.setActive(true);
+        QTRY_COMPARE(model.rowCount(), 1000);
+
+        // The second request is issued while the first full-tail read may be
+        // in flight. A stale 2,000-row result must trigger the pending 3,000
+        // capacity read rather than becoming the final snapshot.
+        model.loadMore();
+        model.loadMore();
+        QCOMPARE(model.loadLimit(), 3000);
+        QTRY_COMPARE(model.rowCount(), 2500);
+        QVERIFY(!model.hasMoreLines());
+        QCOMPARE(ContentAt(model, 2499), QStringLiteral("line 0"));
+    }
+
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString log_path = dir.filePath("debug.log");
+        QVERIFY(WriteBytes(log_path, NumberedRecords(0, 1200)));
+
+        DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+        model.setActive(true);
+        QTRY_COMPARE(model.rowCount(), 1000);
+
+        model.loadMore();
+        model.setActive(false);
+        model.setActive(true);
+        QTRY_COMPARE(model.rowCount(), 1200);
+        QCOMPARE(model.loadLimit(), 2000);
+        QCOMPARE(ContentAt(model, 1199), QStringLiteral("line 0"));
+    }
+}
+
+void DebugLogModelTests::filter_updatesIncrementallyAndWhileInactive()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path, Record("keep old") + Record("drop old")));
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 2);
+    model.setFilter(QStringLiteral("keep"));
+    QCOMPARE(model.rowCount(), 1);
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("keep old"));
+
+    QSignalSpy insert_spy(&model, &QAbstractItemModel::rowsInserted);
+    QSignalSpy reset_spy(&model, &QAbstractItemModel::modelReset);
+    QVERIFY(WriteBytes(log_path, Record("keep new") + Record("drop new"),
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTRY_COMPARE(model.rowCount(), 2);
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("keep new"));
+    QCOMPARE(insert_spy.count(), 1);
+    QCOMPARE(reset_spy.count(), 0);
+
+    model.setActive(false);
+    model.setFilter(QStringLiteral("drop"));
+    QCOMPARE(model.rowCount(), 2);
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("drop new"));
+    QVERIFY(WriteBytes(log_path, Record("drop while inactive"),
+                       QIODevice::Append | QIODevice::WriteOnly));
+    model.refresh();
+    QTest::qWait(50);
+    QCOMPARE(model.rowCount(), 2);
+
+    QSignalSpy reactivate_reset_spy(&model, &QAbstractItemModel::modelReset);
+    model.setActive(true);
+    QTRY_COMPARE(ContentAt(model, 0), QStringLiteral("drop while inactive"));
+    QCOMPARE(model.rowCount(), 3);
+    QCOMPARE(reactivate_reset_spy.count(), 0);
+}
+
+void DebugLogModelTests::rotation_fallsBackToFullSnapshot()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path, NumberedRecords(0, 5)));
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setActive(true);
     QTRY_COMPARE(model.rowCount(), 5);
 
-    // Two content changes, three refreshes: exactly two resets.
-    QCOMPARE(reset_spy.count(), 2);
+    QSignalSpy reset_spy(&model, &QAbstractItemModel::modelReset);
+    QVERIFY(WriteBytes(log_path, Record("rotated one") + Record("rotated two")));
+    model.refresh();
+    QTRY_COMPARE(model.rowCount(), 2);
+    QCOMPARE(ContentAt(model, 0), QStringLiteral("rotated two"));
+    QCOMPARE(ContentAt(model, 1), QStringLiteral("rotated one"));
+    QCOMPARE(reset_spy.count(), 1);
+}
+
+void DebugLogModelTests::loadLimit_changesKeepRetainedCacheBounded()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+    QVERIFY(WriteBytes(log_path, NumberedRecords(0, 5)));
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    model.setLoadLimit(5);
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 5);
+    model.setActive(false);
+
+    model.setLoadLimit(2);
+    QCOMPARE(model.rowCount(), 2);
+    QVERIFY(model.hasMoreLines());
+
+    // Raising the cap while inactive forces a wider bounded tail read on the
+    // next activation; older rows are appended at the bottom.
+    QSignalSpy insert_spy(&model, &QAbstractItemModel::rowsInserted);
+    model.setLoadLimit(4);
+    QCOMPARE(model.rowCount(), 2);
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 4);
+    QCOMPARE(ContentAt(model, 3), QStringLiteral("line 1"));
+    QCOMPARE(insert_spy.count(), 1);
+    QCOMPARE(insert_spy.at(0).at(1).toInt(), 2);
+    QCOMPARE(insert_spy.at(0).at(2).toInt(), 3);
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN

--- a/test/test_debuglogmodel.cpp
+++ b/test/test_debuglogmodel.cpp
@@ -18,9 +18,45 @@ class DebugLogModelTests : public QObject
     Q_OBJECT
 
 private Q_SLOTS:
+    void inactiveModel_ignoresRefreshUntilActivated();
     void parsed_roles_extract_structured_log_lines();
     void refresh_resetsOnlyOnContentChange();
 };
+
+void DebugLogModelTests::inactiveModel_ignoresRefreshUntilActivated()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString log_path = dir.filePath("debug.log");
+
+    QFile file(log_path);
+    QVERIFY(file.open(QIODevice::WriteOnly));
+    file.write("2026-06-19T10:00:00Z line one\n");
+    file.close();
+
+    DebugLogModel model(fs::PathFromString(log_path.toStdString()));
+    QVERIFY(!model.active());
+
+    model.refresh(/*full_load=*/true);
+    QTest::qWait(50);
+    QCOMPARE(model.rowCount(), 0);
+
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 1);
+
+    model.setActive(false);
+    QVERIFY(!model.active());
+
+    QVERIFY(file.open(QIODevice::Append | QIODevice::WriteOnly));
+    file.write("2026-06-19T10:00:01Z line two\n");
+    file.close();
+    model.refresh(/*full_load=*/true);
+    QTest::qWait(50);
+    QCOMPARE(model.rowCount(), 1);
+
+    model.setActive(true);
+    QTRY_COMPARE(model.rowCount(), 2);
+}
 
 void DebugLogModelTests::parsed_roles_extract_structured_log_lines()
 {
@@ -40,7 +76,7 @@ void DebugLogModelTests::parsed_roles_extract_structured_log_lines()
     append_line("2026-06-19T10:00:02Z UpdateTip: new best=abc height=1");
 
     DebugLogModel model(fs::PathFromString(log_path.toStdString()));
-    model.refresh(/*full_load=*/true);
+    model.setActive(true);
     QTRY_COMPARE(model.rowCount(), 4);
 
     const QModelIndex update_tip = model.index(0, 0);
@@ -96,7 +132,7 @@ void DebugLogModelTests::refresh_resetsOnlyOnContentChange()
     append_line("2026-06-19T10:00:02Z line three");
 
     DebugLogModel model(fs::PathFromString(log_path.toStdString()));
-    model.refresh(/*full_load=*/true);
+    model.setActive(true);
     QTRY_COMPARE(model.rowCount(), 3);
 
     QSignalSpy reset_spy(&model, &QAbstractItemModel::modelReset);


### PR DESCRIPTION
## Summary

- Load and watch the debug log only while its settings page is selected.
- Read the bounded log tail on a worker thread and process ordinary appends incrementally instead of resetting every row.
- Limit individual physical log lines in the viewer to 1 MiB; oversized lines are skipped until their terminating newline without modifying `debug.log`.
- Initially load the newest 1,000 entries and expose older entries in 1,000-row increments through **Load more**.
- Replace the fully instantiated output with a virtualized `ListView`.
- Preserve the visible row and pixel offset across live prepends, tail pruning, and load-more appends.

## Motivation

The previous debug-log view instantiated every displayed row and rebuilt the full output whenever the model reset. A new log write could therefore trigger another full file read, model reset, and delegate rebuild, including while the debug-log page was not selected.

This change treats the model and view as one performance path: the model reads only the new bytes and publishes changed rows during normal appends, while the view instantiates only visible delegates and keeps its scroll anchor stable.

Follow-up to the performance problem described in #784 and the original viewer in #532. Contributes to #576.

Related: #768. Its targeted relative-time role update behavior is already present on `qt6` and remains intact after this refactor; this PR does not close that issue.

## Testing

- Built every commit in the branch independently.
- Built the final application with the matching non-OpenGL depends toolchain.
- Ran Bitcoin commit-message and whitespace checks on every commit.
- Ran Ruff 0.15 and `qmllint` on the changed Python and QML files.
- Ran the complete C++ unit suite: 540 passed, including `DebugLogModelTests`: 19 passed.
- Ran the complete QML suite: 391 passed; the remaining `Send::test_send_uri_import_schedules_fee_estimate` failure (`BitcoinUri is not defined`) reproduces on the PR base.
- Ran `test/functional/qml_test_debug_log.py` against the real application.
- Verified watcher-driven updates remain capped, offscreen rows are virtualized, and **Load more** adds older rows without moving the viewport.
