### PR TITLE
Improve Send and Send Review pages

### DIFF
--- a/qml/components/BitcoinAddressDisplayField.qml
+++ b/qml/components/BitcoinAddressDisplayField.qml
@@ -14,12 +14,12 @@ Item {
     property string labelText: qsTr("Send to")
     property string text: ""
     property string fullText: ""
-    property string expandedObjectName: ""
     property bool expanded: false
     property int labelPixelSize: 18
     property color labelColor: Theme.color.neutral9
     readonly property bool showLabel: labelText.length > 0
     readonly property bool expandable: fullText.length > 0
+    readonly property string displayText: expanded ? fullText : text
 
     Layout.fillWidth: true
     implicitHeight: Math.max(showLabel ? label.implicitHeight + 6 : 0, addressContainer.implicitHeight)
@@ -31,8 +31,8 @@ Item {
     }
 
     function click() {
-        if (expandable && !expanded) {
-            expanded = true
+        if (expandable) {
+            expanded = !expanded
         }
     }
 
@@ -54,55 +54,31 @@ Item {
         anchors.left: root.showLabel ? label.right : parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        implicitHeight: addressColumn.implicitHeight
+        implicitHeight: Math.max(addressText.implicitHeight, 32)
         height: implicitHeight
 
-        Column {
-            id: addressColumn
+        CoreText {
+            id: addressText
+            objectName: root.objectName + "Text"
             width: parent.width
-            spacing: root.expandable && root.expanded ? 6 : 0
+            text: root.displayText
+            wrap: root.expanded
+            elide: root.expanded ? Text.ElideNone : Text.ElideRight
+            horizontalAlignment: root.expandable ? Text.AlignRight : Text.AlignLeft
+            verticalAlignment: Text.AlignTop
+            font: Theme.text.monoBody.font
+            lineHeight: Theme.text.monoBody.lineHeight
+            lineHeightMode: Text.FixedHeight
+            color: Theme.color.neutral9
 
-            CoreText {
-                id: addressText
-                width: parent.width
-                text: root.text
-                wrap: true
-                wrapMode: Text.WordWrap
-                horizontalAlignment: root.expandable ? Text.AlignRight : Text.AlignLeft
-                verticalAlignment: Text.AlignTop
-                height: Math.max(implicitHeight, 32)
-                font.pixelSize: 18
-                color: Theme.color.neutral9
-
-                HoverHandler {
-                    enabled: root.expandable
-                    cursorShape: Qt.PointingHandCursor
-                }
-
-                TapHandler {
-                    enabled: root.expandable
-                    onTapped: root.click()
-                }
+            HoverHandler {
+                enabled: root.expandable
+                cursorShape: Qt.PointingHandCursor
             }
 
-            TextArea {
-                id: fullAddressText
-                objectName: root.expandedObjectName
-                width: parent.width
-                visible: root.expandable && root.expanded
-                readOnly: true
-                text: root.fullText
-                wrapMode: Text.WordWrap
-                leftPadding: 0
-                topPadding: 0
-                rightPadding: 0
-                bottomPadding: 0
-                height: visible ? Math.max(contentHeight, 32) : 0
-                font.family: Theme.text.family
-                font.styleName: "Regular"
-                font.pixelSize: 18
-                color: Theme.color.neutral7
-                background: Item {}
+            TapHandler {
+                enabled: root.expandable
+                onTapped: root.click()
             }
         }
     }

--- a/qml/components/BitcoinAddressInputField.qml
+++ b/qml/components/BitcoinAddressInputField.qml
@@ -17,9 +17,35 @@ ColumnLayout {
     property string labelText: qsTr("Send to")
     property bool enabled: true
     property alias inputObjectName: addressInput.objectName
+    property bool interceptPaste: false
 
     signal textChanged()
     signal editingFinished()
+    signal pasteRequested()
+
+    function paymentUri(text) {
+        const trimmedText = String(text).trim()
+        return root.interceptPaste && trimmedText.toLowerCase().startsWith("bitcoin:")
+            ? trimmedText
+            : ""
+    }
+
+    function pastedPaymentUri(previousText, currentText) {
+        const clipboardText = Clipboard.text()
+        const uri = paymentUri(clipboardText)
+        if (uri.length === 0 || previousText === currentText) return ""
+        return String(currentText).indexOf(clipboardText) === -1 ? "" : uri
+    }
+
+    function paste() {
+        addressInput.paste()
+    }
+
+    function syncFromAddress() {
+        addressInput.syncFromAddress()
+    }
+
+    onAddressChanged: syncFromAddress()
 
     Layout.fillWidth: true
     spacing: 4
@@ -43,13 +69,34 @@ ColumnLayout {
 
         TextArea {
             id: addressInput
+            property bool syncingFromAddress: false
+
+            function syncFromAddress() {
+                const formattedAddress = root.address ? root.address.formattedAddress : ""
+                if (text === formattedAddress) return
+                syncingFromAddress = true
+                text = formattedAddress
+                syncingFromAddress = false
+            }
+
+            function handlePaymentUriInput() {
+                const previousText = root.address ? root.address.formattedAddress : ""
+                const uri = root.pastedPaymentUri(previousText, text)
+                if (uri.length === 0) return false
+                syncFromAddress()
+                root.pasteRequested()
+                syncFromAddress()
+                return true
+            }
+
             objectName: root.inputObjectName
             anchors.left: label.right
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             enabled: root.enabled
             placeholderText: qsTr("Enter address...")
-            text: root.address ? root.address.formattedAddress : ""
+            text: ""
+            Component.onCompleted: syncFromAddress()
             wrapMode: Text.WrapAnywhere
             leftPadding: 0
             topPadding: 0
@@ -62,7 +109,19 @@ ColumnLayout {
             background: Item {}
             selectByMouse: true
 
+            Keys.onPressed: (event) => {
+                if (root.interceptPaste && event.matches(StandardKey.Paste)) {
+                    root.pasteRequested()
+                    event.accepted = true
+                }
+            }
+
             onTextChanged: {
+                if (syncingFromAddress) {
+                    root.textChanged()
+                    return
+                }
+                if (handlePaymentUriInput()) return
                 if (root.address) {
                     cursorPosition = root.address.setAddress(text, cursorPosition)
                 }
@@ -79,6 +138,13 @@ ColumnLayout {
             onActiveFocusChanged: {
                 if (!activeFocus && root.address) {
                     root.address.setAddress(text)
+                }
+            }
+
+            Connections {
+                target: root.address ? root.address : null
+                function onFormattedAddressChanged() {
+                    addressInput.syncFromAddress()
                 }
             }
         }

--- a/qml/components/BitcoinAmountInputField.qml
+++ b/qml/components/BitcoinAmountInputField.qml
@@ -22,13 +22,45 @@ ColumnLayout {
     property alias errorTextObjectName: errorTextLabel.objectName
     property bool enabled: true
     property string placeholderText: root.amount ? root.amountInputPlaceholder(root.amount.unit) : "0.00000000"
+    property bool interceptPaste: false
 
     signal inputTextChanged
     signal textEdited
     signal editingFinished(string value)
+    signal pasteRequested()
 
     function syncFromAmount(force) {
         amountInput.syncFromAmount(force)
+    }
+
+    function paymentUri(text) {
+        const trimmedText = String(text).trim()
+        return root.interceptPaste && trimmedText.toLowerCase().startsWith("bitcoin:")
+            ? trimmedText
+            : ""
+    }
+
+    function pastedPaymentUri(previousText, currentText) {
+        const clipboardText = Clipboard.text()
+        const uri = paymentUri(clipboardText)
+        if (uri.length === 0 || previousText === currentText) return ""
+
+        let offset = String(currentText).indexOf(clipboardText)
+        while (offset !== -1) {
+            const prefix = String(currentText).slice(0, offset)
+            const suffix = String(currentText).slice(offset + clipboardText.length)
+            if (String(previousText).startsWith(prefix)
+                    && String(previousText).endsWith(suffix)
+                    && prefix.length + suffix.length <= String(previousText).length) {
+                return uri
+            }
+            offset = String(currentText).indexOf(clipboardText, offset + 1)
+        }
+        return ""
+    }
+
+    function paste() {
+        amountInput.paste()
     }
 
     function amountInputPlaceholder(unit) {
@@ -79,6 +111,7 @@ ColumnLayout {
         TextField {
             id: amountInput
             property bool syncingFromAmount: false
+            property string lastAcceptedText: ""
 
             function amountDisplay() {
                 return root.amount ? root.amount.display : ""
@@ -89,9 +122,20 @@ ColumnLayout {
             function syncFromAmount(force) {
                 if (!force && activeFocus) return
                 const display = amountDisplay()
-                if (text === display) return
+                if (text === display) {
+                    lastAcceptedText = display
+                    return
+                }
                 syncingFromAmount = true
                 text = display
+                lastAcceptedText = display
+                syncingFromAmount = false
+            }
+
+            function restoreLastAcceptedText() {
+                if (text === lastAcceptedText) return
+                syncingFromAmount = true
+                text = lastAcceptedText
                 syncingFromAmount = false
             }
 
@@ -110,6 +154,23 @@ ColumnLayout {
                 root.editingFinished(text)
             }
 
+            function handlePaymentUriInput() {
+                const uri = root.pastedPaymentUri(lastAcceptedText, text)
+                if (uri.length === 0) {
+                    // Paste interception disables the validator so native
+                    // context-menu paste can be observed. Reject URI-like text
+                    // unless it is the exact text currently on the clipboard.
+                    if (!root.interceptPaste || String(text).toLowerCase().indexOf("bitcoin:") === -1) return false
+                    restoreLastAcceptedText()
+                    return true
+                }
+                const previousDisplay = amountDisplay()
+                restoreLastAcceptedText()
+                root.pasteRequested()
+                if (amountDisplay() !== previousDisplay) root.syncFromAmount(true)
+                return true
+            }
+
             Accessible.name: root.accessibleName
             anchors.left: lbl.right
             anchors.right: unitToggle.left
@@ -123,16 +184,39 @@ ColumnLayout {
             placeholderText: root.placeholderText
             selectByMouse: true
 
+            Keys.onPressed: (event) => {
+                if (root.interceptPaste && event.matches(StandardKey.Paste)) {
+                    root.pasteRequested()
+                    event.accepted = true
+                }
+            }
+
             text: ""
             Component.onCompleted: root.syncFromAmount(true)
 
             onTextChanged: {
+                if (handlePaymentUriInput()) return
                 if (!syncingFromAmount) {
+                    if (root.amount && root.amountInputPattern(root.amount.unit).test(String(text))) {
+                        lastAcceptedText = text
+                    }
                     root.inputTextChanged()
                 }
             }
 
             onTextEdited: {
+                if (handlePaymentUriInput()) return
+                // The validator is disabled while paste interception is active
+                // so an URI inserted beside the current amount reaches this
+                // handler. Preserve the same numeric validation by restoring
+                // the last model value before an invalid edit is committed.
+                if (root.interceptPaste
+                        && root.amount
+                        && !root.amountInputPattern(root.amount.unit).test(String(text))) {
+                    restoreLastAcceptedText()
+                    return
+                }
+                lastAcceptedText = text
                 commitAmountText()
                 root.textEdited()
             }
@@ -145,10 +229,17 @@ ColumnLayout {
                 }
             }
 
-            validator: RegularExpressionValidator {
-                regularExpression: root.amount ? root.amountInputPattern(root.amount.unit) : /^(0|[1-9]\d{0,7})(\.\d{0,8})?$/
+            validator: root.interceptPaste ? null : amountValidator
+
+            RegularExpressionValidator {
+                id: amountValidator
+                regularExpression: root.amount
+                    ? root.amountInputPattern(root.amount.unit)
+                    : /^(0|[1-9]\d{0,7})(\.\d{0,8})?$/
             }
-            maximumLength: root.amount ? root.amountInputMaximumLength(root.amount.unit) : 17
+            maximumLength: root.interceptPaste
+                ? 2048 + (root.amount ? root.amountInputMaximumLength(root.amount.unit) : 17)
+                : (root.amount ? root.amountInputMaximumLength(root.amount.unit) : 17)
 
             Connections {
                 target: root

--- a/qml/components/MultipleRecipientsSummary.qml
+++ b/qml/components/MultipleRecipientsSummary.qml
@@ -15,6 +15,7 @@ ColumnLayout {
 
     property WalletQmlModel wallet: walletController.selectedWallet
     property WalletQmlModelTransaction transaction: wallet ? wallet.currentTransaction : null
+    property var recipients: wallet ? wallet.recipients : null
 
     spacing: 15
 
@@ -27,7 +28,7 @@ ColumnLayout {
         objectName: "multipleSendReviewRecipientsList"
         Layout.fillWidth: true
         Layout.preferredHeight: contentHeight
-        model: root.wallet ? root.wallet.recipients : null
+        model: root.recipients
         clip: true
         interactive: false
 
@@ -42,12 +43,11 @@ ColumnLayout {
             required property string amount;
             required property string formattedAddress;
             required property string amountUnitLabel;
+            required property int index;
             property bool expanded: false
             readonly property bool expandable: formattedAddress.length > 0
             readonly property string amountText: amountUnitLabel.length > 0 ? amount + " " + amountUnitLabel : amount
-            readonly property string primaryText: label.length > 0 ? label : address
-            readonly property string secondaryText: expanded ? formattedAddress : (label.length > 0 ? address : "")
-            readonly property bool secondaryVisible: secondaryText.length > 0
+            readonly property string addressText: expanded ? formattedAddress : address
 
             activeFocusOnTab: expandable
             Accessible.role: Accessible.Button
@@ -86,33 +86,58 @@ ColumnLayout {
                     height: 15
                 }
 
-                RowLayout {
+                GridLayout {
                     width: parent.width
-                    spacing: 10
-
-                    HoverHandler {
-                        enabled: delegate.expandable
-                        cursorShape: Qt.PointingHandCursor
-                    }
-
-                    TapHandler {
-                        enabled: delegate.expandable
-                        onTapped: delegate.click()
-                    }
+                    columns: 2
+                    columnSpacing: 10
+                    rowSpacing: 0
 
                     CoreText {
                         objectName: "multipleSendReviewRecipient" + index + "PrimaryText"
+                        visible: delegate.label.length > 0
+                        Layout.row: 0
+                        Layout.column: 0
                         Layout.fillWidth: true
                         Layout.preferredWidth: 0
                         horizontalAlignment: Text.AlignLeft
                         verticalAlignment: Text.AlignTop
                         wrap: false
                         elide: Text.ElideRight
-                        text: delegate.primaryText
+                        text: delegate.label
                         font: Theme.text.description.font
                         lineHeight: Theme.text.description.lineHeight
                         lineHeightMode: Text.FixedHeight
                         color: Theme.color.neutral9
+                    }
+
+                    CoreText {
+                        id: addressTextItem
+                        objectName: "multipleSendReviewRecipient" + index + "AddressText"
+                        Layout.row: delegate.label.length > 0 ? 1 : 0
+                        Layout.column: 0
+                        Layout.columnSpan: delegate.label.length > 0 ? 2 : 1
+                        Layout.fillWidth: true
+                        Layout.preferredWidth: 0
+                        Layout.topMargin: delegate.label.length > 0 ? 10 : 0
+                        horizontalAlignment: Text.AlignLeft
+                        verticalAlignment: Text.AlignTop
+                        wrap: delegate.expanded
+                        elide: delegate.expanded ? Text.ElideNone : Text.ElideRight
+                        text: delegate.addressText
+                        font: Theme.text.monoBody.font
+                        lineHeight: Theme.text.monoBody.lineHeight
+                        lineHeightMode: Text.FixedHeight
+                        color: Theme.color.neutral9
+
+                        HoverHandler {
+                            enabled: delegate.expandable
+                            cursorShape: Qt.PointingHandCursor
+                        }
+
+                        TapHandler {
+                            enabled: delegate.expandable
+                            onTapped: delegate.click()
+                        }
                     }
 
                     Item {
@@ -121,6 +146,8 @@ ColumnLayout {
                         property string text: delegate.amountText
                         implicitWidth: amountRow.implicitWidth
                         implicitHeight: amountRow.implicitHeight
+                        Layout.row: 0
+                        Layout.column: 1
                         Layout.alignment: Qt.AlignRight | Qt.AlignTop
 
                         RowLayout {
@@ -152,37 +179,13 @@ ColumnLayout {
 
                 Item {
                     width: 1
-                    height: 10
-                    visible: delegate.secondaryVisible
-                }
-
-                TextArea {
-                    objectName: "multipleSendReviewRecipient" + index + "SecondaryText"
-                    width: parent.width
-                    visible: delegate.secondaryVisible
-                    readOnly: true
-                    selectByMouse: true
-                    text: delegate.secondaryText
-                    wrapMode: Text.WordWrap
-                    leftPadding: 0
-                    topPadding: 0
-                    rightPadding: 0
-                    bottomPadding: 0
-                    height: visible ? Math.max(contentHeight, 21) : 0
-                    font: Theme.text.description.font
-                    color: Theme.color.neutral9
-                    background: Item {}
-                }
-
-                Item {
-                    width: 1
                     height: 15
-                    visible: index < ListView.view.count - 1
+                    visible: index < inputsList.count - 1
                 }
 
                 Separator {
                     width: parent.width
-                    visible: index < ListView.view.count - 1
+                    visible: index < inputsList.count - 1
                 }
             }
 

--- a/qml/components/MultipleRecipientsSummary.qml
+++ b/qml/components/MultipleRecipientsSummary.qml
@@ -86,39 +86,38 @@ ColumnLayout {
                     height: 15
                 }
 
-                GridLayout {
+                CoreText {
+                    objectName: "multipleSendReviewRecipient" + index + "PrimaryText"
+                    visible: delegate.label.length > 0
                     width: parent.width
-                    columns: 2
-                    columnSpacing: 10
-                    rowSpacing: 0
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignTop
+                    wrap: false
+                    elide: Text.ElideRight
+                    text: delegate.label
+                    font: Theme.text.description.font
+                    lineHeight: Theme.text.description.lineHeight
+                    lineHeightMode: Text.FixedHeight
+                    color: Theme.color.neutral9
+                }
 
-                    CoreText {
-                        objectName: "multipleSendReviewRecipient" + index + "PrimaryText"
-                        visible: delegate.label.length > 0
-                        Layout.row: 0
-                        Layout.column: 0
-                        Layout.fillWidth: true
-                        Layout.preferredWidth: 0
-                        horizontalAlignment: Text.AlignLeft
-                        verticalAlignment: Text.AlignTop
-                        wrap: false
-                        elide: Text.ElideRight
-                        text: delegate.label
-                        font: Theme.text.description.font
-                        lineHeight: Theme.text.description.lineHeight
-                        lineHeightMode: Text.FixedHeight
-                        color: Theme.color.neutral9
-                    }
+                Item {
+                    width: 1
+                    height: 10
+                    visible: delegate.label.length > 0
+                }
+
+                Item {
+                    width: parent.width
+                    height: Math.max(addressTextItem.implicitHeight, amountDisplay.implicitHeight)
 
                     CoreText {
                         id: addressTextItem
                         objectName: "multipleSendReviewRecipient" + index + "AddressText"
-                        Layout.row: delegate.label.length > 0 ? 1 : 0
-                        Layout.column: 0
-                        Layout.columnSpan: delegate.label.length > 0 ? 2 : 1
-                        Layout.fillWidth: true
-                        Layout.preferredWidth: 0
-                        Layout.topMargin: delegate.label.length > 0 ? 10 : 0
+                        anchors.left: parent.left
+                        anchors.right: amountDisplay.left
+                        anchors.rightMargin: 10
+                        anchors.top: parent.top
                         horizontalAlignment: Text.AlignLeft
                         verticalAlignment: Text.AlignTop
                         wrap: delegate.expanded
@@ -146,9 +145,10 @@ ColumnLayout {
                         property string text: delegate.amountText
                         implicitWidth: amountRow.implicitWidth
                         implicitHeight: amountRow.implicitHeight
-                        Layout.row: 0
-                        Layout.column: 1
-                        Layout.alignment: Qt.AlignRight | Qt.AlignTop
+                        anchors.right: parent.right
+                        anchors.top: addressTextItem.top
+                        width: implicitWidth
+                        height: implicitHeight
 
                         RowLayout {
                             id: amountRow
@@ -156,20 +156,20 @@ ColumnLayout {
                             spacing: 5
 
                             CoreText {
+                                objectName: "multipleSendReviewRecipient" + index + "AmountValue"
                                 text: delegate.amount
-                                font: Theme.text.description.font
-                                lineHeight: Theme.text.description.lineHeight
-                                lineHeightMode: Text.FixedHeight
+                                font.family: optionsModel.moneyFont.family
+                                font.weight: optionsModel.moneyFont.weight
+                                font.pixelSize: Theme.text.body.pixelSize
                                 wrap: false
                                 color: Theme.color.neutral9
                             }
 
                             CoreText {
+                                objectName: "multipleSendReviewRecipient" + index + "AmountUnit"
                                 visible: delegate.amountUnitLabel.length > 0
                                 text: delegate.amountUnitLabel
-                                font: Theme.text.description.font
-                                lineHeight: Theme.text.description.lineHeight
-                                lineHeightMode: Text.FixedHeight
+                                font: Theme.text.body.font
                                 wrap: false
                                 color: Theme.color.neutral9
                             }
@@ -180,12 +180,11 @@ ColumnLayout {
                 Item {
                     width: 1
                     height: 15
-                    visible: index < inputsList.count - 1
                 }
 
                 Separator {
+                    objectName: "multipleSendReviewRecipient" + index + "Separator"
                     width: parent.width
-                    visible: index < inputsList.count - 1
                 }
             }
 

--- a/qml/components/Separator.qml
+++ b/qml/components/Separator.qml
@@ -8,7 +8,7 @@ import "../controls"
 
 Rectangle {
     height: 1
-    color: enabled ? Theme.color.neutral5 : Theme.color.neutral4
+    color: enabled ? Theme.color.neutral3 : Theme.color.neutral2
 
     Behavior on color {
         ColorAnimation { duration: 150 }

--- a/qml/components/SingleRecipientSummary.qml
+++ b/qml/components/SingleRecipientSummary.qml
@@ -21,7 +21,6 @@ ColumnLayout {
 
     BitcoinAddressDisplayField {
         objectName: "sendReviewAddressField"
-        expandedObjectName: "sendReviewFullAddressField"
         labelPixelSize: Theme.text.description.pixelSize
         labelColor: Theme.color.neutral7
         text: root.recipient ? root.recipient.address.ellipsesAddress : ""

--- a/qml/components/WalletPassphrasePopup.qml
+++ b/qml/components/WalletPassphrasePopup.qml
@@ -22,15 +22,56 @@ Popup {
     property string cancelButtonObjectName: ""
     property string confirmButtonObjectName: ""
     property bool busy: false
+    property real verticalOffset: 0
 
     signal submitted(string passphrase)
 
     objectName: popupObjectName
     modal: true
+    dim: true
     padding: 0
     implicitWidth: 420
     implicitHeight: columnLayout.implicitHeight
-    anchors.centerIn: parent
+    x: parent ? Math.round((parent.width - width) / 2) : 0
+    y: parent ? Math.round((parent.height - height) / 2) + verticalOffset : verticalOffset
+
+    Overlay.modal: Rectangle {
+        color: Qt.rgba(0, 0, 0, 0.4)
+    }
+
+    enter: Transition {
+        NumberAnimation {
+            property: "opacity"
+            from: 0
+            to: 1
+            duration: 300
+            easing.type: Easing.OutCubic
+        }
+        NumberAnimation {
+            property: "verticalOffset"
+            from: -30
+            to: 0
+            duration: 300
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    exit: Transition {
+        NumberAnimation {
+            property: "opacity"
+            from: 1
+            to: 0
+            duration: 250
+            easing.type: Easing.InCubic
+        }
+        NumberAnimation {
+            property: "verticalOffset"
+            from: 0
+            to: -30
+            duration: 250
+            easing.type: Easing.InCubic
+        }
+    }
 
     function clearPassphraseField() {
         if (passphraseField.text.length > 0) {
@@ -49,13 +90,14 @@ Popup {
         clearPassphraseField()
         passphraseField.forceActiveFocus()
     }
+    onAboutToHide: clearPassphraseField()
     onClosed: clearPassphraseField()
     Component.onDestruction: clearPassphraseField()
 
     background: Rectangle {
-        color: Theme.color.background
+        color: Theme.color.neutral1
         radius: 10
-        border.color: Theme.color.neutral4
+        border.color: Theme.color.neutral2
         border.width: 1
     }
 
@@ -76,6 +118,7 @@ Popup {
 
         Separator {
             Layout.fillWidth: true
+            color: Theme.color.neutral2
         }
 
         Header {
@@ -95,6 +138,17 @@ Popup {
             Layout.rightMargin: 20
             hideText: true
             placeholderText: qsTr("Enter password...")
+            background: Rectangle {
+                color: Theme.color.neutral2
+                radius: 5
+                border.color: Theme.color.neutral2
+                border.width: 1
+            }
+            onAccepted: {
+                if (confirmButton.enabled) {
+                    root.submitPassphrase()
+                }
+            }
         }
 
         CoreText {
@@ -126,6 +180,7 @@ Popup {
             }
 
             ContinueButton {
+                id: confirmButton
                 objectName: root.confirmButtonObjectName
                 Layout.fillWidth: true
                 Layout.minimumWidth: 120

--- a/qml/components/WalletPassphrasePopup.qml
+++ b/qml/components/WalletPassphrasePopup.qml
@@ -36,7 +36,7 @@ Popup {
     y: parent ? Math.round((parent.height - height) / 2) + verticalOffset : verticalOffset
 
     Overlay.modal: Rectangle {
-        color: Qt.rgba(0, 0, 0, 0.4)
+        color: Qt.rgba(0, 0, 0, 0.5)
     }
 
     enter: Transition {

--- a/qml/controls/LabeledTextInput.qml
+++ b/qml/controls/LabeledTextInput.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import org.bitcoincore.qt 1.0
 
 Item {
     property alias labelText: label.text
@@ -18,11 +19,46 @@ Item {
     property alias maximumLength: input.maximumLength
     property alias cursorPosition: input.cursorPosition
     property alias inputActiveFocus: input.activeFocus
+    property bool interceptPaste: false
+    property string paymentUriRestoreText: ""
 
     signal iconClicked
     signal textEdited
     signal editingFinished
     signal inputFocusChanged
+    signal pasteRequested()
+
+    function paymentUri(text) {
+        const trimmedText = String(text).trim()
+        return root.interceptPaste && trimmedText.toLowerCase().startsWith("bitcoin:")
+            ? trimmedText
+            : ""
+    }
+
+    function pastedPaymentUri(previousText, currentText) {
+        const clipboardText = Clipboard.text()
+        const uri = paymentUri(clipboardText)
+        if (uri.length === 0 || previousText === currentText) return ""
+
+        let offset = String(currentText).indexOf(clipboardText)
+        while (offset !== -1) {
+            const prefix = String(currentText).slice(0, offset)
+            const suffix = String(currentText).slice(offset + clipboardText.length)
+            if (String(previousText).startsWith(prefix)
+                    && String(previousText).endsWith(suffix)
+                    && prefix.length + suffix.length <= String(previousText).length) {
+                return uri
+            }
+            offset = String(currentText).indexOf(clipboardText, offset + 1)
+        }
+        return ""
+    }
+
+    function paste() {
+        input.paste()
+    }
+
+    onPaymentUriRestoreTextChanged: if (root.interceptPaste) input.syncFromModel()
 
     id: root
     implicitHeight: 56
@@ -40,6 +76,24 @@ Item {
 
     TextField {
         id: input
+        property bool syncingFromModel: false
+
+        function syncFromModel() {
+            if (text === root.paymentUriRestoreText) return
+            syncingFromModel = true
+            text = root.paymentUriRestoreText
+            syncingFromModel = false
+        }
+
+        function handlePaymentUriInput() {
+            const uri = root.pastedPaymentUri(root.paymentUriRestoreText, text)
+            if (uri.length === 0) return false
+            syncFromModel()
+            root.pasteRequested()
+            syncFromModel()
+            return true
+        }
+
         anchors.left: label.right
         anchors.right: iconContainer.left
         anchors.verticalCenter: parent.verticalCenter
@@ -49,7 +103,17 @@ Item {
         placeholderTextColor: enabled ? Theme.color.neutral7 : Theme.color.neutral4
         background: Item {}
         selectByMouse: true
-        onTextEdited: root.textEdited()
+
+        Keys.onPressed: (event) => {
+            if (root.interceptPaste && event.matches(StandardKey.Paste)) {
+                root.pasteRequested()
+                event.accepted = true
+            }
+        }
+
+        Component.onCompleted: if (root.interceptPaste) syncFromModel()
+        onTextChanged: if (!syncingFromModel) handlePaymentUriInput()
+        onTextEdited: if (!handlePaymentUriInput()) root.textEdited()
         onEditingFinished: root.editingFinished()
         onActiveFocusChanged: root.inputFocusChanged()
     }

--- a/qml/controls/OutlineButton.qml
+++ b/qml/controls/OutlineButton.qml
@@ -50,7 +50,7 @@ Button {
     background: Rectangle {
         id: bg
         implicitHeight: 46
-        color: Theme.color.background
+        color: "transparent"
         radius: 5
         border {
             width: 1

--- a/qml/models/activitylistmodel.cpp
+++ b/qml/models/activitylistmodel.cpp
@@ -97,6 +97,8 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         return tx->requestId;
     case NetAmountSatRole:
         return QVariant::fromValue<qlonglong>(tx->netAmount());
+    case OutputIndexRole:
+        return tx->idx;
     default:
         return QVariant();
     }
@@ -120,6 +122,7 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const
     roles[IsPendingRequestRole] = "isPendingRequest";
     roles[RequestIdRole] = "requestId";
     roles[NetAmountSatRole] = "netAmountSat";
+    roles[OutputIndexRole] = "outputIndex";
     return roles;
 }
 
@@ -131,31 +134,60 @@ void ActivityListModel::reload()
     endResetModel();
 }
 
-QVariantMap ActivityListModel::transactionDetails(const QString& txid) const
+QVariantMap ActivityListModel::firstTransactionDetails(const QString& txid) const
 {
+    QSharedPointer<Transaction> first;
     for (const auto& tx : m_transactions) {
-        if (tx->txid == txid) {
-            updateTransactionStatus(tx);
-            updateTransactionLabel(tx);
-            const QVariantList payment_requests = m_wallet_model && m_wallet_model->receiveRequests()
-                ? m_wallet_model->receiveRequests()->matchingEntriesForAddress(tx->address)
-                : QVariantList{};
-            return {
-                {"txid", tx->txid},
-                {"canBump", m_wallet_model ? m_wallet_model->canBumpTransaction(tx->hash) : false},
-                {"replacedByTxid", tx->replacedByTxid},
-                {"amount", tx->prettyAmount(m_display_unit)},
-                {"date", tx->dateTimeString()},
-                {"depth", tx->depth},
-                {"type", tx->type},
-                {"status", tx->status},
-                {"address", tx->address},
-                {"label", tx->label},
-                {"paymentRequests", payment_requests}
-            };
+        if (tx->txid != txid) {
+            continue;
+        }
+        const bool prefer_outgoing_tie = first && tx->idx == first->idx
+            && tx->debit < 0 && first->debit >= 0;
+        if (!first || tx->idx < first->idx || prefer_outgoing_tie) {
+            first = tx;
         }
     }
-    return {};
+    return transactionDetails(first);
+}
+
+QVariantMap ActivityListModel::transactionDetails(const QString& txid, int output_index) const
+{
+    QSharedPointer<Transaction> match;
+    for (const auto& tx : m_transactions) {
+        if (tx->txid != txid || tx->idx != output_index) {
+            continue;
+        }
+        if (!match || (tx->debit < 0 && match->debit >= 0)) {
+            match = tx;
+        }
+    }
+    return transactionDetails(match);
+}
+
+QVariantMap ActivityListModel::transactionDetails(const QSharedPointer<Transaction>& tx) const
+{
+    if (!tx) {
+        return {};
+    }
+    updateTransactionStatus(tx);
+    updateTransactionLabel(tx);
+    const QVariantList payment_requests = m_wallet_model && m_wallet_model->receiveRequests()
+        ? m_wallet_model->receiveRequests()->matchingEntriesForAddress(tx->address)
+        : QVariantList{};
+    return {
+        {"txid", tx->txid},
+        {"outputIndex", tx->idx},
+        {"canBump", m_wallet_model ? m_wallet_model->canBumpTransaction(tx->hash) : false},
+        {"replacedByTxid", tx->replacedByTxid},
+        {"amount", tx->prettyAmount(m_display_unit)},
+        {"date", tx->dateTimeString()},
+        {"depth", tx->depth},
+        {"type", tx->type},
+        {"status", tx->status},
+        {"address", tx->address},
+        {"label", tx->label},
+        {"paymentRequests", payment_requests}
+    };
 }
 
 void ActivityListModel::setDisplayUnit(int unit)

--- a/qml/models/activitylistmodel.h
+++ b/qml/models/activitylistmodel.h
@@ -43,11 +43,13 @@ public:
         TimestampRole,
         IsPendingRequestRole,
         RequestIdRole,
-        NetAmountSatRole
+        NetAmountSatRole,
+        OutputIndexRole
     };
 
     Q_INVOKABLE void reload();
-    Q_INVOKABLE QVariantMap transactionDetails(const QString& txid) const;
+    Q_INVOKABLE QVariantMap firstTransactionDetails(const QString& txid) const;
+    Q_INVOKABLE QVariantMap transactionDetails(const QString& txid, int output_index) const;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int count() const { return rowCount(); }
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
@@ -71,6 +73,7 @@ private:
     void unsubscribeFromCoreSignals();
     void updateTransaction(const uint256& hash, const interfaces::WalletTxStatus& wtx,
                            int num_blocks, int64_t block_time);
+    QVariantMap transactionDetails(const QSharedPointer<Transaction>& tx) const;
     int findTransactionIndex(const uint256& hash) const;
     int findPendingRequestIndex(const QString& address) const;
     void fulfillPendingRequest(int index, const QSharedPointer<Transaction>& real_tx);

--- a/qml/models/bitcoinaddress.cpp
+++ b/qml/models/bitcoinaddress.cpp
@@ -10,7 +10,12 @@ constexpr int MAX_BITCOIN_ADDRESS_LENGTH = 90;
 bool IsBitcoinAddressChar(const QChar c)
 {
     const ushort ch = c.unicode();
-    return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z');
+    // The union of the Base58Check and Bech32/Bech32m alphabets contains
+    // every ASCII digit and lowercase letter, and every uppercase letter
+    // except the ambiguous I and O characters.
+    return (ch >= '0' && ch <= '9') ||
+           (ch >= 'a' && ch <= 'z') ||
+           (ch >= 'A' && ch <= 'Z' && ch != 'I' && ch != 'O');
 }
 } // namespace
 
@@ -83,6 +88,12 @@ int BitcoinAddress::setAddress(const QString& input, int cursorPosition)
     }
 
     if (raw == m_address && fmt == m_formattedAddress) {
+        // A rejected character does not change either stored value, but the
+        // input field still needs a notification to replace its edited text
+        // with the normalized formatted address.
+        if (input != fmt) {
+            Q_EMIT formattedAddressChanged();
+        }
         return newCursor;
     }
 

--- a/qml/models/sendrecipientslistmodel.cpp
+++ b/qml/models/sendrecipientslistmodel.cpp
@@ -158,6 +158,20 @@ void SendRecipientsListModel::connectRecipientSignals(SendRecipient* recipient)
     connect(recipient->amount(), &BitcoinAmount::unitChanged, this, [emit_roles_changed] {
         emit_roles_changed({AmountRole, AmountUnitLabelRole});
     });
+    connect(recipient->amount(), &BitcoinAmount::unitChanged, this, [this, recipient] {
+        if (m_syncing_units) {
+            return;
+        }
+
+        m_syncing_units = true;
+        const BitcoinAmount::Unit unit = recipient->amount()->unit();
+        for (auto* other_recipient : m_recipients) {
+            if (other_recipient != recipient) {
+                other_recipient->amount()->setUnit(unit);
+            }
+        }
+        m_syncing_units = false;
+    });
     connect(recipient, &SendRecipient::subtractFeeFromAmountChanged,
             this, &SendRecipientsListModel::subtractFeeFromAmountChanged);
     connect(recipient, &SendRecipient::isValidChanged, this, &SendRecipientsListModel::validationChanged);

--- a/qml/models/sendrecipientslistmodel.h
+++ b/qml/models/sendrecipientslistmodel.h
@@ -72,6 +72,7 @@ private:
     QList<SendRecipient*> m_recipients;
     int m_current{0};
     qint64 m_totalAmount{0};
+    bool m_syncing_units{false};
 };
 
 #endif // BITCOIN_QML_MODELS_SENDRECIPIENTSLISTMODEL_H

--- a/qml/models/walletqmlmodeltransaction.cpp
+++ b/qml/models/walletqmlmodeltransaction.cpp
@@ -17,9 +17,7 @@ WalletQmlModelTransaction::WalletQmlModelTransaction(const SendRecipientsListMod
       m_total_amount(new BitcoinAmount(this)),
       m_wtx(nullptr)
 {
-    const BitcoinAmount::Unit display_unit = recipient->count() == 1
-        ? recipient->recipients().at(0)->amount()->unit()
-        : BitcoinAmount::Unit::BTC;
+    const BitcoinAmount::Unit display_unit = recipient->recipients().at(0)->amount()->unit();
     m_amount_amount->setUnit(display_unit);
     m_amount_amount->setSatoshi(m_amount);
     m_fee_amount->setUnit(display_unit);

--- a/qml/models/walletqmlmodeltransaction.cpp
+++ b/qml/models/walletqmlmodeltransaction.cpp
@@ -70,6 +70,11 @@ QString WalletQmlModelTransaction::label() const
     return m_label;
 }
 
+QString WalletQmlModelTransaction::txid() const
+{
+    return m_wtx ? QString::fromStdString(m_wtx->GetHash().ToString()) : QString{};
+}
+
 void WalletQmlModelTransaction::setDisplayUnit(int unit)
 {
     if (unit != m_display_unit) {
@@ -87,7 +92,11 @@ CTransactionRef& WalletQmlModelTransaction::getWtx()
 
 void WalletQmlModelTransaction::setWtx(const CTransactionRef& newTx)
 {
+    const QString old_txid{txid()};
     m_wtx = newTx;
+    if (txid() != old_txid) {
+        Q_EMIT txidChanged();
+    }
 }
 
 CAmount WalletQmlModelTransaction::getTransactionFee() const

--- a/qml/models/walletqmlmodeltransaction.h
+++ b/qml/models/walletqmlmodeltransaction.h
@@ -22,6 +22,7 @@ class WalletQmlModelTransaction : public QObject
     Q_PROPERTY(QString fee READ fee NOTIFY feeChanged)
     Q_PROPERTY(QString total READ total NOTIFY totalChanged)
     Q_PROPERTY(QString label READ label CONSTANT)
+    Q_PROPERTY(QString txid READ txid NOTIFY txidChanged)
 public:
     explicit WalletQmlModelTransaction(const SendRecipientsListModel* recipient, QObject* parent = nullptr);
 
@@ -32,6 +33,7 @@ public:
     QString fee() const;
     QString total() const;
     QString label() const;
+    QString txid() const;
 
     CTransactionRef& getWtx();
     void setWtx(const CTransactionRef&);
@@ -49,6 +51,7 @@ Q_SIGNALS:
     void amountChanged();
     void feeChanged();
     void totalChanged();
+    void txidChanged();
 
 private:
     static QString formatWithUnit(CAmount value, int display_unit);

--- a/qml/pages/MainWindow.qml
+++ b/qml/pages/MainWindow.qml
@@ -18,6 +18,15 @@ ApplicationWindow {
     minimumWidth: 800
     minimumHeight: 665
     color: Theme.color.background
+    palette.window: Theme.color.neutral1 // Context menu background
+    palette.windowText: Theme.color.neutral8 // Menu item text and icons
+    palette.dark: Theme.dark ? Theme.color.neutral2 : Theme.color.neutral3 // Menu border
+    palette.mid: Theme.dark ? Theme.color.neutral2 : Theme.color.neutral3 // Menu separators
+    palette.light: Theme.color.neutral3 // Highlighted menu item background
+    palette.midlight: Theme.color.neutral3 // Pressed menu item background
+    palette.disabled.windowText: Theme.color.neutral4 // Disabled item text and icons
+    palette.disabled.light: Theme.color.neutral1 // Disabled item highlight background
+    palette.disabled.midlight: Theme.color.neutral1 // Disabled item pressed background
 
     // The window starts hidden and is shown at the end of Component.onCompleted,
     // after the saved size has been applied (below). Applying the size while

--- a/qml/pages/MainWindow.qml
+++ b/qml/pages/MainWindow.qml
@@ -232,7 +232,7 @@ ApplicationWindow {
             onBack: {
                 main.pop()
             }
-            onTransactionSent: {
+            onTransactionSent: (txid) => {
                 const externalSignerWallet = walletController.selectedWallet.hasExternalSigner
                 const descriptionText = externalSignerWallet
                     ? qsTr("Approved on external signer. It should be confirmed within the next 10 minutes.")
@@ -241,7 +241,8 @@ ApplicationWindow {
                 walletController.selectedWallet.recipients.clear()
                 main.push(sendResultPage, {
                     "descriptionText": descriptionText,
-                    "actionText": actionText
+                    "actionText": actionText,
+                    "txid": txid
                 })
             }
         }
@@ -253,7 +254,12 @@ ApplicationWindow {
             onDone: {
                 main.pop(null)
             }
-            onViewNewTransaction: {
+            onViewNewTransaction: (txid) => {
+                if (walletController.selectedWallet) {
+                    walletController.selectedWallet.activityListModel.reload()
+                }
+                const walletPage = main.get(0)
+                walletPage.navigateToTransaction(txid)
                 main.pop(null)
             }
         }

--- a/qml/pages/wallet/Activity.qml
+++ b/qml/pages/wallet/Activity.qml
@@ -15,11 +15,14 @@ PageStack {
     id: stackView
     objectName: "activityStack"
 
-    function navigateToTransaction(txid) {
+    function navigateToTransaction(txid, outputIndex) {
         if (!walletController.selectedWallet)
             return
 
-        var details = walletController.selectedWallet.activityListModel.transactionDetails(txid)
+        const model = walletController.selectedWallet.activityListModel
+        var details = outputIndex === undefined || outputIndex < 0
+            ? model.firstTransactionDetails(txid)
+            : model.transactionDetails(txid, outputIndex)
         if (Object.keys(details).length === 0)
             return
 
@@ -441,6 +444,7 @@ PageStack {
                         required property string replacedByTxid
                         required property bool isPendingRequest
                         required property string requestId
+                        required property int outputIndex
 
                         HoverHandler {
                             cursorShape: Qt.PointingHandCursor
@@ -521,6 +525,7 @@ PageStack {
                                 id: detailsPage
                                 ActivityDetails {
                                     txid: delegate.txid
+                                    outputIndex: delegate.outputIndex
                                     canBump: delegate.canBump
                                     replacedByTxid: delegate.replacedByTxid
                                     amount: delegate.amount

--- a/qml/pages/wallet/ActivityDetails.qml
+++ b/qml/pages/wallet/ActivityDetails.qml
@@ -18,6 +18,7 @@ Page {
     signal showTransaction(string txid)
 
     property string txid: ""
+    property int outputIndex: -1
     property bool canBump: false
     property string replacedByTxid: ""
     property string message: ""
@@ -311,7 +312,8 @@ Page {
         anchors.centerIn: parent
         onBumpSucceeded: {
             var page = root.StackView.view.push("SendResult.qml", {
-                resultType: SendResult.ResultType.SpeedUp
+                resultType: SendResult.ResultType.SpeedUp,
+                txid: speedUpOverlay.newTxid
             })
             page.done.connect(function() {
                 if (walletController.selectedWallet) {
@@ -319,12 +321,12 @@ Page {
                 }
                 root.StackView.view.pop(null)
             })
-            page.viewNewTransaction.connect(function() {
+            page.viewNewTransaction.connect(function(txid) {
                 if (walletController.selectedWallet) {
                     walletController.selectedWallet.activityListModel.reload()
                 }
                 root.StackView.view.pop(null)
-                root.showTransaction(speedUpOverlay.newTxid)
+                root.showTransaction(txid)
             })
         }
     }

--- a/qml/pages/wallet/ActivityDetails.qml
+++ b/qml/pages/wallet/ActivityDetails.qml
@@ -70,6 +70,7 @@ Page {
     header: NavigationBar2 {
         id: navbar
         leftItem: NavButton {
+            objectName: "activityDetailsBackButton"
             iconSource: "image://images/caret-left"
             text: qsTr("Back")
             onClicked: {

--- a/qml/pages/wallet/DesktopWallets.qml
+++ b/qml/pages/wallet/DesktopWallets.qml
@@ -24,6 +24,11 @@ Page {
     signal addWallet()
     signal sendTransaction(bool multipleRecipientsEnabled)
 
+    function navigateToTransaction(txid, outputIndex) {
+        activityTabButton.checked = true
+        activityPage.navigateToTransaction(txid, outputIndex)
+    }
+
     function toggleWalletSelection() {
         if (!walletController.initialized) {
             return
@@ -294,8 +299,7 @@ Page {
                 root.sendTransaction(multipleRecipientsEnabled)
             }
             onViewTransactionInActivity: (txid) => {
-                activityTabButton.checked = true
-                activityPage.navigateToTransaction(txid)
+                root.navigateToTransaction(txid)
             }
         }
         RequestPayment {

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -69,6 +69,8 @@ PageStack {
             sendPage.m_filledUri = ""
             sendPage.m_dismissedUri = ""
             sendPage.m_applyingUri = false
+            sendPage.clearPendingPaymentUriPaste()
+            paymentUriOverwritePopup.close()
         }
     }
 
@@ -91,6 +93,8 @@ PageStack {
             sendPage.paymentRequestStatus = ""
             sendPage.paymentRequestIsError = false
             sendPage.paymentRequestMessage = ""
+            sendPage.clearPendingPaymentUriPaste()
+            paymentUriOverwritePopup.close()
         }
     }
 
@@ -285,6 +289,76 @@ PageStack {
         // Guard that prevents field-change Connections from triggering a
         // re-check while a programmatic URI fill is writing to the form.
         property bool m_applyingUri: false
+        property var m_pendingPastedPaymentRequest: null
+        property string m_pendingPastedPaymentRequestText: ""
+
+        function looksLikePaymentUri(text) {
+            return String(text).trim().toLowerCase().startsWith("bitcoin:")
+        }
+
+        function pasteIntoFocusedRecipientField(field) {
+            if (field === "address") {
+                addressField.paste()
+            } else if (field === "label") {
+                label.paste()
+            } else if (field === "amount") {
+                amountInput.paste()
+            }
+        }
+
+        function paymentUriConflicts(result, sourceField) {
+            if (!root.recipient) return false
+
+            const addressConflict = sourceField !== "address"
+                && root.recipient.address.address.length > 0
+                && root.recipient.address.address !== result.address
+            const amountConflict = sourceField !== "amount"
+                && result.hasAmount
+                && root.recipient.amount.satoshi !== 0
+                && root.recipient.amount.satoshi !== result.amountSats
+            const labelConflict = sourceField !== "label"
+                && result.hasLabel
+                && root.recipient.label.length > 0
+                && root.recipient.label !== result.label
+            return addressConflict || amountConflict || labelConflict
+        }
+
+        function clearPendingPaymentUriPaste() {
+            m_pendingPastedPaymentRequest = null
+            m_pendingPastedPaymentRequestText = ""
+        }
+
+        function applyPastedPaymentRequest(result, text) {
+            applyParsedPaymentRequest(result, qsTr("clipboard"))
+            if (result.success && Clipboard.text() === text) {
+                m_filledUri = text
+                showClipboardUriBanner = false
+            }
+        }
+
+        function handlePaymentUriPaste(text, sourceField) {
+            const result = BitcoinUri.parseBitcoinUri(text)
+            if (!result.success) {
+                applyParsedPaymentRequest(result, qsTr("clipboard"))
+                return
+            }
+            if (paymentUriConflicts(result, sourceField)) {
+                m_pendingPastedPaymentRequest = result
+                m_pendingPastedPaymentRequestText = text
+                paymentUriOverwritePopup.open()
+                return
+            }
+            applyPastedPaymentRequest(result, text)
+        }
+
+        function handleClipboardPaste(field) {
+            const text = Clipboard.text()
+            if (looksLikePaymentUri(text)) {
+                handlePaymentUriPaste(text, field)
+            } else {
+                pasteIntoFocusedRecipientField(field)
+            }
+        }
 
         function checkClipboard() {
             // Skip parsing when the Send tab is not visible or no wallet is
@@ -375,6 +449,39 @@ PageStack {
         function applyPaymentRequestFromFile(path) {
             const result = BitcoinUri.parseBitcoinUriFromFile(path)
             applyParsedPaymentRequest(result, qsTr("file"))
+        }
+
+        AlertPopup {
+            id: paymentUriOverwritePopup
+            objectName: "sendPaymentUriOverwritePopup"
+            parent: Overlay.overlay
+            title: qsTr("Confirm paste?")
+            message: qsTr("The payment request from the clipboard contains information that differs from the currently populated values. Pasting will replace the values.")
+            messageObjectName: "sendPaymentUriOverwriteMessage"
+
+            AlertAction {
+                text: qsTr("Cancel")
+                role: AlertAction.Cancel
+                buttonObjectName: "sendPaymentUriOverwriteCancelButton"
+                closesPopup: false
+                onTriggered: {
+                    sendPage.clearPendingPaymentUriPaste()
+                    paymentUriOverwritePopup.close()
+                }
+            }
+
+            AlertAction {
+                text: qsTr("Paste")
+                buttonObjectName: "sendPaymentUriOverwriteConfirmButton"
+                closesPopup: false
+                onTriggered: {
+                    const result = sendPage.m_pendingPastedPaymentRequest
+                    const text = sendPage.m_pendingPastedPaymentRequestText
+                    sendPage.clearPendingPaymentUriPaste()
+                    paymentUriOverwritePopup.close()
+                    if (result) sendPage.applyPastedPaymentRequest(result, text)
+                }
+            }
         }
 
         Connections {
@@ -796,12 +903,15 @@ PageStack {
                 }
 
                 BitcoinAddressInputField {
+                    id: addressField
                     objectName: "sendAddressField"
                     Layout.fillWidth: true
                     inputObjectName: "sendAddressInput"
+                    interceptPaste: true
                     enabled: walletController.initialized
                     address: root.recipient.address
                     errorText: root.recipient.addressError
+                    onPasteRequested: sendPage.handleClipboardPaste("address")
                     onTextChanged: {
                         root.clearPrepareTransactionError()
                         root.scheduleFeeEstimates()
@@ -818,9 +928,11 @@ PageStack {
                     objectName: "sendNoteField"
                     inputObjectName: "sendNoteInput"
                     Layout.fillWidth: true
+                    interceptPaste: true
                     labelText: qsTr("Note to self")
                     placeholderText: qsTr("Recommended")
-                    text: root.recipient.label
+                    paymentUriRestoreText: root.recipient.label
+                    onPasteRequested: sendPage.handleClipboardPaste("label")
                     onTextEdited: root.recipient.label = label.text
                 }
 
@@ -832,11 +944,13 @@ PageStack {
                     id: amountInput
                     Layout.fillWidth: true
                     inputObjectName: "sendAmountInput"
+                    interceptPaste: true
                     unitToggleObjectName: "sendAmountUnitToggle"
                     unitLabelObjectName: "sendAmountUnitLabel"
                     errorTextObjectName: "sendAmountErrorText"
                     amount: root.recipient ? root.recipient.amount : null
                     errorText: root.recipient ? root.recipient.amountError : ""
+                    onPasteRequested: sendPage.handleClipboardPaste("amount")
                     onInputTextChanged: {
                         root.clearPrepareTransactionError()
                         root.scheduleFeeEstimates()

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -1221,7 +1221,7 @@ PageStack {
     WalletPassphrasePopup {
         id: reviewPassphrasePopup
         parent: Overlay.overlay
-        width: Math.min(420, root.width - 40)
+        width: Math.min(480, root.width - 40)
         popupObjectName: "reviewPassphrasePopup"
         passphraseFieldObjectName: "reviewPassphraseField"
         errorTextObjectName: "reviewPassphraseErrorText"

--- a/qml/pages/wallet/Send.qml
+++ b/qml/pages/wallet/Send.qml
@@ -537,17 +537,18 @@ PageStack {
             anchors.centerIn: Overlay.overlay
             width: Math.min(sendPage.width - 40, 420)
             modal: true
+            dim: true
             padding: 20
 
-            background: Item {
-                anchors.fill: parent
-                Rectangle {
-                    color: Theme.color.neutral0
-                    border.color: Theme.color.neutral4
-                    radius: 5
-                    border.width: 1
-                    anchors.fill: parent
-                }
+            Overlay.modal: Rectangle {
+                color: Qt.rgba(0, 0, 0, 0.5)
+            }
+
+            background: Rectangle {
+                color: Theme.color.neutral1
+                border.color: Theme.color.neutral2
+                radius: 5
+                border.width: 1
             }
 
             contentItem: ColumnLayout {
@@ -565,6 +566,11 @@ PageStack {
                     objectName: "sendUriImportInput"
                     Layout.fillWidth: true
                     placeholderText: qsTr("bitcoin:address?amount=…")
+                    background: Rectangle {
+                        color: Theme.color.neutral2
+                        radius: 5
+                        border.width: 0
+                    }
                 }
 
                 RowLayout {
@@ -573,6 +579,7 @@ PageStack {
 
                     OutlineButton {
                         Layout.fillWidth: true
+                        Layout.preferredWidth: 0
                         text: qsTr("Cancel")
                         onClicked: sendUriImportPopup.close()
                     }
@@ -580,6 +587,7 @@ PageStack {
                     ContinueButton {
                         objectName: "sendUriImportApplyButton"
                         Layout.fillWidth: true
+                        Layout.preferredWidth: 0
                         text: qsTr("Apply")
                         enabled: uriImportInput.text.trim().length > 0
                         onClicked: {
@@ -731,6 +739,7 @@ PageStack {
                 Rectangle {
                     objectName: "clipboardUriBanner"
                     Layout.fillWidth: true
+                    Layout.bottomMargin: visible ? 16 : 0
                     visible: sendPage.showClipboardUriBanner
                     color: Theme.color.neutral1
                     radius: 5
@@ -1125,7 +1134,9 @@ PageStack {
                 ContinueButton {
                     id: continueButton
                     objectName: "sendReviewButton"
-                    Layout.fillWidth: true
+                    Layout.preferredWidth: 300
+                    Layout.maximumWidth: 300
+                    Layout.alignment: Qt.AlignHCenter
                     Layout.topMargin: 36
                     Layout.bottomMargin: 24
                     text: root.externalSignerWallet ? qsTr("Review transaction") : qsTr("Review")

--- a/qml/pages/wallet/SendResult.qml
+++ b/qml/pages/wallet/SendResult.qml
@@ -16,6 +16,7 @@ Page {
     property bool opened: visible
     property string descriptionText: qsTr("Based on your selected fee, it should be confirmed within the next 10 minutes.")
     property string actionText: qsTr("Done")
+    property string txid: ""
 
     background: Rectangle {
         color: Theme.color.background
@@ -30,7 +31,7 @@ Page {
     property int resultType: SendResult.ResultType.Regular
 
     signal done()
-    signal viewNewTransaction()
+    signal viewNewTransaction(string txid)
 
     ColumnLayout {
         id: columnLayout
@@ -82,13 +83,14 @@ Page {
             spacing: 15
 
             OutlineButton {
+                objectName: "sendResultViewTransactionButton"
                 text: root.resultType === SendResult.ResultType.SpeedUp
                     ? qsTr("View new transaction")
                     : qsTr("View transaction")
                 Layout.fillWidth: true
                 Layout.preferredWidth: 1
                 Layout.minimumWidth: 150
-                onClicked: root.viewNewTransaction()
+                onClicked: root.viewNewTransaction(root.txid)
             }
 
             ContinueButton {

--- a/qml/pages/wallet/SendReview.qml
+++ b/qml/pages/wallet/SendReview.qml
@@ -35,7 +35,7 @@ Page {
 
     signal finished()
     signal back()
-    signal transactionSent()
+    signal transactionSent(string txid)
 
     function commitSend() {
         if (root.sending) {
@@ -43,7 +43,7 @@ Page {
         }
         if (root.wallet && root.wallet.sendTransaction()) {
             root.sending = true
-            root.transactionSent()
+            root.transactionSent(root.transaction.txid)
         } else if (root.wallet && root.wallet.transactionNeedsUnlock) {
             sendPassphrasePopup.errorText = ""
             sendPassphrasePopup.open()
@@ -56,7 +56,7 @@ Page {
         }
         if (root.wallet && root.wallet.broadcastCurrentTransaction()) {
             root.sending = true
-            root.transactionSent()
+            root.transactionSent(root.transaction.txid)
         }
     }
 
@@ -309,7 +309,7 @@ Page {
                 sendPassphrasePopup.busy = false
                 sendPassphrasePopup.close()
                 root.sending = true
-                root.transactionSent()
+                root.transactionSent(root.transaction.txid)
                 return
             }
             sendPassphrasePopup.busy = false

--- a/test/functional/qml_test_activity_filter_export.py
+++ b/test/functional/qml_test_activity_filter_export.py
@@ -273,7 +273,7 @@ def run_test(save_screenshots=False, screenshot_root=None):
         checkpoints.checkpoint("search controls closed and filters reset", gui)
 
         txid, expected_amount = _activity_transaction_row(gui)
-        gui.invoke("activityStack", "navigateToTransaction", [txid])
+        gui.click(f"activityItem_{txid}")
         gui.wait_for_page("activityDetailsPage", timeout_ms=10000)
         actual_amount = gui.get_property("activityDetailsPage", "amount")
         assert actual_amount == expected_amount, (

--- a/test/functional/qml_test_send_receive.py
+++ b/test/functional/qml_test_send_receive.py
@@ -382,7 +382,7 @@ def run_test(*, save_screenshots=False, screenshot_root=None):
         assert gui.get_property("activityDetailsPage", "txid") == txid
         assert gui.get_property("activityDetailsPage", "outputIndex") == receiver_output_index
         checkpoints.checkpoint("view transaction opens the sent activity", gui)
-        gui.invoke("activityStack", "pop")
+        gui.click("activityDetailsBackButton")
         gui.wait_for_property("activityTabButton", "visible", True, timeout_ms=10000)
         gui.click("sendTabButton")
         gui.wait_for_page("sendPage", timeout_ms=10000)

--- a/test/functional/qml_test_send_receive.py
+++ b/test/functional/qml_test_send_receive.py
@@ -202,6 +202,7 @@ def assert_receiver_output(port, txid, receiver_address, expected_sats):
         f"Expected receiver output {expected_sats} sats, got {output_sats} sats "
         f"in transaction {txid}"
     )
+    return matched_outputs[0]["n"]
 
 
 def enable_coin_control_and_select_first_coin(gui, checkpoints):
@@ -367,7 +368,7 @@ def run_test(*, save_screenshots=False, screenshot_root=None):
             f"Broadcast fee {rpc_fee_sats} sats did not match preview estimate "
             f"{estimated_fee_with_subtract_sats} sats"
         )
-        assert_receiver_output(
+        receiver_output_index = assert_receiver_output(
             harness.gui_rpc_port,
             txid,
             receiver_address,
@@ -376,7 +377,12 @@ def run_test(*, save_screenshots=False, screenshot_root=None):
         checkpoints.checkpoint("broadcast fee verified", gui)
 
         gui.wait_for_page("sendResultPopup", timeout_ms=10000)
-        gui.click("sendResultDoneButton")
+        gui.click("sendResultViewTransactionButton")
+        gui.wait_for_page("activityDetailsPage", timeout_ms=10000)
+        assert gui.get_property("activityDetailsPage", "txid") == txid
+        assert gui.get_property("activityDetailsPage", "outputIndex") == receiver_output_index
+        checkpoints.checkpoint("view transaction opens the sent activity", gui)
+        gui.invoke("activityStack", "pop")
         gui.wait_for_property("activityTabButton", "visible", True, timeout_ms=10000)
         gui.click("sendTabButton")
         gui.wait_for_page("sendPage", timeout_ms=10000)

--- a/test/functional/qml_test_send_receive.py
+++ b/test/functional/qml_test_send_receive.py
@@ -383,7 +383,7 @@ def run_test(*, save_screenshots=False, screenshot_root=None):
         assert gui.get_property("activityDetailsPage", "outputIndex") == receiver_output_index
         checkpoints.checkpoint("view transaction opens the sent activity", gui)
         gui.click("activityDetailsBackButton")
-        gui.wait_for_property("activityTabButton", "visible", True, timeout_ms=10000)
+        gui.wait_for_property("activityStack", "depth", 1, timeout_ms=10000)
         gui.click("sendTabButton")
         gui.wait_for_page("sendPage", timeout_ms=10000)
         gui.wait_for_property("sendCoinControlButtonText", "text", "Select", timeout_ms=10000)

--- a/test/functional/qml_test_send_review.py
+++ b/test/functional/qml_test_send_review.py
@@ -218,18 +218,19 @@ def prepare_single_send(gui, address, amount, amount_unit="btc"):
     gui.wait_for_property("sendReviewSendButton", "visible", True, timeout_ms=10000)
 
 
-def prepare_multi_send(gui, first_address, first_amount_btc, second_address, second_amount_sat):
+def prepare_multi_send(gui, first_address, first_amount_btc, second_address, second_amount_btc):
     open_send_page(gui)
     set_multiple_recipients(gui, True)
 
-    set_amount_unit(gui, "sat")
-    gui.set_text("sendAddressInput", second_address)
-    gui.set_text("sendAmountInput", second_amount_sat)
-    gui.click("sendRecipientPrevButton")
     set_amount_unit(gui, "₿")
+    gui.set_text("sendAddressInput", second_address)
+    gui.set_text("sendAmountInput", second_amount_btc)
+    gui.click("sendRecipientPrevButton")
     gui.set_text("sendAddressInput", first_address)
     gui.set_text("sendAmountInput", first_amount_btc)
     gui.set_text("sendNoteInput", "Alice's salary")
+    gui.click("sendRecipientNextButton")
+    set_amount_unit(gui, "sat")
     gui.wait_for_property("sendReviewButton", "enabled", True, timeout_ms=10000)
     gui.click("sendReviewButton")
     gui.wait_for_page("sendReviewPage", timeout_ms=10000)
@@ -388,7 +389,7 @@ def case_multi_review(harness, gui, wallet_name, checkpoints):
         first_address=first_address,
         first_amount_btc="0.50000000",
         second_address=second_address,
-        second_amount_sat="2000",
+        second_amount_btc="0.00002000",
     )
     checkpoints.checkpoint("multi review page displayed", gui)
 
@@ -417,7 +418,7 @@ def case_multi_review(harness, gui, wallet_name, checkpoints):
         view_object_name="multipleSendReviewRecipientsList",
         row_index=0,
         prop="amountText",
-    ) == "0.50000000 ₿"
+    ) == "50000000 sats"
     assert gui.get_list_item_property(
         view_object_name="multipleSendReviewRecipientsList",
         row_index=1,
@@ -428,14 +429,11 @@ def case_multi_review(harness, gui, wallet_name, checkpoints):
         row_index=1,
         prop="formattedAddress",
     ) == format_full_address(second_address)
-    second_amount_text = gui.get_list_item_property(
+    assert gui.get_list_item_property(
         view_object_name="multipleSendReviewRecipientsList",
         row_index=1,
         prop="amountText",
-    )
-    assert second_amount_text in {"2000 sat", "2000 sats"}, (
-        f"Expected second recipient amount to use a satoshi unit, got {second_amount_text!r}"
-    )
+    ) == "2000 sats"
     assert gui.get_list_item_property(
         view_object_name="multipleSendReviewRecipientsList",
         row_index=1,
@@ -459,8 +457,8 @@ def case_multi_review(harness, gui, wallet_name, checkpoints):
         prop="secondaryText",
     ) == format_full_address(second_address)
     checkpoints.checkpoint("multi review recipient expanded", gui)
-    assert_unit_suffix(gui, "multipleSendReviewFeeField", "₿")
-    assert_unit_suffix(gui, "multipleSendReviewTotalField", "₿")
+    assert_unit_suffix(gui, "multipleSendReviewFeeField", "sats")
+    assert_unit_suffix(gui, "multipleSendReviewTotalField", "sats")
     return_to_send_page(gui, "sendReviewBackButton")
 
 

--- a/test/functional/qml_test_send_review.py
+++ b/test/functional/qml_test_send_review.py
@@ -280,24 +280,22 @@ def assert_save_psbt_error(gui, destination):
     assert status.startswith("Could not save PSBT:"), f"Unexpected PSBT save error: {status!r}"
 
 
-def assert_address_expand(gui, short_object_name, full_object_name, address, checkpoints=None, label=None):
+def assert_address_toggle(gui, object_name, address, checkpoints=None, label=None):
     wait_until(
-        lambda: gui.get_text(short_object_name) == format_short_address(address),
-        description=f"{short_object_name} text",
+        lambda: gui.get_property(object_name, "displayText") == format_short_address(address),
+        description=f"{object_name} truncated text",
     )
-    wait_until(
-        lambda: gui.get_property(full_object_name, "visible") is False,
-        description=f"{full_object_name} hidden",
-    )
+    assert gui.get_property(object_name, "expanded") is False
 
-    gui.click(short_object_name)
-    gui.wait_for_property(full_object_name, "visible", True, timeout_ms=5000)
+    gui.click(object_name)
+    gui.wait_for_property(object_name, "expanded", True, timeout_ms=5000)
     if checkpoints and label:
         checkpoints.checkpoint(f"{label} address expanded", gui)
-    assert gui.get_text(full_object_name) == format_full_address(address)
+    assert gui.get_property(object_name, "displayText") == format_full_address(address)
 
-    gui.click(short_object_name)
-    gui.wait_for_property(full_object_name, "visible", True, timeout_ms=5000)
+    gui.click(object_name)
+    gui.wait_for_property(object_name, "expanded", False, timeout_ms=5000)
+    assert gui.get_property(object_name, "displayText") == format_short_address(address)
 
 
 def return_to_send_page(gui, back_button):
@@ -311,10 +309,9 @@ def case_single_btc(harness, gui, wallet_name, checkpoints):
     prepare_single_send(gui, recipient_address, "1.25000000", amount_unit="btc")
     checkpoints.checkpoint("single-btc review page displayed", gui)
 
-    assert_address_expand(
+    assert_address_toggle(
         gui,
         "sendReviewAddressField",
-        "sendReviewFullAddressField",
         recipient_address,
         checkpoints=checkpoints,
         label="single-btc review",
@@ -334,10 +331,9 @@ def case_single_sat(harness, gui, wallet_name, checkpoints):
     prepare_single_send(gui, recipient_address, "1250", amount_unit="sat")
     checkpoints.checkpoint("single-sat review page displayed", gui)
 
-    assert_address_expand(
+    assert_address_toggle(
         gui,
         "sendReviewAddressField",
-        "sendReviewFullAddressField",
         recipient_address,
         checkpoints=checkpoints,
         label="single-sat review",
@@ -407,13 +403,8 @@ def case_multi_review(harness, gui, wallet_name, checkpoints):
     assert gui.get_list_item_property(
         view_object_name="multipleSendReviewRecipientsList",
         row_index=0,
-        prop="secondaryText",
+        prop="addressText",
     ) == format_short_address(first_address)
-    assert gui.get_list_item_property(
-        view_object_name="multipleSendReviewRecipientsList",
-        row_index=0,
-        prop="secondaryVisible",
-    ) is True
     assert gui.get_list_item_property(
         view_object_name="multipleSendReviewRecipientsList",
         row_index=0,
@@ -437,8 +428,8 @@ def case_multi_review(harness, gui, wallet_name, checkpoints):
     assert gui.get_list_item_property(
         view_object_name="multipleSendReviewRecipientsList",
         row_index=1,
-        prop="secondaryVisible",
-    ) is False
+        prop="addressText",
+    ) == format_short_address(second_address)
     gui.click_list_item(
         view_object_name="multipleSendReviewRecipientsList",
         row_index=1,
@@ -447,16 +438,33 @@ def case_multi_review(harness, gui, wallet_name, checkpoints):
         lambda: gui.get_list_item_property(
             view_object_name="multipleSendReviewRecipientsList",
             row_index=1,
-            prop="secondaryVisible",
+            prop="expanded",
         ) is True,
         description="multiple recipient row expanded",
     )
     assert gui.get_list_item_property(
         view_object_name="multipleSendReviewRecipientsList",
         row_index=1,
-        prop="secondaryText",
+        prop="addressText",
     ) == format_full_address(second_address)
     checkpoints.checkpoint("multi review recipient expanded", gui)
+    gui.click_list_item(
+        view_object_name="multipleSendReviewRecipientsList",
+        row_index=1,
+    )
+    wait_until(
+        lambda: gui.get_list_item_property(
+            view_object_name="multipleSendReviewRecipientsList",
+            row_index=1,
+            prop="expanded",
+        ) is False,
+        description="multiple recipient row collapsed",
+    )
+    assert gui.get_list_item_property(
+        view_object_name="multipleSendReviewRecipientsList",
+        row_index=1,
+        prop="addressText",
+    ) == format_short_address(second_address)
     assert_unit_suffix(gui, "multipleSendReviewFeeField", "sats")
     assert_unit_suffix(gui, "multipleSendReviewTotalField", "sats")
     return_to_send_page(gui, "sendReviewBackButton")

--- a/test/functional/qml_test_uri_import.py
+++ b/test/functional/qml_test_uri_import.py
@@ -217,8 +217,61 @@ def run_tests():
         )
         print("Test 7 PASSED: DropArea hasUrls + non-file URL branch.")
 
+        # ----------------------------------------------------------------
+        # Test 8: Native text-control paste from every recipient field
+        # Calling paste() exercises the same control path as a context-menu
+        # Paste action without assuming a platform-specific keyboard shortcut.
+        # ----------------------------------------------------------------
+        amount_field_uri = (
+            f"bitcoin:{target_address}"
+            f"?amount=0.07000000&label=drop-url"
+        )
+        gui.set_clipboard_text(amount_field_uri)
+        gui.click("sendAmountInput")
+        gui.invoke("sendAmountInput", "paste")
+        gui.wait_for_property(
+            "sendAmountInput", "text",
+            lambda v: "0.07000000" in str(v), timeout_ms=5000,
+        )
+
+        label_field_uri = (
+            f"bitcoin:{target_address}"
+            f"?amount=0.07000000&label=field-paste"
+        )
+        gui.set_clipboard_text(label_field_uri)
+        gui.click("sendNoteInput")
+        gui.invoke("sendNoteInput", "paste")
+        gui.wait_for_property(
+            "sendNoteInput", "text", "field-paste", timeout_ms=5000,
+        )
+
+        address_field_uri = (
+            f"bitcoin:{target_address}"
+            f"?amount=0.07000000&label=field-paste&message=address-field-paste"
+        )
+        gui.set_clipboard_text(address_field_uri)
+        gui.click("sendAddressInput")
+        gui.invoke("sendAddressInput", "paste")
+        gui.wait_for_property(
+            "sendPaymentRequestMessageText", "text",
+            "address-field-paste", timeout_ms=5000,
+        )
+        print("Test 8 PASSED: native paste from recipient fields.")
+
+        # ----------------------------------------------------------------
+        # Test 9: Non-URI context-menu paste keeps normal text behavior
+        # ----------------------------------------------------------------
+        gui.set_clipboard_text("-ordinary-paste")
+        gui.click("sendNoteInput")
+        gui.invoke("sendNoteInput", "paste")
+        gui.wait_for_property(
+            "sendNoteInput", "text",
+            lambda v: "-ordinary-paste" in str(v), timeout_ms=5000,
+        )
+        print("Test 9 PASSED: non-URI native paste remains unchanged.")
+
         print("\n" + "=" * 50)
-        print("All URI import tests PASSED (7/7)")
+        print("All URI import tests PASSED (9/9)")
         print("=" * 50)
 
     except Exception as exc:

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -19,6 +19,7 @@
 #include <qqml.h>
 
 #include <algorithm>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -1278,6 +1279,7 @@ class MockWalletQmlModelTransaction : public QObject
     Q_PROPERTY(QString amount MEMBER m_amount CONSTANT)
     Q_PROPERTY(QString fee MEMBER m_fee CONSTANT)
     Q_PROPERTY(QString total MEMBER m_total CONSTANT)
+    Q_PROPERTY(QString txid MEMBER m_txid CONSTANT)
     Q_PROPERTY(QObject* amountAmount READ amountAmount CONSTANT)
     Q_PROPERTY(QObject* feeAmount READ feeAmount CONSTANT)
     Q_PROPERTY(QObject* totalAmount READ totalAmount CONSTANT)
@@ -1295,6 +1297,7 @@ public:
     QString m_amount{QStringLiteral("0.01000000 BTC")};
     QString m_fee{QStringLiteral("0.00001000 BTC")};
     QString m_total{QStringLiteral("0.01001000 BTC")};
+    QString m_txid{QStringLiteral("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")};
     MockBitcoinAmount m_amount_amount;
     MockBitcoinAmount m_fee_amount;
     MockBitcoinAmount m_total_amount;
@@ -2784,7 +2787,8 @@ public:
         IsPendingRequestRole,
         RequestIdRole,
         TimestampRole,
-        NetAmountSatRole
+        NetAmountSatRole,
+        OutputIndexRole
     };
 
     int rowCount(const QModelIndex& parent = QModelIndex{}) const override
@@ -2815,12 +2819,18 @@ public:
             case RequestIdRole: return QString{};
             case TimestampRole: return 1767225600;
             case NetAmountSatRole: return 1000000;
+            case OutputIndexRole: return 0;
             default: return {};
             }
         }
+        const bool first_send_output = index.row() >= 2;
         switch (role) {
-        case AddressRole: return QStringLiteral("bcrt1qsendaddress");
-        case AmountRole: return QStringLiteral("-0.00100000 BTC");
+        case AddressRole: return first_send_output
+                ? QStringLiteral("bcrt1qfirstsendaddress")
+                : QStringLiteral("bcrt1qsecondsendaddress");
+        case AmountRole: return first_send_output
+                ? QStringLiteral("-0.00200000 BTC")
+                : QStringLiteral("-0.00100000 BTC");
         case DateRole: return QStringLiteral("2026-01-02 00:00");
         case DepthRole: return 0;
         case LabelRole: return QStringLiteral("coffee");
@@ -2833,7 +2843,8 @@ public:
         case IsPendingRequestRole: return false;
         case RequestIdRole: return QString{};
         case TimestampRole: return 1767312000;
-        case NetAmountSatRole: return -100000;
+        case NetAmountSatRole: return first_send_output ? -200000 : -100000;
+        case OutputIndexRole: return first_send_output ? 1 : 2;
         default: return {};
         }
     }
@@ -2856,10 +2867,39 @@ public:
             {RequestIdRole, "requestId"},
             {TimestampRole, "timestamp"},
             {NetAmountSatRole, "netAmountSat"},
+            {OutputIndexRole, "outputIndex"},
         };
     }
 
     Q_INVOKABLE void reload() {}
+    Q_INVOKABLE QVariantMap firstTransactionDetails(const QString& txid) const
+    {
+        int first_row{-1};
+        int first_output{std::numeric_limits<int>::max()};
+        for (int row = 0; row < rowCount(); ++row) {
+            const QModelIndex model_index = index(row, 0);
+            if (data(model_index, TxidRole).toString() != txid) continue;
+            const int output_index = data(model_index, OutputIndexRole).toInt();
+            if (output_index < first_output) {
+                first_row = row;
+                first_output = output_index;
+            }
+        }
+        return transactionDetailsForRow(first_row);
+    }
+
+    Q_INVOKABLE QVariantMap transactionDetails(const QString& txid, int output_index) const
+    {
+        for (int row = 0; row < rowCount(); ++row) {
+            const QModelIndex model_index = index(row, 0);
+            if (data(model_index, TxidRole).toString() == txid
+                && data(model_index, OutputIndexRole).toInt() == output_index) {
+                return transactionDetailsForRow(row);
+            }
+        }
+        return {};
+    }
+
     Q_INVOKABLE void setCountForTest(int count)
     {
         if (m_count == count) return;
@@ -2873,6 +2913,26 @@ Q_SIGNALS:
     void countChanged();
 
 private:
+    QVariantMap transactionDetailsForRow(int row) const
+    {
+        if (row < 0 || row >= rowCount()) return {};
+        const QModelIndex model_index = index(row, 0);
+        return {
+            {"txid", data(model_index, TxidRole)},
+            {"outputIndex", data(model_index, OutputIndexRole)},
+            {"canBump", data(model_index, CanBumpRole)},
+            {"replacedByTxid", data(model_index, ReplacedByTxidRole)},
+            {"amount", data(model_index, AmountRole)},
+            {"date", data(model_index, DateRole)},
+            {"depth", data(model_index, DepthRole)},
+            {"type", data(model_index, TypeRole)},
+            {"status", data(model_index, StatusRole)},
+            {"address", data(model_index, AddressRole)},
+            {"label", data(model_index, LabelRole)},
+            {"paymentRequests", QVariantList{}},
+        };
+    }
+
     int m_count{2};
 };
 

--- a/test/qml/tst_activity.qml
+++ b/test/qml/tst_activity.qml
@@ -123,6 +123,26 @@ TestCase {
         }
     }
 
+    function test_navigateToTransaction_uses_lowest_output_and_supports_exact_output() {
+        testActivityListModel.setCountForTest(3)
+        const page = createTemporaryObject(activityComponent, this)
+        verify(page !== null)
+
+        page.navigateToTransaction("bbbb")
+        tryCompare(page, "depth", 2)
+        compare(page.currentItem.txid, "bbbb")
+        compare(page.currentItem.outputIndex, 1)
+        compare(page.currentItem.address, "bcrt1qfirstsendaddress")
+
+        page.pop()
+        tryCompare(page, "depth", 1)
+        page.navigateToTransaction("bbbb", 2)
+        tryCompare(page, "depth", 2)
+        compare(page.currentItem.txid, "bbbb")
+        compare(page.currentItem.outputIndex, 2)
+        compare(page.currentItem.address, "bcrt1qsecondsendaddress")
+    }
+
     function test_selectedWalletChanged_pops_to_root() {
         const page = createTemporaryObject(activityComponent, this)
         verify(page !== null)

--- a/test/qml/tst_address_components.qml
+++ b/test/qml/tst_address_components.qml
@@ -91,8 +91,46 @@ TestCase {
         id: addressLabelComponent
 
         AddressLabel {
+            objectName: "referenceAddressLabel"
             width: 120
             address: "abcdefghijklmnopqrst"
+        }
+    }
+
+    Component {
+        id: addressDisplayFieldComponent
+
+        BitcoinAddressDisplayField {
+            objectName: "toggleAddressField"
+            width: 320
+            text: "abcd efgh ... mnop qrst"
+            fullText: "abcd efgh ijkl mnop qrst"
+        }
+    }
+
+    Component {
+        id: multipleRecipientsSummaryComponent
+
+        MultipleRecipientsSummary {
+            width: 450
+            wallet: null
+            transaction: null
+            recipients: ListModel {
+                ListElement {
+                    address: "abcd efgh ... uvwx yz12"
+                    label: ""
+                    amount: "1000"
+                    formattedAddress: "abcd efgh ijkl mnop qrst uvwx yz12"
+                    amountUnitLabel: "sats"
+                }
+                ListElement {
+                    address: "2345 6789 ... uvwx yz12"
+                    label: "Alice"
+                    amount: "2000"
+                    formattedAddress: "2345 6789 abcd efgh ijkl mnop qrst uvwx yz12"
+                    amountUnitLabel: "sats"
+                }
+            }
         }
     }
 
@@ -107,6 +145,66 @@ TestCase {
         verify(label.formattedText.indexOf("<font color=\"" + primary + "\">ijkl</font>") !== -1)
         verify(label.formattedText.indexOf("<font color=\"" + secondary + "\">mnop</font>") !== -1)
         verify(label.formattedText.indexOf("<font color=\"" + primary + "\">qrst</font>") !== -1)
+    }
+
+    function test_addressDisplayField_toggles_same_monospace_text() {
+        const field = createTemporaryObject(addressDisplayFieldComponent, host)
+        const referenceLabel = createTemporaryObject(addressLabelComponent, host)
+        verify(field !== null)
+        verify(referenceLabel !== null)
+
+        const addressText = findObject(field, "toggleAddressFieldText")
+        const referenceText = findObject(referenceLabel, "referenceAddressLabelValue")
+        verify(addressText !== null)
+        verify(referenceText !== null)
+        compare(addressText.font.family, referenceText.font.family)
+        compare(addressText.font.styleName, referenceText.font.styleName)
+        compare(addressText.font.pixelSize, referenceText.font.pixelSize)
+        compare(addressText.text, "abcd efgh ... mnop qrst")
+        compare(field.expanded, false)
+
+        field.click()
+        compare(field.expanded, true)
+        compare(addressText.text, "abcd efgh ijkl mnop qrst")
+
+        field.click()
+        compare(field.expanded, false)
+        compare(addressText.text, "abcd efgh ... mnop qrst")
+        compare(findObject(field, "toggleAddressFieldText"), addressText)
+    }
+
+    function test_multipleRecipients_toggle_each_address_in_place() {
+        const summary = createTemporaryObject(multipleRecipientsSummaryComponent, host)
+        const referenceLabel = createTemporaryObject(addressLabelComponent, host)
+        verify(summary !== null)
+        verify(referenceLabel !== null)
+
+        tryVerify(function() {
+            return findObject(summary, "multipleSendReviewRecipient0AddressText") !== null
+                && findObject(summary, "multipleSendReviewRecipient1AddressText") !== null
+        })
+        const firstAddress = findObject(summary, "multipleSendReviewRecipient0AddressText")
+        const secondAddress = findObject(summary, "multipleSendReviewRecipient1AddressText")
+        const secondLabel = findObject(summary, "multipleSendReviewRecipient1PrimaryText")
+        const referenceText = findObject(referenceLabel, "referenceAddressLabelValue")
+        verify(secondLabel !== null)
+        verify(referenceText !== null)
+        compare(firstAddress.font.family, referenceText.font.family)
+        compare(secondAddress.font.family, referenceText.font.family)
+        compare(firstAddress.text, "abcd efgh ... uvwx yz12")
+        compare(secondLabel.text, "Alice")
+        compare(secondAddress.text, "2345 6789 ... uvwx yz12")
+
+        mouseClick(firstAddress, firstAddress.width / 2, firstAddress.height / 2)
+        compare(firstAddress.text, "abcd efgh ijkl mnop qrst uvwx yz12")
+        mouseClick(firstAddress, firstAddress.width / 2, firstAddress.height / 2)
+        compare(firstAddress.text, "abcd efgh ... uvwx yz12")
+
+        mouseClick(secondAddress, secondAddress.width / 2, secondAddress.height / 2)
+        compare(secondLabel.text, "Alice")
+        compare(secondAddress.text, "2345 6789 abcd efgh ijkl mnop qrst uvwx yz12")
+        mouseClick(secondAddress, secondAddress.width / 2, secondAddress.height / 2)
+        compare(secondAddress.text, "2345 6789 ... uvwx yz12")
     }
 
     function test_row_uses_display_amount_and_emits_actions() {

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -575,10 +575,10 @@ TestCase {
         testSendRecipient.amount.satoshi = 100000000
         testSendRecipient.label = "existing label"
 
-        const page = createTemporaryObject(sendComponent, testWindow.contentItem)
+        const page = createTemporaryObject(sendComponent, testCase.Window.window.contentItem)
         verify(page !== null)
-        page.width = testWindow.width
-        page.height = testWindow.height
+        page.width = testCase.width
+        page.height = testCase.height
         page.visible = true
 
         const sendPage = findChild(page, "walletSendPage")
@@ -643,7 +643,7 @@ TestCase {
         testSendRecipient.amount.satoshi = 100000000
         testSendRecipient.label = "existing label"
 
-        const page = createTemporaryObject(sendComponent, testWindow.contentItem)
+        const page = createTemporaryObject(sendComponent, testCase.Window.window.contentItem)
         verify(page !== null)
         const sendPage = findChild(page, "walletSendPage")
         const overwritePopup = findChild(page, "sendPaymentUriOverwritePopup")

--- a/test/qml/tst_send.qml
+++ b/test/qml/tst_send.qml
@@ -45,6 +45,11 @@ TestCase {
         testRecipientsModel.totalAmountSatoshi = 0
         optionsModel.displayUnit = BitcoinAmount.BTC
         testCoinsListModel.reset()
+        Clipboard.currentText = ""
+    }
+
+    function pasteShortcut() {
+        keyClick(Qt.Key_V, Qt.ControlModifier)
     }
 
     function test_review_only_psbt_closes_and_discards_on_wallet_change() {
@@ -529,5 +534,127 @@ TestCase {
         compare(testSendRecipient.label, "uri-label")
         compare(sendPage.paymentRequestStatus, "Payment request imported from clipboard")
         compare(sendPage.paymentRequestIsError, false)
+    }
+
+    function test_send_payment_uri_paste_applies_from_each_recipient_field_data() {
+        return [
+            { tag: "address", inputObjectName: "sendAddressInput" },
+            { tag: "label", inputObjectName: "sendNoteInput" },
+            { tag: "amount", inputObjectName: "sendAmountInput" },
+        ]
+    }
+
+    function test_send_payment_uri_paste_applies_from_each_recipient_field(data) {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const sendPage = findChild(page, "walletSendPage")
+        const input = findChild(page, data.inputObjectName)
+        const overwritePopup = findChild(page, "sendPaymentUriOverwritePopup")
+        verify(sendPage !== null)
+        verify(input !== null)
+        verify(overwritePopup !== null)
+
+        const address = "bcrt1q8rcpp66mqmtsw27mx7awa7yfdrpzytumsapkw4"
+        testSendRecipient.address.setAddress(address, 0)
+        Clipboard.currentText = "bitcoin:" + address + "?amount=100.00000000&label=Alice&message=Pay%20me"
+        input.forceActiveFocus()
+        verify(input.activeFocus)
+        pasteShortcut()
+
+        compare(overwritePopup.opened, false)
+        compare(testSendRecipient.address.address, address)
+        compare(testSendRecipient.amount.satoshi, 10000000000)
+        compare(testSendRecipient.label, "Alice")
+        compare(sendPage.paymentRequestMessage, "Pay me")
+        compare(sendPage.paymentRequestStatus, "Payment request imported from clipboard")
+        compare(sendPage.paymentRequestIsError, false)
+    }
+
+    function test_send_payment_uri_paste_confirms_overwriting_other_fields() {
+        testSendRecipient.amount.satoshi = 100000000
+        testSendRecipient.label = "existing label"
+
+        const page = createTemporaryObject(sendComponent, testWindow.contentItem)
+        verify(page !== null)
+        page.width = testWindow.width
+        page.height = testWindow.height
+        page.visible = true
+
+        const sendPage = findChild(page, "walletSendPage")
+        const addressInput = findChild(page, "sendAddressInput")
+        const overwritePopup = findChild(page, "sendPaymentUriOverwritePopup")
+        verify(sendPage !== null)
+        verify(addressInput !== null)
+        verify(overwritePopup !== null)
+
+        const uri = "bitcoin:bcrt1qreplacement?amount=0.02000000&label=replacement-label"
+        Clipboard.currentText = uri
+        sendPage.handleClipboardPaste("address")
+        tryCompare(overwritePopup, "opened", true)
+
+        verify(addressInput.text !== uri)
+        compare(testSendRecipient.address.address, "bcrt1qsendtoaddress")
+        compare(testSendRecipient.amount.satoshi, 100000000)
+        compare(testSendRecipient.label, "existing label")
+
+        const cancelButton = findChild(overwritePopup.contentItem, "sendPaymentUriOverwriteCancelButton")
+        verify(cancelButton !== null)
+        cancelButton.clicked()
+        tryCompare(overwritePopup, "opened", false)
+        compare(testSendRecipient.address.address, "bcrt1qsendtoaddress")
+        compare(testSendRecipient.amount.satoshi, 100000000)
+        compare(testSendRecipient.label, "existing label")
+
+        sendPage.handleClipboardPaste("address")
+        tryCompare(overwritePopup, "opened", true)
+        const confirmButton = findChild(overwritePopup.contentItem, "sendPaymentUriOverwriteConfirmButton")
+        verify(confirmButton !== null)
+        confirmButton.clicked()
+        tryCompare(overwritePopup, "opened", false)
+
+        compare(testSendRecipient.address.address, "bcrt1qreplacement")
+        compare(testSendRecipient.amount.satoshi, 2000000)
+        compare(testSendRecipient.label, "replacement-label")
+    }
+
+    function test_send_payment_uri_model_label_is_not_reparsed() {
+        const page = createTemporaryObject(sendComponent, this)
+        verify(page !== null)
+
+        const sendPage = findChild(page, "walletSendPage")
+        const addressInput = findChild(page, "sendAddressInput")
+        verify(sendPage !== null)
+        verify(addressInput !== null)
+
+        const address = "bcrt1q8rcpp66mqmtsw27mx7awa7yfdrpzytumsapkw4"
+        const nestedUri = "bitcoin:" + address + "?amount=1.00000000"
+        Clipboard.currentText = "bitcoin:" + address + "?label=" + encodeURIComponent(nestedUri)
+        addressInput.forceActiveFocus()
+        verify(addressInput.activeFocus)
+        pasteShortcut()
+
+        compare(testSendRecipient.address.address, address)
+        compare(testSendRecipient.label, nestedUri)
+        compare(testSendRecipient.amount.satoshi, 0)
+    }
+
+    function test_send_payment_uri_paste_preserves_omitted_fields() {
+        testSendRecipient.amount.satoshi = 100000000
+        testSendRecipient.label = "existing label"
+
+        const page = createTemporaryObject(sendComponent, testWindow.contentItem)
+        verify(page !== null)
+        const sendPage = findChild(page, "walletSendPage")
+        const overwritePopup = findChild(page, "sendPaymentUriOverwritePopup")
+        verify(sendPage !== null)
+        verify(overwritePopup !== null)
+
+        sendPage.handlePaymentUriPaste("bitcoin:bcrt1qreplacement", "address")
+
+        compare(overwritePopup.opened, false)
+        compare(testSendRecipient.address.address, "bcrt1qreplacement")
+        compare(testSendRecipient.amount.satoshi, 100000000)
+        compare(testSendRecipient.label, "existing label")
     }
 }

--- a/test/qml/tst_walletpassphrasepopup.qml
+++ b/test/qml/tst_walletpassphrasepopup.qml
@@ -87,6 +87,49 @@ TestCase {
         compare(field.text, "")
     }
 
+    function test_enter_or_return_submits_data() {
+        return [
+            { tag: "return", key: Qt.Key_Return },
+            { tag: "enter", key: Qt.Key_Enter }
+        ]
+    }
+
+    function test_enter_or_return_submits(data) {
+        const popup = createPopup()
+        const field = findObjectByName(popup, "testPassphraseField")
+        verify(field !== null)
+        tryCompare(field, "activeFocus", true)
+
+        const passphrase = "correct horse battery staple"
+        field.text = passphrase
+        keyClick(data.key)
+
+        compare(submittedCount, 1)
+        compare(submittedPassphrase, passphrase)
+        compare(field.text, "")
+    }
+
+    function test_return_does_not_submit_when_confirm_is_disabled_data() {
+        return [
+            { tag: "empty", passphrase: "", busy: false },
+            { tag: "busy", passphrase: "secret", busy: true }
+        ]
+    }
+
+    function test_return_does_not_submit_when_confirm_is_disabled(data) {
+        const popup = createPopup()
+        const field = findObjectByName(popup, "testPassphraseField")
+        verify(field !== null)
+        tryCompare(field, "activeFocus", true)
+
+        field.text = data.passphrase
+        popup.busy = data.busy
+        keyClick(Qt.Key_Return)
+
+        compare(submittedCount, 0)
+        compare(field.text, data.passphrase)
+    }
+
     function test_close_clears_field_without_submitting() {
         const popup = createPopup()
         const field = findObjectByName(popup, "testPassphraseField")

--- a/test/test_bitcoinaddress.cpp
+++ b/test/test_bitcoinaddress.cpp
@@ -11,9 +11,35 @@ class BitcoinAddressTests : public QObject
     Q_OBJECT
 
 private Q_SLOTS:
+    void setAddress_acceptsSupportedAddressCharacters();
+    void setAddress_rejectsUnsupportedCharactersImmediately();
     void formattedAddress_groupsCharactersInFours();
     void ellipsesAddress_keepsVisiblePrefixAndSuffix();
 };
+
+void BitcoinAddressTests::setAddress_acceptsSupportedAddressCharacters()
+{
+    const QString input{QStringLiteral("0123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")};
+    BitcoinAddress address;
+
+    address.setAddress(input, static_cast<int>(input.size()));
+
+    QCOMPARE(address.address(), input);
+}
+
+void BitcoinAddressTests::setAddress_rejectsUnsupportedCharactersImmediately()
+{
+    BitcoinAddress address{QStringLiteral("bc1qexampleaddress")};
+    QSignalSpy formatted_address_changed{&address, &BitcoinAddress::formattedAddressChanged};
+    const QString input{address.formattedAddress() + QStringLiteral(".[]IO")};
+
+    const int cursor_position{address.setAddress(input, static_cast<int>(input.size()))};
+
+    QCOMPARE(address.address(), QStringLiteral("bc1qexampleaddress"));
+    QCOMPARE(address.formattedAddress(), QStringLiteral("bc1q exam plea ddre ss"));
+    QCOMPARE(cursor_position, static_cast<int>(address.formattedAddress().size()));
+    QCOMPARE(formatted_address_changed.count(), 1);
+}
 
 void BitcoinAddressTests::formattedAddress_groupsCharactersInFours()
 {

--- a/test/test_sendrecipientslistmodel.cpp
+++ b/test/test_sendrecipientslistmodel.cpp
@@ -22,6 +22,7 @@ class SendRecipientsListModelTests : public QObject
 
 private Q_SLOTS:
     void clearKeepsCurrentRecipientValidForQmlBindings();
+    void unitChangesApplyToEveryRecipient();
 };
 
 void SendRecipientsListModelTests::clearKeepsCurrentRecipientValidForQmlBindings()
@@ -66,6 +67,31 @@ void SendRecipientsListModelTests::clearKeepsCurrentRecipientValidForQmlBindings
     QVERIFY(observer->property("address").toString().isEmpty());
     QVERIFY(observer->property("label").toString().isEmpty());
     QCOMPARE(observer->property("amount").value<QObject*>(), recipients.currentRecipient()->amount());
+}
+
+void SendRecipientsListModelTests::unitChangesApplyToEveryRecipient()
+{
+    SendRecipientsListModel recipients;
+    auto* first = recipients.currentRecipient();
+    first->amount()->setSatoshi(COIN / 2);
+
+    recipients.add();
+    auto* second = recipients.currentRecipient();
+    second->amount()->setSatoshi(2'000);
+    second->amount()->setUnit(BitcoinAmount::Unit::SAT);
+
+    QCOMPARE(first->amount()->unit(), BitcoinAmount::Unit::SAT);
+    QCOMPARE(second->amount()->unit(), BitcoinAmount::Unit::SAT);
+    QCOMPARE(
+        recipients.data(recipients.index(0, 0), SendRecipientsListModel::AmountRole).toString(),
+        QStringLiteral("50000000"));
+    QCOMPARE(
+        recipients.data(recipients.index(0, 0), SendRecipientsListModel::AmountUnitLabelRole).toString(),
+        QStringLiteral("sats"));
+
+    first->amount()->setUnit(BitcoinAmount::Unit::BTC);
+    QCOMPARE(first->amount()->unit(), BitcoinAmount::Unit::BTC);
+    QCOMPARE(second->amount()->unit(), BitcoinAmount::Unit::BTC);
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -184,6 +184,32 @@ void SetValidRecipient(WalletQmlModel& model,
     QVERIFY2(recipient->isValid(), "Recipient must be valid before scheduling fee estimates");
 }
 
+interfaces::WalletTx MakeOutgoingActivityWalletTx(const std::vector<CAmount>& output_values,
+                                                   const std::vector<bool>& output_is_mine,
+                                                   const std::vector<bool>& output_is_change)
+{
+    CMutableTransaction transaction;
+    transaction.vin.emplace_back(COutPoint{Txid::FromUint256(uint256{1}), 0});
+    for (const CAmount value : output_values) {
+        transaction.vout.emplace_back(value, CScript{});
+    }
+
+    interfaces::WalletTx wallet_tx;
+    wallet_tx.tx = MakeTransactionRef(std::move(transaction));
+    wallet_tx.txin_is_mine = {true};
+    wallet_tx.txout_is_mine = output_is_mine;
+    wallet_tx.txout_is_change = output_is_change;
+    wallet_tx.txout_address.assign(output_values.size(), DecodeDestination(VALID_MAINNET_ADDRESS.toStdString()));
+    wallet_tx.txout_address_is_mine = output_is_mine;
+    wallet_tx.credit = std::inner_product(
+        output_values.begin(), output_values.end(), output_is_mine.begin(), CAmount{0});
+    wallet_tx.debit = std::accumulate(output_values.begin(), output_values.end(), CAmount{0}) + 1'000;
+    wallet_tx.change = 0;
+    wallet_tx.time = 0;
+    wallet_tx.is_coinbase = false;
+    return wallet_tx;
+}
+
 class FakePasswordWallet : public StubWallet
 {
 public:
@@ -522,6 +548,8 @@ private Q_SLOTS:
     void availableReceiveAddressTypesHideUnavailableTaproot();
     void receiveAddressTypeDefaultPersistsPerWallet();
     void removeReceiveRequestRemovesPendingActivityRow();
+    void activityDetailsSelectLowestOutputIndex();
+    void activityDetailsPreferOutgoingForSelfPayment();
     void prepareTransactionOnLockedWalletRequiresPassword();
     void prepareTransactionWithPrivateKeysDisabledDoesNotRequirePassword();
     void sendRecipientRejectsDustAmount();
@@ -1613,6 +1641,42 @@ void WalletQmlModelTests::removeReceiveRequestRemovesPendingActivityRow()
     QCOMPARE(wallet->set_address_receive_request_calls, 2);
     QCOMPARE(wallet->receive_request_ids.back(), std::string{"1"});
     QCOMPARE(model->activityListModel()->rowCount(), 0);
+}
+
+void WalletQmlModelTests::activityDetailsSelectLowestOutputIndex()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    const interfaces::WalletTx wallet_tx = MakeOutgoingActivityWalletTx(
+        {10'000, 20'000, 30'000},
+        {true, false, false},
+        {true, false, false});
+    ON_CALL(*wallet, getWalletTxs()).WillByDefault(Return(std::set<interfaces::WalletTx>{wallet_tx}));
+    model->activityListModel()->reload();
+
+    const QString txid = QString::fromStdString(wallet_tx.tx->GetHash().ToString());
+    const QVariantMap first = model->activityListModel()->firstTransactionDetails(txid);
+    QCOMPARE(first.value("outputIndex").toInt(), 1);
+
+    const QVariantMap exact = model->activityListModel()->transactionDetails(txid, 2);
+    QCOMPARE(exact.value("outputIndex").toInt(), 2);
+}
+
+void WalletQmlModelTests::activityDetailsPreferOutgoingForSelfPayment()
+{
+    NiceMock<MockWallet>* wallet{nullptr};
+    auto model = MakeWalletModel(wallet);
+    const interfaces::WalletTx wallet_tx = MakeOutgoingActivityWalletTx(
+        {20'000},
+        {true},
+        {false});
+    ON_CALL(*wallet, getWalletTxs()).WillByDefault(Return(std::set<interfaces::WalletTx>{wallet_tx}));
+    model->activityListModel()->reload();
+
+    const QString txid = QString::fromStdString(wallet_tx.tx->GetHash().ToString());
+    const QVariantMap details = model->activityListModel()->firstTransactionDetails(txid);
+    QCOMPARE(details.value("outputIndex").toInt(), 0);
+    QVERIFY(details.value("amount").toString().startsWith('-'));
 }
 
 void WalletQmlModelTests::prepareTransactionOnLockedWalletRequiresPassword()

--- a/test/test_walletqmlmodel.cpp
+++ b/test/test_walletqmlmodel.cpp
@@ -1645,13 +1645,14 @@ void WalletQmlModelTests::removeReceiveRequestRemovesPendingActivityRow()
 
 void WalletQmlModelTests::activityDetailsSelectLowestOutputIndex()
 {
-    NiceMock<MockWallet>* wallet{nullptr};
-    auto model = MakeWalletModel(wallet);
+    auto [wallet, model] = MakeWalletModel();
     const interfaces::WalletTx wallet_tx = MakeOutgoingActivityWalletTx(
         {10'000, 20'000, 30'000},
         {true, false, false},
         {true, false, false});
-    ON_CALL(*wallet, getWalletTxs()).WillByDefault(Return(std::set<interfaces::WalletTx>{wallet_tx}));
+    wallet->get_wallet_txs_fn = [wallet_tx] {
+        return std::set<interfaces::WalletTx>{wallet_tx};
+    };
     model->activityListModel()->reload();
 
     const QString txid = QString::fromStdString(wallet_tx.tx->GetHash().ToString());
@@ -1664,13 +1665,14 @@ void WalletQmlModelTests::activityDetailsSelectLowestOutputIndex()
 
 void WalletQmlModelTests::activityDetailsPreferOutgoingForSelfPayment()
 {
-    NiceMock<MockWallet>* wallet{nullptr};
-    auto model = MakeWalletModel(wallet);
+    auto [wallet, model] = MakeWalletModel();
     const interfaces::WalletTx wallet_tx = MakeOutgoingActivityWalletTx(
         {20'000},
         {true},
         {false});
-    ON_CALL(*wallet, getWalletTxs()).WillByDefault(Return(std::set<interfaces::WalletTx>{wallet_tx}));
+    wallet->get_wallet_txs_fn = [wallet_tx] {
+        return std::set<interfaces::WalletTx>{wallet_tx};
+    };
     model->activityListModel()->reload();
 
     const QString txid = QString::fromStdString(wallet_tx.tx->GetHash().ToString());

--- a/test/test_walletqmlmodeltransaction.cpp
+++ b/test/test_walletqmlmodeltransaction.cpp
@@ -20,6 +20,7 @@ private Q_SLOTS:
     void multipleRecipientReviewAmountsStayInBtc();
     void recipientRolesExposeFormattedAddressAndUnitLabel();
     void removingRecipientUpdatesTotalOnce();
+    void txidTracksAssignedTransaction();
 };
 
 void WalletQmlModelTransactionTests::singleRecipientReviewAmountsInheritRecipientUnit()
@@ -88,6 +89,25 @@ void WalletQmlModelTransactionTests::removingRecipientUpdatesTotalOnce()
 
     QCOMPARE(recipients.totalAmountSatoshi(), 1000);
     QCOMPARE(total_changed_spy.count(), 1);
+}
+
+void WalletQmlModelTransactionTests::txidTracksAssignedTransaction()
+{
+    SendRecipientsListModel recipients;
+    WalletQmlModelTransaction transaction(&recipients);
+    QVERIFY(transaction.txid().isEmpty());
+
+    CMutableTransaction mutable_transaction;
+    mutable_transaction.vout.emplace_back(1'000, CScript{});
+    const CTransactionRef wallet_transaction = MakeTransactionRef(std::move(mutable_transaction));
+    QSignalSpy txid_changed_spy{&transaction, &WalletQmlModelTransaction::txidChanged};
+
+    transaction.setWtx(wallet_transaction);
+    QCOMPARE(transaction.txid(), QString::fromStdString(wallet_transaction->GetHash().ToString()));
+    QCOMPARE(txid_changed_spy.count(), 1);
+
+    transaction.setWtx(wallet_transaction);
+    QCOMPARE(txid_changed_spy.count(), 1);
 }
 
 #ifdef BITCOINQML_NO_TEST_MAIN

--- a/test/test_walletqmlmodeltransaction.cpp
+++ b/test/test_walletqmlmodeltransaction.cpp
@@ -17,7 +17,7 @@ class WalletQmlModelTransactionTests : public QObject
 
 private Q_SLOTS:
     void singleRecipientReviewAmountsInheritRecipientUnit();
-    void multipleRecipientReviewAmountsStayInBtc();
+    void multipleRecipientReviewAmountsInheritSharedUnit();
     void recipientRolesExposeFormattedAddressAndUnitLabel();
     void removingRecipientUpdatesTotalOnce();
     void txidTracksAssignedTransaction();
@@ -39,7 +39,7 @@ void WalletQmlModelTransactionTests::singleRecipientReviewAmountsInheritRecipien
     QCOMPARE(transaction.totalAmount()->toDisplay(), QString("1300"));
 }
 
-void WalletQmlModelTransactionTests::multipleRecipientReviewAmountsStayInBtc()
+void WalletQmlModelTransactionTests::multipleRecipientReviewAmountsInheritSharedUnit()
 {
     SendRecipientsListModel recipients;
     auto* first = recipients.currentRecipient();
@@ -54,10 +54,11 @@ void WalletQmlModelTransactionTests::multipleRecipientReviewAmountsStayInBtc()
     WalletQmlModelTransaction transaction(&recipients);
     transaction.setTransactionFee(1000);
 
-    QCOMPARE(transaction.feeAmount()->unit(), BitcoinAmount::Unit::BTC);
-    QCOMPARE(transaction.totalAmount()->unit(), BitcoinAmount::Unit::BTC);
-    QCOMPARE(transaction.feeAmount()->toDisplay(), QString("0.00001000"));
-    QCOMPARE(transaction.totalAmount()->toDisplay(), QString("0.50003000"));
+    QCOMPARE(first->amount()->unit(), BitcoinAmount::Unit::SAT);
+    QCOMPARE(transaction.feeAmount()->unit(), BitcoinAmount::Unit::SAT);
+    QCOMPARE(transaction.totalAmount()->unit(), BitcoinAmount::Unit::SAT);
+    QCOMPARE(transaction.feeAmount()->toDisplay(), QString("1000"));
+    QCOMPARE(transaction.totalAmount()->toDisplay(), QString("50003000"));
 }
 
 void WalletQmlModelTransactionTests::recipientRolesExposeFormattedAddressAndUnitLabel()


### PR DESCRIPTION
This is an omnibus PR that fixes a several issues related to Send and Send review pages.

- Allow payment requests to be pasted directly into the address field.
  - Fixes #839 
- Reject invalid characters in the address field.
  - Fixes #836 
- Navigate to the activity details page when selecting “View Transaction” after sending.
  - Fixes #830. 
  - Fixes #831.
- Keep the bitcoin/sats unit preference synchronized on the Send Review page.
  - Fixes #844
 - Fixes #873  
- Widen and animate the wallet passphrase popup.
- Allow addresses to toggle between truncated and full forms on the Send Review page.
- Improve the multiple-recipient Send Review layout.

**Review note:** The changes are organized into focused commits, so this PR is best reviewed commit by commit.