### PR TITLE
fix: ActivityListModel threading race and deprecated injected event params

### DIFF
--- a/qml/models/activitylistmodel.cpp
+++ b/qml/models/activitylistmodel.cpp
@@ -8,9 +8,19 @@
 #include <qml/models/walletqmlmodel.h>
 
 #include <QDateTime>
+#include <QMetaObject>
+#include <QThread>
 #include <QVariantList>
 
 #include <algorithm>
+#include <cassert>
+
+namespace {
+void assertModelThread(const QObject& model)
+{
+    assert(QThread::currentThread() == model.thread());
+}
+} // namespace
 
 ActivityListModel::ActivityListModel(WalletQmlModel *parent)
     : QAbstractListModel(parent)
@@ -35,7 +45,7 @@ int ActivityListModel::rowCount(const QModelIndex &parent) const
 
 void ActivityListModel::updateTransactionStatus(QSharedPointer<Transaction> tx) const
 {
-    if (m_wallet_model == nullptr || tx->isPendingRequest) {
+    if (m_wallet_model == nullptr || tx.isNull() || tx->isPendingRequest) {
         return;
     }
     interfaces::WalletTxStatus wtx;
@@ -50,7 +60,7 @@ void ActivityListModel::updateTransactionStatus(QSharedPointer<Transaction> tx) 
 
 void ActivityListModel::updateTransactionLabel(QSharedPointer<Transaction> tx) const
 {
-    if (m_wallet_model == nullptr) {
+    if (m_wallet_model == nullptr || tx.isNull()) {
         return;
     }
 
@@ -63,6 +73,9 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         return QVariant();
 
     QSharedPointer<Transaction> tx = m_transactions.at(index.row());
+    if (tx.isNull())
+        return QVariant();
+
     updateTransactionStatus(tx);
 
     switch (role) {
@@ -128,6 +141,7 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const
 
 void ActivityListModel::reload()
 {
+    assertModelThread(*this);
     beginResetModel();
     m_transactions.clear();
     refreshWallet();
@@ -192,6 +206,7 @@ QVariantMap ActivityListModel::transactionDetails(const QSharedPointer<Transacti
 
 void ActivityListModel::setDisplayUnit(int unit)
 {
+    assertModelThread(*this);
     if (unit != m_display_unit) {
         m_display_unit = unit;
         if (!m_transactions.isEmpty()) {
@@ -252,6 +267,7 @@ void ActivityListModel::addPendingReceiveRequests()
 void ActivityListModel::addReceiveRequest(const QString& address, const QString& label,
                                           CAmount amount, qint64 timestamp, const QString& requestId)
 {
+    assertModelThread(*this);
     uint256 zero_hash;
     auto tx = QSharedPointer<Transaction>::create(zero_hash, timestamp,
         Transaction::RecvWithAddress, address, CAmount{0}, amount);
@@ -269,6 +285,7 @@ void ActivityListModel::addReceiveRequest(const QString& address, const QString&
 
 void ActivityListModel::updateReceiveRequest(const QString& requestId, const QString& label, CAmount amount)
 {
+    assertModelThread(*this);
     for (int i = 0; i < m_transactions.size(); ++i) {
         if (m_transactions[i]->isPendingRequest && m_transactions[i]->requestId == requestId) {
             m_transactions[i]->label = label.isEmpty() ? tr("Payment request") : label;
@@ -281,6 +298,7 @@ void ActivityListModel::updateReceiveRequest(const QString& requestId, const QSt
 
 void ActivityListModel::removePendingReceiveRequest(const QString& requestId)
 {
+    assertModelThread(*this);
     for (int i = 0; i < m_transactions.size(); ++i) {
         if (!m_transactions[i]->isPendingRequest || m_transactions[i]->requestId != requestId) {
             continue;
@@ -306,6 +324,7 @@ void ActivityListModel::removePendingReceiveRequest(const QString& requestId)
 
 void ActivityListModel::updateTransaction(const uint256& hash, const interfaces::WalletTxStatus& tx_status, int num_blocks, int64_t block_time)
 {
+    assertModelThread(*this);
     int index = findTransactionIndex(hash);
 
     if (index != -1) {
@@ -389,9 +408,12 @@ void ActivityListModel::subscribeToCoreSignals()
         interfaces::WalletTxStatus wtx;
         int num_blocks;
         int64_t block_time;
-        if (m_wallet_model->tryGetTxStatus(hash, wtx, num_blocks, block_time)) {
-            updateTransaction(hash, wtx, num_blocks, block_time);
+        if (!m_wallet_model->tryGetTxStatus(hash, wtx, num_blocks, block_time)) {
+            return;
         }
+        QMetaObject::invokeMethod(this, [this, hash, wtx, num_blocks, block_time] {
+            updateTransaction(hash, wtx, num_blocks, block_time);
+        }, Qt::QueuedConnection);
     });
 }
 

--- a/qml/pages/node/CommandConsole.qml
+++ b/qml/pages/node/CommandConsole.qml
@@ -329,8 +329,8 @@ Page {
                 // popup is open; otherwise it submits the command. This mirrors the
                 // Tab behaviour and avoids submitting the raw half-typed text while a
                 // completion is highlighted.
-                Keys.onReturnPressed: root.acceptHighlightedOrSubmit(event)
-                Keys.onEnterPressed: root.acceptHighlightedOrSubmit(event)
+                Keys.onReturnPressed: (event) => root.acceptHighlightedOrSubmit(event)
+                Keys.onEnterPressed: (event) => root.acceptHighlightedOrSubmit(event)
 
                 // Up/Down: navigate autocomplete when popup is open,
                 // otherwise browse command history.
@@ -362,7 +362,7 @@ Page {
                 }
 
                 // Tab key: accept the top autocomplete suggestion.
-                Keys.onTabPressed: {
+                Keys.onTabPressed: (event) => {
                     if (!root.searchMode && autocompletePopup.visible && filteredCommands.length > 0) {
                         applySuggestion(filteredCommands[autocompleteIndex])
                         event.accepted = true

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(bitcoinqml_unit_tests
   test_transaction.cpp
   test_activityfilterproxymodel.cpp
   test_qtinfolog.cpp
+  test_activitylistmodel.cpp
   test_qtmessagefilter.cpp
   test_rpccommandexecutor.cpp
   test_rpcconsolemodel.cpp

--- a/test/mocks/mockwallet.h
+++ b/test/mocks/mockwallet.h
@@ -153,6 +153,8 @@ public:
     std::function<CoinsList()> list_coins_fn;
     std::function<OutputType()> get_default_address_type_fn;
     std::function<std::unique_ptr<interfaces::Handler>(TransactionChangedFn)> handle_transaction_changed_fn;
+    std::function<interfaces::WalletTx(const Txid&)> get_wallet_tx_fn;
+    std::function<bool(const Txid&, interfaces::WalletTxStatus&, int&, int64_t&)> try_get_tx_status_fn;
     std::function<bool(const Txid&)> transaction_can_be_bumped_fn;
     std::function<bool(const Txid&, const wallet::CCoinControl&, std::vector<bilingual_str>&, CAmount&, CAmount&, CMutableTransaction&)> create_bump_transaction_fn;
     std::function<bool(CMutableTransaction&)> sign_bump_transaction_fn;
@@ -162,6 +164,8 @@ public:
         CallCounter getNewDestination{"getNewDestination"};
         CallCounter createTransaction{"createTransaction"};
         CallCounter getWalletTxs{"getWalletTxs"};
+        CallCounter getWalletTx{"getWalletTx"};
+        CallCounter tryGetTxStatus{"tryGetTxStatus"};
         CallCounter getBalance{"getBalance"};
         CallCounter getAvailableBalance{"getAvailableBalance"};
         CallCounter getRequiredFee{"getRequiredFee"};
@@ -207,6 +211,18 @@ public:
     {
         ++calls.getWalletTxs;
         return get_wallet_txs_fn ? get_wallet_txs_fn() : std::set<interfaces::WalletTx>{};
+    }
+
+    interfaces::WalletTx getWalletTx(const Txid& txid) override
+    {
+        ++calls.getWalletTx;
+        return get_wallet_tx_fn ? get_wallet_tx_fn(txid) : interfaces::WalletTx{};
+    }
+
+    bool tryGetTxStatus(const Txid& txid, interfaces::WalletTxStatus& tx_status, int& num_blocks, int64_t& block_time) override
+    {
+        ++calls.tryGetTxStatus;
+        return try_get_tx_status_fn ? try_get_tx_status_fn(txid, tx_status, num_blocks, block_time) : false;
     }
 
     CAmount getBalance() override

--- a/test/qml/bitcoin_qmltests.qrc
+++ b/test/qml/bitcoin_qmltests.qrc
@@ -4,6 +4,7 @@
         <file>tst_activity.qml</file>
         <file>tst_address_components.qml</file>
         <file>tst_blockclock.qml</file>
+        <file>tst_commandconsole.qml</file>
         <file>tst_contextmenubutton.qml</file>
         <file>tst_contextmenudivider.qml</file>
         <file>tst_contextmenupicker.qml</file>

--- a/test/qml/qml_tests_main.cpp
+++ b/test/qml/qml_tests_main.cpp
@@ -5,6 +5,7 @@
 #include <QtQuickTest/quicktest.h>
 
 #include <QAbstractListModel>
+#include <QColor>
 #include <QDateTime>
 #include <QFont>
 #include <QHash>
@@ -3377,6 +3378,160 @@ private:
     int m_next_old_row{0};
 };
 
+class MockRpcOutputListModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
+
+public:
+    enum Role {
+        TimestampRole = Qt::UserRole + 1,
+        ContentRole,
+        CategoryRole,
+    };
+    Q_ENUM(Role)
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override
+    {
+        return parent.isValid() ? 0 : m_rows.size();
+    }
+
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override
+    {
+        if (!index.isValid() || index.row() < 0 || index.row() >= m_rows.size()) return {};
+        const Row& row = m_rows.at(index.row());
+        switch (role) {
+        case TimestampRole: return row.timestamp;
+        case ContentRole: return row.content;
+        case CategoryRole: return row.category;
+        default: return {};
+        }
+    }
+
+    QHash<int, QByteArray> roleNames() const override
+    {
+        return {
+            {TimestampRole, "timestamp"},
+            {ContentRole, "content"},
+            {CategoryRole, "category"},
+        };
+    }
+
+    void appendRow(const QString& content, int category)
+    {
+        beginInsertRows(QModelIndex(), m_rows.size(), m_rows.size());
+        m_rows.append(Row{QStringLiteral("00:00:00"), content, category});
+        endInsertRows();
+        Q_EMIT countChanged();
+    }
+
+    void resetAll()
+    {
+        if (m_rows.isEmpty()) return;
+        beginResetModel();
+        m_rows.clear();
+        endResetModel();
+        Q_EMIT countChanged();
+    }
+
+Q_SIGNALS:
+    void countChanged();
+
+private:
+    struct Row {
+        QString timestamp;
+        QString content;
+        int category{0};
+    };
+
+    QList<Row> m_rows;
+};
+
+class MockRpcConsoleModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool executing READ executing NOTIFY executingChanged)
+    Q_PROPERTY(QStringList availableCommands READ availableCommands NOTIFY availableCommandsChanged)
+    Q_PROPERTY(QAbstractListModel* outputModel READ outputModel CONSTANT)
+    Q_PROPERTY(QColor requestColor MEMBER m_request_color)
+    Q_PROPERTY(QColor replyColor MEMBER m_reply_color)
+    Q_PROPERTY(QColor errorColor MEMBER m_error_color)
+    Q_PROPERTY(QColor keyColor MEMBER m_key_color)
+    // Test-only observation point: every command the console accepted.
+    Q_PROPERTY(QStringList submittedCommands READ submittedCommands NOTIFY submittedCommandsChanged)
+
+public:
+    bool executing() const { return m_executing; }
+    QStringList availableCommands() const { return m_available_commands; }
+    QAbstractListModel* outputModel() { return &m_output_model; }
+    QStringList submittedCommands() const { return m_submitted_commands; }
+
+    Q_INVOKABLE bool submitCommand(const QString& command, const QString& /*wallet_name*/ = {})
+    {
+        if (!m_accept_commands) return false;
+        m_submitted_commands.append(command);
+        m_output_model.appendRow(command, 0);
+        Q_EMIT submittedCommandsChanged();
+        return true;
+    }
+
+    Q_INVOKABLE void ensureWelcomeMessage()
+    {
+        if (m_output_model.rowCount() > 0) return;
+        m_output_model.appendRow(QStringLiteral("Welcome"), 0);
+    }
+
+    // No history is replayed; Up/Down leave the typed text as it is.
+    Q_INVOKABLE QString browseHistory(int /*direction*/, const QString& current_text) { return current_text; }
+
+    Q_INVOKABLE void resetHistoryNavigation() {}
+
+    Q_INVOKABLE void clear()
+    {
+        m_output_model.resetAll();
+        ensureWelcomeMessage();
+    }
+
+    // Reset every observable back to a known state between test functions.
+    Q_INVOKABLE void resetForTest()
+    {
+        m_output_model.resetAll();
+        m_submitted_commands.clear();
+        m_accept_commands = true;
+        setAvailableCommands({QStringLiteral("getbalance"),
+                              QStringLiteral("getblockcount"),
+                              QStringLiteral("getblockhash"),
+                              QStringLiteral("help")});
+        Q_EMIT submittedCommandsChanged();
+    }
+
+    Q_INVOKABLE void setAvailableCommands(const QStringList& commands)
+    {
+        if (m_available_commands == commands) return;
+        m_available_commands = commands;
+        Q_EMIT availableCommandsChanged();
+    }
+
+    // Make submitCommand() refuse, mirroring a console that is still busy.
+    Q_INVOKABLE void setAcceptCommands(bool accept) { m_accept_commands = accept; }
+
+Q_SIGNALS:
+    void executingChanged();
+    void availableCommandsChanged();
+    void submittedCommandsChanged();
+
+private:
+    MockRpcOutputListModel m_output_model;
+    QStringList m_available_commands;
+    QStringList m_submitted_commands;
+    bool m_executing{false};
+    bool m_accept_commands{true};
+    QColor m_request_color;
+    QColor m_reply_color;
+    QColor m_error_color;
+    QColor m_key_color;
+};
+
 class QmlTestsSetup : public QObject
 {
     Q_OBJECT
@@ -3408,6 +3563,8 @@ public Q_SLOTS:
         static MockBumpTransactionModel bump_model;
         static MockDesktopWindowBehaviorModel desktop_window_behavior_model;
         static MockDebugLogModel debug_log_model;
+        static MockRpcConsoleModel rpc_console_model;
+        rpc_console_model.resetForTest();
         recipients_model.setCurrent(&send_recipient);
         wallet_model.setActivityListModel(&activity_list_model);
         wallet_model.setBumpModel(&bump_model);
@@ -3475,6 +3632,8 @@ public Q_SLOTS:
         engine->rootContext()->setContextProperty(QStringLiteral("desktopWindowBehaviorModel"), &desktop_window_behavior_model);
         engine->rootContext()->setContextProperty(QStringLiteral("debugLogModel"), &debug_log_model);
         engine->rootContext()->setContextProperty(QStringLiteral("testDebugLogModel"), &debug_log_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("rpcConsoleModel"), &rpc_console_model);
+        engine->rootContext()->setContextProperty(QStringLiteral("testRpcConsoleModel"), &rpc_console_model);
         engine->addImportPath(QStringLiteral(BITCOINQML_QML_SOURCE_DIR));
     }
 };

--- a/test/qml/tst_commandconsole.qml
+++ b/test/qml/tst_commandconsole.qml
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import QtQuick 2.15
+import QtQuick.Window 2.15
+import QtTest 1.2
+import org.bitcoincore.qt 1.0
+import "../../qml/pages/node"
+
+TestCase {
+    id: testCase
+    name: "CommandConsole"
+    when: windowShown
+    width: 640
+    height: 480
+
+    Component {
+        id: consoleComponent
+
+        CommandConsole {
+            objectName: "testCommandConsole"
+        }
+    }
+
+    function init() {
+        testRpcConsoleModel.resetForTest()
+    }
+
+    function createConsole() {
+        const page = createTemporaryObject(consoleComponent, testCase.Window.window.contentItem)
+        verify(page !== null)
+        page.width = testCase.width
+        page.height = testCase.height
+        page.visible = true
+
+        const input = findChild(page, "consoleInput")
+        verify(input !== null)
+        input.forceActiveFocus()
+        tryCompare(input, "activeFocus", true)
+        return page
+    }
+
+    function typeCommand(page, text) {
+        const input = findChild(page, "consoleInput")
+        input.text = ""
+        for (let i = 0; i < text.length; ++i) {
+            keyClick(text[i])
+        }
+        compare(input.text, text)
+        return input
+    }
+
+    function test_return_runs_the_highlighted_suggestion() {
+        const page = createConsole()
+        const popup = findChild(page, "consoleAutocompletePopup")
+        verify(popup !== null)
+
+        const input = typeCommand(page, "getbl")
+        tryCompare(popup, "visible", true)
+        compare(page.filteredCommands.length, 2)
+        compare(page.autocompleteIndex, 0)
+
+        keyClick(Qt.Key_Return)
+
+        compare(testRpcConsoleModel.submittedCommands.length, 1)
+        compare(testRpcConsoleModel.submittedCommands[0], "getblockcount")
+        compare(input.text, "")
+        tryCompare(popup, "visible", false)
+    }
+
+    function test_keypad_enter_submits_typed_command() {
+        const page = createConsole()
+        const popup = findChild(page, "consoleAutocompletePopup")
+        verify(popup !== null)
+
+        const input = typeCommand(page, "foobar")
+        compare(popup.visible, false)
+
+        keyClick(Qt.Key_Enter)
+
+        compare(testRpcConsoleModel.submittedCommands.length, 1)
+        compare(testRpcConsoleModel.submittedCommands[0], "foobar")
+        compare(input.text, "")
+    }
+
+    function test_return_keeps_refused_command_in_the_field() {
+        const page = createConsole()
+        testRpcConsoleModel.setAcceptCommands(false)
+
+        const input = typeCommand(page, "foobar")
+        keyClick(Qt.Key_Return)
+
+        compare(testRpcConsoleModel.submittedCommands.length, 0)
+        compare(input.text, "foobar")
+    }
+
+    function test_tab_fills_in_the_highlighted_suggestion() {
+        const page = createConsole()
+        const popup = findChild(page, "consoleAutocompletePopup")
+        verify(popup !== null)
+
+        const input = typeCommand(page, "getbl")
+        tryCompare(popup, "visible", true)
+
+        keyClick(Qt.Key_Tab)
+
+        compare(input.text, "getblockcount ")
+        compare(input.cursorPosition, input.text.length)
+        compare(testRpcConsoleModel.submittedCommands.length, 0)
+        tryCompare(popup, "visible", false)
+        compare(input.activeFocus, true)
+    }
+
+    function test_tab_without_suggestions_leaves_the_input_alone() {
+        const page = createConsole()
+        const popup = findChild(page, "consoleAutocompletePopup")
+        verify(popup !== null)
+
+        // "foobar" matches nothing, so there is no suggestion to complete.
+        const input = typeCommand(page, "foobar")
+        compare(popup.visible, false)
+
+        keyClick(Qt.Key_Tab)
+
+        compare(input.text, "foobar")
+        compare(testRpcConsoleModel.submittedCommands.length, 0)
+    }
+
+    function test_search_mode_ignores_the_submit_keys() {
+        const page = createConsole()
+        page.toggleSearchMode()
+        compare(page.searchMode, true)
+
+        const input = typeCommand(page, "getbl")
+        compare(findChild(page, "consoleAutocompletePopup").visible, false)
+
+        keyClick(Qt.Key_Return)
+        keyClick(Qt.Key_Enter)
+        keyClick(Qt.Key_Tab)
+
+        compare(testRpcConsoleModel.submittedCommands.length, 0)
+        compare(input.text, "getbl")
+        compare(page.searchDraft, "getbl")
+    }
+}

--- a/test/test_activitylistmodel.cpp
+++ b/test/test_activitylistmodel.cpp
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <interfaces/handler.h>
+#include <interfaces/wallet.h>
+#include <primitives/transaction.h>
+#include <qml/models/activityfilterproxymodel.h>
+#include <qml/models/activitylistmodel.h>
+#include <qml/models/transaction.h>
+#include <qml/models/walletqmlmodel.h>
+#include <script/script.h>
+#include <test/mocks/mockwallet.h>
+#include <test/qt_test_registry.h>
+#include <uint256.h>
+
+#include <QAbstractItemModel>
+#include <QCoreApplication>
+#include <QModelIndex>
+#include <QThread>
+#include <QtTest/QtTest>
+
+#include <atomic>
+#include <map>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+constexpr CAmount COIN_VALUE{100'000'000};
+constexpr auto ASYNC_TIMEOUT_MS{5'000};
+
+CTxDestination Destination(unsigned char value)
+{
+    uint160 id;
+    id.begin()[0] = value;
+    return PKHash{id};
+}
+
+//! `seed` makes the txid unique.
+interfaces::WalletTx MakeIncomingWalletTx(unsigned int seed)
+{
+    uint256 prevout_hash;
+    prevout_hash.begin()[0] = static_cast<unsigned char>(seed & 0xff);
+    prevout_hash.begin()[1] = static_cast<unsigned char>((seed >> 8) & 0xff);
+
+    CMutableTransaction mtx;
+    mtx.vin.emplace_back(COutPoint{Txid::FromUint256(prevout_hash), 0});
+    mtx.vout.emplace_back(5 * COIN_VALUE, CScript{});
+
+    interfaces::WalletTx wtx;
+    wtx.tx = MakeTransactionRef(std::move(mtx));
+    wtx.txin_is_mine = {false};
+    wtx.txout_is_mine = {true};
+    wtx.txout_is_change = {false};
+    wtx.txout_address = {Destination(static_cast<unsigned char>(seed + 1))};
+    wtx.txout_address_is_mine = {true};
+    wtx.credit = 5 * COIN_VALUE;
+    wtx.debit = 0;
+    wtx.change = 0;
+    wtx.time = 1'700'000'000 + seed;
+    wtx.is_coinbase = false;
+    return wtx;
+}
+
+int ReadAllRows(const QAbstractItemModel& model)
+{
+    const int rows = model.rowCount();
+    for (int row = 0; row < rows; ++row) {
+        const QModelIndex index = model.index(row, 0);
+        model.data(index, ActivityListModel::AmountRole);
+        model.data(index, ActivityListModel::LabelRole);
+        model.data(index, ActivityListModel::StatusRole);
+        model.data(index, ActivityListModel::TxIdRole);
+    }
+    return rows;
+}
+
+class NotifyingWallet
+{
+public:
+    explicit NotifyingWallet(int transaction_count)
+    {
+        auto wallet = std::make_unique<MockWallet>();
+
+        for (int i = 0; i < transaction_count; ++i) {
+            const interfaces::WalletTx wtx = MakeIncomingWalletTx(static_cast<unsigned int>(i));
+            const Txid txid = wtx.tx->GetHash();
+            m_txids.push_back(txid);
+            m_txs.emplace(txid, wtx);
+        }
+
+        wallet->handle_transaction_changed_fn = [this](interfaces::Wallet::TransactionChangedFn fn) {
+            m_callbacks.push_back(std::move(fn));
+            return interfaces::MakeCleanupHandler([] {});
+        };
+        wallet->get_wallet_tx_fn = [this](const Txid& txid) {
+            auto it = m_txs.find(txid);
+            return it == m_txs.end() ? interfaces::WalletTx{} : it->second;
+        };
+        wallet->try_get_tx_status_fn = [this](const Txid& txid, interfaces::WalletTxStatus& tx_status, int& num_blocks, int64_t& block_time) {
+            if (!m_txs.count(txid)) return false;
+            if (m_status_thread_guard != nullptr && QThread::currentThread() == m_status_thread_guard) return false;
+            tx_status.depth_in_main_chain = 1;
+            tx_status.is_in_main_chain = true;
+            num_blocks = 100;
+            block_time = 1'700'000'000;
+            return true;
+        };
+
+        m_model = std::make_unique<WalletQmlModel>(std::move(wallet));
+    }
+
+    WalletQmlModel& model() { return *m_model; }
+    ActivityListModel& activity() { return *m_model->activityListModel(); }
+    const std::vector<Txid>& txids() const { return m_txids; }
+
+    void OnlyServeStatusOffThread(QThread* model_thread)
+    {
+        m_status_thread_guard = model_thread;
+    }
+
+    void Notify(const Txid& txid) const
+    {
+        for (const auto& callback : m_callbacks) {
+            callback(txid, CT_NEW);
+        }
+    }
+
+private:
+    QThread* m_status_thread_guard{nullptr};
+    std::vector<interfaces::Wallet::TransactionChangedFn> m_callbacks;
+    std::map<Txid, interfaces::WalletTx> m_txs;
+    std::vector<Txid> m_txids;
+    std::unique_ptr<WalletQmlModel> m_model;
+};
+} // namespace
+
+class ActivityListModelTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase();
+    void walletNotificationFromAnotherThreadIsAppliedOnTheModelThread();
+    void walletStatusIsReadOnTheNotifyingThread();
+    void concurrentWalletNotificationsAndProxyReadsStayConsistent();
+};
+
+void ActivityListModelTests::initTestCase()
+{
+    SelectParams(ChainType::REGTEST);
+}
+
+//! Wallet notifications arrive on validation and network threads, but the model is
+//! read on the GUI thread, so the work must be marshalled onto the model thread.
+void ActivityListModelTests::walletNotificationFromAnotherThreadIsAppliedOnTheModelThread()
+{
+    NotifyingWallet wallet{/*transaction_count=*/1};
+    ActivityListModel& activity = wallet.activity();
+    QCOMPARE(activity.rowCount(), 0);
+
+    std::atomic<QThread*> insert_thread{nullptr};
+    QObject::connect(&activity, &QAbstractItemModel::rowsInserted, &activity,
+                     [&insert_thread](const QModelIndex&, int, int) {
+                         insert_thread = QThread::currentThread();
+                     },
+                     Qt::DirectConnection);
+
+    QThread* const model_thread = activity.thread();
+    std::atomic<QThread*> notifying_thread{nullptr};
+    std::thread worker([&] {
+        notifying_thread = QThread::currentThread();
+        wallet.Notify(wallet.txids().front());
+    });
+    worker.join();
+
+    QVERIFY(notifying_thread.load() != model_thread);
+
+    // Nothing has run on the model thread yet.
+    QCOMPARE(activity.rowCount(), 0);
+    QCOMPARE(insert_thread.load(), nullptr);
+
+    QTRY_COMPARE_WITH_TIMEOUT(activity.rowCount(), 1, ASYNC_TIMEOUT_MS);
+    QCOMPARE(insert_thread.load(), model_thread);
+    QCOMPARE(activity.data(activity.index(0), ActivityListModel::TxIdRole).toString(),
+             QString::fromStdString(wallet.txids().front().ToUint256().GetHex()));
+}
+
+void ActivityListModelTests::walletStatusIsReadOnTheNotifyingThread()
+{
+    NotifyingWallet wallet{/*transaction_count=*/1};
+    ActivityListModel& activity = wallet.activity();
+    wallet.OnlyServeStatusOffThread(activity.thread());
+
+    std::thread worker([&] { wallet.Notify(wallet.txids().front()); });
+    worker.join();
+
+    QTRY_COMPARE_WITH_TIMEOUT(activity.rowCount(), 1, ASYNC_TIMEOUT_MS);
+}
+
+//! Direct mutation from the notifying thread trips the model-thread assertions.
+void ActivityListModelTests::concurrentWalletNotificationsAndProxyReadsStayConsistent()
+{
+    constexpr int TRANSACTION_COUNT{64};
+    NotifyingWallet wallet{TRANSACTION_COUNT};
+    ActivityListModel& activity = wallet.activity();
+
+    ActivityFilterProxyModel proxy;
+    proxy.setSourceModel(&activity);
+    QCOMPARE(proxy.rowCount(), 0);
+
+    std::thread worker([&] {
+        for (const Txid& txid : wallet.txids()) {
+            wallet.Notify(txid);
+            // Runs the update path alongside the insert path.
+            wallet.Notify(txid);
+        }
+    });
+
+    QTRY_COMPARE_WITH_TIMEOUT(ReadAllRows(proxy), TRANSACTION_COUNT, ASYNC_TIMEOUT_MS);
+    worker.join();
+
+    QTRY_COMPARE_WITH_TIMEOUT(ReadAllRows(proxy), TRANSACTION_COUNT, ASYNC_TIMEOUT_MS);
+    QCOMPARE(activity.rowCount(), TRANSACTION_COUNT);
+}
+
+#ifdef BITCOINQML_NO_TEST_MAIN
+BITCOINQML_REGISTER_QT_TEST(ActivityListModelTests)
+#else
+QTEST_MAIN(ActivityListModelTests)
+#endif
+#include "test_activitylistmodel.moc"


### PR DESCRIPTION
- `ActivityListModel` was updated straight from the wallet's transaction-changed callback, which arrives on validation and network threads, while the GUI thread and `ActivityFilterProxyModel` read the same model. The notification is now queued onto the model thread, like the other wallet-signal handlers in `WalletQmlModel` already do. Fix #870

- The `Return`, `Enter` and `Tab` handlers in `CommandConsole.qml` used an undeclared `event`, relying on Qt's deprecated signal-parameter injection. They now declare the parameter explicitly. Fix #869
