### PR TITLE
Close console autocomplete when leaving Console tab

### DIFF
--- a/qml/pages/node/CommandConsole.qml
+++ b/qml/pages/node/CommandConsole.qml
@@ -30,6 +30,14 @@ Page {
     property string commandDraft: ""
     property string searchDraft: ""
 
+    // True while this view's tab is the selected one. As a persistent StackLayout
+    // child, the console is never destroyed on tab changes, and its autocomplete
+    // Popup renders in the window overlay layer, so it is not hidden along with
+    // the view. The embedder binds this to its tab's checked state; when the tab
+    // is left, dismiss the popup so it cannot linger over the newly selected tab.
+    property bool tabActive: true
+    onTabActiveChanged: if (!tabActive) autocompletePopup.close()
+
     function _pushPalette() {
         rpcConsoleModel.requestColor = consoleRequestColor
         rpcConsoleModel.replyColor   = consoleReplyColor

--- a/qml/pages/wallet/DesktopWallets.qml
+++ b/qml/pages/wallet/DesktopWallets.qml
@@ -346,6 +346,7 @@ Page {
         }
         CommandConsole {
             showHeader: false
+            tabActive: consoleTabButton.checked
             walletName: walletController.isWalletLoaded && walletController.selectedWallet
                 ? walletController.selectedWallet.name
                 : ""

--- a/test/qml/tst_desktopwallets.qml
+++ b/test/qml/tst_desktopwallets.qml
@@ -97,6 +97,26 @@ TestCase {
         compare(tabs[3].iconSize, 30)
     }
 
+    function test_console_autocomplete_closes_when_switching_tabs() {
+        const page = createDesktopWallets()
+        const consoleTab = findChild(page, "consoleTabButton")
+        const activityTab = findChild(page, "activityTabButton")
+        const popup = findChild(page, "consoleAutocompletePopup")
+
+        verify(consoleTab !== null)
+        verify(activityTab !== null)
+        verify(popup !== null)
+
+        consoleTab.checked = true
+        tryCompare(consoleTab, "checked", true)
+        popup.open()
+        tryCompare(popup, "visible", true)
+
+        activityTab.checked = true
+        tryCompare(activityTab, "checked", true)
+        tryCompare(popup, "visible", false)
+    }
+
     function test_receive_options_view_address_history_opens_settings_address_stack() {
         const page = createDesktopWallets()
         const receiveTab = findChild(page, "receiveTabButton")


### PR DESCRIPTION
The RPC console lives as a persistent StackLayout child and its
autocomplete Popup renders in the window overlay layer, so hiding
the console on a tab switch does not hide the popup. It lingers over
the newly selected tab.

Add a `tabActive` property to CommandConsole, bound by DesktopWallets
to `consoleTabButton.checked`, and close the popup when the tab is
left. Keyed off the tab ButtonGroup rather than StackLayout visibility,
which never reports the transition.

fix #782