### PR TITLE
fix: use root instead of the nullable parent

### DIFF
--- a/qml/pages/wallet/ImportWalletOptions.qml
+++ b/qml/pages/wallet/ImportWalletOptions.qml
@@ -19,7 +19,7 @@ Page {
     signal next
     background: null
     readonly property bool hasImportError: walletController.walletLoadError.length > 0
-    readonly property real heroWidth: Math.min(parent.width - 40, 520)
+    readonly property real heroWidth: Math.min(root.width - 40, 520)
     readonly property int heroTopMargin: 64
     readonly property int importHeroTopMargin: heroTopMargin + 10
     readonly property int heroIconSize: 60

--- a/test/qml/bitcoin_qmltests.qrc
+++ b/test/qml/bitcoin_qmltests.qrc
@@ -20,6 +20,7 @@
         <file>tst_dropdownbutton.qml</file>
         <file>tst_externalsignerreviewactions.qml</file>
         <file>tst_feeselection.qml</file>
+        <file>tst_importwalletoptions.qml</file>
         <file>tst_mainrouting.qml</file>
         <file>tst_mempoolinformationrows.qml</file>
         <file>tst_mempoolinformationsettings.qml</file>

--- a/test/qml/tst_importwalletoptions.qml
+++ b/test/qml/tst_importwalletoptions.qml
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/pages/wallet"
+
+TestCase {
+    name: "ImportWalletOptions"
+    when: windowShown
+    width: 520
+    height: 720
+
+    Item {
+        id: pageContainer
+        width: 460
+        height: 680
+    }
+
+    Component {
+        id: importWalletOptionsComponent
+
+        ImportWalletOptions {
+            width: 460
+            height: 680
+        }
+    }
+
+    function init() {
+        walletController.reset()
+    }
+
+    function test_hero_width_without_a_parent() {
+        const page = createTemporaryObject(importWalletOptionsComponent, null)
+        verify(page !== null)
+        compare(page.parent, null)
+        compare(page.heroWidth, 420)
+
+        const errorView = findChild(page, "importWalletErrorView")
+        verify(errorView !== null)
+        compare(errorView.width, 420)
+    }
+
+    function test_hero_width_follows_the_page_width() {
+        const page = createTemporaryObject(importWalletOptionsComponent, pageContainer)
+        verify(page !== null)
+        compare(page.heroWidth, 420)
+
+        page.width = 300
+        compare(page.heroWidth, 260)
+
+        page.width = 900
+        compare(page.heroWidth, 520)
+    }
+
+    function test_error_view_reports_the_wallet_load_error() {
+        const page = createTemporaryObject(importWalletOptionsComponent, pageContainer)
+        verify(page !== null)
+        verify(!page.hasImportError)
+
+        walletController.walletLoadError = "Corrupted wallet file."
+
+        verify(page.hasImportError)
+        const errorView = findChild(page, "importWalletErrorView")
+        verify(errorView !== null)
+        compare(errorView.width, page.heroWidth)
+        const errorDescription = findChild(page, "importWalletErrorDescription")
+        verify(errorDescription !== null)
+        compare(errorDescription.text, "Corrupted wallet file.")
+    }
+}


### PR DESCRIPTION
The parent may be null in the `ImportWalletOptions`, so it's better to use the root instead. Also adding a test for this case

fix #868