### PR TITLE
Fix crash when clearing send recipients

### DIFF
--- a/qml/models/sendrecipientslistmodel.cpp
+++ b/qml/models/sendrecipientslistmodel.cpp
@@ -189,9 +189,7 @@ QString SendRecipientsListModel::totalAmount() const
 void SendRecipientsListModel::clear()
 {
     beginResetModel();
-    for (auto* recipient : m_recipients) {
-        delete recipient;
-    }
+    const QList<SendRecipient*> old_recipients{m_recipients};
     m_recipients.clear();
     m_current = 0;
     m_totalAmount = 0;
@@ -208,6 +206,13 @@ void SendRecipientsListModel::clear()
     Q_EMIT currentRecipientChanged();
     Q_EMIT currentIndexChanged();
     Q_EMIT validationChanged();
+
+    // Defer deletion so QML bindings can switch to the replacement recipient
+    // without temporarily observing a null object.
+    for (auto* recipient : old_recipients) {
+        recipient->deleteLater();
+    }
+
     if (m_wallet) {
         m_wallet->clearSelectedCoins();
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(bitcoinqml_unit_tests
   test_qtmessagefilter.cpp
   test_rpccommandexecutor.cpp
   test_rpcconsolemodel.cpp
+  test_sendrecipientslistmodel.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../bitcoin/src/util/chaintype.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../qml/models/bitcoinuri.cpp
 )

--- a/test/test_sendrecipientslistmodel.cpp
+++ b/test/test_sendrecipientslistmodel.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QtTest/QtTest>
+
+#include <qml/models/sendrecipient.h>
+#include <qml/models/sendrecipientslistmodel.h>
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <QQmlComponent>
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QUrl>
+
+#include <memory>
+
+class SendRecipientsListModelTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void clearKeepsCurrentRecipientValidForQmlBindings();
+};
+
+void SendRecipientsListModelTests::clearKeepsCurrentRecipientValidForQmlBindings()
+{
+    SendRecipientsListModel recipients;
+    recipients.currentRecipient()->address()->setAddress(QStringLiteral("first"));
+    recipients.currentRecipient()->setLabel(QStringLiteral("First recipient"));
+    recipients.currentRecipient()->amount()->setSatoshi(1'000);
+    recipients.add();
+    recipients.currentRecipient()->address()->setAddress(QStringLiteral("second"));
+    recipients.currentRecipient()->setLabel(QStringLiteral("Second recipient"));
+    recipients.currentRecipient()->amount()->setSatoshi(2'000);
+
+    QQmlEngine engine;
+    engine.rootContext()->setContextProperty(QStringLiteral("recipientsModel"), &recipients);
+    QQmlComponent component{&engine};
+    component.setData(R"QML(
+        import QtQml
+
+        QtObject {
+            property QtObject currentRecipient: recipientsModel.current
+            property bool sawNullRecipient: false
+            property string address: currentRecipient.address.address
+            property string label: currentRecipient.label
+            property QtObject amount: currentRecipient.amount
+
+            onCurrentRecipientChanged: {
+                if (currentRecipient === null) sawNullRecipient = true
+            }
+        }
+    )QML", QUrl{});
+    std::unique_ptr<QObject> observer{component.create()};
+    QVERIFY2(observer, qPrintable(component.errorString()));
+    QCOMPARE(observer->property("address").toString(), QStringLiteral("second"));
+    QCOMPARE(observer->property("label").toString(), QStringLiteral("Second recipient"));
+
+    recipients.clear();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+
+    QVERIFY(!observer->property("sawNullRecipient").toBool());
+    QCOMPARE(observer->property("currentRecipient").value<QObject*>(), recipients.currentRecipient());
+    QVERIFY(observer->property("address").toString().isEmpty());
+    QVERIFY(observer->property("label").toString().isEmpty());
+    QCOMPARE(observer->property("amount").value<QObject*>(), recipients.currentRecipient()->amount());
+}
+
+#ifdef BITCOINQML_NO_TEST_MAIN
+#include <test/qt_test_registry.h>
+BITCOINQML_REGISTER_QT_TEST(SendRecipientsListModelTests)
+#else
+QTEST_MAIN(SendRecipientsListModelTests)
+#endif
+#include "test_sendrecipientslistmodel.moc"


### PR DESCRIPTION
This PR fixes a crash when clearing send recipients. The affected clear path is used in two scenarios:

  - after sending a transaction
  - when selecting **Clear form**

`SendRecipientsListModel::clear()` synchronously deleted the current recipient before QML switched its bindings to the replacement. This temporarily left the address, amount, and label bindings with a null recipient and could crash the app, as reported with multiple labeled recipients.

Create and notify QML of the replacement recipient first, then defer deletion of the old recipients until control returns to the event loop.

Added a C++ unit test using a real `QQmlEngine` and `SendRecipientsListModel`. The test binds to the current recipient and its address, label, and amount, then clears multiple recipients. The test fails with the previous
  synchronous deletion behavior and passes with the deferred deletion.

Fixes #825
Fixes #841