### PR TITLE
ci: Update GHA `actions/upload-artifact`

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -70,7 +70,7 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ matrix.os }}-ccache-${{ github.run_id }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: unsecure_${{ matrix.os }}_gui
           path: build/bin/bitcoin-core-app

--- a/.github/workflows/depends-build.yml
+++ b/.github/workflows/depends-build.yml
@@ -157,7 +157,7 @@ jobs:
           ctest --test-dir "${BUILD_DIR}" --output-on-failure --parallel "${JOBS}"
 
       - name: Upload depends logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: depends-logs-${{ matrix.cache-id }}
@@ -165,7 +165,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bitcoin-core-app-${{ matrix.cache-id }}
           path: ${{ env.BUILD_DIR }}/bin/bitcoin-core-app


### PR DESCRIPTION
This was overlooked in https://github.com/bitcoin-core/gui-qml/pull/884.

Fixes the remaining "Node.js 20 is deprecated" CI warnings.