### PR TITLE
stage, ci: Exclude Qt autogenerated files from compilation database

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -222,7 +222,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
   set -eo pipefail
   # Filter out:
   # * qt qrc and moc generated files
-  jq 'map(select(.file | test("src/qt/.*_autogen/.*\\.cpp$") | not))' "${BASE_BUILD_DIR}/compile_commands.json" > tmp.json
+  jq 'map(select(.file | test("src/(qt|qml)/.*_autogen/.*\\.cpp$") | not))' "${BASE_BUILD_DIR}/compile_commands.json" > tmp.json
   mv tmp.json "${BASE_BUILD_DIR}/compile_commands.json"
 
   cd "${BASE_BUILD_DIR}/src/"


### PR DESCRIPTION
Exclude Qt autogenerated files under the `qml` subdirectory from the compilation database used in "tidy" CI job.