### PR TITLE
Activity: advanced filters, edited request labels, and used-address requests

### DIFF
--- a/.github/workflows/gui-functional-tests.yml
+++ b/.github/workflows/gui-functional-tests.yml
@@ -162,6 +162,7 @@ jobs:
           python3 test/functional/qml_test_password_wallet.py
           python3 test/functional/qml_test_send_receive.py
           python3 test/functional/qml_test_addresses.py
+          python3 test/functional/qml_test_address_label_sync.py
           python3 test/functional/qml_test_send_review.py
           python3 test/functional/qml_test_psbt.py
           python3 test/functional/qml_test_wallet_migration.py

--- a/qml/bitcoin_qml.qrc
+++ b/qml/bitcoin_qml.qrc
@@ -60,6 +60,7 @@
         <file>controls/ContextMenuDivider.qml</file>
         <file>controls/ContextMenuPicker.qml</file>
         <file>controls/ContextMenuToggle.qml</file>
+        <file>controls/ActivityCalendar.qml</file>
         <file>controls/ContinueButton.qml</file>
         <file>controls/DropdownButton.qml</file>
         <file>controls/CoreCheckBox.qml</file>

--- a/qml/controls/ActivityCalendar.qml
+++ b/qml/controls/ActivityCalendar.qml
@@ -1,0 +1,551 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
+
+// Date-range calendar for the Activity custom date range filter: From/To
+// display, month/year navigation, a weekday header, and a day grid with range
+// selection, hover preview, and keyboard support. It owns the selection state;
+// the caller reads startDate/endDate (or startIso/endIso) and valid/hasSelection
+// and drives it with seed()/reset()/refreshToday(). It does not touch the model:
+// applying or clearing the filter is left to the caller.
+ColumnLayout {
+    id: root
+    spacing: 8
+
+    // Public interface ------------------------------------------------------
+
+    // The picked range as local Date values (null until picked).
+    readonly property var startDate: root.customFrom
+    readonly property var endDate: root.customTo
+    // The picked range as yyyy-MM-dd strings ("" until picked). Pass these to
+    // the model rather than the Dates: a JS Date converted straight to QDate can
+    // shift a day across time zones.
+    readonly property string startIso: root.customFrom ? root.isoDate(root.customFrom) : ""
+    readonly property string endIso: root.customTo ? root.isoDate(root.customTo) : ""
+    // Both ends picked (a complete range), and any end picked.
+    readonly property bool valid: root.customFrom !== null && root.customTo !== null
+    readonly property bool hasSelection: root.customFrom !== null || root.customTo !== null
+
+    // Clear the picked range so a new one can be chosen.
+    function reset() {
+        root.customFrom = null
+        root.customTo = null
+        root.pickingEnd = false
+        root.hoverDate = null
+    }
+
+    // Refresh "today" (call when the calendar is shown) so a page left up past
+    // midnight does not keep marking yesterday as today, and drop the focus ring.
+    function refreshToday() {
+        root.todayDate = new Date()
+        root.calendarFocusDate = null
+    }
+
+    // Seed the calendar with an existing range (or nulls to start clean) and
+    // show the month of its start.
+    function seed(from, to) {
+        root.customFrom = from
+        root.customTo = to
+        root.pickingEnd = false
+        root.hoverDate = null
+        root.showCalendarMonth(from)
+    }
+
+    // Internal state --------------------------------------------------------
+
+    // Dates are shown in the same long shape as the rest of the app (see
+    // Transaction::dateTimeString), but rendered with toLocaleDateString so
+    // month names localize (a Qt.formatDate format string renders C-locale
+    // English in Qt 6), matching the localized month header and weekday row.
+    readonly property string activityDateFormat: "MMMM d, yyyy"
+
+    // customFrom and customTo are local Date values (or null). While pickingEnd
+    // is true the start is chosen and the next click sets the end; hoverDate
+    // previews the range on desktop. The calendar shows calMonth/calYear.
+    property var customFrom: null
+    property var customTo: null
+    property bool pickingEnd: false
+    property var hoverDate: null
+    property int calMonth: (new Date()).getMonth()
+    property int calYear: (new Date()).getFullYear()
+    // First day of the week for the locale, as Qt::DayOfWeek
+    // (1 = Monday .. 7 = Sunday). The mod-7 arithmetic in calendarCells() and
+    // the weekday header maps it onto JS getDay()'s 0 = Sunday .. 6 = Saturday
+    // numbering (7 % 7 == 0).
+    readonly property int weekStart: Qt.locale().firstDayOfWeek
+    property var todayDate: new Date()
+    // Day the keyboard focus ring is on while the day grid has active focus;
+    // null until the grid is first focused after opening.
+    property var calendarFocusDate: null
+
+    // The chips are too narrow for the long Activity date format (a month
+    // like September wraps), so they use the locale's short date form.
+    function formatRangeDate(date) {
+        if (!date || isNaN(date.getTime())) {
+            return ""
+        }
+        return date.toLocaleDateString(Qt.locale(), Locale.ShortFormat)
+    }
+
+    function isoDate(date) {
+        return Qt.formatDate(date, "yyyy-MM-dd")
+    }
+
+    function sameDay(a, b) {
+        return a && b && root.isoDate(a) === root.isoDate(b)
+    }
+
+    // The two ends of the range currently in play: the committed range, or the
+    // tentative one while hovering after the first click.
+    function rangeBounds() {
+        if (root.customFrom && root.customTo) {
+            return [root.customFrom, root.customTo]
+        }
+        if (root.pickingEnd && root.customFrom && root.hoverDate) {
+            return root.hoverDate < root.customFrom
+                ? [root.hoverDate, root.customFrom]
+                : [root.customFrom, root.hoverDate]
+        }
+        return null
+    }
+
+    function isRangeEndpoint(date) {
+        // Check the picked ends directly so the start lights up on the click,
+        // not only once the mouse moves and a hover range exists.
+        return root.sameDay(date, root.customFrom)
+            || root.sameDay(date, root.customTo)
+            || (root.pickingEnd && root.customFrom && root.hoverDate
+                && root.sameDay(date, root.hoverDate))
+    }
+
+    function isInRange(date) {
+        const b = root.rangeBounds()
+        return b !== null && date >= b[0] && date <= b[1]
+    }
+
+    // Cells for the displayed month: leading blanks (null) so the first day
+    // lands under its weekday for the locale, then one Date per day.
+    function calendarCells() {
+        var cells = []
+        var firstDow = new Date(root.calYear, root.calMonth, 1).getDay()
+        var lead = (firstDow - root.weekStart + 7) % 7
+        for (var i = 0; i < lead; ++i) {
+            cells.push(null)
+        }
+        var days = new Date(root.calYear, root.calMonth + 1, 0).getDate()
+        for (var d = 1; d <= days; ++d) {
+            cells.push(new Date(root.calYear, root.calMonth, d))
+        }
+        return cells
+    }
+
+    function showCalendarMonth(date) {
+        var base = (date && !isNaN(date.getTime())) ? date : new Date()
+        root.calMonth = base.getMonth()
+        root.calYear = base.getFullYear()
+    }
+
+    function stepCalendarMonth(delta) {
+        var m = root.calMonth + delta
+        var y = root.calYear
+        while (m < 0) { m += 12; y -= 1 }
+        while (m > 11) { m -= 12; y += 1 }
+        root.calMonth = m
+        root.calYear = y
+    }
+
+    // Seed the keyboard focus ring when the day grid gains focus (or after the
+    // displayed month changed under it): prefer the picked start, then today,
+    // when they are in the displayed month.
+    function ensureCalendarFocusDate() {
+        var f = root.calendarFocusDate
+        if (f && f.getMonth() === root.calMonth && f.getFullYear() === root.calYear) {
+            return
+        }
+        var seed = root.customFrom || root.todayDate
+        if (seed.getMonth() === root.calMonth && seed.getFullYear() === root.calYear) {
+            root.calendarFocusDate = new Date(seed.getFullYear(), seed.getMonth(), seed.getDate())
+        } else {
+            root.calendarFocusDate = new Date(root.calYear, root.calMonth, 1)
+        }
+    }
+
+    function moveCalendarFocus(deltaDays) {
+        root.ensureCalendarFocusDate()
+        var f = root.calendarFocusDate
+        var d = new Date(f.getFullYear(), f.getMonth(), f.getDate() + deltaDays)
+        root.calendarFocusDate = d
+        root.showCalendarMonth(d)
+    }
+
+    // Month (or, with delta +-12, year) step that carries the focus ring along,
+    // clamping the day to the target month's length.
+    function stepCalendarFocusMonth(delta) {
+        root.ensureCalendarFocusDate()
+        var f = root.calendarFocusDate
+        var m = f.getMonth() + delta
+        var y = f.getFullYear()
+        while (m < 0) { m += 12; y -= 1 }
+        while (m > 11) { m -= 12; y += 1 }
+        var days = new Date(y, m + 1, 0).getDate()
+        root.calendarFocusDate = new Date(y, m, Math.min(f.getDate(), days))
+        root.showCalendarMonth(root.calendarFocusDate)
+    }
+
+    // Range selection: the first click sets the start, the next sets the end
+    // (reordered if earlier). Once both ends are set, the next click starts a
+    // fresh range, so a reopened calendar seeded with the applied range stays
+    // usable without hitting Reset first.
+    function selectCalendarDate(date) {
+        if (root.customFrom && root.customTo) {
+            root.customFrom = null
+            root.customTo = null
+            root.pickingEnd = false
+        }
+        if (!root.pickingEnd) {
+            root.customFrom = date
+            root.customTo = null
+            root.pickingEnd = true
+        } else {
+            if (date < root.customFrom) {
+                root.customTo = root.customFrom
+                root.customFrom = date
+            } else {
+                root.customTo = date
+            }
+            root.pickingEnd = false
+        }
+        root.hoverDate = null
+    }
+
+    // Accessible label for a calendar day: the full localized date plus its
+    // selection state, so the state is announced to a screen reader and not
+    // conveyed by color alone.
+    function dayCellAccessibleName(cell) {
+        var base = cell.modelData.toLocaleDateString(Qt.locale(), root.activityDateFormat)
+        if (cell.endpoint) {
+            //: Screen reader label for a chosen start or end day in the Activity custom date range calendar. %1 is the date.
+            return qsTr("%1, selected range endpoint").arg(base)
+        }
+        if (cell.ranged) {
+            //: Screen reader label for a day inside the chosen Activity date range. %1 is the date.
+            return qsTr("%1, in selected range").arg(base)
+        }
+        if (cell.isToday) {
+            //: Screen reader label for today in the Activity date range calendar. %1 is the date.
+            return qsTr("%1, today").arg(base)
+        }
+        return base
+    }
+
+    // UI --------------------------------------------------------------------
+
+    // From / To display. The highlighted chip is the endpoint the next calendar
+    // click will set.
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        DateRangeChip {
+            objectName: "activityDateFromChip"
+            Layout.fillWidth: true
+            //: Label for the start date of the Activity custom date range.
+            label: qsTr("From")
+            value: root.formatRangeDate(root.customFrom)
+            // Lit whenever the next click sets the start: before a range is
+            // picked, and again once both ends are set (the next click then
+            // starts a fresh range).
+            highlighted: !root.pickingEnd
+        }
+
+        DateRangeChip {
+            objectName: "activityDateToChip"
+            Layout.fillWidth: true
+            //: Label for the end date of the Activity custom date range.
+            label: qsTr("To")
+            value: root.formatRangeDate(root.customTo)
+            highlighted: root.pickingEnd
+        }
+    }
+
+    // Month / year navigation: single chevrons step a month, double chevrons
+    // jump a year (to reach distant dates fast).
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 2
+
+        CalNavButton {
+            objectName: "calendarPrevYear"
+            iconSource: "image://images/caret-left"
+            doubled: true
+            //: Accessibility label for the Activity calendar control that jumps back one year.
+            accessibleName: qsTr("Previous year")
+            onClicked: root.stepCalendarMonth(-12)
+        }
+        CalNavButton {
+            objectName: "calendarPrev"
+            iconSource: "image://images/caret-left"
+            //: Accessibility label for the Activity calendar control that steps back one month.
+            accessibleName: qsTr("Previous month")
+            onClicked: root.stepCalendarMonth(-1)
+        }
+
+        CoreText {
+            objectName: "calendarMonthLabel"
+            Layout.fillWidth: true
+            // toLocaleDateString localizes the month name (a Qt.formatDate
+            // format string would render C-locale English), matching the
+            // localized weekday header.
+            text: (new Date(root.calYear, root.calMonth, 1)).toLocaleDateString(Qt.locale(), "MMMM yyyy")
+            horizontalAlignment: Text.AlignHCenter
+            color: Theme.color.neutral9
+            font.pixelSize: 15
+            bold: true
+        }
+
+        CalNavButton {
+            objectName: "calendarNext"
+            iconSource: "image://images/caret-right"
+            //: Accessibility label for the Activity calendar control that steps forward one month.
+            accessibleName: qsTr("Next month")
+            onClicked: root.stepCalendarMonth(1)
+        }
+        CalNavButton {
+            objectName: "calendarNextYear"
+            iconSource: "image://images/caret-right"
+            doubled: true
+            //: Accessibility label for the Activity calendar control that jumps forward one year.
+            accessibleName: qsTr("Next year")
+            onClicked: root.stepCalendarMonth(12)
+        }
+    }
+
+    // Weekday header, ordered by the locale's first day of week to match the day
+    // grid. Use a Grid positioner, never a Quick Layout: a Repeater inside a
+    // RowLayout/ColumnLayout/GridLayout hits a Qt 6.4 use-after-free that
+    // SIGSEGVs only headed.
+    Grid {
+        Layout.alignment: Qt.AlignHCenter
+        columns: 7
+        spacing: 0
+
+        Repeater {
+            model: 7
+            delegate: CoreText {
+                required property int index
+                readonly property int jsDay: (root.weekStart + index) % 7
+                width: 36
+                height: 22
+                text: Qt.locale().dayName(jsDay === 0 ? 7 : jsDay, Locale.ShortFormat)
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                color: Theme.color.neutral6
+                font.pixelSize: 12
+            }
+        }
+    }
+
+    // Day grid: one ItemDelegate per cell so each day is independently clickable
+    // (and reachable by the test bridge).
+    Grid {
+        id: dayGrid
+        objectName: "activityCalendarGrid"
+        Layout.alignment: Qt.AlignHCenter
+        columns: 7
+        columnSpacing: 0
+        rowSpacing: 2
+
+        // The grid is a single tab stop; arrows move the focus ring between
+        // days, PageUp/PageDown step a month (with Ctrl, a year), Enter or Space
+        // picks the day.
+        activeFocusOnTab: true
+        onActiveFocusChanged: {
+            if (activeFocus) {
+                root.ensureCalendarFocusDate()
+            }
+        }
+        Keys.onPressed: function(event) {
+            switch (event.key) {
+            case Qt.Key_Left: root.moveCalendarFocus(-1); break
+            case Qt.Key_Right: root.moveCalendarFocus(1); break
+            case Qt.Key_Up: root.moveCalendarFocus(-7); break
+            case Qt.Key_Down: root.moveCalendarFocus(7); break
+            case Qt.Key_PageUp:
+                root.stepCalendarFocusMonth(event.modifiers & Qt.ControlModifier ? -12 : -1)
+                break
+            case Qt.Key_PageDown:
+                root.stepCalendarFocusMonth(event.modifiers & Qt.ControlModifier ? 12 : 1)
+                break
+            case Qt.Key_Return:
+            case Qt.Key_Enter:
+            case Qt.Key_Space:
+                root.ensureCalendarFocusDate()
+                root.selectCalendarDate(root.calendarFocusDate)
+                break
+            default:
+                return
+            }
+            event.accepted = true
+        }
+
+        // Clear the hover preview when the pointer leaves the grid.
+        HoverHandler {
+            enabled: AppMode.isDesktop
+            onHoveredChanged: if (!hovered) root.hoverDate = null
+        }
+
+        Repeater {
+            model: root.calendarCells()
+            delegate: ItemDelegate {
+                id: dayCell
+                required property var modelData
+                width: 36
+                height: 32
+                padding: 0
+                enabled: modelData !== null
+                objectName: modelData ? "calendarDay_" + root.isoDate(modelData) : ""
+                Accessible.role: Accessible.Button
+                Accessible.name: modelData ? root.dayCellAccessibleName(dayCell) : ""
+
+                readonly property bool endpoint: modelData !== null && root.isRangeEndpoint(modelData)
+                readonly property bool ranged: modelData !== null && root.isInRange(modelData)
+                readonly property bool isToday: modelData !== null && root.sameDay(modelData, root.todayDate)
+                readonly property bool keyFocused: modelData !== null && dayGrid.activeFocus
+                    && root.calendarFocusDate !== null && root.sameDay(modelData, root.calendarFocusDate)
+
+                onClicked: {
+                    if (modelData) {
+                        root.selectCalendarDate(modelData)
+                    }
+                }
+
+                HoverHandler {
+                    enabled: AppMode.isDesktop && dayCell.modelData !== null
+                    cursorShape: Qt.PointingHandCursor
+                    onHoveredChanged: if (hovered) root.hoverDate = dayCell.modelData
+                }
+
+                background: Rectangle {
+                    visible: dayCell.modelData !== null
+                    radius: 4
+                    // Hover and press tints mark the day as clickable; the
+                    // range tint wins so the preview stays readable.
+                    color: dayCell.endpoint
+                        ? Theme.color.orange
+                        : dayCell.ranged
+                            ? Theme.color.neutral3
+                            : dayCell.down
+                                ? Theme.color.neutral4
+                                : dayCell.hovered
+                                    ? Theme.color.neutral2
+                                    : "transparent"
+                    // The 2px neutral keyboard focus ring wins over the 1px
+                    // orange today ring, so the focused day is always
+                    // identifiable.
+                    border.width: dayCell.keyFocused ? 2 : 1
+                    border.color: dayCell.keyFocused
+                        ? Theme.color.neutral9
+                        : dayCell.isToday && !dayCell.endpoint
+                            ? Theme.color.orange
+                            : "transparent"
+                }
+
+                contentItem: CoreText {
+                    text: dayCell.modelData ? dayCell.modelData.getDate() : ""
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    color: dayCell.endpoint ? Theme.color.white : Theme.color.neutral9
+                    font.pixelSize: 13
+                    // Mark today by weight too, so it does not rely on the ring color alone.
+                    bold: dayCell.isToday
+                }
+            }
+        }
+    }
+
+    // Private sub-components -------------------------------------------------
+
+    component DateRangeChip: Rectangle {
+        id: chip
+        property string label: ""
+        property string value: ""
+        property bool highlighted: false
+        //: Read for an Activity date range endpoint that has no date picked yet.
+        readonly property string accessibleValue: chip.value !== "" ? chip.value : qsTr("no date selected")
+        implicitHeight: 46
+        radius: 5
+        color: Theme.color.neutral2
+        border.color: chip.highlighted ? Theme.color.orange : "transparent"
+        border.width: 1
+        Accessible.role: Accessible.StaticText
+        Accessible.name: chip.highlighted
+            //: Accessibility name of the active Activity date range endpoint. %1 is "From" or "To", %2 the picked date or "no date selected".
+            ? qsTr("%1, %2, the next calendar selection sets this date").arg(chip.label).arg(chip.accessibleValue)
+            //: Accessibility name of an inactive Activity date range endpoint. %1 is "From" or "To", %2 the picked date or "no date selected".
+            : qsTr("%1, %2").arg(chip.label).arg(chip.accessibleValue)
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.leftMargin: 10
+            anchors.rightMargin: 10
+            anchors.topMargin: 6
+            anchors.bottomMargin: 6
+            spacing: 1
+            CoreText {
+                Layout.fillWidth: true
+                text: chip.label
+                color: Theme.color.neutral7
+                font.pixelSize: 11
+                // Weight marks the active endpoint too, so the state does not
+                // rely on the border color alone.
+                bold: chip.highlighted
+                horizontalAlignment: Text.AlignLeft
+            }
+            CoreText {
+                Layout.fillWidth: true
+                //: Placeholder in the Activity date range From/To field before a date is picked.
+                text: chip.value !== "" ? chip.value : qsTr("Select date")
+                color: chip.value !== "" ? Theme.color.neutral9 : Theme.color.neutral6
+                font.pixelSize: 14
+                horizontalAlignment: Text.AlignLeft
+                // CoreText wraps by default, which would defeat the elide and
+                // overflow the fixed-height chip on long dates.
+                wrap: false
+                elide: Text.ElideRight
+            }
+        }
+    }
+
+    // A calendar month/year step button. One caret steps a month; the year jump
+    // shows two carets, composed from the caret already in the Bitcoin Icons set
+    // (the set has no double-caret glyph).
+    component CalNavButton: ItemDelegate {
+        id: navButton
+        property url iconSource
+        property bool doubled: false
+        property string accessibleName: ""
+        implicitWidth: 28
+        implicitHeight: 28
+        padding: 0
+        Accessible.role: Accessible.Button
+        Accessible.name: navButton.accessibleName
+        contentItem: Item {
+            Row {
+                anchors.centerIn: parent
+                spacing: -5
+                Repeater {
+                    model: navButton.doubled ? 2 : 1
+                    delegate: Icon {
+                        source: navButton.iconSource
+                        color: Theme.color.orange
+                        size: 14
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/controls/ActivityCalendar.qml
+++ b/qml/controls/ActivityCalendar.qml
@@ -58,11 +58,11 @@ ColumnLayout {
 
     // Internal state --------------------------------------------------------
 
-    // Dates are shown in the same long shape as the rest of the app (see
-    // Transaction::dateTimeString), but rendered with toLocaleDateString so
-    // month names localize (a Qt.formatDate format string renders C-locale
-    // English in Qt 6), matching the localized month header and weekday row.
-    readonly property string activityDateFormat: "MMMM d, yyyy"
+    // Every date the calendar renders goes through toLocaleDateString with a
+    // Locale format rather than an explicit pattern, so the locale decides the
+    // field order as well as the month and weekday names. The chips take the
+    // short form because they are narrow; the day cells take the long form
+    // because they are only ever read aloud.
 
     // customFrom and customTo are local Date values (or null). While pickingEnd
     // is true the start is chosen and the next click sets the end; hoverDate
@@ -83,8 +83,8 @@ ColumnLayout {
     // null until the grid is first focused after opening.
     property var calendarFocusDate: null
 
-    // The chips are too narrow for the long Activity date format (a month
-    // like September wraps), so they use the locale's short date form.
+    // The chips are too narrow for a long date (a month like September wraps),
+    // so they use the locale's short date form.
     function formatRangeDate(date) {
         if (!date || isNaN(date.getTime())) {
             return ""
@@ -227,7 +227,7 @@ ColumnLayout {
     // selection state, so the state is announced to a screen reader and not
     // conveyed by color alone.
     function dayCellAccessibleName(cell) {
-        var base = cell.modelData.toLocaleDateString(Qt.locale(), root.activityDateFormat)
+        var base = cell.modelData.toLocaleDateString(Qt.locale(), Locale.LongFormat)
         if (cell.endpoint) {
             //: Screen reader label for a chosen start or end day in the Activity custom date range calendar. %1 is the date.
             return qsTr("%1, selected range endpoint").arg(base)
@@ -298,9 +298,10 @@ ColumnLayout {
         CoreText {
             objectName: "calendarMonthLabel"
             Layout.fillWidth: true
-            // toLocaleDateString localizes the month name (a Qt.formatDate
-            // format string would render C-locale English), matching the
-            // localized weekday header.
+            // The one place a pattern is unavoidable: Locale has no month-and-year
+            // format to ask for. toLocaleDateString still localizes the month name
+            // here (a Qt.formatDate format string would render C-locale English),
+            // so only the field order is fixed.
             text: (new Date(root.calYear, root.calMonth, 1)).toLocaleDateString(Qt.locale(), "MMMM yyyy")
             horizontalAlignment: Text.AlignHCenter
             color: Theme.color.neutral9

--- a/qml/controls/ActivityCalendar.qml
+++ b/qml/controls/ActivityCalendar.qml
@@ -535,16 +535,24 @@ ColumnLayout {
         Accessible.role: Accessible.Button
         Accessible.name: navButton.accessibleName
         contentItem: Item {
+            // Two plain Icons rather than a Repeater over a 1-or-2 model: a
+            // delegate inside an inline component is not wrapped in an implicit
+            // Component on Qt 6.2, which reads the delegate as the Component
+            // itself and fails to load the whole calendar. Row leaves out an
+            // invisible child, so the single caret sits exactly where it did.
             Row {
                 anchors.centerIn: parent
                 spacing: -5
-                Repeater {
-                    model: navButton.doubled ? 2 : 1
-                    delegate: Icon {
-                        source: navButton.iconSource
-                        color: Theme.color.orange
-                        size: 14
-                    }
+                Icon {
+                    source: navButton.iconSource
+                    color: Theme.color.orange
+                    size: 14
+                }
+                Icon {
+                    visible: navButton.doubled
+                    source: navButton.iconSource
+                    color: Theme.color.orange
+                    size: 14
                 }
             }
         }

--- a/qml/models/activityfilterproxymodel.cpp
+++ b/qml/models/activityfilterproxymodel.cpp
@@ -155,6 +155,80 @@ void ActivityFilterProxyModel::setDisplayUnit(int display_unit)
     Q_EMIT displayUnitChanged();
 }
 
+CAmount ActivityFilterProxyModel::minAmount() const
+{
+    return m_min_amount;
+}
+
+void ActivityFilterProxyModel::setMinAmount(CAmount min_amount)
+{
+    // Anything below zero clears the filter; amounts are always non-negative.
+    const CAmount normalized = min_amount < 0 ? -1 : min_amount;
+    if (m_min_amount == normalized) return;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    beginFilterChange();
+#endif
+    m_min_amount = normalized;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
+    invalidateFilter();
+#endif
+    Q_EMIT minAmountChanged();
+    Q_EMIT countChanged();
+}
+
+QDate ActivityFilterProxyModel::rangeStart() const
+{
+    return m_range_start;
+}
+
+void ActivityFilterProxyModel::setRangeStart(const QDate& range_start)
+{
+    if (m_range_start == range_start) return;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    beginFilterChange();
+#endif
+    m_range_start = range_start;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
+    invalidateFilter();
+#endif
+    Q_EMIT rangeChanged();
+    Q_EMIT countChanged();
+}
+
+QDate ActivityFilterProxyModel::rangeEnd() const
+{
+    return m_range_end;
+}
+
+void ActivityFilterProxyModel::setRangeEnd(const QDate& range_end)
+{
+    if (m_range_end == range_end) return;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    beginFilterChange();
+#endif
+    m_range_end = range_end;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
+    invalidateFilter();
+#endif
+    Q_EMIT rangeChanged();
+    Q_EMIT countChanged();
+}
+
+void ActivityFilterProxyModel::setCustomRange(const QString& start_iso, const QString& end_iso)
+{
+    setRangeStart(QDate::fromString(start_iso, Qt::ISODate));
+    setRangeEnd(QDate::fromString(end_iso, Qt::ISODate));
+}
+
 int ActivityFilterProxyModel::count() const
 {
     return rowCount();
@@ -174,6 +248,15 @@ bool ActivityFilterProxyModel::filterAcceptsRow(int source_row, const QModelInde
     const TypeFilter row_type = filterTypeForIndex(source_index);
     if (m_type_filter != TypeAll && row_type != m_type_filter) {
         return false;
+    }
+
+    if (m_min_amount >= 0) {
+        const CAmount net_amount = source_index.data(ActivityListModel::NetAmountSatRole).toLongLong();
+        // Compare absolute value so a send and a receive of the same size both
+        // pass a threshold, matching the Qt Widgets amount filter.
+        if (qAbs(net_amount) < m_min_amount) {
+            return false;
+        }
     }
 
     const QString search = m_search_text.trimmed();
@@ -273,6 +356,17 @@ bool ActivityFilterProxyModel::dateMatches(qint64 timestamp) const
         start_date = QDate(current_date.year(), 1, 1);
         end_date = start_date.addYears(1);
         break;
+    case CustomRange: {
+        const QDateTime row_time = QDateTime::fromSecsSinceEpoch(timestamp);
+        if (m_range_start.isValid() && row_time < QDateTime(m_range_start, QTime(0, 0))) {
+            return false;
+        }
+        // The end date is inclusive, so accept the whole of that day.
+        if (m_range_end.isValid() && row_time >= QDateTime(m_range_end.addDays(1), QTime(0, 0))) {
+            return false;
+        }
+        return true;
+    }
     case DateAll:
         return true;
     }

--- a/qml/models/activityfilterproxymodel.cpp
+++ b/qml/models/activityfilterproxymodel.cpp
@@ -241,6 +241,14 @@ bool ActivityFilterProxyModel::filterAcceptsRow(int source_row, const QModelInde
     const QModelIndex source_index = sourceModel()->index(source_row, 0, source_parent);
     if (!source_index.isValid()) return false;
 
+    // A payment request whose address already has a real transaction is only
+    // surfaced under the Payment request filter; everywhere else it is hidden so
+    // it does not duplicate that address's real transaction row.
+    if (source_index.data(ActivityListModel::IsUsedAddressRequestRole).toBool()
+        && m_type_filter != PaymentRequest) {
+        return false;
+    }
+
     if (!dateMatches(source_index.data(ActivityListModel::TimestampRole).toLongLong())) {
         return false;
     }

--- a/qml/models/activityfilterproxymodel.cpp
+++ b/qml/models/activityfilterproxymodel.cpp
@@ -184,49 +184,43 @@ QDate ActivityFilterProxyModel::rangeStart() const
     return m_range_start;
 }
 
-void ActivityFilterProxyModel::setRangeStart(const QDate& range_start)
-{
-    if (m_range_start == range_start) return;
-
-#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-    beginFilterChange();
-#endif
-    m_range_start = range_start;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-    endFilterChange(QSortFilterProxyModel::Direction::Rows);
-#else
-    invalidateFilter();
-#endif
-    Q_EMIT rangeChanged();
-    Q_EMIT countChanged();
-}
-
 QDate ActivityFilterProxyModel::rangeEnd() const
 {
     return m_range_end;
 }
 
-void ActivityFilterProxyModel::setRangeEnd(const QDate& range_end)
+bool ActivityFilterProxyModel::applyCustomRange(const QString& start_iso, const QString& end_iso)
 {
-    if (m_range_end == range_end) return;
+    const QDate start = QDate::fromString(start_iso, Qt::ISODate);
+    const QDate end = QDate::fromString(end_iso, Qt::ISODate);
+    // Reject a half-picked or inverted range outright: filtering on one would
+    // silently show nothing, which reads as a broken filter rather than a
+    // rejected input.
+    if (!start.isValid() || !end.isValid() || start > end) return false;
+
+    const bool range_changed = start != m_range_start || end != m_range_end;
+    const bool filter_changed = m_date_filter != CustomRange;
+    if (!range_changed && !filter_changed) return true;
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
     beginFilterChange();
 #endif
-    m_range_end = range_end;
+    m_range_start = start;
+    m_range_end = end;
+    m_date_filter = CustomRange;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
     endFilterChange(QSortFilterProxyModel::Direction::Rows);
 #else
     invalidateFilter();
 #endif
-    Q_EMIT rangeChanged();
-    Q_EMIT countChanged();
-}
 
-void ActivityFilterProxyModel::setCustomRange(const QString& start_iso, const QString& end_iso)
-{
-    setRangeStart(QDate::fromString(start_iso, Qt::ISODate));
-    setRangeEnd(QDate::fromString(end_iso, Qt::ISODate));
+    // Both dates and the date filter move together, so the view refilters once
+    // instead of passing through the intermediate half-applied ranges two
+    // separate setters would have published.
+    if (range_changed) Q_EMIT rangeChanged();
+    if (filter_changed) Q_EMIT dateFilterChanged();
+    Q_EMIT countChanged();
+    return true;
 }
 
 int ActivityFilterProxyModel::count() const

--- a/qml/models/activityfilterproxymodel.cpp
+++ b/qml/models/activityfilterproxymodel.cpp
@@ -350,10 +350,6 @@ bool ActivityFilterProxyModel::dateMatches(qint64 timestamp) const
         start_date = QDate(current_date.year(), current_date.month(), 1);
         end_date = start_date.addMonths(1);
         break;
-    case LastMonth:
-        end_date = QDate(current_date.year(), current_date.month(), 1);
-        start_date = end_date.addMonths(-1);
-        break;
     case ThisYear:
         start_date = QDate(current_date.year(), 1, 1);
         end_date = start_date.addYears(1);

--- a/qml/models/activityfilterproxymodel.cpp
+++ b/qml/models/activityfilterproxymodel.cpp
@@ -356,11 +356,14 @@ bool ActivityFilterProxyModel::dateMatches(qint64 timestamp) const
         break;
     case CustomRange: {
         const QDateTime row_time = QDateTime::fromSecsSinceEpoch(timestamp);
-        if (m_range_start.isValid() && row_time < QDateTime(m_range_start, QTime(0, 0))) {
+        // startOfDay() instead of midnight: when daylight saving skips
+        // midnight, QDateTime{date, QTime(0, 0)} is invalid and compares
+        // before every valid time, breaking both bounds.
+        if (m_range_start.isValid() && row_time < m_range_start.startOfDay()) {
             return false;
         }
         // The end date is inclusive, so accept the whole of that day.
-        if (m_range_end.isValid() && row_time >= QDateTime(m_range_end.addDays(1), QTime(0, 0))) {
+        if (m_range_end.isValid() && row_time >= m_range_end.addDays(1).startOfDay()) {
             return false;
         }
         return true;
@@ -369,8 +372,8 @@ bool ActivityFilterProxyModel::dateMatches(qint64 timestamp) const
         return true;
     }
 
-    const QDateTime start_of_range{start_date, QTime(0, 0)};
-    const QDateTime end_of_range{end_date, QTime(0, 0)};
+    const QDateTime start_of_range = start_date.startOfDay();
+    const QDateTime end_of_range = end_date.startOfDay();
     const QDateTime row_time = QDateTime::fromSecsSinceEpoch(timestamp);
     return row_time >= start_of_range && row_time < end_of_range;
 }

--- a/qml/models/activityfilterproxymodel.cpp
+++ b/qml/models/activityfilterproxymodel.cpp
@@ -214,9 +214,10 @@ ActivityFilterProxyModel::TypeFilter ActivityFilterProxyModel::filterTypeForInde
         return Mined;
     case Transaction::SendToAddress:
     case Transaction::SendToOther:
+        return Sent;
     case Transaction::Other:
     default:
-        return Sent;
+        return Other;
     }
 }
 
@@ -263,6 +264,10 @@ bool ActivityFilterProxyModel::dateMatches(qint64 timestamp) const
     case ThisMonth:
         start_date = QDate(current_date.year(), current_date.month(), 1);
         end_date = start_date.addMonths(1);
+        break;
+    case LastMonth:
+        end_date = QDate(current_date.year(), current_date.month(), 1);
+        start_date = end_date.addMonths(-1);
         break;
     case ThisYear:
         start_date = QDate(current_date.year(), 1, 1);

--- a/qml/models/activityfilterproxymodel.h
+++ b/qml/models/activityfilterproxymodel.h
@@ -5,7 +5,10 @@
 #ifndef BITCOIN_QML_MODELS_ACTIVITYFILTERPROXYMODEL_H
 #define BITCOIN_QML_MODELS_ACTIVITYFILTERPROXYMODEL_H
 
+#include <consensus/amount.h>
+
 #include <QByteArray>
+#include <QDate>
 #include <QHash>
 #include <QModelIndex>
 #include <QSortFilterProxyModel>
@@ -18,6 +21,9 @@ class ActivityFilterProxyModel : public QSortFilterProxyModel
     Q_PROPERTY(DateFilter dateFilter READ dateFilter WRITE setDateFilter NOTIFY dateFilterChanged)
     Q_PROPERTY(TypeFilter typeFilter READ typeFilter WRITE setTypeFilter NOTIFY typeFilterChanged)
     Q_PROPERTY(int displayUnit READ displayUnit WRITE setDisplayUnit NOTIFY displayUnitChanged)
+    Q_PROPERTY(qint64 minAmount READ minAmount WRITE setMinAmount NOTIFY minAmountChanged)
+    Q_PROPERTY(QDate rangeStart READ rangeStart WRITE setRangeStart NOTIFY rangeChanged)
+    Q_PROPERTY(QDate rangeEnd READ rangeEnd WRITE setRangeEnd NOTIFY rangeChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
 
 public:
@@ -27,7 +33,8 @@ public:
         ThisWeek,
         ThisMonth,
         LastMonth,
-        ThisYear
+        ThisYear,
+        CustomRange
     };
     Q_ENUM(DateFilter)
 
@@ -59,6 +66,20 @@ public:
     int displayUnit() const;
     void setDisplayUnit(int display_unit);
 
+    CAmount minAmount() const;
+    void setMinAmount(CAmount min_amount);
+
+    QDate rangeStart() const;
+    void setRangeStart(const QDate& range_start);
+
+    QDate rangeEnd() const;
+    void setRangeEnd(const QDate& range_end);
+
+    // Set the custom range from ISO yyyy-MM-dd strings. QML passes strings
+    // rather than assigning the QDate properties directly because the
+    // JavaScript Date to QDate conversion shifts the day across time zones.
+    Q_INVOKABLE void setCustomRange(const QString& start_iso, const QString& end_iso);
+
     int count() const;
 
     Q_INVOKABLE bool exportCsv(const QString& path) const;
@@ -68,6 +89,8 @@ Q_SIGNALS:
     void dateFilterChanged();
     void typeFilterChanged();
     void displayUnitChanged();
+    void minAmountChanged();
+    void rangeChanged();
     void countChanged();
 
 protected:
@@ -84,6 +107,9 @@ private:
     DateFilter m_date_filter{DateAll};
     TypeFilter m_type_filter{TypeAll};
     int m_display_unit{0};
+    CAmount m_min_amount{-1};
+    QDate m_range_start;
+    QDate m_range_end;
 };
 
 #endif // BITCOIN_QML_MODELS_ACTIVITYFILTERPROXYMODEL_H

--- a/qml/models/activityfilterproxymodel.h
+++ b/qml/models/activityfilterproxymodel.h
@@ -32,7 +32,6 @@ public:
         Today,
         ThisWeek,
         ThisMonth,
-        LastMonth,
         ThisYear,
         CustomRange
     };

--- a/qml/models/activityfilterproxymodel.h
+++ b/qml/models/activityfilterproxymodel.h
@@ -26,6 +26,7 @@ public:
         Today,
         ThisWeek,
         ThisMonth,
+        LastMonth,
         ThisYear
     };
     Q_ENUM(DateFilter)
@@ -36,6 +37,7 @@ public:
         Sent,
         SentToSelf,
         Mined,
+        Other,
         PaymentRequest
     };
     Q_ENUM(TypeFilter)

--- a/qml/models/activityfilterproxymodel.h
+++ b/qml/models/activityfilterproxymodel.h
@@ -22,8 +22,8 @@ class ActivityFilterProxyModel : public QSortFilterProxyModel
     Q_PROPERTY(TypeFilter typeFilter READ typeFilter WRITE setTypeFilter NOTIFY typeFilterChanged)
     Q_PROPERTY(int displayUnit READ displayUnit WRITE setDisplayUnit NOTIFY displayUnitChanged)
     Q_PROPERTY(qint64 minAmount READ minAmount WRITE setMinAmount NOTIFY minAmountChanged)
-    Q_PROPERTY(QDate rangeStart READ rangeStart WRITE setRangeStart NOTIFY rangeChanged)
-    Q_PROPERTY(QDate rangeEnd READ rangeEnd WRITE setRangeEnd NOTIFY rangeChanged)
+    Q_PROPERTY(QDate rangeStart READ rangeStart NOTIFY rangeChanged)
+    Q_PROPERTY(QDate rangeEnd READ rangeEnd NOTIFY rangeChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
 
 public:
@@ -70,15 +70,16 @@ public:
     void setMinAmount(CAmount min_amount);
 
     QDate rangeStart() const;
-    void setRangeStart(const QDate& range_start);
-
     QDate rangeEnd() const;
-    void setRangeEnd(const QDate& range_end);
 
-    // Set the custom range from ISO yyyy-MM-dd strings. QML passes strings
-    // rather than assigning the QDate properties directly because the
-    // JavaScript Date to QDate conversion shifts the day across time zones.
-    Q_INVOKABLE void setCustomRange(const QString& start_iso, const QString& end_iso);
+    // Apply a custom date range from ISO yyyy-MM-dd strings, selecting the
+    // CustomRange date filter with it. QML passes strings rather than assigning
+    // the QDate properties directly because the JavaScript Date to QDate
+    // conversion shifts the day across time zones. Returns false, changing
+    // nothing, when either date is unparseable or the range is inverted; the
+    // range is only ever set through here, which is why the two date properties
+    // are read-only.
+    Q_INVOKABLE bool applyCustomRange(const QString& start_iso, const QString& end_iso);
 
     int count() const;
 

--- a/qml/models/activitylistmodel.cpp
+++ b/qml/models/activitylistmodel.cpp
@@ -103,6 +103,8 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         return QVariant::fromValue<qlonglong>(tx->netAmount());
     case OutputIndexRole:
         return tx->idx;
+    case IsUsedAddressRequestRole:
+        return tx->isUsedAddressRequest;
     default:
         return QVariant();
     }
@@ -127,6 +129,7 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const
     roles[RequestIdRole] = "requestId";
     roles[NetAmountSatRole] = "netAmountSat";
     roles[OutputIndexRole] = "outputIndex";
+    roles[IsUsedAddressRequestRole] = "isUsedAddressRequest";
     return roles;
 }
 
@@ -241,7 +244,7 @@ void ActivityListModel::addPendingReceiveRequests()
     for (int i = 0; i < history->rowCount(); ++i) {
         QModelIndex idx = history->index(i);
         QString address = history->data(idx, ReceiveRequestHistoryModel::AddressRole).toString();
-        if (address.isEmpty() || existing_addresses.contains(address)) continue;
+        if (address.isEmpty()) continue;
 
         QString label = history->data(idx, ReceiveRequestHistoryModel::LabelRole).toString();
         CAmount amount = history->data(idx, ReceiveRequestHistoryModel::AmountSatRole).toLongLong();
@@ -249,12 +252,17 @@ void ActivityListModel::addPendingReceiveRequests()
         qint64 timestamp = QDateTime::fromString(dateIso, Qt::ISODate).toSecsSinceEpoch();
         QString reqId = history->data(idx, ReceiveRequestHistoryModel::IdRole).toString();
 
-        addReceiveRequest(address, label, amount, timestamp, reqId);
+        // A request whose address already has a real transaction is still
+        // materialized (used_address), but the proxy shows it only under the
+        // Payment request filter so it does not duplicate the real row.
+        const bool used_address = existing_addresses.contains(address);
+        addReceiveRequest(address, label, amount, timestamp, reqId, used_address);
     }
 }
 
 void ActivityListModel::addReceiveRequest(const QString& address, const QString& label,
-                                          CAmount amount, qint64 timestamp, const QString& requestId)
+                                          CAmount amount, qint64 timestamp, const QString& requestId,
+                                          bool used_address)
 {
     uint256 zero_hash;
     auto tx = QSharedPointer<Transaction>::create(zero_hash, timestamp,
@@ -262,11 +270,17 @@ void ActivityListModel::addReceiveRequest(const QString& address, const QString&
     tx->label = label.isEmpty() ? tr("Payment request") : label;
     tx->status = Transaction::Unconfirmed;
     tx->isPendingRequest = true;
+    tx->isUsedAddressRequest = used_address;
     tx->requestId = requestId;
 
     beginInsertRows(QModelIndex(), 0, 0);
     m_transactions.push_front(tx);
-    m_pending_request_addresses.insert(address);
+    // A used-address request has no unfulfilled payment to wait for, so it is
+    // not tracked for fulfillment; only unused pending requests promote to a
+    // real row when a matching transaction arrives.
+    if (!used_address) {
+        m_pending_request_addresses.insert(address);
+    }
     endInsertRows();
     Q_EMIT countChanged();
 }
@@ -363,27 +377,29 @@ int ActivityListModel::findPendingRequestIndex(const QString& address) const
 
 void ActivityListModel::fulfillPendingRequest(int index, const QSharedPointer<Transaction>& real_tx)
 {
-    QSharedPointer<Transaction> pending = m_transactions.at(index);
+    const QString address = m_transactions.at(index)->address;
 
-    pending->hash = real_tx->hash;
-    pending->status = real_tx->status;
-    pending->depth = real_tx->depth;
-    pending->time = real_tx->time;
-    pending->credit = real_tx->credit;
-    pending->debit = real_tx->debit;
-    pending->type = real_tx->type;
-    pending->idx = real_tx->idx;
-    pending->txid = real_tx->txid;
-    pending->countsForBalance = real_tx->countsForBalance;
-    pending->involvesWatchAddress = real_tx->involvesWatchAddress;
-    pending->isPendingRequest = false;
-    if (!real_tx->label.isEmpty()) {
-        pending->label = real_tx->label;
+    // The request's address now has a real transaction. Rather than consuming
+    // a request in place, keep it as a used-address request (surfaced only
+    // under the Payment request filter) and insert the transaction as its own
+    // row, so the live list matches the state rebuilt on reload. Core supports
+    // multiple receive requests per address, so mark every request for the
+    // address, not just the row that triggered the match: a single marked row
+    // would strand its siblings as pending for the rest of the session while
+    // a reload marks them all used.
+    for (int i = 0; i < m_transactions.size(); ++i) {
+        if (m_transactions[i]->isPendingRequest && m_transactions[i]->address == address &&
+            !m_transactions[i]->isUsedAddressRequest) {
+            m_transactions[i]->isUsedAddressRequest = true;
+            Q_EMIT dataChanged(this->index(i), this->index(i));
+        }
     }
+    m_pending_request_addresses.remove(address);
 
-    m_pending_request_addresses.remove(pending->address);
-
-    Q_EMIT dataChanged(this->index(index), this->index(index));
+    beginInsertRows(QModelIndex(), 0, 0);
+    m_transactions.push_front(real_tx);
+    endInsertRows();
+    Q_EMIT countChanged();
 }
 
 void ActivityListModel::subscribeToCoreSignals()

--- a/qml/models/activitylistmodel.cpp
+++ b/qml/models/activitylistmodel.cpp
@@ -50,7 +50,11 @@ void ActivityListModel::updateTransactionStatus(QSharedPointer<Transaction> tx) 
 
 void ActivityListModel::updateTransactionLabel(QSharedPointer<Transaction> tx) const
 {
-    if (m_wallet_model == nullptr) {
+    // Pending receive requests carry their own label, set when the request is
+    // saved and refreshed when it is edited. Re-reading the address book here
+    // would overwrite an edited request label with the older stored address
+    // label, so leave pending requests untouched.
+    if (m_wallet_model == nullptr || tx->isPendingRequest) {
         return;
     }
 

--- a/qml/models/activitylistmodel.cpp
+++ b/qml/models/activitylistmodel.cpp
@@ -404,14 +404,26 @@ void ActivityListModel::fulfillPendingRequest(int index, const QSharedPointer<Tr
 
 void ActivityListModel::subscribeToCoreSignals()
 {
-    // Connect signals to wallet
+    // Connect signals to wallet. The callback fires on the wallet's
+    // notification thread.
     m_handler_transaction_changed = m_wallet_model->handleTransactionChanged([this](const uint256& hash, ChangeType status) {
+        // Read the status here, on the wallet's notification thread: it already
+        // holds cs_wallet, so the try-lock inside tryGetTxStatus is guaranteed
+        // to succeed. Deferred to the GUI thread it can lose the try-lock while
+        // the wallet is still processing the block and silently drop the update.
         interfaces::WalletTxStatus wtx;
         int num_blocks;
         int64_t block_time;
-        if (m_wallet_model->tryGetTxStatus(hash, wtx, num_blocks, block_time)) {
-            updateTransaction(hash, wtx, num_blocks, block_time);
+        if (!m_wallet_model->tryGetTxStatus(hash, wtx, num_blocks, block_time)) {
+            return;
         }
+        // Apply the update on the thread the model (and its attached proxy and
+        // views) lives on: emitting row signals from the notification thread
+        // corrupts the proxy's row mapping. This is the same marshalling the
+        // Widgets TransactionTableModel does for this notification.
+        QMetaObject::invokeMethod(this, [this, hash, wtx, num_blocks, block_time] {
+            updateTransaction(hash, wtx, num_blocks, block_time);
+        }, Qt::QueuedConnection);
     });
 }
 

--- a/qml/models/activitylistmodel.h
+++ b/qml/models/activitylistmodel.h
@@ -44,7 +44,8 @@ public:
         IsPendingRequestRole,
         RequestIdRole,
         NetAmountSatRole,
-        OutputIndexRole
+        OutputIndexRole,
+        IsUsedAddressRequestRole
     };
 
     Q_INVOKABLE void reload();
@@ -56,8 +57,12 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     void setDisplayUnit(int unit);
+    // A payment request row. Set used_address when the request's address
+    // already has a real transaction; the row is then only shown under the
+    // Payment request filter and is not tracked for pending-request fulfillment.
     void addReceiveRequest(const QString& address, const QString& label,
-                           CAmount amount, qint64 timestamp, const QString& requestId);
+                           CAmount amount, qint64 timestamp, const QString& requestId,
+                           bool used_address = false);
     void updateReceiveRequest(const QString& requestId, const QString& label, CAmount amount);
     void removePendingReceiveRequest(const QString& requestId);
 

--- a/qml/models/receiverequesthistorymodel.cpp
+++ b/qml/models/receiverequesthistorymodel.cpp
@@ -162,6 +162,18 @@ QVariantList ReceiveRequestHistoryModel::matchingEntriesForAddress(const QString
     return matches;
 }
 
+std::vector<QmlRecentRequestEntry> ReceiveRequestHistoryModel::entriesForAddress(const QString& address) const
+{
+    std::vector<QmlRecentRequestEntry> matches;
+    if (address.isEmpty()) return matches;
+    for (const auto& entry : m_entries) {
+        if (QString::fromStdString(entry.recipient.address) == address) {
+            matches.push_back(entry);
+        }
+    }
+    return matches;
+}
+
 std::optional<QmlRecentRequestEntry> ReceiveRequestHistoryModel::entryById(const QString& request_id) const
 {
     bool ok{false};

--- a/qml/models/receiverequesthistorymodel.h
+++ b/qml/models/receiverequesthistorymodel.h
@@ -50,6 +50,10 @@ public:
     void prependOrReplace(const QmlRecentRequestEntry& entry);
     bool removeByRequestId(const QString& request_id);
     Q_INVOKABLE QVariantList matchingEntriesForAddress(const QString& address) const;
+    // Same match as matchingEntriesForAddress, but returns the entries so a
+    // caller can update and re-store them (used to sync a request label with an
+    // edited address book label).
+    std::vector<QmlRecentRequestEntry> entriesForAddress(const QString& address) const;
 
     std::optional<QmlRecentRequestEntry> entryById(const QString& request_id) const;
     int64_t maxId() const;

--- a/qml/models/transaction.cpp
+++ b/qml/models/transaction.cpp
@@ -58,7 +58,13 @@ QString Transaction::prettyAmount(int display_unit) const
 
 QString Transaction::dateTimeString() const
 {
-    if (isPendingRequest) return tr("Pending receive");
+    // Only a request still awaiting payment reads "Pending receive". A
+    // used-address request falls through to its creation date instead: the
+    // address having appeared in a transaction does not prove this request
+    // was paid (dust, a replaced or conflicted transaction, or a different
+    // amount all mark the address used), so no receipt is claimed, mirroring
+    // the Widgets request history, which only ever shows a request's date.
+    if (isPendingRequest && !isUsedAddressRequest) return tr("Pending receive");
 
     QDateTime dateTime = QDateTime::fromSecsSinceEpoch(time);
     QDateTime now = QDateTime::currentDateTimeUtc();

--- a/qml/models/transaction.h
+++ b/qml/models/transaction.h
@@ -71,6 +71,10 @@ public:
     bool countsForBalance;
     bool involvesWatchAddress;
     bool isPendingRequest{false};
+    // A payment request whose address already has a real transaction. It is
+    // materialized so the Payment request filter can surface it, but hidden
+    // elsewhere so it does not duplicate the address's real transaction row.
+    bool isUsedAddressRequest{false};
     QString requestId;
 
     static QList<QSharedPointer<Transaction>> fromWalletTx(const interfaces::WalletTx& tx);

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -1265,6 +1265,16 @@ void WalletQmlModel::syncPaymentRequestLabelToAddress(const QString& address, co
         if (m_activity_list_model) {
             m_activity_list_model->updateReceiveRequest(request_id, label, entry.recipient.amount);
         }
+        // A detail page or editor holding this request would otherwise keep
+        // showing its stale copy until reloaded. Skip the editor mid-edit so
+        // an unsaved draft is not clobbered.
+        if (m_detail_payment_request && m_detail_payment_request->id() == request_id) {
+            m_detail_payment_request->setLabel(label);
+        }
+        if (m_current_payment_request && m_current_payment_request->id() == request_id &&
+            !m_current_payment_request->isEditing()) {
+            m_current_payment_request->setLabel(label);
+        }
     }
 }
 

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -931,6 +931,16 @@ bool WalletQmlModel::saveCurrentPaymentRequest()
         return false;
     }
 
+    // Capture the stored label before this save replaces the entry, so the
+    // address book sync below can tell a label edit from a save that only
+    // touched other fields (amount, message).
+    std::optional<QString> previous_label;
+    if (is_update && m_receive_requests) {
+        if (const auto previous_entry = m_receive_requests->entryById(request_id_text)) {
+            previous_label = QString::fromStdString(previous_entry->recipient.label);
+        }
+    }
+
     QmlRecentRequestEntry request_entry;
     request_entry.id = request_id;
     request_entry.date = is_update ? m_current_payment_request->created() : QDateTime::currentDateTime();
@@ -978,14 +988,16 @@ bool WalletQmlModel::saveCurrentPaymentRequest()
     // Keep the address book label in sync with the request label, so the
     // Addresses page and any other address-book reader reflect an edited
     // request, matching what getNewDestination writes at creation time.
-    // Only write when this save actually changes the label, and never let an
-    // empty request label clear a label the user may have set independently
-    // on the Addresses page. Write the address book alone: Core supports
-    // multiple requests per address with their own labels, so saving this
-    // request must not fan its label out to sibling requests the way an
-    // Addresses page edit deliberately does.
+    // Only write when this edit actually changed the request label: a save
+    // that only touched the amount or message must not re-assert the request
+    // label over one set independently on the Addresses page, and an empty
+    // request label must never clear such a label. Write the address book
+    // alone: Core supports multiple requests per address with their own
+    // labels, so saving this request must not fan its label out to sibling
+    // requests the way an Addresses page edit deliberately does.
     const QString request_label = m_current_payment_request->label();
-    if (!request_label.isEmpty() && request_label != getAddressLabel(m_current_payment_request->address())) {
+    const bool label_edited = !previous_label.has_value() || request_label != *previous_label;
+    if (label_edited && !request_label.isEmpty() && request_label != getAddressLabel(m_current_payment_request->address())) {
         writeAddressBookLabel(m_current_payment_request->address(), request_label);
     }
 

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -980,10 +980,13 @@ bool WalletQmlModel::saveCurrentPaymentRequest()
     // request, matching what getNewDestination writes at creation time.
     // Only write when this save actually changes the label, and never let an
     // empty request label clear a label the user may have set independently
-    // on the Addresses page.
+    // on the Addresses page. Write the address book alone: Core supports
+    // multiple requests per address with their own labels, so saving this
+    // request must not fan its label out to sibling requests the way an
+    // Addresses page edit deliberately does.
     const QString request_label = m_current_payment_request->label();
     if (!request_label.isEmpty() && request_label != getAddressLabel(m_current_payment_request->address())) {
-        setAddressLabel(m_current_payment_request->address(), request_label);
+        writeAddressBookLabel(m_current_payment_request->address(), request_label);
     }
 
     m_current_payment_request->setIsEditing(false);
@@ -1200,6 +1203,22 @@ QString WalletQmlModel::getAddressLabel(const QString& address) const
 
 bool WalletQmlModel::setAddressLabel(const QString& address, const QString& label)
 {
+    if (!writeAddressBookLabel(address, label)) {
+        return false;
+    }
+
+    // Keep any payment request for this address in step with the edited label,
+    // so editing it on the Addresses page also updates the request and its
+    // Activity row instead of letting them diverge. This is the reverse of
+    // saveCurrentPaymentRequest, which writes an edited request label back to
+    // the address book (through writeAddressBookLabel alone: that direction
+    // must not rewrite sibling requests on the same address).
+    syncPaymentRequestLabelToAddress(address, label);
+    return true;
+}
+
+bool WalletQmlModel::writeAddressBookLabel(const QString& address, const QString& label)
+{
     if (!m_wallet || address.isEmpty()) {
         return false;
     }
@@ -1215,6 +1234,38 @@ bool WalletQmlModel::setAddressLabel(const QString& address, const QString& labe
     }
 
     return m_wallet->setAddressBook(destination, label.toStdString(), purpose);
+}
+
+void WalletQmlModel::syncPaymentRequestLabelToAddress(const QString& address, const QString& label)
+{
+    if (!m_wallet || !m_receive_requests) {
+        return;
+    }
+
+    const CTxDestination destination{DecodeDestination(address.toStdString())};
+    if (!IsValidDestination(destination)) {
+        return;
+    }
+
+    for (QmlRecentRequestEntry entry : m_receive_requests->entriesForAddress(address)) {
+        // Already in step: nothing to re-store.
+        if (QString::fromStdString(entry.recipient.label) == label) {
+            continue;
+        }
+        entry.recipient.label = label.toStdString();
+        const QString request_id{QString::number(entry.id)};
+        // Only mirror the new label into the in-memory models once it is
+        // persisted; a failed write must not leave them showing a label the
+        // wallet does not hold.
+        if (!m_wallet->setAddressReceiveRequest(destination, request_id.toStdString(),
+                                                ReceiveRequestHistoryModel::SerializeEntry(entry))) {
+            continue;
+        }
+        m_receive_requests->prependOrReplace(entry);
+        if (m_activity_list_model) {
+            m_activity_list_model->updateReceiveRequest(request_id, label, entry.recipient.amount);
+        }
+    }
 }
 
 std::vector<interfaces::WalletAddress> WalletQmlModel::getAddresses() const

--- a/qml/models/walletqmlmodel.cpp
+++ b/qml/models/walletqmlmodel.cpp
@@ -975,6 +975,17 @@ bool WalletQmlModel::saveCurrentPaymentRequest()
         }
     }
 
+    // Keep the address book label in sync with the request label, so the
+    // Addresses page and any other address-book reader reflect an edited
+    // request, matching what getNewDestination writes at creation time.
+    // Only write when this save actually changes the label, and never let an
+    // empty request label clear a label the user may have set independently
+    // on the Addresses page.
+    const QString request_label = m_current_payment_request->label();
+    if (!request_label.isEmpty() && request_label != getAddressLabel(m_current_payment_request->address())) {
+        setAddressLabel(m_current_payment_request->address(), request_label);
+    }
+
     m_current_payment_request->setIsEditing(false);
 
     if (m_detail_payment_request && m_detail_payment_request->id() == m_current_payment_request->id()) {

--- a/qml/models/walletqmlmodel.h
+++ b/qml/models/walletqmlmodel.h
@@ -177,6 +177,14 @@ public:
                         int64_t& block_time) const;
     QString getAddressLabel(const QString& address) const;
     bool setAddressLabel(const QString& address, const QString& label);
+    // Write a label to the address book only, without touching any payment
+    // request saved for the address. This is the request-save direction: a
+    // request's label is its own, so saving one request must not rewrite the
+    // labels of sibling requests on the same address.
+    bool writeAddressBookLabel(const QString& address, const QString& label);
+    // Propagate an edited address book label to any payment request saved for
+    // that address (the reverse of the request-save address book sync).
+    void syncPaymentRequestLabelToAddress(const QString& address, const QString& label);
     std::vector<interfaces::WalletAddress> getAddresses() const;
     std::map<QString, CAmount> addressBalances() const;
     std::set<QString> usedAddresses() const;

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -558,6 +558,7 @@ PageStack {
                         required property bool canBump
                         required property string replacedByTxid
                         required property bool isPendingRequest
+                        required property bool isUsedAddressRequest
                         required property string requestId
                         required property int outputIndex
 

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -115,9 +115,6 @@ PageStack {
                     return qsTr("This week")
                 case ActivityFilterProxyModel.ThisMonth:
                     return qsTr("This month")
-                case ActivityFilterProxyModel.LastMonth:
-                    //: Activity date filter option for the previous calendar month.
-                    return qsTr("Last month")
                 case ActivityFilterProxyModel.ThisYear:
                     return qsTr("This year")
                 case ActivityFilterProxyModel.CustomRange:
@@ -802,8 +799,6 @@ PageStack {
                         { text: qsTr("Today"),        value: ActivityFilterProxyModel.Today,       objectName: "activityDateToday" },
                         { text: qsTr("This week"),    value: ActivityFilterProxyModel.ThisWeek,    objectName: "activityDateThisWeek" },
                         { text: qsTr("This month"),   value: ActivityFilterProxyModel.ThisMonth,   objectName: "activityDateThisMonth" },
-                        //: Activity date filter menu entry for the previous calendar month.
-                        { text: qsTr("Last month"),   value: ActivityFilterProxyModel.LastMonth,   objectName: "activityDateLastMonth" },
                         { text: qsTr("This year"),    value: ActivityFilterProxyModel.ThisYear,    objectName: "activityDateThisYear" },
                         //: Activity date filter menu entry that opens the custom start/end date calendar.
                         { text: qsTr("Custom range"), value: ActivityFilterProxyModel.CustomRange, objectName: "activityDateCustomRange" }

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -899,10 +899,10 @@ PageStack {
                             hoverEnabled: enabled && AppMode.isDesktop
                             // Pass ISO strings rather than the Dates: a JS Date
                             // converted straight to QDate can shift a day across
-                            // time zones.
+                            // time zones. applyCustomRange selects the custom
+                            // date filter along with the range.
                             onClicked: {
-                                activityFilterProxy.setCustomRange(calendar.startIso, calendar.endIso)
-                                activityFilterProxy.dateFilter = ActivityFilterProxyModel.CustomRange
+                                activityFilterProxy.applyCustomRange(calendar.startIso, calendar.endIso)
                                 datePopup.close()
                             }
                         }

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -50,6 +50,7 @@ PageStack {
     initialItem: RowLayout {
         Page {
             id: root
+            objectName: "activityPage"
 
             Layout.alignment: Qt.AlignCenter
             Layout.fillHeight: true
@@ -64,14 +65,17 @@ PageStack {
             readonly property bool activityFiltersActive: activityFilterProxy.searchText.trim().length > 0
                 || activityFilterProxy.dateFilter !== ActivityFilterProxyModel.DateAll
                 || activityFilterProxy.typeFilter !== ActivityFilterProxyModel.TypeAll
+                || activityFilterProxy.minAmount >= 0
 
             function clearFilters() {
                 activityFilterProxy.searchText = ""
                 activityFilterProxy.dateFilter = ActivityFilterProxyModel.DateAll
                 activityFilterProxy.typeFilter = ActivityFilterProxyModel.TypeAll
+                activityFilterProxy.minAmount = -1
                 searchField.text = ""
                 datePopup.close()
                 typePopup.close()
+                amountPopup.close()
             }
 
             function toggleFilters() {
@@ -112,12 +116,92 @@ PageStack {
                 case ActivityFilterProxyModel.ThisMonth:
                     return qsTr("This month")
                 case ActivityFilterProxyModel.LastMonth:
+                    //: Activity date filter option for the previous calendar month.
                     return qsTr("Last month")
                 case ActivityFilterProxyModel.ThisYear:
                     return qsTr("This year")
+                case ActivityFilterProxyModel.CustomRange:
+                    //: Activity date filter option for a user-picked start and end date.
+                    return qsTr("Custom range")
                 default:
                     return qsTr("All dates")
                 }
+            }
+
+            function amountFilterText() {
+                if (activityFilterProxy.minAmount >= 0) {
+                    //: Activity amount filter button: shows the active minimum with its unit, e.g. "≥ 0.50000000 ₿".
+                    return qsTr("≥ %1").arg(amountFormatter.displayWithUnit)
+                }
+                //: Activity amount filter button default: no minimum amount is set.
+                return qsTr("Any amount")
+            }
+
+            // Placeholder and input mask for the minimum amount field, per
+            // display unit. The integer digits keep any accepted value below
+            // MAX_MONEY (2.1e15 sat) and within the JS exact integer range for
+            // the display round trip.
+            //
+            // The unit is a BitcoinAmount.Unit value, compared by number rather
+            // than by name: QML only exposes enum values whose name begins with
+            // a capital letter, so BitcoinAmount.mBTC and BitcoinAmount.uBTC
+            // read as undefined here and every comparison against them is false.
+            function minAmountPlaceholder(unit) {
+                switch (unit) {
+                case 3: return "0"           // SAT
+                case 2: return "0.00"        // uBTC (bits)
+                case 1: return "0.00000"     // mBTC
+                default: return "0.00000000" // BTC
+                }
+            }
+
+            function minAmountPattern(unit) {
+                switch (unit) {
+                case 3: return /^[0-9]{0,15}$/                    // SAT
+                case 2: return /^[0-9]{0,13}(\.[0-9]{0,2})?$/     // uBTC (bits)
+                case 1: return /^[0-9]{0,10}(\.[0-9]{0,5})?$/     // mBTC
+                default: return /^[0-9]{0,8}(\.[0-9]{0,8})?$/     // BTC
+                }
+            }
+
+            // A filter popup right-aligns to its button, but a wide popup on a
+            // button near the left edge (the date preset menu, sized for the
+            // calendar) would spill past the page. Clamp x so the popup stays
+            // within the page horizontally instead of overflowing the list area.
+            // Callers assign this from onAboutToShow rather than binding x to
+            // it: mapToItem is not dependency-tracked, so a binding would keep
+            // a clamp computed from stale geometry.
+            function filterPopupX(button, popup) {
+                const anchorX = button.mapToItem(root, 0, 0).x
+                const rightAligned = button.width - popup.width
+                const minX = -anchorX
+                const maxX = root.width - popup.width - anchorX
+                return Math.max(minX, Math.min(rightAligned, maxX))
+            }
+
+            // A QDate read back from the model reaches QML as a JS Date at UTC
+            // midnight; rebuild it at local midnight on the same calendar day so
+            // seeding the calendar does not read it a day early west of UTC (the
+            // read-side mirror of the Apply path, which hands the model ISO
+            // strings for the same reason).
+            function modelDateToLocal(date) {
+                return (date && !isNaN(date.getTime()))
+                    ? new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+                    : null
+            }
+
+            function applyMinAmount() {
+                var trimmed = minAmountField.text.trim()
+                if (trimmed.length === 0) {
+                    activityFilterProxy.minAmount = -1
+                    amountPopup.close()
+                    return
+                }
+                amountParser.unit = optionsModel.displayUnit
+                amountParser.display = trimmed
+                var sats = amountParser.satoshi
+                activityFilterProxy.minAmount = sats > 0 ? sats : -1
+                amountPopup.close()
             }
 
             function typeFilterText() {
@@ -131,6 +215,7 @@ PageStack {
                 case ActivityFilterProxyModel.Mined:
                     return qsTr("Mined")
                 case ActivityFilterProxyModel.Other:
+                    //: Activity type filter option for transactions that are not received, sent, sent to yourself, or mined.
                     return qsTr("Other")
                 case ActivityFilterProxyModel.PaymentRequest:
                     return qsTr("Payment request")
@@ -170,7 +255,8 @@ PageStack {
                     return qsTr("Once you send or receive bitcoin, your transactions will appear here.")
                 }
                 if (activityFiltersActive) {
-                    return qsTr("Try changing your search, date, or type filters.")
+                    //: Empty state hint when the active search, date, type, or amount filters match no transactions.
+                    return qsTr("Try changing your search, date, type, or amount filters.")
                 }
                 return ""
             }
@@ -193,6 +279,15 @@ PageStack {
                 sourceModel: walletController.selectedWallet.activityListModel
                 displayUnit: optionsModel.displayUnit
             }
+
+            // Helpers for the amount filter: amountFormatter tracks the active
+            // minimum for display; amountParser parses typed input on Apply.
+            BitcoinAmount {
+                id: amountFormatter
+                unit: optionsModel.displayUnit
+                satoshi: Math.max(0, activityFilterProxy.minAmount)
+            }
+            BitcoinAmount { id: amountParser }
 
             AppSettings {
                 id: activitySettings
@@ -270,13 +365,13 @@ PageStack {
                     }
                 }
 
-                RowLayout {
+                ColumnLayout {
                     id: filterRow
                     anchors.left: parent.left
                     anchors.right: parent.right
                     anchors.top: activityHeader.bottom
                     anchors.topMargin: 10
-                    spacing: 15
+                    spacing: 10
                     visible: root.filtersVisible
                     height: visible ? implicitHeight : 0
 
@@ -284,7 +379,6 @@ PageStack {
                         id: searchField
                         objectName: "activitySearchField"
                         Layout.fillWidth: true
-                        Layout.minimumWidth: 160
                         implicitHeight: 37
                         leftPadding: 15
                         rightPadding: clearSearchButton.visible ? 36 : 10
@@ -318,24 +412,41 @@ PageStack {
                         }
                     }
 
-                    DropdownButton {
-                        id: dateFilterButton
-                        objectName: "activityDateFilterButton"
-                        text: root.dateFilterText()
-                        textColor: Theme.color.neutral7
-                        textAlignment: Text.AlignHCenter
-                        opened: datePopup.visible
-                        onClicked: datePopup.opened ? datePopup.close() : datePopup.open()
-                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 15
 
-                    DropdownButton {
-                        id: typeFilterButton
-                        objectName: "activityTypeFilterButton"
-                        text: root.typeFilterText()
-                        textColor: Theme.color.neutral7
-                        textAlignment: Text.AlignHCenter
-                        opened: typePopup.visible
-                        onClicked: typePopup.opened ? typePopup.close() : typePopup.open()
+                        DropdownButton {
+                            id: dateFilterButton
+                            objectName: "activityDateFilterButton"
+                            text: root.dateFilterText()
+                            textColor: Theme.color.neutral7
+                            textAlignment: Text.AlignHCenter
+                            opened: datePopup.visible
+                            onClicked: datePopup.opened ? datePopup.close() : datePopup.open()
+                        }
+
+                        DropdownButton {
+                            id: typeFilterButton
+                            objectName: "activityTypeFilterButton"
+                            text: root.typeFilterText()
+                            textColor: Theme.color.neutral7
+                            textAlignment: Text.AlignHCenter
+                            opened: typePopup.visible
+                            onClicked: typePopup.opened ? typePopup.close() : typePopup.open()
+                        }
+
+                        DropdownButton {
+                            id: amountFilterButton
+                            objectName: "activityAmountFilterButton"
+                            text: root.amountFilterText()
+                            textColor: Theme.color.neutral7
+                            textAlignment: Text.AlignHCenter
+                            opened: amountPopup.visible
+                            onClicked: amountPopup.opened ? amountPopup.close() : amountPopup.open()
+                        }
+
+                        Item { Layout.fillWidth: true }
                     }
                 }
             }
@@ -637,25 +748,155 @@ PageStack {
                 id: datePopup
                 objectName: "activityDateFilterPopup"
                 parent: dateFilterButton
-                x: datePopup.parent.width - datePopup.width
                 y: datePopup.parent.height + 2
+                minMenuWidth: 280
                 modal: true
                 dim: false
 
+                property bool dateCustomExpanded: false
+
+                // Seed before the popup becomes visible, not from onOpened:
+                // onOpened only fires once the enter transition finishes, so a
+                // click landing during the animation (a fast user, or the test
+                // bridge) would be undone by the late re-seed.
+                onAboutToShow: {
+                    x = root.filterPopupX(dateFilterButton, datePopup)
+                    calendar.refreshToday()
+                    var applied = activityFilterProxy.dateFilter === ActivityFilterProxyModel.CustomRange
+                    datePopup.dateCustomExpanded = applied
+                    // Only seed the draft from an applied range; otherwise start
+                    // clean, so a reset or a discarded selection does not reappear.
+                    if (applied) {
+                        calendar.seed(root.modelDateToLocal(activityFilterProxy.rangeStart),
+                                      root.modelDateToLocal(activityFilterProxy.rangeEnd))
+                    } else {
+                        calendar.seed(null, null)
+                    }
+                }
+
+                onClosed: {
+                    // Restore the pane to match the applied filter on close, so a
+                    // reopen shows the right pane from the first frame instead of
+                    // flashing the calendar before it collapses back to presets.
+                    datePopup.dateCustomExpanded =
+                        activityFilterProxy.dateFilter === ActivityFilterProxyModel.CustomRange
+                }
+
                 ContextMenuPicker {
+                    // Hidden while picking a custom range so the popup shows the
+                    // calendar instead of presets plus calendar (which overflows).
+                    visible: !datePopup.dateCustomExpanded
                     objectNameRole: "objectName"
                     currentValue: activityFilterProxy.dateFilter
                     model: [
-                        { text: qsTr("All"),         value: ActivityFilterProxyModel.DateAll,   objectName: "activityDateAll" },
-                        { text: qsTr("Today"),       value: ActivityFilterProxyModel.Today,     objectName: "activityDateToday" },
-                        { text: qsTr("This week"),   value: ActivityFilterProxyModel.ThisWeek,  objectName: "activityDateThisWeek" },
-                        { text: qsTr("This month"),  value: ActivityFilterProxyModel.ThisMonth, objectName: "activityDateThisMonth" },
-                        { text: qsTr("Last month"),  value: ActivityFilterProxyModel.LastMonth, objectName: "activityDateLastMonth" },
-                        { text: qsTr("This year"),   value: ActivityFilterProxyModel.ThisYear,  objectName: "activityDateThisYear" }
+                        { text: qsTr("All"),          value: ActivityFilterProxyModel.DateAll,     objectName: "activityDateAll" },
+                        { text: qsTr("Today"),        value: ActivityFilterProxyModel.Today,       objectName: "activityDateToday" },
+                        { text: qsTr("This week"),    value: ActivityFilterProxyModel.ThisWeek,    objectName: "activityDateThisWeek" },
+                        { text: qsTr("This month"),   value: ActivityFilterProxyModel.ThisMonth,   objectName: "activityDateThisMonth" },
+                        //: Activity date filter menu entry for the previous calendar month.
+                        { text: qsTr("Last month"),   value: ActivityFilterProxyModel.LastMonth,   objectName: "activityDateLastMonth" },
+                        { text: qsTr("This year"),    value: ActivityFilterProxyModel.ThisYear,    objectName: "activityDateThisYear" },
+                        //: Activity date filter menu entry that opens the custom start/end date calendar.
+                        { text: qsTr("Custom range"), value: ActivityFilterProxyModel.CustomRange, objectName: "activityDateCustomRange" }
                     ]
                     onActivated: function(value) {
+                        if (value === ActivityFilterProxyModel.CustomRange) {
+                            datePopup.dateCustomExpanded = true
+                            return
+                        }
                         activityFilterProxy.dateFilter = value
+                        datePopup.dateCustomExpanded = false
                         datePopup.close()
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 8
+                    Layout.rightMargin: 8
+                    Layout.bottomMargin: 6
+                    spacing: 8
+                    visible: datePopup.dateCustomExpanded
+
+                    // Return to the preset list.
+                    ItemDelegate {
+                        objectName: "activityDatePresetsBack"
+                        Layout.fillWidth: true
+                        implicitHeight: 30
+                        padding: 0
+                        //: Accessibility label for the control that leaves the custom date range calendar and returns to the date presets.
+                        Accessible.name: qsTr("Back to date presets")
+                        Accessible.role: Accessible.Button
+                        contentItem: RowLayout {
+                            spacing: 4
+                            Icon {
+                                source: "image://images/caret-left"
+                                color: Theme.color.orange
+                                size: 14
+                            }
+                            CoreText {
+                                Layout.fillWidth: true
+                                //: Activity custom date range: link back to the list of date presets.
+                                text: qsTr("Presets")
+                                color: Theme.color.orange
+                                font.pixelSize: 14
+                                horizontalAlignment: Text.AlignLeft
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                        }
+                        onClicked: datePopup.dateCustomExpanded = false
+                    }
+
+                    Separator { Layout.fillWidth: true }
+
+                    ActivityCalendar {
+                        id: calendar
+                        objectName: "activityCalendar"
+                        Layout.fillWidth: true
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 2
+
+                        TextButton {
+                            objectName: "activityDateRangeReset"
+                            //: Button that clears the Activity custom date range.
+                            text: qsTr("Reset")
+                            textSize: 15
+                            // Nothing to reset until a date has been picked.
+                            enabled: calendar.hasSelection
+                            textColor: enabled ? Theme.color.neutral7 : Theme.color.neutral5
+                            // A disabled control still receives hover, which would
+                            // trigger the button's hover recolor; gate it on enabled.
+                            hoverEnabled: enabled && AppMode.isDesktop
+                            // Clear the picked dates and drop the applied filter,
+                            // but stay in the calendar so a new range can be picked.
+                            onClicked: {
+                                calendar.reset()
+                                activityFilterProxy.dateFilter = ActivityFilterProxyModel.DateAll
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        TextButton {
+                            objectName: "activityDateRangeApply"
+                            //: Button that applies the picked Activity custom date range.
+                            text: qsTr("Apply")
+                            textSize: 15
+                            enabled: calendar.valid
+                            textColor: enabled ? Theme.color.orange : Theme.color.neutral5
+                            hoverEnabled: enabled && AppMode.isDesktop
+                            // Pass ISO strings rather than the Dates: a JS Date
+                            // converted straight to QDate can shift a day across
+                            // time zones.
+                            onClicked: {
+                                activityFilterProxy.setCustomRange(calendar.startIso, calendar.endIso)
+                                activityFilterProxy.dateFilter = ActivityFilterProxyModel.CustomRange
+                                datePopup.close()
+                            }
+                        }
                     }
                 }
             }
@@ -664,10 +905,11 @@ PageStack {
                 id: typePopup
                 objectName: "activityTypeFilterPopup"
                 parent: typeFilterButton
-                x: typePopup.parent.width - typePopup.width
                 y: typePopup.parent.height + 2
                 modal: true
                 dim: false
+
+                onAboutToShow: x = root.filterPopupX(typeFilterButton, typePopup)
 
                 ContextMenuPicker {
                     objectNameRole: "objectName"
@@ -678,6 +920,7 @@ PageStack {
                         { text: qsTr("Sent"),             value: ActivityFilterProxyModel.Sent,           objectName: "activityTypeSent" },
                         { text: qsTr("Sent to yourself"), value: ActivityFilterProxyModel.SentToSelf,     objectName: "activityTypeSentToSelf" },
                         { text: qsTr("Mined"),            value: ActivityFilterProxyModel.Mined,          objectName: "activityTypeMined" },
+                        //: Activity type filter menu entry for other transaction types.
                         { text: qsTr("Other"),            value: ActivityFilterProxyModel.Other,          objectName: "activityTypeOther" },
                         { text: qsTr("Payment request"),  value: ActivityFilterProxyModel.PaymentRequest, objectName: "activityTypePaymentRequest" }
                     ]
@@ -687,6 +930,111 @@ PageStack {
                     }
                 }
             }
+
+            ContextMenu {
+                id: amountPopup
+                objectName: "activityAmountFilterPopup"
+                parent: amountFilterButton
+                y: amountFilterButton.height + 2
+                minMenuWidth: 280
+                modal: true
+                dim: false
+
+                onAboutToShow: {
+                    x = root.filterPopupX(amountFilterButton, amountPopup)
+                    minAmountField.text = activityFilterProxy.minAmount >= 0 ? amountFormatter.display : ""
+                }
+
+                onOpened: {
+                    minAmountField.forceActiveFocus()
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    Layout.margins: 6
+                    spacing: 6
+
+                    CoreText {
+                        //: Heading of the Activity amount filter popup.
+                        text: qsTr("Minimum amount")
+                        color: Theme.color.neutral7
+                        font.pixelSize: 13
+                        horizontalAlignment: Text.AlignLeft
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        ActivityFilterInput {
+                            id: minAmountField
+                            objectName: "activityMinAmountField"
+                            //: Accessibility label for the Activity minimum amount filter input.
+                            Accessible.name: qsTr("Minimum amount")
+                            Layout.fillWidth: true
+                            inputMethodHints: Qt.ImhFormattedNumbersOnly
+                            placeholderText: root.minAmountPlaceholder(amountFormatter.unit)
+                            validator: RegularExpressionValidator {
+                                regularExpression: root.minAmountPattern(amountFormatter.unit)
+                            }
+                            onAccepted: root.applyMinAmount()
+                        }
+
+                        CoreText {
+                            text: amountFormatter.unitLabel
+                            color: Theme.color.neutral7
+                            font.pixelSize: 15
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 2
+
+                        TextButton {
+                            objectName: "activityMinAmountReset"
+                            //: Button that clears the Activity minimum amount filter.
+                            text: qsTr("Reset")
+                            textSize: 15
+                            textColor: Theme.color.neutral7
+                            onClicked: {
+                                minAmountField.text = ""
+                                activityFilterProxy.minAmount = -1
+                                amountPopup.close()
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        TextButton {
+                            objectName: "activityMinAmountApply"
+                            //: Button that applies the Activity minimum amount filter.
+                            text: qsTr("Apply")
+                            textSize: 15
+                            onClicked: root.applyMinAmount()
+                        }
+                    }
+                }
+            }
+
+            component ActivityFilterInput: TextField {
+                implicitHeight: 37
+                leftPadding: 12
+                rightPadding: 12
+                topPadding: 0
+                bottomPadding: 0
+                color: Theme.color.neutral9
+                placeholderTextColor: Theme.color.neutral7
+                font.family: "BitcoinCoreSans"
+                font.pixelSize: 15
+                verticalAlignment: TextInput.AlignVCenter
+                selectByMouse: true
+                background: Rectangle {
+                    color: Theme.color.neutral2
+                    radius: 5
+                }
+            }
+
         }
     }
 }

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -111,6 +111,8 @@ PageStack {
                     return qsTr("This week")
                 case ActivityFilterProxyModel.ThisMonth:
                     return qsTr("This month")
+                case ActivityFilterProxyModel.LastMonth:
+                    return qsTr("Last month")
                 case ActivityFilterProxyModel.ThisYear:
                     return qsTr("This year")
                 default:
@@ -128,6 +130,8 @@ PageStack {
                     return qsTr("Sent to yourself")
                 case ActivityFilterProxyModel.Mined:
                     return qsTr("Mined")
+                case ActivityFilterProxyModel.Other:
+                    return qsTr("Other")
                 case ActivityFilterProxyModel.PaymentRequest:
                     return qsTr("Payment request")
                 default:
@@ -646,6 +650,7 @@ PageStack {
                         { text: qsTr("Today"),       value: ActivityFilterProxyModel.Today,     objectName: "activityDateToday" },
                         { text: qsTr("This week"),   value: ActivityFilterProxyModel.ThisWeek,  objectName: "activityDateThisWeek" },
                         { text: qsTr("This month"),  value: ActivityFilterProxyModel.ThisMonth, objectName: "activityDateThisMonth" },
+                        { text: qsTr("Last month"),  value: ActivityFilterProxyModel.LastMonth, objectName: "activityDateLastMonth" },
                         { text: qsTr("This year"),   value: ActivityFilterProxyModel.ThisYear,  objectName: "activityDateThisYear" }
                     ]
                     onActivated: function(value) {
@@ -673,6 +678,7 @@ PageStack {
                         { text: qsTr("Sent"),             value: ActivityFilterProxyModel.Sent,           objectName: "activityTypeSent" },
                         { text: qsTr("Sent to yourself"), value: ActivityFilterProxyModel.SentToSelf,     objectName: "activityTypeSentToSelf" },
                         { text: qsTr("Mined"),            value: ActivityFilterProxyModel.Mined,          objectName: "activityTypeMined" },
+                        { text: qsTr("Other"),            value: ActivityFilterProxyModel.Other,          objectName: "activityTypeOther" },
                         { text: qsTr("Payment request"),  value: ActivityFilterProxyModel.PaymentRequest, objectName: "activityTypePaymentRequest" }
                     ]
                     onActivated: function(value) {

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -310,23 +310,31 @@ PageStack {
 
             header: Item {
                 id: pageHeader
-                implicitHeight: 50 + (root.filtersVisible ? filterRow.implicitHeight + 10 : 0)
+                // Mirror the Send/Receive title block: 36 above the title and
+                // 36 below it, with the ListView's own top margin counted
+                // toward the lower gap.
+                implicitHeight: 36 + activityHeader.height + 36 - root.activityListTopMargin
+                    + (root.filtersVisible ? filterRow.implicitHeight + 10 : 0)
 
                 RowLayout {
                     id: activityHeader
                     anchors.left: parent.left
                     anchors.right: parent.right
                     anchors.top: parent.top
-                    anchors.topMargin: 15
-                    height: 30
+                    anchors.topMargin: 36
+                    height: activityTitle.implicitHeight
                     spacing: 10
 
                     CoreText {
+                        id: activityTitle
+                        objectName: "activityTitle"
                         Layout.fillWidth: true
                         horizontalAlignment: Text.AlignLeft
                         text: qsTr("Activity")
-                        font.pixelSize: 21
-                        bold: true
+                        font: Theme.text.subtitle.font
+                        lineHeight: Theme.text.subtitle.lineHeight
+                        lineHeightMode: Text.FixedHeight
+                        color: Theme.color.neutral9
                     }
 
                     IconButton {

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -26,6 +26,13 @@ PageStack {
         if (Object.keys(details).length === 0)
             return
 
+        // Show the transaction on top of the Activity list rather than on top of
+        // whatever detail page is still open. The wallet tabs are a StackLayout
+        // that keeps this stack alive, so a detail page opened before the user
+        // went to Send is still here when that send's "View Transaction" arrives:
+        // without the reset, Back walks into that stale page, which by then is
+        // bound to rows the accompanying reload() has already invalidated.
+        stackView.pop(null)
         var page = stackView.push("ActivityDetails.qml", details)
         page.showTransaction.connect(stackView.navigateToTransaction)
     }

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -928,10 +928,10 @@ PageStack {
                         { text: qsTr("Received"),         value: ActivityFilterProxyModel.Received,       objectName: "activityTypeReceived" },
                         { text: qsTr("Sent"),             value: ActivityFilterProxyModel.Sent,           objectName: "activityTypeSent" },
                         { text: qsTr("Sent to yourself"), value: ActivityFilterProxyModel.SentToSelf,     objectName: "activityTypeSentToSelf" },
+                        { text: qsTr("Payment request"),  value: ActivityFilterProxyModel.PaymentRequest, objectName: "activityTypePaymentRequest" },
                         { text: qsTr("Mined"),            value: ActivityFilterProxyModel.Mined,          objectName: "activityTypeMined" },
                         //: Activity type filter menu entry for other transaction types.
-                        { text: qsTr("Other"),            value: ActivityFilterProxyModel.Other,          objectName: "activityTypeOther" },
-                        { text: qsTr("Payment request"),  value: ActivityFilterProxyModel.PaymentRequest, objectName: "activityTypePaymentRequest" }
+                        { text: qsTr("Other"),            value: ActivityFilterProxyModel.Other,          objectName: "activityTypeOther" }
                     ]
                     onActivated: function(value) {
                         activityFilterProxy.typeFilter = value

--- a/qml/pages/wallet/ActivityTransactionVisuals.qml
+++ b/qml/pages/wallet/ActivityTransactionVisuals.qml
@@ -20,6 +20,10 @@ QtObject {
     readonly property bool confirmedLike: root.transactionStatus == Transaction.Confirmed
         || root.transactionStatus == Transaction.Immature
 
+    // Requests use the receive triangle like any incoming entry and stay
+    // purple whether or not their address has been used: address use alone
+    // does not prove the request was paid, so the green receive color is
+    // reserved for real transaction rows.
     readonly property url iconSource: root.transactionType == Transaction.Generated
         ? "qrc:/icons/coinbase"
         : root.incoming ? "qrc:/icons/triangle-down" : "qrc:/icons/triangle-up"

--- a/qml/pages/wallet/RequestPayment.qml
+++ b/qml/pages/wallet/RequestPayment.qml
@@ -628,6 +628,15 @@ Page {
                         noteSelfInput.text = root.requestValue("noteSelf")
                     }
                 }
+                function onLabelChanged() {
+                    // The field's declarative binding is gone once anything
+                    // assigns its text, so follow an external label change
+                    // (the Addresses page reverse sync) by hand. Only while
+                    // locked: an in-progress edit must not be clobbered.
+                    if (!root.requestIsEditing()) {
+                        nameInput.text = root.requestValue("label")
+                    }
+                }
             }
 
             Connections {

--- a/test/functional/qml_test_activity_filter_export.py
+++ b/test/functional/qml_test_activity_filter_export.py
@@ -342,6 +342,54 @@ def run_test(save_screenshots=False, screenshot_root=None):
         assert cleared_date_filter in (0, "DateAll"), f"Custom range reset failed: {cleared_date_filter!r}"
         checkpoints.checkpoint("custom date range cleared", gui)
 
+        # Issue #726: paying a pending request's address keeps the request under
+        # the Payment request filter as a used-address request, with no reload,
+        # and surfaces the real transaction as its own row in the default view.
+        # Toggle the controls to guarantee a clean, popup-free starting state.
+        gui.click("activitySearchToggle")
+        gui.wait_for_property("activitySearchToggle", "checked", False, timeout_ms=5000)
+        gui.click("activitySearchToggle")
+        gui.wait_for_property("activitySearchToggle", "checked", True, timeout_ms=5000)
+        gui.wait_for_property("activityFilterProxyModel", "count", 2, timeout_ms=10000)
+
+        gui.click("activityTypeFilterButton")
+        gui.click("activityTypePaymentRequest")
+        gui.wait_for_property("activityFilterProxyModel", "count", 1, timeout_ms=10000)
+        checkpoints.checkpoint("pending request shown under Payment request filter", gui)
+
+        # Mine a block to the request address to fulfill the pending request live.
+        rpc_call(harness.gui_rpc_port, "generatetoaddress", [1, payment_request_address])
+
+        # The address now has its own mined transaction row; waiting on it is the
+        # synchronization point for the live fulfillment.
+        gui.click("activityTypeFilterButton")
+        gui.click("activityTypeMined")
+        gui.set_text("activitySearchField", payment_request_address)
+        gui.wait_for_property("activityFilterProxyModel", "count", 1, timeout_ms=20000)
+        checkpoints.checkpoint("request address gained its own mined transaction row", gui)
+
+        # The request itself is still surfaced under the Payment request filter,
+        # now as a used-address request, without a reload. Before the live
+        # fulfillment fix it dropped out of the filter until the wallet reloaded.
+        gui.click("activityTypeFilterButton")
+        gui.click("activityTypePaymentRequest")
+        gui.wait_for_property("activityFilterProxyModel", "count", 1, timeout_ms=10000)
+        used_request_export_path = os.path.join(harness.tmpdir, "activity-used-request.csv")
+        used_request_csv = _export_activity_csv(gui, used_request_export_path)
+        assert '"Payment request"' in used_request_csv, f"Fulfilled request left the Payment request filter: {used_request_csv!r}"
+        assert '"Alice"' in used_request_csv, f"Used-address request missing its label: {used_request_csv!r}"
+        assert f'"{payment_request_address}"' in used_request_csv, f"Used-address request missing its address: {used_request_csv!r}"
+        gui.click("activityExportResultCloseButton")
+        checkpoints.checkpoint("fulfilled request stays a used-address request under the filter", gui)
+
+        # In the default view the request is hidden, so it does not duplicate the
+        # real transaction to its address; only the two mined rows remain.
+        gui.set_text("activitySearchField", "")
+        gui.click("activityTypeFilterButton")
+        gui.click("activityTypeAll")
+        gui.wait_for_property("activityFilterProxyModel", "count", 2, timeout_ms=10000)
+        checkpoints.checkpoint("used-address request hidden from the default Activity view", gui)
+
         txid, expected_amount = _activity_transaction_row(gui)
         gui.click(f"activityItem_{txid}")
         gui.wait_for_page("activityDetailsPage", timeout_ms=10000)

--- a/test/functional/qml_test_activity_filter_export.py
+++ b/test/functional/qml_test_activity_filter_export.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 import time
-from datetime import datetime
+from datetime import date, datetime
 from urllib.parse import urlparse
 
 from qml_test_harness import dump_qml_tree
@@ -189,10 +189,12 @@ def run_test(save_screenshots=False, screenshot_root=None):
         gui.wait_for_property("activityFilterProxyModel", "count", 2, timeout_ms=10000)
 
         gui.click("activityDateFilterButton")
+        gui.wait_for_property("activityDateFilterPopup", "opened", True, timeout_ms=5000)
         checkpoints.checkpoint("date filter menu opened", gui)
         gui.click("activityDateToday")
 
         gui.click("activityTypeFilterButton")
+        gui.wait_for_property("activityTypeFilterPopup", "opened", True, timeout_ms=5000)
         checkpoints.checkpoint("type filter menu opened", gui)
         gui.click("activityTypeMined")
         gui.wait_for_property("activityFilterProxyModel", "count", 1, timeout_ms=10000)
@@ -212,6 +214,7 @@ def run_test(save_screenshots=False, screenshot_root=None):
         gui.click("activityExportResultCloseButton")
 
         gui.click("activityTypeFilterButton")
+        gui.wait_for_property("activityTypeFilterPopup", "opened", True, timeout_ms=5000)
         gui.click("activityTypePaymentRequest")
         gui.wait_for_property("activityFilterProxyModel", "count", 1, timeout_ms=10000)
         checkpoints.checkpoint("Today and Payment request filters applied", gui)
@@ -257,7 +260,7 @@ def run_test(save_screenshots=False, screenshot_root=None):
         gui.wait_for_property(
             "activityEmptyStateDescription",
             "text",
-            "Try changing your search, date, or type filters.",
+            "Try changing your search, date, type, or amount filters.",
             timeout_ms=10000,
         )
         checkpoints.checkpoint("filtered-empty Activity state shown", gui)
@@ -271,6 +274,73 @@ def run_test(save_screenshots=False, screenshot_root=None):
         assert type_filter in (0, "TypeAll"), f"Type filter was not reset: {type_filter!r}"
         gui.wait_for_property("activityFilterProxyModel", "count", 2, timeout_ms=10000)
         checkpoints.checkpoint("search controls closed and filters reset", gui)
+
+        # Re-open the filter controls to exercise the amount and custom-range
+        # filters from a clean, fully reset state.
+        gui.click("activitySearchToggle")
+        gui.wait_for_property("activitySearchToggle", "checked", True, timeout_ms=5000)
+        gui.wait_for_property("activityFilterProxyModel", "count", 2, timeout_ms=10000)
+
+        # Minimum amount filter. The display unit is sats here, so a 100000 sat
+        # (0.001 BTC) minimum keeps the 50 BTC mined row and drops the 0.0001
+        # BTC (10000 sat) payment request.
+        gui.click("activityAmountFilterButton")
+        gui.wait_for_property("activityAmountFilterPopup", "opened", True, timeout_ms=5000)
+        checkpoints.checkpoint("amount filter menu opened", gui)
+        gui.set_text("activityMinAmountField", "100000")
+        gui.click("activityMinAmountApply")
+        gui.wait_for_property("activityFilterProxyModel", "count", 1, timeout_ms=10000)
+        checkpoints.checkpoint("minimum amount filter applied", gui)
+
+        min_amount_export_path = os.path.join(harness.tmpdir, "activity-min-amount.csv")
+        min_amount_csv = _export_activity_csv(gui, min_amount_export_path)
+        assert '"Mined"' in min_amount_csv, f"Min-amount export missing mined row: {min_amount_csv!r}"
+        assert '"Payment request"' not in min_amount_csv, f"Min-amount export kept request row: {min_amount_csv!r}"
+        gui.click("activityExportResultCloseButton")
+
+        gui.click("activityAmountFilterButton")
+        gui.wait_for_property("activityAmountFilterPopup", "opened", True, timeout_ms=5000)
+        gui.click("activityMinAmountReset")
+        gui.wait_for_property("activityFilterProxyModel", "count", 2, timeout_ms=10000)
+        checkpoints.checkpoint("minimum amount filter cleared", gui)
+
+        # Custom date range via the calendar picker. Navigate one month back
+        # and pick a window there; it is entirely in the past, so today's rows
+        # drop out of the list.
+        gui.click("activityDateFilterButton")
+        gui.wait_for_property("activityDateFilterPopup", "opened", True, timeout_ms=5000)
+        gui.click("activityDateCustomRange")
+        checkpoints.checkpoint("custom date range calendar revealed", gui)
+        gui.click("calendarPrev")
+        gui.settle()
+
+        # Read the displayed month back from the calendar instead of predicting
+        # it from Python's clock: the GUI clock decides which month one Prev
+        # step lands on, so deriving the target days from the shown month keeps
+        # them valid even across a month rollover mid-test. calMonth is 0-based.
+        shown_month = date(gui.get_property("activityCalendar", "calYear"),
+                           gui.get_property("activityCalendar", "calMonth") + 1, 1)
+        assert shown_month < date.today().replace(day=1), \
+            f"Calendar did not navigate to a past month: showing {shown_month.isoformat()}"
+        from_day = shown_month.replace(day=10).isoformat()
+        to_day = shown_month.replace(day=20).isoformat()
+        gui.wait_for_object(f"calendarDay_{from_day}", timeout_ms=5000)
+
+        gui.click(f"calendarDay_{from_day}")
+        gui.click(f"calendarDay_{to_day}")
+        gui.click("activityDateRangeApply")
+        gui.wait_for_property("activityFilterProxyModel", "count", 0, timeout_ms=10000)
+        date_filter = gui.get_property("activityFilterProxyModel", "dateFilter")
+        assert date_filter in (6, "CustomRange"), f"Custom range was not applied: {date_filter!r}"
+        checkpoints.checkpoint("past custom range excludes today's rows", gui)
+
+        gui.click("activityDateFilterButton")
+        gui.wait_for_property("activityDateFilterPopup", "opened", True, timeout_ms=5000)
+        gui.click("activityDateRangeReset")
+        gui.wait_for_property("activityFilterProxyModel", "count", 2, timeout_ms=10000)
+        cleared_date_filter = gui.get_property("activityFilterProxyModel", "dateFilter")
+        assert cleared_date_filter in (0, "DateAll"), f"Custom range reset failed: {cleared_date_filter!r}"
+        checkpoints.checkpoint("custom date range cleared", gui)
 
         txid, expected_amount = _activity_transaction_row(gui)
         gui.click(f"activityItem_{txid}")

--- a/test/functional/qml_test_address_label_sync.py
+++ b/test/functional/qml_test_address_label_sync.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Reverse label sync: editing an address label on the Addresses page updates the
+matching payment request and its Activity row, not just the address book."""
+
+import sys
+
+from qml_test_harness import dump_qml_tree
+from qml_test_receive import (
+    _address_from_bip21,
+    _create_request,
+    _import_wallet,
+    _open_activity,
+    _open_receive,
+    _request_qr_payload,
+)
+from qml_test_addresses import open_address_list_from_settings
+from qml_wallet_test_lib import WalletFlowHarness
+
+ORIGINAL_LABEL = "Alice"
+NEW_LABEL = "Renamed on Addresses page"
+
+
+def _address_row_index(gui, address):
+    count = gui.get_property("addressListView", "count")
+    for row in range(count):
+        if gui.get_list_item_property("addressListView", row, "address") == address:
+            return row
+    raise AssertionError(f"Address {address!r} not found in the address list")
+
+
+def _activity_request_label(gui):
+    # No funding in this flow, so the pending request is the only Activity row.
+    gui.wait_for_property("activityListView", "count", lambda c: c >= 1, timeout_ms=10000)
+    # Force the delegate to instantiate offscreen before reading its label.
+    gui.set_property("activityListView", "currentIndex", 0)
+    gui.invoke("activityListView", "forceLayout")
+    gui.settle()
+    return gui.get_list_item_property("activityListView", 0, "label")
+
+
+def run_test():
+    harness = WalletFlowHarness("qml_address_label_sync", port_offset=75)
+    try:
+        gui = _import_wallet(harness)
+
+        # Save a payment request labelled ORIGINAL_LABEL; creating it also labels
+        # its receive address in the address book.
+        _open_receive(gui)
+        _create_request(gui, "0.0001", ORIGINAL_LABEL, "pizza")
+        request_address = _address_from_bip21(_request_qr_payload(gui))
+
+        # The pending request shows the original label in Activity.
+        _open_activity(gui)
+        assert _activity_request_label(gui) == ORIGINAL_LABEL, (
+            f"Expected Activity request label {ORIGINAL_LABEL!r}, "
+            f"got {_activity_request_label(gui)!r}"
+        )
+
+        # Edit the label on the Addresses page.
+        open_address_list_from_settings(gui)
+        row = _address_row_index(gui, request_address)
+        assert gui.get_list_item_property("addressListView", row, "label") == ORIGINAL_LABEL
+        gui.click_list_item("addressListView", row, "addressRowNoteButton")
+        gui.wait_for_object("addressLabelInput", timeout_ms=5000)
+        gui.set_text("addressLabelInput", NEW_LABEL)
+        gui.click("addressLabelSaveButton")
+        gui.settle()
+
+        # Surface 1: the Addresses page reflects the edit.
+        row = _address_row_index(gui, request_address)
+        assert gui.get_list_item_property("addressListView", row, "label") == NEW_LABEL, (
+            "Addresses page did not show the edited label"
+        )
+
+        # Surface 2: the reverse sync carried the edit to the request's Activity row.
+        _open_activity(gui)
+        actual = _activity_request_label(gui)
+        assert actual == NEW_LABEL, (
+            "Activity request row did not follow the Addresses-page label edit: "
+            f"expected {NEW_LABEL!r}, got {actual!r}"
+        )
+
+        print("Address label reverse-sync flow passed.")
+        return 0
+    except Exception as err:  # noqa: BLE001 - preserve GUI context on failures
+        print(f"\nFAILED [qml_address_label_sync]: {err}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        try:
+            dump_qml_tree(harness.driver)
+        except Exception:  # noqa: BLE001
+            pass
+        return 1
+    finally:
+        harness.stop()
+
+
+if __name__ == "__main__":
+    sys.exit(run_test())

--- a/test/functional/qml_test_address_label_sync.py
+++ b/test/functional/qml_test_address_label_sync.py
@@ -83,6 +83,16 @@ def run_test():
             f"expected {NEW_LABEL!r}, got {actual!r}"
         )
 
+        # Surface 3: the Receive tab kept the request open in its locked editor
+        # the whole time; switching back must show the edited label, not the
+        # stale text the form held when the label was edited elsewhere.
+        _open_receive(gui)
+        editor_label = gui.get_text("requestPaymentYourNameInput")
+        assert editor_label == NEW_LABEL, (
+            "Held-open request editor did not follow the Addresses-page label edit: "
+            f"expected {NEW_LABEL!r}, got {editor_label!r}"
+        )
+
         print("Address label reverse-sync flow passed.")
         return 0
     except Exception as err:  # noqa: BLE001 - preserve GUI context on failures

--- a/test/mocks/mockwallet.h
+++ b/test/mocks/mockwallet.h
@@ -146,7 +146,9 @@ public:
 
     std::function<util::Result<CTransactionRef>(const std::vector<wallet::CRecipient>&, const wallet::CCoinControl&, bool, int&, CAmount&)> create_transaction_fn;
     std::function<CTxDestination(OutputType, const std::string&)> get_new_destination_fn;
+    std::function<interfaces::WalletTx(const Txid&)> get_wallet_tx_fn;
     std::function<std::set<interfaces::WalletTx>()> get_wallet_txs_fn;
+    std::function<bool(const Txid&, interfaces::WalletTxStatus&, int&, int64_t&)> try_get_tx_status_fn;
     std::function<CAmount()> get_balance_fn;
     std::function<CAmount(const wallet::CCoinControl&)> get_available_balance_fn;
     std::function<CAmount(unsigned int)> get_required_fee_fn;
@@ -161,7 +163,9 @@ public:
     struct Calls {
         CallCounter getNewDestination{"getNewDestination"};
         CallCounter createTransaction{"createTransaction"};
+        CallCounter getWalletTx{"getWalletTx"};
         CallCounter getWalletTxs{"getWalletTxs"};
+        CallCounter tryGetTxStatus{"tryGetTxStatus"};
         CallCounter getBalance{"getBalance"};
         CallCounter getAvailableBalance{"getAvailableBalance"};
         CallCounter getRequiredFee{"getRequiredFee"};
@@ -203,10 +207,22 @@ public:
         return util::Error{Untranslated("no create_transaction_fn installed")};
     }
 
+    interfaces::WalletTx getWalletTx(const Txid& txid) override
+    {
+        ++calls.getWalletTx;
+        return get_wallet_tx_fn ? get_wallet_tx_fn(txid) : interfaces::WalletTx{};
+    }
+
     std::set<interfaces::WalletTx> getWalletTxs() override
     {
         ++calls.getWalletTxs;
         return get_wallet_txs_fn ? get_wallet_txs_fn() : std::set<interfaces::WalletTx>{};
+    }
+
+    bool tryGetTxStatus(const Txid& txid, interfaces::WalletTxStatus& tx_status, int& num_blocks, int64_t& block_time) override
+    {
+        ++calls.tryGetTxStatus;
+        return try_get_tx_status_fn ? try_get_tx_status_fn(txid, tx_status, num_blocks, block_time) : false;
     }
 
     CAmount getBalance() override

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -2986,7 +2986,6 @@ public:
         Today,
         ThisWeek,
         ThisMonth,
-        LastMonth,
         ThisYear,
         CustomRange
     };

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -2976,8 +2976,8 @@ class MockActivityFilterProxyModel : public QSortFilterProxyModel
     Q_PROPERTY(TypeFilter typeFilter READ typeFilter WRITE setTypeFilter NOTIFY typeFilterChanged)
     Q_PROPERTY(int displayUnit READ displayUnit WRITE setDisplayUnit NOTIFY displayUnitChanged)
     Q_PROPERTY(qint64 minAmount READ minAmount WRITE setMinAmount NOTIFY minAmountChanged)
-    Q_PROPERTY(QDate rangeStart READ rangeStart WRITE setRangeStart NOTIFY rangeChanged)
-    Q_PROPERTY(QDate rangeEnd READ rangeEnd WRITE setRangeEnd NOTIFY rangeChanged)
+    Q_PROPERTY(QDate rangeStart READ rangeStart NOTIFY rangeChanged)
+    Q_PROPERTY(QDate rangeEnd READ rangeEnd NOTIFY rangeChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
 
 public:
@@ -3108,43 +3108,34 @@ public:
     }
 
     QDate rangeStart() const { return m_range_start; }
-    void setRangeStart(const QDate& range_start)
-    {
-        if (m_range_start == range_start) return;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-        beginFilterChange();
-#endif
-        m_range_start = range_start;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-        endFilterChange(QSortFilterProxyModel::Direction::Rows);
-#else
-        invalidateFilter();
-#endif
-        Q_EMIT rangeChanged();
-        Q_EMIT countChanged();
-    }
-
     QDate rangeEnd() const { return m_range_end; }
-    void setRangeEnd(const QDate& range_end)
+
+    Q_INVOKABLE bool applyCustomRange(const QString& start_iso, const QString& end_iso)
     {
-        if (m_range_end == range_end) return;
+        const QDate start = QDate::fromString(start_iso, Qt::ISODate);
+        const QDate end = QDate::fromString(end_iso, Qt::ISODate);
+        if (!start.isValid() || !end.isValid() || start > end) return false;
+
+        const bool range_changed = start != m_range_start || end != m_range_end;
+        const bool filter_changed = m_date_filter != CustomRange;
+        if (!range_changed && !filter_changed) return true;
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
         beginFilterChange();
 #endif
-        m_range_end = range_end;
+        m_range_start = start;
+        m_range_end = end;
+        m_date_filter = CustomRange;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
         endFilterChange(QSortFilterProxyModel::Direction::Rows);
 #else
         invalidateFilter();
 #endif
-        Q_EMIT rangeChanged();
-        Q_EMIT countChanged();
-    }
 
-    Q_INVOKABLE void setCustomRange(const QString& start_iso, const QString& end_iso)
-    {
-        setRangeStart(QDate::fromString(start_iso, Qt::ISODate));
-        setRangeEnd(QDate::fromString(end_iso, Qt::ISODate));
+        if (range_changed) Q_EMIT rangeChanged();
+        if (filter_changed) Q_EMIT dateFilterChanged();
+        Q_EMIT countChanged();
+        return true;
     }
 
     int count() const { return rowCount(); }

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -2796,7 +2796,8 @@ public:
         RequestIdRole,
         TimestampRole,
         NetAmountSatRole,
-        OutputIndexRole
+        OutputIndexRole,
+        IsUsedAddressRequestRole
     };
 
     int rowCount(const QModelIndex& parent = QModelIndex{}) const override
@@ -2810,6 +2811,16 @@ public:
     QVariant data(const QModelIndex& index, int role) const override
     {
         if (!index.isValid() || index.row() < 0 || index.row() >= rowCount()) return {};
+        if (index.row() == m_used_request_row) {
+            switch (role) {
+            case IsPendingRequestRole: return true;
+            case IsUsedAddressRequestRole: return true;
+            case TxidRole: return QString{};
+            case RequestIdRole: return QStringLiteral("used-req-1");
+            default: break;
+            }
+        }
+        if (role == IsUsedAddressRequestRole) return false;
         if (index.row() == 0) {
             switch (role) {
             case AddressRole: return QStringLiteral("bcrt1qreceiveaddress");
@@ -2876,6 +2887,7 @@ public:
             {TimestampRole, "timestamp"},
             {NetAmountSatRole, "netAmountSat"},
             {OutputIndexRole, "outputIndex"},
+            {IsUsedAddressRequestRole, "isUsedAddressRequest"},
         };
     }
 
@@ -2917,6 +2929,17 @@ public:
         Q_EMIT countChanged();
     }
 
+    // Marks one row as a used-address payment request (-1 for none), so tests
+    // can cover the paid-request rendering path in the Activity delegate.
+    Q_INVOKABLE void setUsedAddressRequestRowForTest(int row)
+    {
+        if (m_used_request_row == row) return;
+        beginResetModel();
+        m_used_request_row = row;
+        endResetModel();
+        Q_EMIT countChanged();
+    }
+
 Q_SIGNALS:
     void countChanged();
 
@@ -2942,6 +2965,7 @@ private:
     }
 
     int m_count{2};
+    int m_used_request_row{-1};
 };
 
 class MockActivityFilterProxyModel : public QSortFilterProxyModel

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -2959,6 +2959,7 @@ public:
         Today,
         ThisWeek,
         ThisMonth,
+        LastMonth,
         ThisYear
     };
     Q_ENUM(DateFilter)
@@ -2969,6 +2970,7 @@ public:
         Sent,
         SentToSelf,
         Mined,
+        Other,
         PaymentRequest
     };
     Q_ENUM(TypeFilter)

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -2951,6 +2951,9 @@ class MockActivityFilterProxyModel : public QSortFilterProxyModel
     Q_PROPERTY(DateFilter dateFilter READ dateFilter WRITE setDateFilter NOTIFY dateFilterChanged)
     Q_PROPERTY(TypeFilter typeFilter READ typeFilter WRITE setTypeFilter NOTIFY typeFilterChanged)
     Q_PROPERTY(int displayUnit READ displayUnit WRITE setDisplayUnit NOTIFY displayUnitChanged)
+    Q_PROPERTY(qint64 minAmount READ minAmount WRITE setMinAmount NOTIFY minAmountChanged)
+    Q_PROPERTY(QDate rangeStart READ rangeStart WRITE setRangeStart NOTIFY rangeChanged)
+    Q_PROPERTY(QDate rangeEnd READ rangeEnd WRITE setRangeEnd NOTIFY rangeChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
 
 public:
@@ -2960,7 +2963,8 @@ public:
         ThisWeek,
         ThisMonth,
         LastMonth,
-        ThisYear
+        ThisYear,
+        CustomRange
     };
     Q_ENUM(DateFilter)
 
@@ -3061,6 +3065,64 @@ public:
         Q_EMIT displayUnitChanged();
     }
 
+    qint64 minAmount() const { return m_min_amount; }
+    void setMinAmount(qint64 min_amount)
+    {
+        const qint64 normalized = min_amount < 0 ? -1 : min_amount;
+        if (m_min_amount == normalized) return;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        beginFilterChange();
+#endif
+        m_min_amount = normalized;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
+        invalidateFilter();
+#endif
+        Q_EMIT minAmountChanged();
+        Q_EMIT countChanged();
+    }
+
+    QDate rangeStart() const { return m_range_start; }
+    void setRangeStart(const QDate& range_start)
+    {
+        if (m_range_start == range_start) return;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        beginFilterChange();
+#endif
+        m_range_start = range_start;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
+        invalidateFilter();
+#endif
+        Q_EMIT rangeChanged();
+        Q_EMIT countChanged();
+    }
+
+    QDate rangeEnd() const { return m_range_end; }
+    void setRangeEnd(const QDate& range_end)
+    {
+        if (m_range_end == range_end) return;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        beginFilterChange();
+#endif
+        m_range_end = range_end;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
+        invalidateFilter();
+#endif
+        Q_EMIT rangeChanged();
+        Q_EMIT countChanged();
+    }
+
+    Q_INVOKABLE void setCustomRange(const QString& start_iso, const QString& end_iso)
+    {
+        setRangeStart(QDate::fromString(start_iso, Qt::ISODate));
+        setRangeEnd(QDate::fromString(end_iso, Qt::ISODate));
+    }
+
     int count() const { return rowCount(); }
 
     Q_INVOKABLE bool exportCsv(const QString& path) const
@@ -3084,6 +3146,8 @@ Q_SIGNALS:
     void dateFilterChanged();
     void typeFilterChanged();
     void displayUnitChanged();
+    void minAmountChanged();
+    void rangeChanged();
     void countChanged();
 
 private:
@@ -3091,6 +3155,9 @@ private:
     DateFilter m_date_filter{DateAll};
     TypeFilter m_type_filter{TypeAll};
     int m_display_unit{0};
+    qint64 m_min_amount{-1};
+    QDate m_range_start;
+    QDate m_range_end;
 };
 
 class MockDesktopWindowBehaviorModel : public QObject

--- a/test/qml/tst_activity.qml
+++ b/test/qml/tst_activity.qml
@@ -158,6 +158,30 @@ TestCase {
         compare(page.currentItem.address, "bcrt1qsecondsendaddress")
     }
 
+    function test_navigateToTransaction_resets_a_stale_detail_stack() {
+        testActivityListModel.setCountForTest(3)
+        const page = createTemporaryObject(activityComponent, this)
+        verify(page !== null)
+        compare(page.depth, 1)
+
+        // A detail page the user left open before going to Send. The wallet tabs
+        // are a StackLayout that keeps this stack alive, so it is still here when
+        // that send's "View Transaction" deeplink arrives.
+        page.push(activityDetailsComponent, detailsProperties("tx-stale"))
+        tryCompare(page, "depth", 2)
+        compare(page.currentItem.txid, "tx-stale")
+
+        page.navigateToTransaction("bbbb")
+
+        // The deeplinked transaction replaces the stale page rather than stacking
+        // on top of it, so Back goes to the Activity list and not through a page
+        // left bound to rows a reload() has invalidated.
+        tryCompare(page, "depth", 2)
+        compare(page.currentItem.txid, "bbbb")
+        page.pop()
+        tryCompare(page, "depth", 1)
+    }
+
     function test_selectedWalletChanged_pops_to_root() {
         const page = createTemporaryObject(activityComponent, this)
         verify(page !== null)

--- a/test/qml/tst_activity.qml
+++ b/test/qml/tst_activity.qml
@@ -19,6 +19,7 @@ TestCase {
         testWalletModel.lastLoadedPaymentRequestId = ""
         testWalletModel.lastLoadedPaymentRequestDetailId = ""
         testActivityListModel.setCountForTest(2)
+        testActivityListModel.setUsedAddressRequestRowForTest(-1)
         nodeModel.setBlockSyncActiveForTest(false)
         nodeModel.verificationProgress = 1.0
         walletController.openReceiveRequests = 0
@@ -37,6 +38,12 @@ TestCase {
         id: activityCalendarComponent
 
         ActivityCalendar {}
+    }
+
+    Component {
+        id: transactionVisualsComponent
+
+        ActivityTransactionVisuals {}
     }
 
     Component {
@@ -384,6 +391,43 @@ TestCase {
         calendar.customFrom = new Date(2001, 1, 10)
         calendar.ensureCalendarFocusDate()
         compare(calendar.isoDate(calendar.calendarFocusDate), "2001-02-10")
+    }
+
+    function test_used_address_request_row_exposes_flags() {
+        testActivityListModel.setUsedAddressRequestRowForTest(0)
+
+        const page = createTemporaryObject(activityComponent, this)
+        verify(page !== null)
+
+        let row = null
+        tryVerify(function() {
+            row = findChild(page, "activityItem_pending_0")
+            return row !== null
+        })
+        compare(row.isPendingRequest, true)
+        compare(row.isUsedAddressRequest, true)
+    }
+
+    function test_transaction_visuals_keep_request_rows_purple() {
+        // Address use alone does not prove a request was paid, so a request
+        // row stays purple either way; green is reserved for real
+        // transaction rows.
+        const request = createTemporaryObject(transactionVisualsComponent, this, {
+            transactionType: Transaction.RecvWithAddress,
+            transactionStatus: Transaction.Unconfirmed,
+            isPendingRequest: true
+        })
+        const received = createTemporaryObject(transactionVisualsComponent, this, {
+            transactionType: Transaction.RecvWithAddress,
+            transactionStatus: Transaction.Confirmed
+        })
+        verify(request !== null)
+        verify(received !== null)
+
+        compare(request.iconSource, "qrc:/icons/triangle-down")
+        compare(request.iconColor, Theme.color.purple)
+        compare(received.iconSource, "qrc:/icons/triangle-down")
+        compare(received.iconColor, Theme.color.green)
     }
 
     function test_custom_date_range_reopen_preserves_dates() {

--- a/test/qml/tst_activity.qml
+++ b/test/qml/tst_activity.qml
@@ -441,8 +441,8 @@ TestCase {
         verify(activityPage !== null)
         verify(calendar !== null)
 
-        // Apply a fixed range through the timezone-safe ISO setter.
-        proxy.setCustomRange("2025-06-10", "2025-06-20")
+        // Apply a fixed range through the timezone-safe ISO entry point.
+        verify(proxy.applyCustomRange("2025-06-10", "2025-06-20"))
 
         // Reopening the date popup re-seeds the calendar draft from
         // proxy.rangeStart / rangeEnd, which reach QML as UTC-midnight JS Dates.

--- a/test/qml/tst_activity.qml
+++ b/test/qml/tst_activity.qml
@@ -4,6 +4,8 @@
 
 import QtQuick 2.15
 import QtTest 1.2
+import org.bitcoincore.qt 1.0
+import "../../qml/controls"
 import "../../qml/pages/wallet"
 
 TestCase {
@@ -29,6 +31,12 @@ TestCase {
             width: 600
             height: 700
         }
+    }
+
+    Component {
+        id: activityCalendarComponent
+
+        ActivityCalendar {}
     }
 
     Component {
@@ -104,7 +112,7 @@ TestCase {
         const title = findActivityEmptyStateText(page, "activityEmptyStateTitle")
         const description = findActivityEmptyStateText(page, "activityEmptyStateDescription")
         tryCompare(title, "text", "No activity matches your filters.")
-        compare(description.text, "Try changing your search, date, or type filters.")
+        compare(description.text, "Try changing your search, date, type, or amount filters.")
     }
 
     function test_non_empty_activity_still_shows_transaction_rows() {
@@ -201,5 +209,206 @@ TestCase {
 
         walletController.setSelectedWallet("third-wallet")
         tryCompare(page, "depth", 1)
+    }
+
+    function test_minimum_amount_filter_applies_and_clears() {
+        const page = createTemporaryObject(activityComponent, this)
+        verify(page !== null)
+
+        const proxy = findChild(page, "activityFilterProxyModel")
+        const field = findChild(page, "activityMinAmountField")
+        const applyButton = findChild(page, "activityMinAmountApply")
+        const resetButton = findChild(page, "activityMinAmountReset")
+        verify(proxy !== null)
+        verify(field !== null)
+        verify(applyButton !== null)
+        verify(resetButton !== null)
+
+        // Default display unit is BTC, so "0.5" parses to 50,000,000 sat.
+        compare(optionsModel.displayUnit, 0)
+        field.text = "0.5"
+        applyButton.clicked()
+        compare(proxy.minAmount, 50000000)
+
+        resetButton.clicked()
+        compare(proxy.minAmount, -1)
+    }
+
+    function test_minimum_amount_filter_parses_every_display_unit() {
+        const page = createTemporaryObject(activityComponent, this)
+        verify(page !== null)
+
+        const proxy = findChild(page, "activityFilterProxyModel")
+        const field = findChild(page, "activityMinAmountField")
+        const applyButton = findChild(page, "activityMinAmountApply")
+        verify(proxy !== null)
+        verify(field !== null)
+        verify(applyButton !== null)
+
+        // The threshold is typed in the active display unit, so it must parse
+        // as mBTC and bits too, not only as BTC and sats.
+        const cases = [
+            {unit: 0, text: "0.5", sats: 50000000},
+            {unit: 1, text: "0.5", sats: 50000},
+            {unit: 2, text: "0.5", sats: 50},
+            {unit: 3, text: "50",  sats: 50},
+        ]
+        try {
+            for (const c of cases) {
+                optionsModel.displayUnit = c.unit
+                field.text = c.text
+                applyButton.clicked()
+                compare(proxy.minAmount, c.sats)
+            }
+        } finally {
+            // Leave the shared display unit as found for the other tests.
+            optionsModel.displayUnit = 0
+        }
+
+        // The field's placeholder and input mask follow the unit as well, so a
+        // mBTC or bits threshold is not masked to BTC precision.
+        const activityPage = findChild(page, "activityPage")
+        verify(activityPage !== null)
+        // Units by number: QML cannot name BitcoinAmount.mBTC / uBTC (enum
+        // values starting with a lowercase letter are not exposed).
+        compare(activityPage.minAmountPlaceholder(0), "0.00000000") // BTC
+        compare(activityPage.minAmountPlaceholder(1), "0.00000")    // mBTC
+        compare(activityPage.minAmountPlaceholder(2), "0.00")       // uBTC
+        compare(activityPage.minAmountPlaceholder(3), "0")          // SAT
+        verify(activityPage.minAmountPattern(1).test("1.12345"))
+        verify(!activityPage.minAmountPattern(1).test("1.123456"))
+        verify(activityPage.minAmountPattern(2).test("1.12"))
+        verify(!activityPage.minAmountPattern(2).test("1.123"))
+        verify(!activityPage.minAmountPattern(3).test("1.5"))
+    }
+
+    function test_custom_date_range_filter_applies() {
+        const page = createTemporaryObject(activityComponent, this)
+        verify(page !== null)
+
+        const proxy = findChild(page, "activityFilterProxyModel")
+        const applyButton = findChild(page, "activityDateRangeApply")
+        verify(proxy !== null)
+        verify(applyButton !== null)
+
+        // The calendar opens on the current month; pick day 10 (From) and day
+        // 20 (To), which exist in every month. Clicking a day delegate fires
+        // its clicked() handler the same way a real tap does.
+        const now = new Date()
+        const fromIso = Qt.formatDate(new Date(now.getFullYear(), now.getMonth(), 10), "yyyy-MM-dd")
+        const toIso = Qt.formatDate(new Date(now.getFullYear(), now.getMonth(), 20), "yyyy-MM-dd")
+        // Repeater-generated cells are visual children of the grid but not
+        // QObject children, so look them up via the grid rather than findChild.
+        const grid = findChild(page, "activityCalendarGrid")
+        verify(grid !== null)
+        function dayCell(iso) {
+            for (var i = 0; i < grid.children.length; ++i) {
+                if (grid.children[i].objectName === "calendarDay_" + iso) {
+                    return grid.children[i]
+                }
+            }
+            return null
+        }
+        const fromDay = dayCell(fromIso)
+        const toDay = dayCell(toIso)
+        verify(fromDay !== null)
+        verify(toDay !== null)
+
+        fromDay.clicked() // From is active by default, then advances to To
+        toDay.clicked()
+        applyButton.clicked()
+
+        compare(proxy.dateFilter, ActivityFilterProxyModel.CustomRange)
+        // Assert via the same formatting the UI uses, so the round trip is
+        // checked independently of the local time zone.
+        compare(Qt.formatDate(proxy.rangeStart, "yyyy-MM-dd"), fromIso)
+        compare(Qt.formatDate(proxy.rangeEnd, "yyyy-MM-dd"), toIso)
+    }
+
+    function test_calendar_click_after_complete_range_starts_fresh_range() {
+        const calendar = createTemporaryObject(activityCalendarComponent, this)
+        verify(calendar !== null)
+
+        // A reopened calendar is seeded with the applied range; a further day
+        // click must start a fresh range rather than being swallowed, so the
+        // user can re-pick without hitting Reset first.
+        calendar.seed(new Date(2001, 0, 10), new Date(2001, 0, 20))
+        verify(calendar.valid)
+
+        calendar.selectCalendarDate(new Date(2001, 0, 5))
+        compare(calendar.startIso, "2001-01-05")
+        compare(calendar.endIso, "")
+        compare(calendar.pickingEnd, true)
+
+        calendar.selectCalendarDate(new Date(2001, 0, 15))
+        compare(calendar.startIso, "2001-01-05")
+        compare(calendar.endIso, "2001-01-15")
+        verify(calendar.valid)
+    }
+
+    function test_calendar_keyboard_focus_helpers() {
+        const calendar = createTemporaryObject(activityCalendarComponent, this)
+        verify(calendar !== null)
+
+        // Offscreen tests cannot drive real key events through the popup, so
+        // exercise the functions the grid's Keys handler calls directly.
+        // A month far in the past keeps "today" out of the seeding path.
+        calendar.calMonth = 0
+        calendar.calYear = 2001
+        calendar.customFrom = null
+        calendar.calendarFocusDate = null
+
+        calendar.ensureCalendarFocusDate()
+        compare(calendar.isoDate(calendar.calendarFocusDate), "2001-01-01")
+
+        // Left from the first of the month crosses into the previous month
+        // and carries the displayed month along.
+        calendar.moveCalendarFocus(-1)
+        compare(calendar.isoDate(calendar.calendarFocusDate), "2000-12-31")
+        compare(calendar.calMonth, 11)
+        compare(calendar.calYear, 2000)
+
+        // Down (a week) moves back into January.
+        calendar.moveCalendarFocus(7)
+        compare(calendar.isoDate(calendar.calendarFocusDate), "2001-01-07")
+        compare(calendar.calMonth, 0)
+
+        // A month step clamps the day to the target month's length.
+        calendar.calendarFocusDate = new Date(2001, 0, 31)
+        calendar.stepCalendarFocusMonth(1)
+        compare(calendar.isoDate(calendar.calendarFocusDate), "2001-02-28")
+        compare(calendar.calMonth, 1)
+
+        // A picked start inside the displayed month seeds the focus ring.
+        calendar.calendarFocusDate = null
+        calendar.customFrom = new Date(2001, 1, 10)
+        calendar.ensureCalendarFocusDate()
+        compare(calendar.isoDate(calendar.calendarFocusDate), "2001-02-10")
+    }
+
+    function test_custom_date_range_reopen_preserves_dates() {
+        const page = createTemporaryObject(activityComponent, this)
+        verify(page !== null)
+
+        const proxy = findChild(page, "activityFilterProxyModel")
+        const activityPage = findChild(page, "activityPage")
+        const calendar = createTemporaryObject(activityCalendarComponent, this)
+        verify(proxy !== null)
+        verify(activityPage !== null)
+        verify(calendar !== null)
+
+        // Apply a fixed range through the timezone-safe ISO setter.
+        proxy.setCustomRange("2025-06-10", "2025-06-20")
+
+        // Reopening the date popup re-seeds the calendar draft from
+        // proxy.rangeStart / rangeEnd, which reach QML as UTC-midnight JS Dates.
+        // modelDateToLocal must keep the same calendar day; before it, the local
+        // formatting read them a day early west of UTC and Apply then shifted the
+        // applied range by a day on every reopen. Drive the whole reopen path
+        // (convert, seed, read back the ISO the Apply button sends to the model).
+        calendar.seed(activityPage.modelDateToLocal(proxy.rangeStart),
+                      activityPage.modelDateToLocal(proxy.rangeEnd))
+        compare(calendar.startIso, "2025-06-10")
+        compare(calendar.endIso, "2025-06-20")
     }
 }

--- a/test/qml/tst_requestpayment.qml
+++ b/test/qml/tst_requestpayment.qml
@@ -413,6 +413,33 @@ TestCase {
         compare(testPaymentRequest.amount.display, "0.00200000")
     }
 
+    function test_lockedEditorNameFollowsExternalLabelChange() {
+        const page = createTemporaryObject(requestPaymentComponent, this)
+        verify(page !== null)
+        page.wallet = testWalletModel
+        page.request = testPaymentRequest
+
+        const nameField = findChild(page, "requestPaymentYourNameInput")
+        verify(nameField !== null)
+
+        // Typing replaces the field's declarative binding, like a real session.
+        nameField.text = "Alice"
+        testPaymentRequest.label = "Alice"
+        testWalletModel.commitPaymentRequest()
+        compare(nameField.text, "Alice")
+
+        // An Addresses page edit reverse-syncs the held request's label while
+        // the form is locked; the field must follow.
+        testPaymentRequest.label = "Bob"
+        compare(nameField.text, "Bob")
+
+        // Mid-edit, an external label change must not clobber the draft.
+        testPaymentRequest.edit()
+        nameField.text = "Unsaved draft"
+        testPaymentRequest.label = "Carol"
+        compare(nameField.text, "Unsaved draft")
+    }
+
     function test_editingRequestDeleteAction_removes_and_clears_request() {
         const page = createTemporaryObject(requestPaymentComponent, this)
         verify(page !== null)

--- a/test/test_activityfilterproxymodel.cpp
+++ b/test/test_activityfilterproxymodel.cpp
@@ -141,6 +141,8 @@ private Q_SLOTS:
     void searchMatchesLabelAddressAndTxid();
     void filtersByDateBuckets();
     void filtersByCustomDateRange();
+    void rejectsInvalidCustomRange();
+    void appliesCustomRangeWithOneNotification();
     void filtersByTypeBucketsAndKeepsPendingRequestsExclusive();
     void usedAddressRequestsOnlyVisibleUnderPaymentRequestFilter();
     void filtersByMinimumAmount();
@@ -442,9 +444,8 @@ void ActivityFilterProxyModelTests::filtersByCustomDateRange()
 
     ActivityFilterProxyModel proxy;
     proxy.setSourceModel(&source);
-    proxy.setRangeStart(start);
-    proxy.setRangeEnd(end);
-    proxy.setDateFilter(ActivityFilterProxyModel::CustomRange);
+    QVERIFY(proxy.applyCustomRange(start.toString(Qt::ISODate), end.toString(Qt::ISODate)));
+    QCOMPARE(proxy.dateFilter(), ActivityFilterProxyModel::CustomRange);
 
     QCOMPARE(proxy.rowCount(), 3);
     QVERIFY(ContainsLabel(proxy, "On start")); // lower bound inclusive
@@ -452,6 +453,73 @@ void ActivityFilterProxyModelTests::filtersByCustomDateRange()
     QVERIFY(ContainsLabel(proxy, "On end"));   // upper bound inclusive (whole day)
     QVERIFY(!ContainsLabel(proxy, "Before"));
     QVERIFY(!ContainsLabel(proxy, "After"));
+}
+
+void ActivityFilterProxyModelTests::rejectsInvalidCustomRange()
+{
+    TestActivityListModel source;
+    source.setRows({
+        MakeRow("Inside", Transaction::RecvWithAddress, TimestampForLocalDate(QDate(2025, 6, 15))),
+    });
+
+    ActivityFilterProxyModel proxy;
+    proxy.setSourceModel(&source);
+
+    // An unparseable, empty, or inverted range leaves the model untouched: the
+    // previous filter keeps applying rather than collapsing to an empty list.
+    QVERIFY(!proxy.applyCustomRange("not-a-date", "2025-06-20"));
+    QVERIFY(!proxy.applyCustomRange("2025-06-10", ""));
+    QVERIFY(!proxy.applyCustomRange("2025-06-20", "2025-06-10"));
+
+    QCOMPARE(proxy.dateFilter(), ActivityFilterProxyModel::DateAll);
+    QVERIFY(!proxy.rangeStart().isValid());
+    QVERIFY(!proxy.rangeEnd().isValid());
+    QCOMPARE(proxy.rowCount(), 1);
+
+    // A single-day range is not inverted and is accepted.
+    QVERIFY(proxy.applyCustomRange("2025-06-15", "2025-06-15"));
+    QCOMPARE(proxy.rowCount(), 1);
+}
+
+void ActivityFilterProxyModelTests::appliesCustomRangeWithOneNotification()
+{
+    TestActivityListModel source;
+    source.setRows({
+        MakeRow("Inside", Transaction::RecvWithAddress, TimestampForLocalDate(QDate(2025, 6, 15))),
+    });
+
+    ActivityFilterProxyModel proxy;
+    proxy.setSourceModel(&source);
+
+    QSignalSpy range_spy(&proxy, &ActivityFilterProxyModel::rangeChanged);
+    QSignalSpy date_filter_spy(&proxy, &ActivityFilterProxyModel::dateFilterChanged);
+    QSignalSpy count_spy(&proxy, &ActivityFilterProxyModel::countChanged);
+
+    // Setting both ends and the date filter together notifies once, not once
+    // per end, so no observer sees a half-applied range.
+    QVERIFY(proxy.applyCustomRange("2025-06-10", "2025-06-20"));
+    QCOMPARE(range_spy.count(), 1);
+    QCOMPARE(date_filter_spy.count(), 1);
+    QCOMPARE(count_spy.count(), 1);
+
+    // Re-applying the same range is a no-op and stays silent.
+    QVERIFY(proxy.applyCustomRange("2025-06-10", "2025-06-20"));
+    QCOMPARE(range_spy.count(), 1);
+    QCOMPARE(date_filter_spy.count(), 1);
+    QCOMPARE(count_spy.count(), 1);
+
+    // A rejected range notifies nothing either.
+    QVERIFY(!proxy.applyCustomRange("2025-06-20", "2025-06-10"));
+    QCOMPARE(range_spy.count(), 1);
+    QCOMPARE(date_filter_spy.count(), 1);
+    QCOMPARE(count_spy.count(), 1);
+
+    // Moving only the range while the filter is already CustomRange notifies
+    // the range but not the filter.
+    QVERIFY(proxy.applyCustomRange("2025-06-11", "2025-06-21"));
+    QCOMPARE(range_spy.count(), 2);
+    QCOMPARE(date_filter_spy.count(), 1);
+    QCOMPARE(count_spy.count(), 2);
 }
 
 void ActivityFilterProxyModelTests::filtersByMinimumAmount()

--- a/test/test_activityfilterproxymodel.cpp
+++ b/test/test_activityfilterproxymodel.cpp
@@ -175,6 +175,7 @@ void ActivityFilterProxyModelTests::filtersByDateBuckets()
     const QDate start_of_month{today.year(), today.month(), 1};
     const QDate start_of_year{today.year(), 1, 1};
     const QDate start_of_next_week = start_of_week.addDays(7);
+    const QDate start_of_last_month = start_of_month.addMonths(-1);
     const QDate start_of_next_month = start_of_month.addMonths(1);
     const QDate start_of_next_year = start_of_year.addYears(1);
 
@@ -189,6 +190,8 @@ void ActivityFilterProxyModelTests::filtersByDateBuckets()
         MakeRow("Month start", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_month)),
         MakeRow("Before month", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_month.addDays(-1))),
         MakeRow("Next month", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_next_month)),
+        MakeRow("Last month start", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_last_month)),
+        MakeRow("Before last month", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_last_month.addDays(-1))),
         MakeRow("Year start", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_year)),
         MakeRow("Before year", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_year.addDays(-1))),
         MakeRow("Next year", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_next_year)),
@@ -211,6 +214,12 @@ void ActivityFilterProxyModelTests::filtersByDateBuckets()
     QVERIFY(ContainsLabel(proxy, "Month start"));
     QVERIFY(!ContainsLabel(proxy, "Before month"));
     QVERIFY(!ContainsLabel(proxy, "Next month"));
+
+    proxy.setDateFilter(ActivityFilterProxyModel::LastMonth);
+    QVERIFY(ContainsLabel(proxy, "Last month start"));
+    QVERIFY(ContainsLabel(proxy, "Before month"));
+    QVERIFY(!ContainsLabel(proxy, "Before last month"));
+    QVERIFY(!ContainsLabel(proxy, "Month start"));
 
     proxy.setDateFilter(ActivityFilterProxyModel::ThisYear);
     QVERIFY(ContainsLabel(proxy, "Year start"));
@@ -242,11 +251,12 @@ void ActivityFilterProxyModelTests::filtersByTypeBucketsAndKeepsPendingRequestsE
     QCOMPARE(proxy.index(0, 0).data(ActivityListModel::LabelRole).toString(), QString{"Received"});
 
     proxy.setTypeFilter(ActivityFilterProxyModel::Sent);
-    QCOMPARE(proxy.rowCount(), 2);
-    QVERIFY(ContainsLabel(proxy, "Sent"));
-    QVERIFY(ContainsLabel(proxy, "Other"));
-    QVERIFY(!ContainsLabel(proxy, "Self"));
-    QVERIFY(!ContainsLabel(proxy, "Request"));
+    QCOMPARE(proxy.rowCount(), 1);
+    QCOMPARE(proxy.index(0, 0).data(ActivityListModel::LabelRole).toString(), QString{"Sent"});
+
+    proxy.setTypeFilter(ActivityFilterProxyModel::Other);
+    QCOMPARE(proxy.rowCount(), 1);
+    QCOMPARE(proxy.index(0, 0).data(ActivityListModel::LabelRole).toString(), QString{"Other"});
 
     proxy.setTypeFilter(ActivityFilterProxyModel::SentToSelf);
     QCOMPARE(proxy.rowCount(), 1);

--- a/test/test_activityfilterproxymodel.cpp
+++ b/test/test_activityfilterproxymodel.cpp
@@ -184,7 +184,6 @@ void ActivityFilterProxyModelTests::filtersByDateBuckets()
     const QDate start_of_month{today.year(), today.month(), 1};
     const QDate start_of_year{today.year(), 1, 1};
     const QDate start_of_next_week = start_of_week.addDays(7);
-    const QDate start_of_last_month = start_of_month.addMonths(-1);
     const QDate start_of_next_month = start_of_month.addMonths(1);
     const QDate start_of_next_year = start_of_year.addYears(1);
 
@@ -199,8 +198,6 @@ void ActivityFilterProxyModelTests::filtersByDateBuckets()
         MakeRow("Month start", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_month)),
         MakeRow("Before month", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_month.addDays(-1))),
         MakeRow("Next month", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_next_month)),
-        MakeRow("Last month start", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_last_month)),
-        MakeRow("Before last month", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_last_month.addDays(-1))),
         MakeRow("Year start", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_year)),
         MakeRow("Before year", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_year.addDays(-1))),
         MakeRow("Next year", Transaction::RecvWithAddress, TimestampForLocalDate(start_of_next_year)),
@@ -223,12 +220,6 @@ void ActivityFilterProxyModelTests::filtersByDateBuckets()
     QVERIFY(ContainsLabel(proxy, "Month start"));
     QVERIFY(!ContainsLabel(proxy, "Before month"));
     QVERIFY(!ContainsLabel(proxy, "Next month"));
-
-    proxy.setDateFilter(ActivityFilterProxyModel::LastMonth);
-    QVERIFY(ContainsLabel(proxy, "Last month start"));
-    QVERIFY(ContainsLabel(proxy, "Before month"));
-    QVERIFY(!ContainsLabel(proxy, "Before last month"));
-    QVERIFY(!ContainsLabel(proxy, "Month start"));
 
     proxy.setDateFilter(ActivityFilterProxyModel::ThisYear);
     QVERIFY(ContainsLabel(proxy, "Year start"));

--- a/test/test_activityfilterproxymodel.cpp
+++ b/test/test_activityfilterproxymodel.cpp
@@ -26,6 +26,7 @@ struct ActivityRow {
     qint64 timestamp{0};
     QString txid;
     bool pending_request{false};
+    bool used_address_request{false};
     qlonglong net_amount_sat{0};
 };
 
@@ -63,6 +64,8 @@ public:
             return row.pending_request ? QString{} : row.txid;
         case ActivityListModel::IsPendingRequestRole:
             return row.pending_request;
+        case ActivityListModel::IsUsedAddressRequestRole:
+            return row.used_address_request;
         case ActivityListModel::NetAmountSatRole:
             return row.net_amount_sat;
         default:
@@ -83,6 +86,7 @@ public:
             {ActivityListModel::TimestampRole, "timestamp"},
             {ActivityListModel::TxIdRole, "txid"},
             {ActivityListModel::IsPendingRequestRole, "isPendingRequest"},
+            {ActivityListModel::IsUsedAddressRequestRole, "isUsedAddressRequest"},
             {ActivityListModel::NetAmountSatRole, "netAmountSat"},
         };
     }
@@ -138,6 +142,7 @@ private Q_SLOTS:
     void filtersByDateBuckets();
     void filtersByCustomDateRange();
     void filtersByTypeBucketsAndKeepsPendingRequestsExclusive();
+    void usedAddressRequestsOnlyVisibleUnderPaymentRequestFilter();
     void filtersByMinimumAmount();
     void sortsByTimestampDescending();
     void exportsCurrentFilteredRowsToCsv();
@@ -271,6 +276,44 @@ void ActivityFilterProxyModelTests::filtersByTypeBucketsAndKeepsPendingRequestsE
     proxy.setTypeFilter(ActivityFilterProxyModel::PaymentRequest);
     QCOMPARE(proxy.rowCount(), 1);
     QCOMPARE(proxy.index(0, 0).data(ActivityListModel::LabelRole).toString(), QString{"Request"});
+}
+
+void ActivityFilterProxyModelTests::usedAddressRequestsOnlyVisibleUnderPaymentRequestFilter()
+{
+    // A request whose address already has a real transaction is materialized so
+    // the Payment request filter can surface it, but it must stay hidden in the
+    // default view so it does not duplicate that address's real row.
+    ActivityRow received = MakeRow("Received", Transaction::RecvWithAddress, 30, "tx-received");
+    ActivityRow pending = MakeRow("Pending", Transaction::RecvWithAddress, 20);
+    pending.pending_request = true;
+    ActivityRow used = MakeRow("Used", Transaction::RecvWithAddress, 10);
+    used.pending_request = true;
+    used.used_address_request = true;
+
+    TestActivityListModel source;
+    source.setRows({received, pending, used});
+
+    ActivityFilterProxyModel proxy;
+    proxy.setSourceModel(&source);
+
+    // Default view (all types): the used-address request is hidden.
+    QCOMPARE(proxy.rowCount(), 2);
+    QVERIFY(ContainsLabel(proxy, "Received"));
+    QVERIFY(ContainsLabel(proxy, "Pending"));
+    QVERIFY(!ContainsLabel(proxy, "Used"));
+
+    // Payment request filter: both requests show, the real transaction does not.
+    proxy.setTypeFilter(ActivityFilterProxyModel::PaymentRequest);
+    QCOMPARE(proxy.rowCount(), 2);
+    QVERIFY(ContainsLabel(proxy, "Pending"));
+    QVERIFY(ContainsLabel(proxy, "Used"));
+    QVERIFY(!ContainsLabel(proxy, "Received"));
+
+    // Any other type filter still hides the used-address request.
+    proxy.setTypeFilter(ActivityFilterProxyModel::Received);
+    QCOMPARE(proxy.rowCount(), 1);
+    QVERIFY(ContainsLabel(proxy, "Received"));
+    QVERIFY(!ContainsLabel(proxy, "Used"));
 }
 
 void ActivityFilterProxyModelTests::sortsByTimestampDescending()

--- a/test/test_activityfilterproxymodel.cpp
+++ b/test/test_activityfilterproxymodel.cpp
@@ -136,7 +136,9 @@ class ActivityFilterProxyModelTests : public QObject
 private Q_SLOTS:
     void searchMatchesLabelAddressAndTxid();
     void filtersByDateBuckets();
+    void filtersByCustomDateRange();
     void filtersByTypeBucketsAndKeepsPendingRequestsExclusive();
+    void filtersByMinimumAmount();
     void sortsByTimestampDescending();
     void exportsCurrentFilteredRowsToCsv();
     void exportsCsvUsingDisplayUnit();
@@ -379,6 +381,59 @@ void ActivityFilterProxyModelTests::exportsCsvEscapesSignedRowsAndHandlesFailure
     QVERIFY(csv.contains("\"true\""));
 
     QVERIFY(!proxy.exportCsv(temp_dir.filePath("missing/activity.csv")));
+}
+
+void ActivityFilterProxyModelTests::filtersByCustomDateRange()
+{
+    const QDate start{2025, 6, 10};
+    const QDate end{2025, 6, 20};
+
+    TestActivityListModel source;
+    source.setRows({
+        MakeRow("Before", Transaction::RecvWithAddress, TimestampForLocalDate(start.addDays(-1))),
+        MakeRow("On start", Transaction::RecvWithAddress, TimestampForLocalDate(start)),
+        MakeRow("Inside", Transaction::RecvWithAddress, TimestampForLocalDate(QDate(2025, 6, 15))),
+        MakeRow("On end", Transaction::RecvWithAddress, TimestampForLocalDate(end)),
+        MakeRow("After", Transaction::RecvWithAddress, TimestampForLocalDate(end.addDays(1))),
+    });
+
+    ActivityFilterProxyModel proxy;
+    proxy.setSourceModel(&source);
+    proxy.setRangeStart(start);
+    proxy.setRangeEnd(end);
+    proxy.setDateFilter(ActivityFilterProxyModel::CustomRange);
+
+    QCOMPARE(proxy.rowCount(), 3);
+    QVERIFY(ContainsLabel(proxy, "On start")); // lower bound inclusive
+    QVERIFY(ContainsLabel(proxy, "Inside"));
+    QVERIFY(ContainsLabel(proxy, "On end"));   // upper bound inclusive (whole day)
+    QVERIFY(!ContainsLabel(proxy, "Before"));
+    QVERIFY(!ContainsLabel(proxy, "After"));
+}
+
+void ActivityFilterProxyModelTests::filtersByMinimumAmount()
+{
+    ActivityRow small = MakeRow("Small", Transaction::RecvWithAddress, 10);
+    small.net_amount_sat = 50'000;
+    ActivityRow big_receive = MakeRow("Big receive", Transaction::RecvWithAddress, 20);
+    big_receive.net_amount_sat = 200'000;
+    ActivityRow big_send = MakeRow("Big send", Transaction::SendToAddress, 30);
+    big_send.net_amount_sat = -200'000;
+
+    TestActivityListModel source;
+    source.setRows({small, big_receive, big_send});
+
+    ActivityFilterProxyModel proxy;
+    proxy.setSourceModel(&source);
+
+    proxy.setMinAmount(100'000);
+    QCOMPARE(proxy.rowCount(), 2);
+    QVERIFY(ContainsLabel(proxy, "Big receive"));
+    QVERIFY(ContainsLabel(proxy, "Big send")); // absolute value matches the threshold
+    QVERIFY(!ContainsLabel(proxy, "Small"));
+
+    proxy.setMinAmount(-1); // clearing restores every row
+    QCOMPARE(proxy.rowCount(), 3);
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN

--- a/test/test_activityfilterproxymodel.cpp
+++ b/test/test_activityfilterproxymodel.cpp
@@ -11,8 +11,11 @@
 #include <QAbstractListModel>
 #include <QDateTime>
 #include <QFile>
+#include <QScopeGuard>
 #include <QTemporaryDir>
 #include <QUrl>
+
+#include <ctime>
 
 namespace {
 struct ActivityRow {
@@ -107,6 +110,15 @@ qint64 TimestampForLocalDate(const QDate& date)
     return QDateTime(date, QTime(12, 0)).toSecsSinceEpoch();
 }
 
+void TzSet()
+{
+#ifdef Q_OS_WIN
+    _tzset();
+#else
+    tzset();
+#endif
+}
+
 ActivityRow MakeRow(QString label, int type, qint64 timestamp, QString txid = {}, QString address = {})
 {
     return ActivityRow{
@@ -141,6 +153,7 @@ private Q_SLOTS:
     void searchMatchesLabelAddressAndTxid();
     void filtersByDateBuckets();
     void filtersByCustomDateRange();
+    void customRangeHandlesDstGapDayBoundaries();
     void rejectsInvalidCustomRange();
     void appliesCustomRangeWithOneNotification();
     void filtersByTypeBucketsAndKeepsPendingRequestsExclusive();
@@ -444,6 +457,54 @@ void ActivityFilterProxyModelTests::filtersByCustomDateRange()
     QVERIFY(ContainsLabel(proxy, "On end"));   // upper bound inclusive (whole day)
     QVERIFY(!ContainsLabel(proxy, "Before"));
     QVERIFY(!ContainsLabel(proxy, "After"));
+}
+
+void ActivityFilterProxyModelTests::customRangeHandlesDstGapDayBoundaries()
+{
+    // America/Sao_Paulo entered daylight saving at midnight on 2018-11-04:
+    // clocks jumped from 00:00 to 01:00, so that day has no midnight.
+    // QDateTime{date, QTime(0, 0)} is invalid for it and compares before
+    // every valid time, which silently broke both range boundaries; the
+    // date's startOfDay() is the correct first instant. In a zone without
+    // the gap this degenerates to an ordinary range check and still passes.
+    const QByteArray previous_tz = qgetenv("TZ");
+    qputenv("TZ", "America/Sao_Paulo");
+    TzSet();
+    const auto restore_tz = qScopeGuard([&previous_tz] {
+        if (previous_tz.isEmpty()) {
+            qunsetenv("TZ");
+        } else {
+            qputenv("TZ", previous_tz);
+        }
+        TzSet();
+    });
+
+    const QDate gap_day{2018, 11, 4};
+
+    TestActivityListModel source;
+    source.setRows({
+        MakeRow("Before", Transaction::RecvWithAddress, TimestampForLocalDate(gap_day.addDays(-1))),
+        MakeRow("On gap day", Transaction::RecvWithAddress, TimestampForLocalDate(gap_day)),
+        MakeRow("After", Transaction::RecvWithAddress, TimestampForLocalDate(gap_day.addDays(1))),
+    });
+
+    ActivityFilterProxyModel proxy;
+    proxy.setSourceModel(&source);
+
+    // A range starting on the gap day must still exclude earlier rows.
+    QVERIFY(proxy.applyCustomRange(gap_day.toString(Qt::ISODate),
+                                   gap_day.addDays(1).toString(Qt::ISODate)));
+    QCOMPARE(proxy.rowCount(), 2);
+    QVERIFY(!ContainsLabel(proxy, "Before"));
+    QVERIFY(ContainsLabel(proxy, "On gap day"));
+    QVERIFY(ContainsLabel(proxy, "After"));
+
+    // A range whose exclusive upper bound lands on the gap day (inclusive
+    // end date the day before) must not collapse to rejecting every row.
+    QVERIFY(proxy.applyCustomRange(gap_day.addDays(-1).toString(Qt::ISODate),
+                                   gap_day.addDays(-1).toString(Qt::ISODate)));
+    QCOMPARE(proxy.rowCount(), 1);
+    QVERIFY(ContainsLabel(proxy, "Before"));
 }
 
 void ActivityFilterProxyModelTests::rejectsInvalidCustomRange()

--- a/test/test_transaction.cpp
+++ b/test/test_transaction.cpp
@@ -67,6 +67,7 @@ private Q_SLOTS:
     void fromWalletTx_hidesSenderChangeOutput();
     void fromWalletTx_mixedDebitKeepsNegativeNetAmount();
     void fromWalletTx_showsIncomingPaymentToChangeAddress();
+    void dateTimeString_usedAddressRequestKeepsDate();
 };
 
 void TransactionTests::initTestCase()
@@ -133,6 +134,30 @@ void TransactionTests::fromWalletTx_showsIncomingPaymentToChangeAddress()
     QCOMPARE(parts.at(0)->credit, 5 * COIN_VALUE);
     QCOMPARE(parts.at(0)->netAmount(), 5 * COIN_VALUE);
     QCOMPARE(parts.at(0)->prettyAmount(), QStringLiteral("+5.00000000"));
+}
+
+// Only a request still awaiting payment reads "Pending receive". A
+// used-address request keeps its creation date: address use alone does not
+// prove the request was paid, so no receipt is claimed. Only the branch
+// selection is under test here; the date rendering itself is shared with
+// every transaction row, so the expected string is built with the same
+// formatting call.
+void TransactionTests::dateTimeString_usedAddressRequestKeepsDate()
+{
+    uint256 zero_hash;
+
+    Transaction pending{zero_hash, /*time=*/500, Transaction::RecvWithAddress,
+                        /*address=*/"addr", /*debit=*/0, /*credit=*/COIN_VALUE};
+    pending.isPendingRequest = true;
+    QCOMPARE(pending.dateTimeString(), QStringLiteral("Pending receive"));
+
+    Transaction used{zero_hash, /*time=*/500, Transaction::RecvWithAddress,
+                     /*address=*/"addr", /*debit=*/0, /*credit=*/COIN_VALUE};
+    used.isPendingRequest = true;
+    used.isUsedAddressRequest = true;
+    const QString expected_date =
+        QDateTime::fromSecsSinceEpoch(500).toString("MMMM d, yyyy");
+    QCOMPARE(used.dateTimeString(), expected_date);
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -268,6 +268,8 @@ public:
     std::vector<bool> fill_psbt_sign_args;
     bool get_address_result{false};
     std::string get_address_label;
+    std::string last_set_address_book_label;
+    int set_address_book_calls{0};
     int sign_message_calls{0};
     std::string last_signed_message;
     bool can_bump_transaction{true};
@@ -370,7 +372,12 @@ public:
         return sign_message_fn(message, pkhash, signature);
     }
     bool isSpendable(const CTxDestination&) override { return false; }
-    bool setAddressBook(const CTxDestination&, const std::string&, const std::optional<wallet::AddressPurpose>&) override { return true; }
+    bool setAddressBook(const CTxDestination&, const std::string& name, const std::optional<wallet::AddressPurpose>&) override
+    {
+        last_set_address_book_label = name;
+        ++set_address_book_calls;
+        return true;
+    }
     bool delAddressBook(const CTxDestination&) override { return true; }
     bool getAddress(const CTxDestination&, std::string* name, wallet::AddressPurpose*) override
     {
@@ -577,6 +584,8 @@ private Q_SLOTS:
     void activityDetailsSelectLowestOutputIndex();
     void activityDetailsPreferOutgoingForSelfPayment();
     void editedReceiveRequestLabelShownInActivityRow();
+    void editedRequestSyncsAddressBookLabel();
+    void requestSaveLeavesUneditedAddressBookLabelAlone();
     void usedAddressReceiveRequestRowIsFlaggedAndUntracked();
     void paidPendingRequestBecomesUsedAddressRequestLive();
     void paymentMarksEveryPendingRequestForAddressUsedLive();
@@ -1738,6 +1747,44 @@ void WalletQmlModelTests::editedReceiveRequestLabelShownInActivityRow()
     QCOMPARE(activity->rowCount(), 1);
     QCOMPARE(activity->data(activity->index(0), ActivityListModel::LabelRole).toString(),
              QStringLiteral("New label"));
+}
+
+void WalletQmlModelTests::editedRequestSyncsAddressBookLabel()
+{
+    auto [wallet, model] = MakePasswordWalletModel();
+    // getAddress must succeed for the label sync to reach setAddressBook.
+    wallet->get_address_result = true;
+
+    // Creating the request labels its address.
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Old label"));
+    QVERIFY(model->commitPaymentRequest());
+    QCOMPARE(wallet->last_set_address_book_label, std::string{"Old label"});
+
+    // Editing the label writes the new label back to the address book, so the
+    // Addresses page reflects it instead of keeping the stale label.
+    const int calls_before = wallet->set_address_book_calls;
+    model->currentPaymentRequest()->setLabel(QStringLiteral("New label"));
+    QVERIFY(model->commitPaymentRequest());
+    QVERIFY(wallet->set_address_book_calls > calls_before);
+    QCOMPARE(wallet->last_set_address_book_label, std::string{"New label"});
+}
+
+void WalletQmlModelTests::requestSaveLeavesUneditedAddressBookLabelAlone()
+{
+    auto [wallet, model] = MakePasswordWalletModel();
+    wallet->get_address_result = true;
+    // The address book already carries a label, e.g. set on the Addresses page.
+    wallet->get_address_label = "Book label";
+
+    // Saving a request whose label is empty must not clear the book label.
+    QVERIFY(model->commitPaymentRequest());
+    QCOMPARE(wallet->set_address_book_calls, 0);
+
+    // Saving with an unchanged label (e.g. an amount-only edit) must not
+    // rewrite the book label either.
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Book label"));
+    QVERIFY(model->commitPaymentRequest());
+    QCOMPARE(wallet->set_address_book_calls, 0);
 }
 
 void WalletQmlModelTests::usedAddressReceiveRequestRowIsFlaggedAndUntracked()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -49,6 +49,7 @@
 #include <set>
 #include <span>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -593,6 +594,7 @@ private Q_SLOTS:
     void usedAddressReceiveRequestRowIsFlaggedAndUntracked();
     void paidPendingRequestBecomesUsedAddressRequestLive();
     void paymentMarksEveryPendingRequestForAddressUsedLive();
+    void transactionChangedOffThreadIsQueuedToModelThread();
     void reloadMarksEveryRequestForPaidAddressUsed();
     void prepareTransactionOnLockedWalletRequiresPassword();
     void prepareTransactionWithPrivateKeysDisabledDoesNotRequirePassword();
@@ -1973,8 +1975,9 @@ void WalletQmlModelTests::paidPendingRequestBecomesUsedAddressRequestLive()
 
     // The request is kept as a used-address request (Payment request filter only)
     // and the received transaction is added as its own row, matching the reloaded
-    // state instead of consuming the request in place.
-    QCOMPARE(activity->rowCount(), 2);
+    // state instead of consuming the request in place. The update is queued to
+    // the model's thread, so spin the event loop for it.
+    QTRY_COMPARE(activity->rowCount(), 2);
     QVERIFY(!activity->data(activity->index(0), ActivityListModel::IsPendingRequestRole).toBool());
     QVERIFY(!activity->data(activity->index(0), ActivityListModel::IsUsedAddressRequestRole).toBool());
     QCOMPARE(activity->data(activity->index(0), ActivityListModel::TypeRole).toInt(),
@@ -2050,7 +2053,7 @@ void WalletQmlModelTests::paymentMarksEveryPendingRequestForAddressUsedLive()
         cb(received.tx->GetHash(), CT_NEW);
     }
 
-    QCOMPARE(activity->rowCount(), 4);
+    QTRY_COMPARE(activity->rowCount(), 4);
     const auto states = RequestRowStates(activity);
     QVERIFY(states.at(QStringLiteral("req-a1")).used);
     QVERIFY(states.at(QStringLiteral("req-a2")).used);
@@ -2062,6 +2065,66 @@ void WalletQmlModelTests::paymentMarksEveryPendingRequestForAddressUsedLive()
     QCOMPARE(proxy.rowCount(), 2);
     proxy.setTypeFilter(ActivityFilterProxyModel::PaymentRequest);
     QCOMPARE(proxy.rowCount(), 3);
+}
+
+// The wallet fires transactionChanged on its notification thread. The model
+// must not mutate itself there: the rows and their model signals belong to
+// the thread the attached proxies and views live on, so the update has to be
+// queued and land only once that thread's event loop runs (the marshalling
+// the Widgets TransactionTableModel does for this same notification).
+void WalletQmlModelTests::transactionChangedOffThreadIsQueuedToModelThread()
+{
+    auto wallet = std::make_unique<MockWallet>();
+    auto* wallet_ptr = wallet.get();
+
+    const CTxDestination dest{WitnessV0KeyHash{uint160{std::vector<unsigned char>(20, 7)}}};
+    const QString address = QString::fromStdString(EncodeDestination(dest));
+    const interfaces::WalletTx received = ReceiveWalletTxFor(dest, 50 * COIN);
+
+    std::vector<interfaces::Wallet::TransactionChangedFn> callbacks;
+    wallet_ptr->get_wallet_txs_fn = [] { return std::set<interfaces::WalletTx>{}; };
+    wallet_ptr->get_balance_fn = [] { return 10 * COIN; };
+    wallet_ptr->handle_transaction_changed_fn = [&](interfaces::Wallet::TransactionChangedFn fn) {
+        callbacks.push_back(std::move(fn));
+        return std::unique_ptr<interfaces::Handler>{};
+    };
+    wallet_ptr->get_wallet_tx_fn = [received](const Txid&) { return received; };
+    std::atomic<bool> status_read_on_notifier_thread{false};
+    std::thread::id notifier_id;
+    wallet_ptr->try_get_tx_status_fn = [&](const Txid&, interfaces::WalletTxStatus&, int&, int64_t&) {
+        if (std::this_thread::get_id() == notifier_id) {
+            status_read_on_notifier_thread = true;
+        }
+        return true;
+    };
+
+    WalletQmlModel model{std::move(wallet)};
+    ActivityListModel* activity = model.activityListModel();
+
+    activity->addReceiveRequest(address, QStringLiteral("req"), 0, 100, QStringLiteral("1"));
+    QCOMPARE(activity->rowCount(), 1);
+
+    // Fire the notification from a worker thread, the way the wallet does.
+    QVERIFY(!callbacks.empty());
+    std::thread notifier{[&] {
+        notifier_id = std::this_thread::get_id();
+        for (const auto& cb : callbacks) {
+            cb(received.tx->GetHash(), CT_NEW);
+        }
+    }};
+    notifier.join();
+
+    // The notification thread must only have queued the update, not applied
+    // it: the row set is unchanged until this thread's event loop runs.
+    QCOMPARE(activity->rowCount(), 1);
+
+    // The status snapshot, however, must have been taken on the notification
+    // thread itself: it holds cs_wallet there, so the try-lock inside
+    // tryGetTxStatus cannot fail. Deferred to this thread it can lose the
+    // try-lock and silently drop the update.
+    QVERIFY(status_read_on_notifier_thread);
+
+    QTRY_COMPARE(activity->rowCount(), 2);
 }
 
 // The reload half of the same rule: rebuilding the model from the wallet

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -587,6 +587,7 @@ private Q_SLOTS:
     void editedReceiveRequestLabelShownInActivityRow();
     void editedRequestSyncsAddressBookLabel();
     void requestSaveLeavesUneditedAddressBookLabelAlone();
+    void amountOnlyRequestEditPreservesAddressBookLabel();
     void editedAddressBookLabelSyncsRequestLabel();
     void requestSaveLeavesSiblingRequestLabelsAlone();
     void labelSyncSkipsInMemoryUpdateWhenPersistFails();
@@ -1791,6 +1792,33 @@ void WalletQmlModelTests::requestSaveLeavesUneditedAddressBookLabelAlone()
     model->currentPaymentRequest()->setLabel(QStringLiteral("Book label"));
     QVERIFY(model->commitPaymentRequest());
     QCOMPARE(wallet->set_address_book_calls, 0);
+}
+
+void WalletQmlModelTests::amountOnlyRequestEditPreservesAddressBookLabel()
+{
+    auto [wallet, model] = MakePasswordWalletModel();
+    wallet->get_address_result = true;
+
+    // Creating the request labels its address.
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Request label"));
+    QVERIFY(model->commitPaymentRequest());
+    QCOMPARE(wallet->last_set_address_book_label, std::string{"Request label"});
+
+    // The address is then relabeled independently on the Addresses page.
+    wallet->get_address_label = "Independent label";
+    const int calls_before = wallet->set_address_book_calls;
+
+    // Editing only the amount must not re-assert the request label over the
+    // independent one; the save changed no label.
+    model->currentPaymentRequest()->amount()->setSatoshi(12'345);
+    QVERIFY(model->commitPaymentRequest());
+    QCOMPARE(wallet->set_address_book_calls, calls_before);
+
+    // Editing the request label itself still writes it back.
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Renamed request"));
+    QVERIFY(model->commitPaymentRequest());
+    QVERIFY(wallet->set_address_book_calls > calls_before);
+    QCOMPARE(wallet->last_set_address_book_label, std::string{"Renamed request"});
 }
 
 void WalletQmlModelTests::editedAddressBookLabelSyncsRequestLabel()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -28,8 +28,6 @@
 #include <wallet/coincontrol.h>
 #include <wallet/types.h>
 
-#include <map>
-
 #include <QFile>
 #include <QSemaphore>
 #include <QSettings>
@@ -43,6 +41,7 @@
 #include <array>
 #include <atomic>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <numeric>
@@ -392,8 +391,9 @@ public:
     {
         ++set_address_receive_request_calls;
         receive_request_ids.push_back(id);
-        return true;
+        return set_address_receive_request_result;
     }
+    bool set_address_receive_request_result{true};
     util::Result<void> displayAddress(const CTxDestination&) override { return {}; }
     bool lockCoin(const COutPoint&, const bool) override { return true; }
     bool unlockCoin(const COutPoint&) override { return true; }
@@ -586,6 +586,9 @@ private Q_SLOTS:
     void editedReceiveRequestLabelShownInActivityRow();
     void editedRequestSyncsAddressBookLabel();
     void requestSaveLeavesUneditedAddressBookLabelAlone();
+    void editedAddressBookLabelSyncsRequestLabel();
+    void requestSaveLeavesSiblingRequestLabelsAlone();
+    void labelSyncSkipsInMemoryUpdateWhenPersistFails();
     void usedAddressReceiveRequestRowIsFlaggedAndUntracked();
     void paidPendingRequestBecomesUsedAddressRequestLive();
     void paymentMarksEveryPendingRequestForAddressUsedLive();
@@ -1785,6 +1788,100 @@ void WalletQmlModelTests::requestSaveLeavesUneditedAddressBookLabelAlone()
     model->currentPaymentRequest()->setLabel(QStringLiteral("Book label"));
     QVERIFY(model->commitPaymentRequest());
     QCOMPARE(wallet->set_address_book_calls, 0);
+}
+
+void WalletQmlModelTests::editedAddressBookLabelSyncsRequestLabel()
+{
+    auto [wallet, model] = MakePasswordWalletModel();
+    wallet->get_address_result = true;
+
+    // Create a request; its address carries the request label.
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Old label"));
+    QVERIFY(model->commitPaymentRequest());
+    const QString address = model->currentPaymentRequest()->address();
+    QVERIFY(!address.isEmpty());
+
+    ActivityListModel* activity = model->activityListModel();
+    QCOMPARE(activity->data(activity->index(0), ActivityListModel::LabelRole).toString(),
+             QStringLiteral("Old label"));
+
+    // Editing the label on the Addresses page must propagate to the matching
+    // request, so the request record and its Activity row do not diverge from
+    // the address book (the reverse of editedRequestSyncsAddressBookLabel).
+    QVERIFY(model->setAddressLabel(address, QStringLiteral("New label")));
+
+    QCOMPARE(activity->data(activity->index(0), ActivityListModel::LabelRole).toString(),
+             QStringLiteral("New label"));
+    const QVariantList matches = model->receiveRequests()->matchingEntriesForAddress(address);
+    QCOMPARE(matches.size(), 1);
+    QCOMPARE(matches.at(0).toMap().value(QStringLiteral("label")).toString(),
+             QStringLiteral("New label"));
+}
+
+// Core supports multiple receive requests for one address, each with its own
+// label. Saving one request writes its label to the address book but must not
+// fan it out to the sibling requests; only an Addresses page edit
+// (setAddressLabel) deliberately rewrites every request for the address.
+void WalletQmlModelTests::requestSaveLeavesSiblingRequestLabelsAlone()
+{
+    auto [wallet, model] = MakePasswordWalletModel();
+    wallet->get_address_result = true;
+
+    // Two requests on the same address (the fake wallet hands out one
+    // destination), with their own labels.
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Request A"));
+    QVERIFY(model->commitPaymentRequest());
+    const QString request_a_id = model->currentPaymentRequest()->id();
+    const QString address = model->currentPaymentRequest()->address();
+
+    model->currentPaymentRequest()->clear();
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Request B"));
+    QVERIFY(model->commitPaymentRequest());
+    const QString request_b_id = model->currentPaymentRequest()->id();
+    QVERIFY(request_a_id != request_b_id);
+    QCOMPARE(model->currentPaymentRequest()->address(), address);
+
+    // Editing request A's label updates the address book but leaves request
+    // B's persisted label alone.
+    QVERIFY(model->loadPaymentRequest(request_a_id));
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Edited A"));
+    const int b_writes_before = static_cast<int>(
+        std::count(wallet->receive_request_ids.begin(), wallet->receive_request_ids.end(),
+                   request_b_id.toStdString()));
+    QVERIFY(model->commitPaymentRequest());
+    QCOMPARE(wallet->last_set_address_book_label, std::string{"Edited A"});
+
+    const int b_writes_after = static_cast<int>(
+        std::count(wallet->receive_request_ids.begin(), wallet->receive_request_ids.end(),
+                   request_b_id.toStdString()));
+    QCOMPARE(b_writes_after, b_writes_before);
+    const auto sibling = model->receiveRequests()->entryById(request_b_id);
+    QVERIFY(sibling.has_value());
+    QCOMPARE(QString::fromStdString(sibling->recipient.label), QStringLiteral("Request B"));
+}
+
+// A label sync write that fails to persist must not update the in-memory
+// request models: they would show a label the wallet does not hold, and a
+// reload would silently revert it.
+void WalletQmlModelTests::labelSyncSkipsInMemoryUpdateWhenPersistFails()
+{
+    auto [wallet, model] = MakePasswordWalletModel();
+    wallet->get_address_result = true;
+
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Old label"));
+    QVERIFY(model->commitPaymentRequest());
+    const QString request_id = model->currentPaymentRequest()->id();
+    const QString address = model->currentPaymentRequest()->address();
+
+    wallet->set_address_receive_request_result = false;
+    QVERIFY(model->setAddressLabel(address, QStringLiteral("New label")));
+
+    const auto entry = model->receiveRequests()->entryById(request_id);
+    QVERIFY(entry.has_value());
+    QCOMPARE(QString::fromStdString(entry->recipient.label), QStringLiteral("Old label"));
+    ActivityListModel* activity = model->activityListModel();
+    QCOMPARE(activity->data(activity->index(0), ActivityListModel::LabelRole).toString(),
+             QStringLiteral("Old label"));
 }
 
 void WalletQmlModelTests::usedAddressReceiveRequestRowIsFlaggedAndUntracked()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -13,8 +13,10 @@
 #include <outputtype.h>
 #include <primitives/transaction.h>
 #include <psbt.h>
+#include <qml/models/activityfilterproxymodel.h>
 #include <qml/models/activitylistmodel.h>
 #include <qml/models/psbtqmlmodel.h>
+#include <qml/models/receiverequesthistorymodel.h>
 #include <qml/models/sendrecipient.h>
 #include <qml/models/sendrecipientslistmodel.h>
 #include <qml/models/walletqmlmodel.h>
@@ -25,6 +27,8 @@
 #include <test/mocks/mockwallet.h>
 #include <wallet/coincontrol.h>
 #include <wallet/types.h>
+
+#include <map>
 
 #include <QFile>
 #include <QSemaphore>
@@ -168,6 +172,28 @@ WalletModelHarness<MockWallet> MakeWalletModel(interfaces::Node* node = nullptr)
     };
 
     return {wallet_view, std::make_unique<WalletQmlModel>(std::move(wallet), node)};
+}
+
+// A minimal external incoming payment to `dest`, shaped so that
+// Transaction::fromWalletTx decodes it into a single RecvWithAddress row.
+interfaces::WalletTx ReceiveWalletTxFor(const CTxDestination& dest, CAmount amount)
+{
+    CMutableTransaction mtx;
+    mtx.version = 2;
+    mtx.vout.emplace_back(amount, GetScriptForDestination(dest));
+
+    interfaces::WalletTx wtx;
+    wtx.tx = MakeTransactionRef(mtx);
+    wtx.txin_is_mine = {false}; // an external sender: an incoming payment
+    wtx.txout_is_mine = {true};
+    wtx.txout_address = {dest};
+    wtx.txout_address_is_mine = {true};
+    wtx.txout_is_change = {false};
+    wtx.credit = amount;
+    wtx.debit = 0;
+    wtx.time = 500;
+    wtx.is_coinbase = false;
+    return wtx;
 }
 
 void SetValidRecipient(WalletQmlModel& model,
@@ -551,6 +577,10 @@ private Q_SLOTS:
     void activityDetailsSelectLowestOutputIndex();
     void activityDetailsPreferOutgoingForSelfPayment();
     void editedReceiveRequestLabelShownInActivityRow();
+    void usedAddressReceiveRequestRowIsFlaggedAndUntracked();
+    void paidPendingRequestBecomesUsedAddressRequestLive();
+    void paymentMarksEveryPendingRequestForAddressUsedLive();
+    void reloadMarksEveryRequestForPaidAddressUsed();
     void prepareTransactionOnLockedWalletRequiresPassword();
     void prepareTransactionWithPrivateKeysDisabledDoesNotRequirePassword();
     void sendRecipientRejectsDustAmount();
@@ -1708,6 +1738,203 @@ void WalletQmlModelTests::editedReceiveRequestLabelShownInActivityRow()
     QCOMPARE(activity->rowCount(), 1);
     QCOMPARE(activity->data(activity->index(0), ActivityListModel::LabelRole).toString(),
              QStringLiteral("New label"));
+}
+
+void WalletQmlModelTests::usedAddressReceiveRequestRowIsFlaggedAndUntracked()
+{
+    auto [wallet, model] = MakePasswordWalletModel();
+    ActivityListModel* activity = model->activityListModel();
+    QCOMPARE(activity->rowCount(), 0);
+
+    // An unused-address request is a normal pending row.
+    activity->addReceiveRequest(QStringLiteral("bcrt1qunused"), QStringLiteral("Unused"),
+                                1000, 100, QStringLiteral("1"), /*used_address=*/false);
+    QCOMPARE(activity->rowCount(), 1);
+    QVERIFY(activity->data(activity->index(0), ActivityListModel::IsPendingRequestRole).toBool());
+    QVERIFY(!activity->data(activity->index(0), ActivityListModel::IsUsedAddressRequestRole).toBool());
+
+    // A used-address request is still a payment-request row but is flagged so the
+    // proxy can keep it out of every view except the Payment request filter.
+    activity->addReceiveRequest(QStringLiteral("bcrt1qused"), QStringLiteral("Used"),
+                                2000, 200, QStringLiteral("2"), /*used_address=*/true);
+    QCOMPARE(activity->rowCount(), 2);
+    const QModelIndex used_row = activity->index(0); // rows are pushed to the front
+    QVERIFY(activity->data(used_row, ActivityListModel::IsPendingRequestRole).toBool());
+    QVERIFY(activity->data(used_row, ActivityListModel::IsUsedAddressRequestRole).toBool());
+    QCOMPARE(activity->data(used_row, ActivityListModel::LabelRole).toString(), QStringLiteral("Used"));
+}
+
+void WalletQmlModelTests::paidPendingRequestBecomesUsedAddressRequestLive()
+{
+    auto wallet = std::make_unique<MockWallet>();
+    auto* wallet_ptr = wallet.get();
+
+    const CTxDestination dest{WitnessV0KeyHash{uint160{std::vector<unsigned char>(20, 7)}}};
+    const QString address = QString::fromStdString(EncodeDestination(dest));
+    const interfaces::WalletTx received = ReceiveWalletTxFor(dest, 50 * COIN);
+
+    std::vector<interfaces::Wallet::TransactionChangedFn> callbacks;
+    wallet_ptr->get_wallet_txs_fn = [] { return std::set<interfaces::WalletTx>{}; };
+    wallet_ptr->get_balance_fn = [] { return 10 * COIN; };
+    wallet_ptr->handle_transaction_changed_fn = [&](interfaces::Wallet::TransactionChangedFn fn) {
+        callbacks.push_back(std::move(fn));
+        return std::unique_ptr<interfaces::Handler>{};
+    };
+    wallet_ptr->get_wallet_tx_fn = [received](const Txid&) { return received; };
+    wallet_ptr->try_get_tx_status_fn = [](const Txid&, interfaces::WalletTxStatus&, int&, int64_t&) { return true; };
+
+    WalletQmlModel model{std::move(wallet)};
+    ActivityListModel* activity = model.activityListModel();
+
+    // A pending request for the address that is about to be paid.
+    activity->addReceiveRequest(address, QStringLiteral("req"), 0, 100, QStringLiteral("1"));
+    QCOMPARE(activity->rowCount(), 1);
+    QVERIFY(activity->data(activity->index(0), ActivityListModel::IsPendingRequestRole).toBool());
+    QVERIFY(!activity->data(activity->index(0), ActivityListModel::IsUsedAddressRequestRole).toBool());
+
+    // The payment arrives while the wallet is open (no reload).
+    QVERIFY(!callbacks.empty());
+    for (const auto& cb : callbacks) {
+        cb(received.tx->GetHash(), CT_NEW);
+    }
+
+    // The request is kept as a used-address request (Payment request filter only)
+    // and the received transaction is added as its own row, matching the reloaded
+    // state instead of consuming the request in place.
+    QCOMPARE(activity->rowCount(), 2);
+    QVERIFY(!activity->data(activity->index(0), ActivityListModel::IsPendingRequestRole).toBool());
+    QVERIFY(!activity->data(activity->index(0), ActivityListModel::IsUsedAddressRequestRole).toBool());
+    QCOMPARE(activity->data(activity->index(0), ActivityListModel::TypeRole).toInt(),
+             static_cast<int>(Transaction::RecvWithAddress));
+
+    const QModelIndex request_row = activity->index(1);
+    QVERIFY(activity->data(request_row, ActivityListModel::IsPendingRequestRole).toBool());
+    QVERIFY(activity->data(request_row, ActivityListModel::IsUsedAddressRequestRole).toBool());
+    QCOMPARE(activity->data(request_row, ActivityListModel::LabelRole).toString(), QStringLiteral("req"));
+}
+
+namespace {
+// Collect (label, isPendingRequest, isUsedAddressRequest) per row so the
+// assertions do not depend on the model's insertion order.
+struct RequestRowState {
+    bool pending{false};
+    bool used{false};
+};
+std::map<QString, RequestRowState> RequestRowStates(ActivityListModel* activity)
+{
+    std::map<QString, RequestRowState> states;
+    for (int i = 0; i < activity->rowCount(); ++i) {
+        const QModelIndex row = activity->index(i);
+        states[activity->data(row, ActivityListModel::LabelRole).toString()] = RequestRowState{
+            activity->data(row, ActivityListModel::IsPendingRequestRole).toBool(),
+            activity->data(row, ActivityListModel::IsUsedAddressRequestRole).toBool()};
+    }
+    return states;
+}
+} // namespace
+
+// Core supports multiple receive requests for one address. When a payment
+// arrives, every pending request for the paid address must become a
+// used-address request, not just the row the address lookup found first:
+// a single marked row would strand its siblings as pending for the rest of
+// the session while a reload marks them all used.
+void WalletQmlModelTests::paymentMarksEveryPendingRequestForAddressUsedLive()
+{
+    auto wallet = std::make_unique<MockWallet>();
+    auto* wallet_ptr = wallet.get();
+
+    const CTxDestination dest{WitnessV0KeyHash{uint160{std::vector<unsigned char>(20, 7)}}};
+    const QString address = QString::fromStdString(EncodeDestination(dest));
+    const CTxDestination other_dest{WitnessV0KeyHash{uint160{std::vector<unsigned char>(20, 8)}}};
+    const QString other_address = QString::fromStdString(EncodeDestination(other_dest));
+    const interfaces::WalletTx received = ReceiveWalletTxFor(dest, 50 * COIN);
+
+    std::vector<interfaces::Wallet::TransactionChangedFn> callbacks;
+    wallet_ptr->get_wallet_txs_fn = [] { return std::set<interfaces::WalletTx>{}; };
+    wallet_ptr->get_balance_fn = [] { return 10 * COIN; };
+    wallet_ptr->handle_transaction_changed_fn = [&](interfaces::Wallet::TransactionChangedFn fn) {
+        callbacks.push_back(std::move(fn));
+        return std::unique_ptr<interfaces::Handler>{};
+    };
+    wallet_ptr->get_wallet_tx_fn = [received](const Txid&) { return received; };
+    wallet_ptr->try_get_tx_status_fn = [](const Txid&, interfaces::WalletTxStatus&, int&, int64_t&) { return true; };
+
+    WalletQmlModel model{std::move(wallet)};
+    ActivityListModel* activity = model.activityListModel();
+    ActivityFilterProxyModel proxy;
+    proxy.setSourceModel(activity);
+
+    // Two pending requests for the address about to be paid, and one for an
+    // unrelated address that must stay pending.
+    activity->addReceiveRequest(address, QStringLiteral("req-a1"), 0, 100, QStringLiteral("1"));
+    activity->addReceiveRequest(address, QStringLiteral("req-a2"), 0, 110, QStringLiteral("2"));
+    activity->addReceiveRequest(other_address, QStringLiteral("req-b"), 0, 120, QStringLiteral("3"));
+    QCOMPARE(activity->rowCount(), 3);
+    QCOMPARE(proxy.rowCount(), 3);
+
+    QVERIFY(!callbacks.empty());
+    for (const auto& cb : callbacks) {
+        cb(received.tx->GetHash(), CT_NEW);
+    }
+
+    QCOMPARE(activity->rowCount(), 4);
+    const auto states = RequestRowStates(activity);
+    QVERIFY(states.at(QStringLiteral("req-a1")).used);
+    QVERIFY(states.at(QStringLiteral("req-a2")).used);
+    QVERIFY(states.at(QStringLiteral("req-b")).pending);
+    QVERIFY(!states.at(QStringLiteral("req-b")).used);
+
+    // The default view hides both used rows: the real transaction and the
+    // unrelated pending request remain.
+    QCOMPARE(proxy.rowCount(), 2);
+    proxy.setTypeFilter(ActivityFilterProxyModel::PaymentRequest);
+    QCOMPARE(proxy.rowCount(), 3);
+}
+
+// The reload half of the same rule: rebuilding the model from the wallet
+// marks every request whose address appears in a real transaction as a
+// used-address request, so a restart shows the same state as the live
+// update path.
+void WalletQmlModelTests::reloadMarksEveryRequestForPaidAddressUsed()
+{
+    auto wallet = std::make_unique<MockWallet>();
+    auto* wallet_ptr = wallet.get();
+
+    const CTxDestination dest{WitnessV0KeyHash{uint160{std::vector<unsigned char>(20, 7)}}};
+    const QString address = QString::fromStdString(EncodeDestination(dest));
+    const CTxDestination other_dest{WitnessV0KeyHash{uint160{std::vector<unsigned char>(20, 8)}}};
+    const QString other_address = QString::fromStdString(EncodeDestination(other_dest));
+    const interfaces::WalletTx received = ReceiveWalletTxFor(dest, 50 * COIN);
+
+    wallet_ptr->get_wallet_txs_fn = [received] { return std::set<interfaces::WalletTx>{received}; };
+    wallet_ptr->get_balance_fn = [] { return 10 * COIN; };
+    wallet_ptr->try_get_tx_status_fn = [](const Txid&, interfaces::WalletTxStatus&, int&, int64_t&) { return true; };
+
+    WalletQmlModel model{std::move(wallet)};
+    ActivityListModel* activity = model.activityListModel();
+
+    auto make_entry = [](int64_t id, const QString& addr, const char* label) {
+        QmlRecentRequestEntry entry;
+        entry.id = id;
+        entry.date = QDateTime::fromSecsSinceEpoch(100 + id);
+        entry.recipient.address = addr.toStdString();
+        entry.recipient.label = label;
+        return entry;
+    };
+    std::vector<QmlRecentRequestEntry> entries;
+    entries.push_back(make_entry(1, address, "req-a1"));
+    entries.push_back(make_entry(2, address, "req-a2"));
+    entries.push_back(make_entry(3, other_address, "req-b"));
+    model.receiveRequests()->setEntries(std::move(entries));
+
+    activity->reload();
+
+    QCOMPARE(activity->rowCount(), 4);
+    const auto states = RequestRowStates(activity);
+    QVERIFY(states.at(QStringLiteral("req-a1")).used);
+    QVERIFY(states.at(QStringLiteral("req-a2")).used);
+    QVERIFY(states.at(QStringLiteral("req-b")).pending);
+    QVERIFY(!states.at(QStringLiteral("req-b")).used);
 }
 
 void WalletQmlModelTests::prepareTransactionOnLockedWalletRequiresPassword()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -589,6 +589,7 @@ private Q_SLOTS:
     void editedAddressBookLabelSyncsRequestLabel();
     void requestSaveLeavesSiblingRequestLabelsAlone();
     void labelSyncSkipsInMemoryUpdateWhenPersistFails();
+    void editedAddressBookLabelUpdatesHeldRequestObjects();
     void usedAddressReceiveRequestRowIsFlaggedAndUntracked();
     void paidPendingRequestBecomesUsedAddressRequestLive();
     void paymentMarksEveryPendingRequestForAddressUsedLive();
@@ -1882,6 +1883,34 @@ void WalletQmlModelTests::labelSyncSkipsInMemoryUpdateWhenPersistFails()
     ActivityListModel* activity = model->activityListModel();
     QCOMPARE(activity->data(activity->index(0), ActivityListModel::LabelRole).toString(),
              QStringLiteral("Old label"));
+}
+
+void WalletQmlModelTests::editedAddressBookLabelUpdatesHeldRequestObjects()
+{
+    auto [wallet, model] = MakePasswordWalletModel();
+    wallet->get_address_result = true;
+
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Old label"));
+    QVERIFY(model->commitPaymentRequest());
+    const QString address = model->currentPaymentRequest()->address();
+    const QString request_id = model->currentPaymentRequest()->id();
+    QVERIFY(!address.isEmpty());
+    QVERIFY(model->loadPaymentRequestDetail(request_id));
+
+    // A held-open detail page or locked editor keeps reading these objects,
+    // so an Addresses page label edit must refresh them too, not only the
+    // stored request and its Activity row.
+    QVERIFY(model->setAddressLabel(address, QStringLiteral("New label")));
+    QCOMPARE(model->detailPaymentRequest()->label(), QStringLiteral("New label"));
+    QCOMPARE(model->currentPaymentRequest()->label(), QStringLiteral("New label"));
+
+    // While the editor is mid-edit its unsaved draft must survive the sync;
+    // the detail object still follows.
+    model->currentPaymentRequest()->edit();
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Unsaved draft"));
+    QVERIFY(model->setAddressLabel(address, QStringLiteral("Renamed again")));
+    QCOMPARE(model->currentPaymentRequest()->label(), QStringLiteral("Unsaved draft"));
+    QCOMPARE(model->detailPaymentRequest()->label(), QStringLiteral("Renamed again"));
 }
 
 void WalletQmlModelTests::usedAddressReceiveRequestRowIsFlaggedAndUntracked()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -550,6 +550,7 @@ private Q_SLOTS:
     void removeReceiveRequestRemovesPendingActivityRow();
     void activityDetailsSelectLowestOutputIndex();
     void activityDetailsPreferOutgoingForSelfPayment();
+    void editedReceiveRequestLabelShownInActivityRow();
     void prepareTransactionOnLockedWalletRequiresPassword();
     void prepareTransactionWithPrivateKeysDisabledDoesNotRequirePassword();
     void sendRecipientRejectsDustAmount();
@@ -1679,6 +1680,34 @@ void WalletQmlModelTests::activityDetailsPreferOutgoingForSelfPayment()
     const QVariantMap details = model->activityListModel()->firstTransactionDetails(txid);
     QCOMPARE(details.value("outputIndex").toInt(), 0);
     QVERIFY(details.value("amount").toString().startsWith('-'));
+}
+
+void WalletQmlModelTests::editedReceiveRequestLabelShownInActivityRow()
+{
+    auto [wallet, model] = MakePasswordWalletModel();
+
+    // The address book reports a different label for the request address. A
+    // pending request row must show the request's own label, not the address
+    // book label, so an edited label is not overwritten when Activity renders.
+    wallet->get_address_result = true;
+    wallet->get_address_label = "address book label";
+
+    model->currentPaymentRequest()->setLabel(QStringLiteral("Old label"));
+    QVERIFY(model->commitPaymentRequest());
+
+    ActivityListModel* activity = model->activityListModel();
+    QCOMPARE(activity->rowCount(), 1);
+    const QModelIndex row = activity->index(0);
+    QVERIFY(activity->data(row, ActivityListModel::IsPendingRequestRole).toBool());
+    QCOMPARE(activity->data(row, ActivityListModel::LabelRole).toString(), QStringLiteral("Old label"));
+
+    // Editing the label commits an update for the same request id.
+    model->currentPaymentRequest()->setLabel(QStringLiteral("New label"));
+    QVERIFY(model->commitPaymentRequest());
+
+    QCOMPARE(activity->rowCount(), 1);
+    QCOMPARE(activity->data(activity->index(0), ActivityListModel::LabelRole).toString(),
+             QStringLiteral("New label"));
 }
 
 void WalletQmlModelTests::prepareTransactionOnLockedWalletRequiresPassword()


### PR DESCRIPTION
This PR closes three related gaps in the Activity page. The list filters now reach parity with the Qt Widgets transaction view and payment request labels and used-address requests behave correctly. Fixes #707. Fixes #725. Fixes #726.

 - Added an Other transaction type, a minimum amount and a custom date range as Activity filter options
 - Added a Grid-based calendar component for the custom date range
 - Updated the activity page search and filter options layout and kept filter popups within the list area 
 - Moved the Payment request type filter above Mined and Other
 - Made payment request labels stay in sync both ways. A request edit updates its Activity row and the address book, and an address book edit updates the matching requests and any views already open on them
 - Fixed used-address payment requests. They appear only under the Payment request filter and keep the request presentation (purple icon and creation date, since address use alone does not prove payment) and a payment marks every request for the paid address used so the live list matches a reload
  - Reset the Activity detail stack when opening a transaction from the send flow, so View Transaction shows the new transaction and Back returns to the list instead of a page left open earlier
 - Applied wallet transaction updates to the Activity model on the model's thread. Updating from the notification thread could transiently show an incoming payment twice and hide the matching request row
 - Aligned the Activity title and top padding with the Send and Receive pages

Added unit, QML and functional tests.

<img width="800" height="665" alt="image" src="https://github.com/user-attachments/assets/0658e758-b4f4-4d47-b20e-92c51567a053" />

<img width="800" height="665" alt="image" src="https://github.com/user-attachments/assets/c2b1e127-bfda-4a45-be59-dc33d65da70b" />

<img width="800" height="665" alt="image" src="https://github.com/user-attachments/assets/8e805aa8-84c5-4bdd-a13b-fcc45dde4220" />