### PR TITLE
feat: Port logging Qt environment

### DIFF
--- a/qml/bitcoin.cpp
+++ b/qml/bitcoin.cpp
@@ -540,6 +540,8 @@ int QmlGuiMain(int argc, char* argv[])
     InitLogging(gArgs);
     InitParameterInteraction(gArgs);
 
+    QmlUtil::LogQtInfo();
+
     // legacy GUI: createNode()
     std::unique_ptr<interfaces::Node> node = init->makeNode();
     std::unique_ptr<interfaces::Chain> chain = init->makeChain();

--- a/qml/util.cpp
+++ b/qml/util.cpp
@@ -4,6 +4,7 @@
 
 #include <qml/util.h>
 
+#include <logging.h>
 #include <support/cleanse.h>
 
 #include <cassert>
@@ -11,9 +12,15 @@
 #include <string>
 
 #include <QByteArray>
+#include <QGuiApplication>
+#include <QJsonObject>
+#include <QPluginLoader>
+#include <QQuickStyle>
 #include <QQuickWindow>
+#include <QScreen>
 #include <QSGRendererInterface>
 #include <QString>
+#include <QSysInfo>
 
 namespace QmlUtil {
 
@@ -35,6 +42,35 @@ QString GraphicsApi(QQuickWindow* window)
 #endif
     } // no default case, so the compiler can warn about missing cases
     assert(false);
+}
+
+void LogQtInfo()
+{
+#ifdef QT_STATIC
+    const std::string qt_link{"static"};
+#else
+    const std::string qt_link{"dynamic"};
+#endif
+    LogInfo("Qt %s (%s), plugin=%s\n", qVersion(), qt_link, QGuiApplication::platformName().toStdString());
+
+    const auto static_plugins = QPluginLoader::staticPlugins();
+    if (static_plugins.empty()) {
+        LogInfo("No static plugins.\n");
+    } else {
+        LogInfo("Static plugins:\n");
+        for (const QStaticPlugin& p : static_plugins) {
+            QJsonObject meta_data = p.metaData();
+            const std::string plugin_class = meta_data.take(QString("className")).toString().toStdString();
+            const int plugin_version = meta_data.take(QString("version")).toInt();
+            LogInfo(" %s, version %d\n", plugin_class, plugin_version);
+        }
+    }
+
+    LogInfo("Qt Quick Controls style: %s\n", QQuickStyle::name().toStdString());
+    LogInfo("System: %s, %s\n", QSysInfo::prettyProductName().toStdString(), QSysInfo::buildAbi().toStdString());
+    for (const QScreen* s : QGuiApplication::screens()) {
+        LogInfo("Screen: %s %dx%d, pixel ratio=%.1f\n", s->name().toStdString(), s->size().width(), s->size().height(), s->devicePixelRatio());
+    }
 }
 
 SecureString SecureStringFromQString(const QString& value)

--- a/qml/util.h
+++ b/qml/util.h
@@ -24,6 +24,11 @@ namespace QmlUtil {
 */
 QString GraphicsApi(QQuickWindow* window);
 
+/**
+ * Writes to debug.log short info about the used Qt and the host system.
+ */
+void LogQtInfo();
+
 SecureString SecureStringFromQString(const QString& value);
 void ClearSecureString(SecureString& value);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(bitcoinqml_unit_tests
   test_receiverequesthistorymodel.cpp
   test_transaction.cpp
   test_activityfilterproxymodel.cpp
+  test_qtinfolog.cpp
   test_qtmessagefilter.cpp
   test_rpccommandexecutor.cpp
   test_rpcconsolemodel.cpp

--- a/test/test_qtinfolog.cpp
+++ b/test/test_qtinfolog.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <qml/util.h>
+
+#include <logging.h>
+
+#include <string>
+#include <vector>
+
+#include <QGuiApplication>
+#include <QString>
+
+namespace {
+std::vector<std::string> CaptureQtInfo()
+{
+    std::vector<std::string> lines;
+    LogInstance().m_print_to_file = false;
+    LogInstance().m_print_to_console = false;
+    const auto callback = LogInstance().PushBackCallback([&lines](const std::string& str) {
+        lines.push_back(str);
+    });
+    LogInstance().StartLogging();
+
+    QmlUtil::LogQtInfo();
+
+    LogInstance().DeleteCallback(callback);
+    LogInstance().DisconnectTestLogger();
+    return lines;
+}
+
+bool ContainsSubstring(const std::vector<std::string>& lines, const std::string& needle)
+{
+    for (const std::string& line : lines) {
+        if (line.find(needle) != std::string::npos) return true;
+    }
+    return false;
+}
+} // namespace
+
+class QtInfoLogTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void logsQtVersionAndPlatform();
+    void logsPluginsStyleSystemAndScreens();
+};
+
+void QtInfoLogTests::logsQtVersionAndPlatform()
+{
+    const std::vector<std::string> lines{CaptureQtInfo()};
+
+    QVERIFY(!lines.empty());
+    QVERIFY(ContainsSubstring(lines, std::string{"Qt "} + qVersion()));
+#ifdef QT_STATIC
+    QVERIFY(ContainsSubstring(lines, "(static)"));
+#else
+    QVERIFY(ContainsSubstring(lines, "(dynamic)"));
+#endif
+    QVERIFY(ContainsSubstring(lines, "plugin=" + QGuiApplication::platformName().toStdString()));
+}
+
+void QtInfoLogTests::logsPluginsStyleSystemAndScreens()
+{
+    const std::vector<std::string> lines{CaptureQtInfo()};
+
+    QVERIFY(ContainsSubstring(lines, "static plugins") || ContainsSubstring(lines, "Static plugins:"));
+    QVERIFY(ContainsSubstring(lines, "Qt Quick Controls style:"));
+    QVERIFY(ContainsSubstring(lines, "System: " + QSysInfo::prettyProductName().toStdString()));
+    for (const QScreen* screen : QGuiApplication::screens()) {
+        QVERIFY(ContainsSubstring(lines, "Screen: " + screen->name().toStdString()));
+    }
+}
+
+#ifdef BITCOINQML_NO_TEST_MAIN
+#include <test/qt_test_registry.h>
+BITCOINQML_REGISTER_QT_TEST(QtInfoLogTests)
+#else
+QTEST_MAIN(QtInfoLogTests)
+#endif
+#include "test_qtinfolog.moc"


### PR DESCRIPTION
**output:**

```
$ QT_QPA_PLATFORM=offscreen ./build/bin/bitcoin-core-app -regtest -datadir=/tmp/dd -qml_onboarded=1 -printtoconsole=1
2026-08-01T01:33:30Z Qt 6.11.1 (dynamic), plugin=offscreen
2026-08-01T01:33:30Z No static plugins.
2026-08-01T01:33:30Z Qt Quick Controls style: Basic
2026-08-01T01:33:30Z System: Arch Linux, x86_64-little_endian-lp64
2026-08-01T01:33:30Z Screen:  800x800, pixel ratio=1.0
```

Close #810