### PR TITLE
Receive page improvements

### DIFF
--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/qml">
         <file>components/AboutOptions.qml</file>
         <file>components/AddressDetailRow.qml</file>
+        <file>components/AddressLabel.qml</file>
         <file>components/AlertAction.qml</file>
         <file>components/AlertPopup.qml</file>
         <file>components/BitcoinAddressDisplayField.qml</file>

--- a/qml/components/AddressDetailRow.qml
+++ b/qml/components/AddressDetailRow.qml
@@ -4,7 +4,6 @@
 
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
-import org.bitcoincore.qt 1.0
 
 import "../controls"
 
@@ -19,25 +18,10 @@ Item {
     Layout.fillWidth: true
     implicitHeight: addressCol.implicitHeight + 20
 
-    function formatAddressRichText(addr) {
-        if (!addr) return ""
-        var primaryColor = Theme.color.neutral9
-        var secondaryColor = Theme.color.neutral7
-        var html = ""
-        for (var i = 0; i < addr.length; i += 4) {
-            var chunk = addr.substring(i, Math.min(i + 4, addr.length))
-            var color = (Math.floor(i / 4) % 2 === 0) ? primaryColor : secondaryColor
-            if (i > 0) html += " "
-            html += "<nobr><font color=\"" + color + "\">" + chunk + "</font></nobr>"
-        }
-        return html
-    }
-
     ColumnLayout {
         id: addressCol
         anchors.left: parent.left
-        anchors.right: copyIcon.left
-        anchors.rightMargin: 10
+        anchors.right: parent.right
         anchors.top: parent.top
         anchors.topMargin: 10
         spacing: 4
@@ -52,37 +36,10 @@ Item {
             lineHeightMode: Text.FixedHeight
         }
 
-        CoreText {
+        AddressLabel {
             Layout.fillWidth: true
-            horizontalAlignment: Text.AlignLeft
-            color: Theme.color.neutral9
-            font: Theme.text.monoBody.font
-            lineHeight: Theme.text.monoBody.lineHeight
-            lineHeightMode: Text.FixedHeight
-            textFormat: Text.RichText
-            text: root.formatAddressRichText(root.address)
-            wrapMode: Text.WordWrap
-        }
-    }
-
-    Icon {
-        id: copyIcon
-        anchors.right: parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        source: "qrc:/icons/copy"
-        color: Theme.color.neutral9
-        size: 24
-    }
-
-    MouseArea {
-        anchors.right: parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        width: 44
-        height: 44
-        cursorShape: Qt.PointingHandCursor
-        onClicked: {
-            Clipboard.setText(root.address)
-            root.copied()
+            address: root.address
+            onCopied: root.copied()
         }
     }
 }

--- a/qml/components/AddressLabel.qml
+++ b/qml/components/AddressLabel.qml
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
+
+import "../controls"
+
+AbstractButton {
+    id: root
+
+    property string address: ""
+    property color primaryColor: Theme.color.neutral9
+    property color secondaryColor: Theme.color.neutral7
+    property var clipboard: Clipboard
+    readonly property string formattedText: formatAddressRichText(address)
+    readonly property bool showCopiedStatus: copiedResetTimer.running
+
+    signal copied()
+
+    function formatAddressRichText(value) {
+        if (!value) return ""
+
+        var html = ""
+        for (var i = 0; i < value.length; i += 4) {
+            var chunk = value.substring(i, Math.min(i + 4, value.length))
+            var color = (Math.floor(i / 4) % 2 === 0)
+                ? root.primaryColor
+                : root.secondaryColor
+            if (i > 0) html += " "
+            html += "<nobr><font color=\"" + color + "\">" + chunk + "</font></nobr>"
+        }
+        return html
+    }
+
+    function copy() {
+        if (root.address === "" || !root.clipboard) return
+        root.clipboard.setText(root.address)
+        copiedResetTimer.restart()
+        root.copied()
+    }
+
+    hoverEnabled: AppMode.isDesktop
+    enabled: address !== ""
+    leftPadding: 8
+    rightPadding: 8
+    topPadding: 4
+    bottomPadding: 4
+    implicitHeight: content.implicitHeight + topPadding + bottomPadding
+    Accessible.name: showCopiedStatus ? qsTr("Copied") : qsTr("Copy address")
+
+    HoverHandler {
+        cursorShape: Qt.PointingHandCursor
+    }
+
+    onClicked: copy()
+
+    contentItem: Item {
+        id: content
+        implicitHeight: Math.max(addressText.paintedHeight, copiedRow.implicitHeight)
+
+        CoreText {
+            id: addressText
+            objectName: root.objectName + "Value"
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            height: paintedHeight
+            horizontalAlignment: Text.AlignLeft
+            verticalAlignment: Text.AlignTop
+            font: Theme.text.monoBody.font
+            lineHeight: Theme.text.monoBody.lineHeight
+            lineHeightMode: Text.FixedHeight
+            textFormat: Text.RichText
+            text: root.formattedText
+            wrapMode: Text.WordWrap
+            opacity: root.showCopiedStatus ? 0 : 1
+
+            Behavior on opacity {
+                NumberAnimation { duration: 150 }
+            }
+        }
+
+        RowLayout {
+            id: copiedRow
+            objectName: root.objectName + "CopiedStatus"
+            anchors.centerIn: parent
+            spacing: 6
+            opacity: root.showCopiedStatus ? 1 : 0
+            scale: root.showCopiedStatus ? 1 : 0.8
+
+            Behavior on opacity {
+                NumberAnimation { duration: 150 }
+            }
+
+            Behavior on scale {
+                NumberAnimation {
+                    duration: 150
+                    easing.type: Easing.InOutCubic
+                }
+            }
+
+            Icon {
+                Layout.alignment: Qt.AlignVCenter
+                source: "qrc:/icons/copy"
+                color: Theme.color.neutral9
+                size: 20
+            }
+
+            CoreText {
+                Layout.alignment: Qt.AlignVCenter
+                text: qsTr("Copied")
+                color: Theme.color.neutral9
+                font: Theme.text.body.font
+                lineHeight: Theme.text.body.lineHeight
+                lineHeightMode: Text.FixedHeight
+            }
+        }
+    }
+
+    background: Rectangle {
+        radius: 5
+        color: root.hovered || root.down ? Theme.color.neutral2 : "transparent"
+
+        Behavior on color {
+            ColorAnimation { duration: 150 }
+        }
+    }
+
+    Timer {
+        id: copiedResetTimer
+        interval: 1000
+    }
+}

--- a/qml/components/BitcoinAmountInputField.qml
+++ b/qml/components/BitcoinAmountInputField.qml
@@ -21,6 +21,7 @@ ColumnLayout {
     property alias unitLabelObjectName: unitLabel.objectName
     property alias errorTextObjectName: errorTextLabel.objectName
     property bool enabled: true
+    property string placeholderText: root.amount ? root.amountInputPlaceholder(root.amount.unit) : "0.00000000"
 
     signal inputTextChanged
     signal textEdited
@@ -119,7 +120,7 @@ ColumnLayout {
             color: Theme.color.neutral9
             placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
             background: Item {}
-            placeholderText: root.amount ? root.amountInputPlaceholder(root.amount.unit) : "0.00000000"
+            placeholderText: root.placeholderText
             selectByMouse: true
 
             text: ""

--- a/qml/components/ReceiveOptionsPopup.qml
+++ b/qml/components/ReceiveOptionsPopup.qml
@@ -17,7 +17,9 @@ ContextMenu {
     property alias showNoteSelf: noteSelfToggle.checked
     property alias showAddressType: addressTypeToggle.checked
     property bool showRequestActions: false
+    property bool showEditAction: false
 
+    signal editRequest()
     signal useAsTemplate()
     signal deleteFromHistory()
     signal viewAddressHistory()
@@ -53,6 +55,13 @@ ContextMenu {
     }
 
     ContextMenuDivider {}
+
+    ContextMenuButton {
+        objectName: "receiveOptionsEditButton"
+        visible: root.showEditAction
+        text: qsTr("Edit payment request")
+        onTriggered: root.editRequest()
+    }
 
     ContextMenuButton {
         objectName: "receiveOptionsViewAddressHistoryButton"

--- a/qml/controls/ContinueButton.qml
+++ b/qml/controls/ContinueButton.qml
@@ -22,6 +22,7 @@ Button {
     property color borderPressedColor: "transparent"
     property bool bold: true
     property bool busy: false
+    property url iconSource: ""
     property var textStyle: bold ? Theme.text.buttonStrong : Theme.text.button
     property int textFontPixelSize: textStyle.pixelSize
     property string textFontStyleName: textStyle.styleName
@@ -32,13 +33,21 @@ Button {
         RowLayout {
             id: contentRow
             anchors.centerIn: parent
-            spacing: 8
+            spacing: 4
 
             SpinningIndicator {
                 Layout.alignment: Qt.AlignVCenter
                 visible: root.busy
                 running: root.busy
                 color: root.textColor
+            }
+
+            Icon {
+                Layout.alignment: Qt.AlignVCenter
+                visible: !root.busy && root.iconSource.toString() !== ""
+                source: root.iconSource
+                color: root.textColor
+                size: 24
             }
 
             CoreText {

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -18,6 +18,7 @@ Page {
 
     property WalletQmlModel wallet: walletController.selectedWallet
     property PaymentRequest request: wallet ? wallet.currentPaymentRequest : null
+    property var clipboard: Clipboard
     property string requestError: ""
     property string selectedReceiveAddressType: ""
     property var availableAddressTypes: root.wallet ? root.wallet.availableReceiveAddressTypes() : []
@@ -210,7 +211,11 @@ Page {
                     x: receiveOptionsButton.x - width + receiveOptionsButton.width
                     y: receiveOptionsButton.y + receiveOptionsButton.height
                     showRequestActions: root.hasSavedRequest
+                    showEditAction: root.hasSavedRequest && !root.requestIsEditing()
                     onViewAddressHistory: root.addressHistoryRequested()
+                    onEditRequest: {
+                        if (root.request) root.request.edit()
+                    }
                     onUseAsTemplate: root.useCurrentRequestAsTemplate()
                     onDeleteFromHistory: root.deleteCurrentRequest()
                 }
@@ -224,6 +229,9 @@ Page {
                 amount: root.request ? root.request.amount : null
                 errorText: root.request ? root.request.amountError : ""
                 enabled: root.requestIsEditing()
+                placeholderText: root.requestIsEditing()
+                    ? (amountInput.amount ? amountInput.amountInputPlaceholder(amountInput.amount.unit) : "0.00000000")
+                    : "—"
                 onInputTextChanged: {
                     root.requestError = ""
                 }
@@ -262,7 +270,7 @@ Page {
                 Layout.fillWidth: true
                 visible: receiveOptionsPopup.showName
                 labelText: qsTr("Name")
-                placeholderText: qsTr("Enter name...")
+                placeholderText: root.requestIsEditing() ? qsTr("Enter name...") : "—"
                 enabled: root.requestIsEditing()
                 text: root.requestValue("label")
                 onTextEdited: {
@@ -284,7 +292,7 @@ Page {
                 Layout.fillWidth: true
                 visible: receiveOptionsPopup.showMessage
                 labelText: qsTr("Message")
-                placeholderText: qsTr("Enter message...")
+                placeholderText: root.requestIsEditing() ? qsTr("Enter message...") : "—"
                 enabled: root.requestIsEditing()
                 text: root.requestValue("message")
                 onTextEdited: {
@@ -306,7 +314,7 @@ Page {
                 Layout.fillWidth: true
                 visible: receiveOptionsPopup.showNoteSelf
                 labelText: qsTr("Note to self")
-                placeholderText: qsTr("Enter private note...")
+                placeholderText: root.requestIsEditing() ? qsTr("Enter private note...") : "—"
                 enabled: root.requestIsEditing()
                 text: root.requestValue("noteSelf")
                 onTextEdited: {
@@ -429,16 +437,22 @@ Page {
             }
 
             Item {
+                id: addressRow
+                objectName: "requestPaymentAddressRow"
+                readonly property real contentTop: (56 - Theme.text.body.lineHeight) / 2
                 Layout.fillWidth: true
                 visible: root.hasAddress
-                Layout.topMargin: root.hasAddressType ? 0 : 10
-                implicitHeight: addressLabel.height + copyLabel.height
-                height: addressLabel.height + copyLabel.height
+                implicitHeight: Math.max(
+                    56,
+                    contentTop - addressValue.topPadding + addressValue.implicitHeight
+                )
 
                 CoreText {
                     id: addressLabel
+                    objectName: "requestPaymentAddressFieldLabel"
                     anchors.left: parent.left
                     anchors.top: parent.top
+                    anchors.topMargin: addressRow.contentTop
                     horizontalAlignment: Text.AlignLeft
                     width: 128
                     text: qsTr("Address")
@@ -447,72 +461,32 @@ Page {
                     lineHeightMode: Text.FixedHeight
                 }
 
-                CoreText {
-                    id: copyLabel
-                    anchors.left: parent.left
-                    anchors.top: addressLabel.bottom
-                    horizontalAlignment: Text.AlignLeft
-                    width: 128
-                    text: qsTr("Copy")
-                    font: Theme.text.body.font
-                    lineHeight: Theme.text.body.lineHeight
-                    lineHeightMode: Text.FixedHeight
-                    color: Theme.color.orange
-                }
-
-                CoreText {
+                AddressLabel {
                     id: addressValue
                     objectName: "requestPaymentAddressText"
                     anchors.left: addressLabel.right
                     anchors.right: parent.right
                     anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    horizontalAlignment: Text.AlignLeft
-                    font: Theme.text.monoBody.font
-                    lineHeight: Theme.text.monoBody.lineHeight
-                    lineHeightMode: Text.FixedHeight
-                    wrapMode: Text.WordWrap
-                    text: root.request ? root.request.addressFormatted : ""
-                }
-
-                MouseArea {
-                    anchors.left: parent.left
-                    anchors.top: addressLabel.bottom
-                    anchors.right: parent.right
-                    anchors.bottom: parent.bottom
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        if (root.request) {
-                            Clipboard.setText(root.request.address)
-                            copiedToast.show(copyLabel, (copyLabel.paintedWidth - copyLabel.width) / 2)
-                        }
-                    }
+                    anchors.topMargin: addressRow.contentTop - topPadding
+                    address: root.requestValue("address")
+                    clipboard: root.clipboard
                 }
             }
 
             ContinueButton {
                 id: generateButton
                 objectName: "requestPaymentGenerateButton"
-                Layout.fillWidth: true
+                Layout.preferredWidth: 300
+                Layout.maximumWidth: 300
+                Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: 36
-                text: {
-                    if (!root.request || root.requestIsEditing()) {
-                        return root.hasSavedRequest
-                            ? qsTr("Update payment request")
-                            : qsTr("Generate payment request")
-                    }
-                    return qsTr("New request")
-                }
+                visible: root.requestIsEditing()
+                text: root.hasSavedRequest
+                    ? qsTr("Update payment request")
+                    : qsTr("Generate payment request")
                 onClicked: {
                     if (!root.request) return
-                    if (root.requestIsEditing()) {
-                        root.commitCurrentRequest()
-                    } else {
-                        root.request.clear()
-                        root.requestError = ""
-                        root.resetSelectedReceiveAddressType()
-                    }
+                    root.commitCurrentRequest()
                 }
 
                 Item {
@@ -524,7 +498,9 @@ Page {
 
             OutlineButton {
                 objectName: "requestPaymentCancelButton"
-                Layout.fillWidth: true
+                Layout.preferredWidth: 300
+                Layout.maximumWidth: 300
+                Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: 10
                 visible: root.request ? root.requestIsEditing() && root.hasSavedRequest : false
                 text: qsTr("Cancel")
@@ -535,135 +511,106 @@ Page {
                 }
             }
 
-            RowLayout {
-                id: generatedActions
-                objectName: "requestPaymentGeneratedActions"
+            Item {
+                id: generatedActionsContainer
                 Layout.fillWidth: true
-                Layout.topMargin: 10
+                Layout.topMargin: 36
+                Layout.preferredHeight: generatedActions.implicitHeight
                 visible: root.request ? !root.requestIsEditing() : false
-                spacing: 10
 
-                Button {
-                    id: editButton
-                    objectName: "requestPaymentEditButton"
-                    Layout.fillWidth: true
-                    Layout.preferredWidth: 0
-                    hoverEnabled: AppMode.isDesktop
-                    implicitHeight: 46
-                    Accessible.name: qsTr("Edit payment request")
+                ColumnLayout {
+                    id: generatedActions
+                    objectName: "requestPaymentGeneratedActions"
+                    anchors.top: parent.top
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    width: Math.min(610, generatedActionsContainer.width)
+                    spacing: 10
 
-                    contentItem: RowLayout {
-                        spacing: 6
-                        Item { Layout.fillWidth: true }
-                        Icon {
-                            source: "qrc:/icons/edit"
-                            color: Theme.color.neutral9
-                            size: 24
+                    RowLayout {
+                        objectName: "requestPaymentRequestActions"
+                        Layout.fillWidth: true
+                        spacing: 10
+
+                        ContinueButton {
+                            id: copyButton
+                            objectName: "requestPaymentCopyButton"
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 300
+                            Layout.maximumWidth: 300
+                            text: qsTr("Copy request")
+                            iconSource: "qrc:/icons/copy"
+                            Accessible.name: text
+
+                            onClicked: {
+                                if (root.request) {
+                                    root.clipboard.setText(root.request.qrPayload)
+                                    copiedToast.show(copyButton)
+                                }
+                            }
                         }
-                        CoreText {
-                            text: qsTr("Edit")
-                            bold: true
-                            font.pixelSize: 18
-                            color: Theme.color.neutral9
+
+                        Button {
+                            id: qrButton
+                            objectName: "requestPaymentQRButton"
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 300
+                            Layout.maximumWidth: 300
+                            hoverEnabled: AppMode.isDesktop
+                            implicitHeight: 46
+                            Accessible.name: qsTr("Show QR code")
+
+                            contentItem: RowLayout {
+                                spacing: 6
+                                Item { Layout.fillWidth: true }
+                                Icon {
+                                    source: "qrc:/icons/qr-code"
+                                    color: Theme.color.neutral9
+                                    size: 24
+                                }
+                                CoreText {
+                                    text: qsTr("QR code")
+                                    bold: true
+                                    font.pixelSize: 18
+                                    color: Theme.color.neutral9
+                                }
+                                Item { Layout.fillWidth: true }
+                            }
+
+                            background: Rectangle {
+                                implicitHeight: 46
+                                color: Theme.color.background
+                                radius: 5
+                                border.width: 1
+                                border.color: qrButton.pressed ? Theme.color.orangeLight2 : qrButton.hovered ? Theme.color.neutral9 : Theme.color.neutral6
+                                Behavior on border.color { ColorAnimation { duration: 150 } }
+                            }
+
+                            onClicked: qrPopup.open()
                         }
-                        Item { Layout.fillWidth: true }
                     }
 
-                    background: Rectangle {
-                        implicitHeight: 46
-                        color: Theme.color.background
-                        radius: 5
-                        border.width: 1
-                        border.color: editButton.pressed ? Theme.color.orangeLight2 : editButton.hovered ? Theme.color.neutral9 : Theme.color.neutral6
-                        Behavior on border.color { ColorAnimation { duration: 150 } }
+                    Separator {
+                        objectName: "requestPaymentNewRequestSeparator"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 14
                     }
 
-                    onClicked: {
-                        if (root.request) root.request.edit()
+                    OutlineButton {
+                        id: newRequestButton
+                        objectName: "requestPaymentNewRequestButton"
+                        Layout.preferredWidth: 300
+                        Layout.maximumWidth: 300
+                        Layout.alignment: Qt.AlignHCenter
+                        Layout.topMargin: 14
+                        text: qsTr("New request")
+                        onClicked: {
+                            if (!root.request) return
+                            root.request.clear()
+                            root.requestError = ""
+                            root.resetSelectedReceiveAddressType()
+                        }
                     }
                 }
-
-                Button {
-                    id: copyButton
-                    objectName: "requestPaymentCopyButton"
-                    Layout.fillWidth: true
-                    Layout.preferredWidth: 0
-                    hoverEnabled: AppMode.isDesktop
-                    implicitHeight: 46
-                    Accessible.name: qsTr("Copy payment request")
-
-                    contentItem: RowLayout {
-                        spacing: 6
-                        Item { Layout.fillWidth: true }
-                        Icon {
-                            source: "qrc:/icons/copy"
-                            color: Theme.color.neutral9
-                            size: 24
-                        }
-                        CoreText {
-                            text: qsTr("Copy")
-                            bold: true
-                            font.pixelSize: 18
-                            color: Theme.color.neutral9
-                        }
-                        Item { Layout.fillWidth: true }
-                    }
-
-                    background: Rectangle {
-                        implicitHeight: 46
-                        color: Theme.color.background
-                        radius: 5
-                        border.width: 1
-                        border.color: copyButton.pressed ? Theme.color.orangeLight2 : copyButton.hovered ? Theme.color.neutral9 : Theme.color.neutral6
-                        Behavior on border.color { ColorAnimation { duration: 150 } }
-                    }
-
-                    onClicked: {
-                        if (root.request) {
-                            Clipboard.setText(root.request.qrPayload)
-                            copiedToast.show(copyButton)
-                        }
-                    }
-                }
-
-                Button {
-                    id: qrButton
-                    objectName: "requestPaymentQRButton"
-                    Layout.fillWidth: true
-                    Layout.preferredWidth: 0
-                    hoverEnabled: AppMode.isDesktop
-                    implicitHeight: 46
-                    Accessible.name: qsTr("Show QR code")
-
-                    contentItem: RowLayout {
-                        spacing: 6
-                        Item { Layout.fillWidth: true }
-                        Icon {
-                            source: "qrc:/icons/qr-code"
-                            color: Theme.color.neutral9
-                            size: 24
-                        }
-                        CoreText {
-                            text: qsTr("QR Code")
-                            bold: true
-                            font.pixelSize: 18
-                            color: Theme.color.neutral9
-                        }
-                        Item { Layout.fillWidth: true }
-                    }
-
-                    background: Rectangle {
-                        implicitHeight: 46
-                        color: Theme.color.background
-                        radius: 5
-                        border.width: 1
-                        border.color: qrButton.pressed ? Theme.color.orangeLight2 : qrButton.hovered ? Theme.color.neutral9 : Theme.color.neutral6
-                        Behavior on border.color { ColorAnimation { duration: 150 } }
-                    }
-
-                    onClicked: qrPopup.open()
-                }
-
             }
 
             Item {
@@ -744,7 +691,7 @@ Page {
         label: root.requestValue("label")
         onCopyRequested: {
             if (root.request) {
-                Clipboard.setText(root.request.qrPayload)
+                root.clipboard.setText(root.request.qrPayload)
                 copiedToast.show(copyButton)
             }
             qrPopup.close()

--- a/test/functional/qml_test_addresses.py
+++ b/test/functional/qml_test_addresses.py
@@ -111,7 +111,7 @@ def create_payment_request_from_first_unused_address(gui, expected_address):
     gui.click("addressRowCreatePaymentRequestButton")
     gui.settle()
     wait_for_text(gui, "requestPaymentLabelInput", ADDRESS_LABEL)
-    address = "".join(gui.get_text("requestPaymentAddressText").split())
+    address = gui.get_property("requestPaymentAddressText", "address")
     assert address == expected_address, (
         f"Expected receive view address {expected_address!r}, got {address!r}"
     )

--- a/test/functional/qml_test_receive.py
+++ b/test/functional/qml_test_receive.py
@@ -264,13 +264,13 @@ def run_test():
         assert "message=pizza" in qr_code, f"QR payload missing message: {qr_code!r}"
         print(f"[qml_receive_requests] created request with QR popup payload: {qr_code}")
 
-        # Verify the "Generate QR" button now says "New request"
-        button_text = gui.get_text("requestPaymentGenerateButton")
+        # Verify the generated-state outline button says "New request"
+        button_text = gui.get_text("requestPaymentNewRequestButton")
         assert "New request" in button_text, f"Expected 'New request' button, got: {button_text!r}"
         print("[qml_receive_requests] button text correctly shows 'New request'")
 
         # Click "New request" to reset to editing state
-        gui.click("requestPaymentGenerateButton")
+        gui.click("requestPaymentNewRequestButton")
         gui.wait_for_property("requestPaymentTitle", "text", "Request a payment", timeout_ms=10000)
         button_text = gui.get_text("requestPaymentGenerateButton")
         assert "Generate payment request" in button_text, f"Expected 'Generate payment request' after clear, got: {button_text!r}"

--- a/test/qml/tst_activity.qml
+++ b/test/qml/tst_activity.qml
@@ -169,7 +169,6 @@ TestCase {
         compare(testWalletModel.lastLoadedPaymentRequestDetailId, "req-1")
         compare(testPaymentRequest.id, "req-1")
         compare(testPaymentRequest.isEditing, false)
-
         const editButton = findChild(page.currentItem, "paymentRequestDetailEdit")
         verify(editButton !== null)
         editButton.clicked()

--- a/test/qml/tst_address_components.qml
+++ b/test/qml/tst_address_components.qml
@@ -6,6 +6,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtTest 1.2
+import "../../qml/components"
 import "../../qml/pages/wallet"
 
 TestCase {
@@ -84,6 +85,28 @@ TestCase {
             scriptType: "P2WPKH"
             used: false
         }
+    }
+
+    Component {
+        id: addressLabelComponent
+
+        AddressLabel {
+            width: 120
+            address: "abcdefghijklmnopqrst"
+        }
+    }
+
+    function test_addressLabel_alternates_color_every_four_characters() {
+        const label = createTemporaryObject(addressLabelComponent, host)
+        verify(label !== null)
+
+        const primary = label.primaryColor.toString()
+        const secondary = label.secondaryColor.toString()
+        verify(label.formattedText.indexOf("<font color=\"" + primary + "\">abcd</font>") !== -1)
+        verify(label.formattedText.indexOf("<font color=\"" + secondary + "\">efgh</font>") !== -1)
+        verify(label.formattedText.indexOf("<font color=\"" + primary + "\">ijkl</font>") !== -1)
+        verify(label.formattedText.indexOf("<font color=\"" + secondary + "\">mnop</font>") !== -1)
+        verify(label.formattedText.indexOf("<font color=\"" + primary + "\">qrst</font>") !== -1)
     }
 
     function test_row_uses_display_amount_and_emits_actions() {


### PR DESCRIPTION
Fixes #807 

---

- Add a reusable `AddressLabel` component that:
    - Displays addresses in four-character groups with alternating colors.
    - Highlights on hover. Copies the full address when clicked.
- Use `AddressLabel` in address details and generated payment requests.
- Remove the redundant address Copy control and copied toast.
- Move `Edit payment request` into the overflow menu.
- Move `New Request` below the request actions as an outline button.
- Display an em dash for empty fields after a request is generated.

<img width="1236" height="959" alt="Screenshot 2026-07-29 at 3 33 08 PM" src="https://github.com/user-attachments/assets/216e148f-3a54-4822-b6fc-0fbda4ed6e89" />
