### PR TITLE
fix: QML runtime errors

### DIFF
--- a/qml/controls/CoreCheckBox.qml
+++ b/qml/controls/CoreCheckBox.qml
@@ -4,6 +4,7 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import org.bitcoincore.qt 1.0
 
 AbstractButton {
     id: root

--- a/qml/controls/InformationPage.qml
+++ b/qml/controls/InformationPage.qml
@@ -45,6 +45,7 @@ Page {
 
     background: null
     clip: true
+    contentWidth: root.maximumWidth
 
     header: NavigationBar {
       id: navbar
@@ -60,7 +61,7 @@ Page {
 
         ColumnLayout {
             id: information
-            width: Math.min(parent.width, 600)
+            width: Math.min(parent.width, root.maximumWidth)
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: 0
             Loader {

--- a/qml/models/nodemodel.cpp
+++ b/qml/models/nodemodel.cpp
@@ -808,7 +808,7 @@ void NodeModel::ConnectToBannedListChangedSignal()
     m_handler_notify_banned_list_changed = m_node.handleBannedListChanged([this]() {
         QMetaObject::invokeMethod(this, [this] {
             Q_EMIT bannedListChanged();
-        });
+        }, Qt::QueuedConnection);
     });
 }
 

--- a/qml/pages/node/BannedPeers.qml
+++ b/qml/pages/node/BannedPeers.qml
@@ -15,6 +15,13 @@ Page {
     signal back()
     background: null
 
+    function unbanPeer(row) {
+        if (!banListModel.unbanAt(row)) {
+            unbanActionError.message = qsTr("Could not unban peer. The ban list may have changed.")
+            unbanActionError.open()
+        }
+    }
+
     header: NavigationBar2 {
         leftItem: NavButton {
             objectName: "bannedPeersBackButton"
@@ -96,15 +103,7 @@ Page {
                     bold: false
                     horizontalPadding: 24
                     text: qsTr("Unban")
-                    onClicked: {
-                        if (banListModel.unbanAt(index)) {
-                            banListModel.refresh()
-                        } else {
-                            unbanActionError.message = qsTr("Could not unban peer. The ban list may have changed.")
-                            unbanActionError.open()
-                            banListModel.refresh()
-                        }
-                    }
+                    onClicked: root.unbanPeer(index)
                 }
             }
         }

--- a/qml/pages/settings/SettingsStorage.qml
+++ b/qml/pages/settings/SettingsStorage.qml
@@ -10,6 +10,7 @@ import "../../components"
 
 InformationPage {
     id: root
+    objectName: "settingsStoragePage"
     property var settingsModel: optionsModel
     property bool customStorage: false
     property int customStorageAmount

--- a/qml/pages/settings/SettingsWallet.qml
+++ b/qml/pages/settings/SettingsWallet.qml
@@ -15,8 +15,10 @@ Page {
 
     signal back
     property bool showBackButton: true
+    readonly property int maximumContentWidth: 450
 
     background: null
+    contentWidth: root.maximumContentWidth
 
     header: SettingsHeader {
         title: qsTr("External signer")
@@ -31,7 +33,7 @@ Page {
         clip: true
 
         ColumnLayout {
-            width: Math.min(parent.width, 450)
+            width: Math.min(parent.width, root.maximumContentWidth)
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: 0
 

--- a/qml/pages/wallet/ImportWalletOptions.qml
+++ b/qml/pages/wallet/ImportWalletOptions.qml
@@ -19,7 +19,7 @@ Page {
     signal next
     background: null
     readonly property bool hasImportError: walletController.walletLoadError.length > 0
-    readonly property real heroWidth: Math.min(parent.width - 40, 520)
+    readonly property real heroWidth: Math.min(root.width - 40, 520)
     readonly property int heroTopMargin: 64
     readonly property int importHeroTopMargin: heroTopMargin + 10
     readonly property int heroIconSize: 60

--- a/test/qml/bitcoin_qmltests.qrc
+++ b/test/qml/bitcoin_qmltests.qrc
@@ -9,6 +9,7 @@
         <file>tst_contextmenupicker.qml</file>
         <file>tst_contextmenu.qml</file>
         <file>tst_contextmenutoggle.qml</file>
+        <file>tst_corecheckbox.qml</file>
         <file>tst_createbackup.qml</file>
         <file>tst_createname.qml</file>
         <file>tst_createpassword.qml</file>

--- a/test/qml/bitcoin_qmltests.qrc
+++ b/test/qml/bitcoin_qmltests.qrc
@@ -21,6 +21,7 @@
         <file>tst_dropdownbutton.qml</file>
         <file>tst_externalsignerreviewactions.qml</file>
         <file>tst_feeselection.qml</file>
+        <file>tst_importwalletoptions.qml</file>
         <file>tst_mainrouting.qml</file>
         <file>tst_mempoolinformationrows.qml</file>
         <file>tst_mempoolinformationsettings.qml</file>

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -2483,6 +2483,7 @@ class MockBanListModel : public QAbstractListModel
     Q_OBJECT
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(bool unbanResult MEMBER m_unban_result NOTIFY actionStateChanged)
+    Q_PROPERTY(bool resetOnUnban MEMBER m_reset_on_unban NOTIFY actionStateChanged)
     Q_PROPERTY(int unbanCalls READ unbanCalls NOTIFY actionCallsChanged)
     Q_PROPERTY(int refreshCalls READ refreshCalls NOTIFY refreshCallsChanged)
 
@@ -2527,6 +2528,10 @@ public:
     {
         ++m_unban_calls;
         Q_EMIT actionCallsChanged();
+        if (m_reset_on_unban) {
+            beginResetModel();
+            endResetModel();
+        }
         return row >= 0 && row < count() && m_unban_result;
     }
 
@@ -2539,6 +2544,7 @@ public:
     Q_INVOKABLE void resetTestState()
     {
         m_unban_result = true;
+        m_reset_on_unban = false;
         m_unban_calls = 0;
         m_refresh_calls = 0;
         Q_EMIT actionStateChanged();
@@ -2554,6 +2560,7 @@ Q_SIGNALS:
 
 private:
     bool m_unban_result{true};
+    bool m_reset_on_unban{false};
     int m_unban_calls{0};
     int m_refresh_calls{0};
 };

--- a/test/qml/tst_corecheckbox.qml
+++ b/test/qml/tst_corecheckbox.qml
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import org.bitcoincore.qt 1.0
+import "../../qml/controls"
+
+TestCase {
+    name: "CoreCheckBox"
+    when: windowShown
+    width: 400
+    height: 200
+
+    property bool initialIsDesktop: true
+
+    Component {
+        id: checkBoxComponent
+        CoreCheckBox {}
+    }
+
+    function initTestCase() {
+        // AppMode is a process-wide singleton shared with the other test files.
+        initialIsDesktop = AppMode.isDesktop
+    }
+
+    function cleanupTestCase() {
+        AppMode.isDesktop = initialIsDesktop
+    }
+
+    function test_hover_enabled_follows_app_mode() {
+        const box = createTemporaryObject(checkBoxComponent, this)
+        verify(box !== null)
+
+        AppMode.isDesktop = true
+        compare(box.hoverEnabled, true)
+
+        AppMode.isDesktop = false
+        compare(box.hoverEnabled, false)
+
+        AppMode.isDesktop = true
+        compare(box.hoverEnabled, true)
+    }
+
+    function test_toggles_and_reflects_checked_state() {
+        const box = createTemporaryObject(checkBoxComponent, this)
+        verify(box !== null)
+        verify(box.checkable)
+        verify(!box.checked)
+        compare(box.contentItem.color, "#00000000")
+        compare(box.contentItem.border.color, box.borderColor)
+
+        box.toggle()
+
+        verify(box.checked)
+        compare(box.contentItem.color, box.fillColor)
+        compare(box.contentItem.border.color, box.fillColor)
+
+        box.toggle()
+
+        verify(!box.checked)
+        compare(box.contentItem.color, "#00000000")
+        compare(box.contentItem.border.color, box.borderColor)
+    }
+}

--- a/test/qml/tst_importwalletoptions.qml
+++ b/test/qml/tst_importwalletoptions.qml
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtTest 1.2
+import "../../qml/pages/wallet"
+
+TestCase {
+    name: "ImportWalletOptions"
+    when: windowShown
+    width: 520
+    height: 720
+
+    Item {
+        id: pageContainer
+        width: 460
+        height: 680
+    }
+
+    Component {
+        id: importWalletOptionsComponent
+
+        ImportWalletOptions {
+            width: 460
+            height: 680
+        }
+    }
+
+    function init() {
+        walletController.reset()
+    }
+
+    function test_hero_width_without_a_parent() {
+        const page = createTemporaryObject(importWalletOptionsComponent, null)
+        verify(page !== null)
+        compare(page.parent, null)
+        compare(page.heroWidth, 420)
+
+        const errorView = findChild(page, "importWalletErrorView")
+        verify(errorView !== null)
+        compare(errorView.width, 420)
+    }
+
+    function test_hero_width_follows_the_page_width() {
+        const page = createTemporaryObject(importWalletOptionsComponent, pageContainer)
+        verify(page !== null)
+        compare(page.heroWidth, 420)
+
+        page.width = 300
+        compare(page.heroWidth, 260)
+
+        page.width = 900
+        compare(page.heroWidth, 520)
+    }
+
+    function test_error_view_reports_the_wallet_load_error() {
+        const page = createTemporaryObject(importWalletOptionsComponent, pageContainer)
+        verify(page !== null)
+        verify(!page.hasImportError)
+
+        walletController.walletLoadError = "Corrupted wallet file."
+
+        verify(page.hasImportError)
+        const errorView = findChild(page, "importWalletErrorView")
+        verify(errorView !== null)
+        compare(errorView.width, page.heroWidth)
+        const errorDescription = findChild(page, "importWalletErrorDescription")
+        verify(errorDescription !== null)
+        compare(errorDescription.text, "Corrupted wallet file.")
+    }
+}

--- a/test/qml/tst_nodesettings.qml
+++ b/test/qml/tst_nodesettings.qml
@@ -250,4 +250,30 @@ TestCase {
         verify(walletStack.depth > 1)
         compare(walletSettingsPage.showBackButton, false)
     }
+
+    function test_section_pages_keep_implicit_width_independent_of_layout() {
+        const page = createNodeSettingsPage()
+
+        const sections = [
+            { index: 1, name: "settingsWallet" },
+            { index: 4, name: "settingsStoragePage" },
+            { index: 7, name: "mempoolInformationSettingsPage" }
+        ]
+
+        for (let i = 0; i < sections.length; ++i) {
+            page.currentSection = sections[i].index
+            wait(0)
+
+            const sectionPage = findChild(page, sections[i].name)
+            verify(sectionPage !== null, sections[i].name + " was not created")
+
+            const implicitWidthBefore = sectionPage.implicitWidth
+            const widthBefore = sectionPage.width
+            sectionPage.width = widthBefore / 2
+            verify(sectionPage.width !== widthBefore,
+                   sections[i].name + " ignored the width it was given")
+            compare(sectionPage.implicitWidth, implicitWidthBefore,
+                    sections[i].name + " implicit width followed the width it was given")
+        }
+    }
 }

--- a/test/qml/tst_peeractions.qml
+++ b/test/qml/tst_peeractions.qml
@@ -85,6 +85,15 @@ TestCase {
         verify(message.text.indexOf(expectedText) >= 0)
     }
 
+    function verifyUnbanActionError(page) {
+        const popup = findChild(page, "unbanActionErrorPopup")
+        verify(popup !== null)
+        tryCompare(popup, "opened", true)
+        const message = findChild(popup, "actionErrorMessage")
+        verify(message !== null)
+        verify(message.text.indexOf("Could not unban peer.") >= 0)
+    }
+
     function test_disconnect_success_refreshes_peer_table_without_error() {
         const page = createPeerDetailsPage()
         const button = findChild(page, "peerDisconnectButton")
@@ -151,7 +160,7 @@ TestCase {
         verifyPeerActionError(page, "Could not ban peer.")
     }
 
-    function test_unban_success_refreshes_ban_list_without_error() {
+    function test_unban_success_leaves_refresh_to_the_model_without_error() {
         const page = createBannedPeersPage()
         const button = findChild(page, "unbanButton_0")
         const popup = findChild(page, "unbanActionErrorPopup")
@@ -161,7 +170,7 @@ TestCase {
         button.clicked()
 
         compare(banListModel.unbanCalls, 1)
-        compare(banListModel.refreshCalls, 1)
+        compare(banListModel.refreshCalls, 0)
         compare(popup.opened, false)
     }
 
@@ -174,12 +183,36 @@ TestCase {
         button.clicked()
 
         compare(banListModel.unbanCalls, 1)
-        compare(banListModel.refreshCalls, 1)
+        compare(banListModel.refreshCalls, 0)
+        verifyUnbanActionError(page)
+    }
+
+    function test_unban_survives_synchronous_model_reset() {
+        banListModel.resetOnUnban = true
+        const page = createBannedPeersPage()
+        const button = findChild(page, "unbanButton_0")
         const popup = findChild(page, "unbanActionErrorPopup")
+        verify(button !== null)
         verify(popup !== null)
-        tryCompare(popup, "opened", true)
-        const message = findChild(popup, "actionErrorMessage")
-        verify(message !== null)
-        verify(message.text.indexOf("Could not unban peer.") >= 0)
+
+        button.clicked()
+
+        compare(banListModel.unbanCalls, 1)
+        compare(banListModel.refreshCalls, 0)
+        compare(popup.opened, false)
+    }
+
+    function test_unban_failure_with_synchronous_model_reset_opens_error_popup() {
+        banListModel.resetOnUnban = true
+        banListModel.unbanResult = false
+        const page = createBannedPeersPage()
+        const button = findChild(page, "unbanButton_0")
+        verify(button !== null)
+
+        button.clicked()
+
+        compare(banListModel.unbanCalls, 1)
+        compare(banListModel.refreshCalls, 0)
+        verifyUnbanActionError(page)
     }
 }

--- a/test/test_nodemodel.cpp
+++ b/test/test_nodemodel.cpp
@@ -117,6 +117,7 @@ private Q_SLOTS:
     void initializationSuccessDuringCoreShutdownSkipsReadyState();
     void destructorUnsubscribesCoreSignalsBeforeStoppingPolling();
     void nodeNotificationHandlersUpdateModelThroughQueuedSignals();
+    void bannedListNotificationFromGuiThreadIsNotDeliveredReentrantly();
     void blockTipUpdatesQueuedAcrossThreadsRetainPayloadValues();
     void blockSyncActiveFollowsInitializationAndBlockTipState();
     void alertNotificationsRefreshWarningList();
@@ -542,6 +543,34 @@ void NodeModelTests::nodeNotificationHandlersUpdateModelThroughQueuedSignals()
     QCOMPARE(model.numPeers(), 9);
     QCOMPARE(model.numInboundPeers(), 2);
     QCOMPARE(model.numOutboundPeers(), 7);
+}
+
+void NodeModelTests::bannedListNotificationFromGuiThreadIsNotDeliveredReentrantly()
+{
+    MockNode node;
+    MempoolState mempool;
+    interfaces::Node::BannedListChangedFn banned_list_changed_fn;
+
+    ConfigureNodeModelDefaults(node);
+    ConfigureMempoolGetters(node, mempool);
+    node.handle_banned_list_changed_fn = [&](interfaces::Node::BannedListChangedFn fn) {
+        banned_list_changed_fn = std::move(fn);
+        return MakeNoopHandler();
+    };
+
+    NodeModel model{node};
+    WaitForInitialMempoolRefresh(mempool);
+    QVERIFY(banned_list_changed_fn);
+
+    QSignalSpy banned_list_spy{&model, &NodeModel::bannedListChanged};
+
+    // A ban list change caused by a GUI action reaches the notification handler
+    // on the GUI thread. Delivering it directly would reset the ban list model
+    // while the QML handler that triggered it is still running.
+    banned_list_changed_fn();
+    QCOMPARE(banned_list_spy.count(), 0);
+
+    QTRY_COMPARE_WITH_TIMEOUT(banned_list_spy.count(), 1, ASYNC_TIMEOUT_MS);
 }
 
 void NodeModelTests::blockTipUpdatesQueuedAcrossThreadsRetainPayloadValues()


### PR DESCRIPTION
This bundles four small QML runtime fixes that were opened separately, since each one is a couple of lines plus a test and they are all fixing errors/warnings printed at runtime rather than behaviour changes. Each fix keeps its own commit and its own regression test.

Taken from:

- #878: `ImportWalletOptions` computed `heroWidth` from `parent.width`, but the page's parent can be null (it's not always in a `StackView`), so the binding evaluated on `null` and printed a TypeError. Use `root.width` instead. Fix #868
- #879: `InformationPage` and `SettingsWallet` sized their content `ColumnLayout` from `parent.width` inside a `Flickable` whose `contentWidth` derived from that same content, producing `implicitWidth` binding loops on Qt 6.4. Both pages now set an explicit `contentWidth` from a fixed maximum-width property and the layout reads that property. Fix #866
- #880: Clicking *Unban* invalidated the delegate mid-handler: `handleBannedListChanged` emitted `bannedListChanged` synchronously, which reset the model and destroyed the delegate before the handler finished, leaving `banListModel` undefined. The emit is now queued (`Qt::QueuedConnection`) and the click handler moved to a function on the page. Fix #867
- #881: `CoreCheckBox` uses `AppMode` without importing `org.bitcoincore.qt`, so the type was unresolved at runtime. Added the missing import. Fix #865

